### PR TITLE
feat: show admission queue health in Operations

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -84,7 +84,7 @@ function runSessionShareIdFromLocation(): string | null {
 
 /** Renders the current view (board, activity feed, or backlog). */
 function MainContent() {
-  const { view, goBack, navigateToTask } = useView();
+  const { view, goBack, navigateToTask, navigateToWorkflow } = useView();
   const runSessionShareId = runSessionShareIdFromLocation();
 
   if (runSessionShareId) return <RunSessionShareView shareId={runSessionShareId} />;
@@ -100,7 +100,11 @@ function MainContent() {
   const ViewComponent = LAZY_VIEW_COMPONENTS[view];
   return (
     <Suspense fallback={<ViewLoading view={view} />}>
-      <ViewComponent onBack={goBack} onTaskClick={navigateToTask} />
+      <ViewComponent
+        onBack={goBack}
+        onTaskClick={navigateToTask}
+        onWorkflowClick={navigateToWorkflow}
+      />
     </Suspense>
   );
 }

--- a/web/src/__tests__/admission-queue-panel.test.tsx
+++ b/web/src/__tests__/admission-queue-panel.test.tsx
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION,
+  ADMISSION_QUEUE_LIST_SCHEMA_VERSION,
+  EXECUTION_TREE_IDENTITY_SCHEMA_VERSION,
+  type AdmissionQueueInspectionEntry,
+  type AdmissionQueueListResponse,
+} from '@veritas-kanban/shared';
+import { AdmissionQueuePanel } from '@/components/digest/AdmissionQueuePanel';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  useAdmissionQueue: vi.fn(),
+  refetch: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAdmissionQueue', () => ({
+  useAdmissionQueue: mocks.useAdmissionQueue,
+}));
+
+const entries: AdmissionQueueInspectionEntry[] = [
+  {
+    schemaVersion: ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION,
+    id: 'queue-secret-id-root',
+    state: 'queued',
+    position: 1,
+    rawPriority: 4,
+    effectivePriority: 6,
+    agePromotion: 2,
+    ageMs: 7_500_000,
+    readiness: 'conditional',
+    lease: { posture: 'none' },
+    limitingPolicies: [
+      {
+        scope: 'workspace',
+        scopeKey: 'redacted-workspace-key',
+        limits: { concurrentRuns: 2 },
+      },
+    ],
+    conditionalStartFactors: ['capacity-available', 'policy-recheck'],
+    launch: {
+      source: 'direct',
+      target: 'direct',
+      workspaceId: 'workspace-a',
+      taskKey: 'redacted-task-key',
+      rootTaskKey: 'redacted-root-key',
+      workspaceKey: 'redacted-workspace-key',
+      provider: 'codex-cli',
+      hostKey: 'redacted-host-key',
+      rootObjectiveKey: 'redacted-objective-key',
+      nodeKey: 'redacted-node-key',
+    },
+    navigation: {
+      taskId: 'task-a',
+      attemptId: 'attempt-a',
+      executionTree: {
+        schemaVersion: EXECUTION_TREE_IDENTITY_SCHEMA_VERSION,
+        rootObjectiveId: 'objective-a',
+        nodeId: 'node-root',
+        edge: 'root',
+        depth: 0,
+      },
+    },
+    retry: {
+      count: 0,
+      maximum: 3,
+      availableAt: '2026-07-25T20:00:00.000Z',
+    },
+    createdAt: '2026-07-25T19:00:00.000Z',
+    updatedAt: '2026-07-25T20:00:00.000Z',
+  },
+  {
+    schemaVersion: ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION,
+    id: 'queue-secret-id-child',
+    state: 'leased',
+    position: 2,
+    rawPriority: 8,
+    effectivePriority: 8,
+    agePromotion: 0,
+    ageMs: 600_000,
+    readiness: 'reserved',
+    lease: {
+      posture: 'active',
+      expiresAt: '2026-07-25T20:10:00.000Z',
+    },
+    limitingPolicies: [
+      {
+        scope: 'global',
+        scopeKey: 'redacted-global-key',
+        limits: { concurrentRuns: 4 },
+      },
+    ],
+    conditionalStartFactors: ['active-reservation-release'],
+    launch: {
+      source: 'workflow',
+      target: 'workflow-step',
+      workspaceId: 'workspace-b',
+      taskKey: 'redacted-task-key',
+      rootTaskKey: 'redacted-root-key',
+      workspaceKey: 'redacted-workspace-key',
+      provider: 'workflow-control',
+      hostKey: 'redacted-host-key',
+      workflowRunKey: 'redacted-run-key',
+      workflowStepKey: 'redacted-step-key',
+      rootObjectiveKey: 'redacted-objective-key',
+      nodeKey: 'redacted-node-key',
+    },
+    navigation: {
+      taskId: 'task-b',
+      attemptId: 'attempt-b',
+      workflowId: 'workflow-a',
+      workflowRunId: 'run-a',
+      workflowStepId: 'step-a',
+      executionTree: {
+        schemaVersion: EXECUTION_TREE_IDENTITY_SCHEMA_VERSION,
+        rootObjectiveId: 'objective-a',
+        nodeId: 'node-child',
+        parentNodeId: 'node-root',
+        edge: 'workflow-step',
+        depth: 1,
+      },
+    },
+    retry: {
+      count: 1,
+      maximum: 3,
+      availableAt: '2026-07-25T20:00:00.000Z',
+    },
+    createdAt: '2026-07-25T19:50:00.000Z',
+    updatedAt: '2026-07-25T20:00:00.000Z',
+  },
+];
+
+const response: AdmissionQueueListResponse = {
+  schemaVersion: ADMISSION_QUEUE_LIST_SCHEMA_VERSION,
+  generatedAt: '2026-07-25T20:00:00.000Z',
+  conditional: true,
+  depth: {
+    global: { current: 2, limit: 2 },
+    workspaces: [
+      {
+        workspaceId: 'workspace-a',
+        workspaceKey: 'redacted-workspace-a',
+        current: 2,
+        limit: 2,
+      },
+      {
+        workspaceId: 'workspace-b',
+        workspaceKey: 'redacted-workspace-b',
+        current: 1,
+        limit: 3,
+      },
+    ],
+  },
+  pagination: {
+    page: 1,
+    limit: 100,
+    total: 103,
+    hasMore: true,
+    snapshotTruncated: true,
+  },
+  entries,
+};
+
+function queueResult(overrides: Record<string, unknown> = {}) {
+  return {
+    data: response,
+    error: null,
+    isLoading: false,
+    isFetching: false,
+    isStale: false,
+    refetch: mocks.refetch,
+    ...overrides,
+  };
+}
+
+describe('AdmissionQueuePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.refetch.mockResolvedValue({});
+    mocks.useAdmissionQueue.mockReturnValue(queueResult());
+  });
+
+  afterEach(() => cleanup());
+
+  it('shows bounded saturation, queue context, and safe drilldowns', async () => {
+    const user = userEvent.setup();
+    const onTaskClick = vi.fn();
+    const onWorkflowClick = vi.fn();
+    const { container } = renderWithProviders(
+      <AdmissionQueuePanel onTaskClick={onTaskClick} onWorkflowClick={onWorkflowClick} />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Admission Runway' })).toBeDefined();
+    expect(screen.getByText('Saturated')).toBeDefined();
+    expect(screen.getByText('Partial view')).toBeDefined();
+    expect(screen.getByText('Conditional, no start-time promise')).toBeDefined();
+    expect(screen.getByText('Root')).toBeDefined();
+    expect(screen.getByText('Descendant · depth 1')).toBeDefined();
+    expect(screen.getAllByText('workspace-a').length).toBeGreaterThan(0);
+    expect(
+      screen
+        .getByRole('progressbar', { name: 'Global admission queue capacity' })
+        .getAttribute('aria-valuenow')
+    ).toBe('2');
+
+    await user.click(screen.getByRole('button', { name: 'Open attempt at queue position 1' }));
+    expect(onTaskClick).toHaveBeenCalledWith('task-a', {
+      tab: 'timeline',
+      timelineAttemptId: 'attempt-a',
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Open workflow for queue position 2' }));
+    expect(onWorkflowClick).toHaveBeenCalledWith('workflow-a');
+
+    expect(container.textContent).not.toContain('queue-secret-id-root');
+    expect(container.textContent).not.toContain('redacted-workspace-key');
+  });
+
+  it('renders an explicit loading state', () => {
+    mocks.useAdmissionQueue.mockReturnValue(
+      queueResult({ data: undefined, isLoading: true, isFetching: true })
+    );
+    renderWithProviders(<AdmissionQueuePanel />);
+    expect(screen.getByText('Loading bounded admission queue…')).toBeDefined();
+  });
+
+  it('renders an explicit empty state', () => {
+    mocks.useAdmissionQueue.mockReturnValue(
+      queueResult({
+        data: {
+          ...response,
+          depth: { global: { current: 0, limit: 50 }, workspaces: [] },
+          pagination: {
+            ...response.pagination,
+            total: 0,
+            hasMore: false,
+            snapshotTruncated: false,
+          },
+          entries: [],
+        },
+      })
+    );
+    renderWithProviders(<AdmissionQueuePanel />);
+    expect(screen.getByText('Admission runway is clear')).toBeDefined();
+  });
+
+  it('keeps cached data visible when refresh fails', () => {
+    mocks.useAdmissionQueue.mockReturnValue(
+      queueResult({ error: new Error('Temporary connection failure'), isStale: true })
+    );
+    renderWithProviders(<AdmissionQueuePanel />);
+    expect(screen.getByText('Stale snapshot')).toBeDefined();
+    expect(screen.getByText(/Showing the last available bounded snapshot/)).toBeDefined();
+    expect(screen.getByText('Root')).toBeDefined();
+  });
+
+  it('renders a recoverable error when no snapshot is available', async () => {
+    const user = userEvent.setup();
+    mocks.useAdmissionQueue.mockReturnValue(
+      queueResult({
+        data: undefined,
+        error: new Error('Admission service unavailable'),
+      })
+    );
+    renderWithProviders(<AdmissionQueuePanel />);
+    expect(screen.getByText('Admission queue unavailable')).toBeDefined();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(mocks.refetch).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/__tests__/operations-digest-mantine.test.tsx
+++ b/web/src/__tests__/operations-digest-mantine.test.tsx
@@ -40,6 +40,10 @@ vi.mock('@/components/ui/MarkdownRenderer', () => ({
   ),
 }));
 
+vi.mock('@/components/digest/AdmissionQueuePanel', () => ({
+  AdmissionQueuePanel: () => <div data-testid="admission-queue-panel" />,
+}));
+
 const digest: AgentOperationsDigest = {
   period: {
     start: '2026-06-04T00:00:00.000Z',
@@ -315,6 +319,7 @@ describe('OperationsDigestPage', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Operations Digest' })).toBeDefined();
+    expect(screen.getByTestId('admission-queue-panel')).toBeDefined();
     expect(screen.getByText('platform / veritas-kanban / /worktrees/platform')).toBeDefined();
     expect(screen.getByText('Daily Delivery')).toBeDefined();
     expect(screen.getByText('Configured')).toBeDefined();

--- a/web/src/__tests__/use-task-sync-admission.test.ts
+++ b/web/src/__tests__/use-task-sync-admission.test.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTaskSync } from '@/hooks/useTaskSync';
+import type { UseWebSocketOptions } from '@/hooks/useWebSocket';
+
+const socketMocks = vi.hoisted(() => ({
+  options: null as UseWebSocketOptions | null,
+  useWebSocket: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWebSocket', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/hooks/useWebSocket')>();
+  return {
+    ...original,
+    useWebSocket: socketMocks.useWebSocket,
+  };
+});
+
+describe('admission queue realtime invalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socketMocks.options = null;
+    socketMocks.useWebSocket.mockImplementation((options: UseWebSocketOptions) => {
+      socketMocks.options = options;
+      return {
+        isConnected: true,
+        connectionState: 'connected',
+        reconnectAttempt: 0,
+        connect: vi.fn(),
+      };
+    });
+  });
+
+  it.each(['task:changed', 'telemetry:event', 'workflow:status'])(
+    'invalidates the queue from the existing socket on %s',
+    (type) => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+      const wrapper = ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children);
+
+      renderHook(() => useTaskSync(), { wrapper });
+      act(() => socketMocks.options?.onMessage?.({ type }));
+
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ['admission-queue'] });
+    }
+  );
+});

--- a/web/src/__tests__/view-context-navigation.test.tsx
+++ b/web/src/__tests__/view-context-navigation.test.tsx
@@ -6,7 +6,15 @@ import { ViewProvider, useView } from '@/contexts/ViewContext';
 import { renderWithProviders } from './test-utils';
 
 function NavigationHarness() {
-  const { view, setView, navigateToTask, pendingTaskId, goBack, returnFromTask } = useView();
+  const {
+    view,
+    setView,
+    navigateToTask,
+    navigateToWorkflow,
+    pendingTaskId,
+    goBack,
+    returnFromTask,
+  } = useView();
 
   return (
     <>
@@ -20,6 +28,9 @@ function NavigationHarness() {
       </button>
       <button type="button" onClick={() => navigateToTask('task-route-context')}>
         Open Task
+      </button>
+      <button type="button" onClick={() => navigateToWorkflow('workflow-route-context')}>
+        Open Workflow Detail
       </button>
       <button type="button" onClick={returnFromTask}>
         Close Task
@@ -102,6 +113,19 @@ describe('ViewContext route history', () => {
 
     expect(screen.getByTestId('current-view').textContent).toBe('workflows');
     expect(window.location.pathname).toBe('/workflows/release-blueprint/edit');
+  });
+
+  it('opens workflow detail from a full-page view with an in-app return path', async () => {
+    const user = userEvent.setup();
+    renderNavigationHarness();
+
+    await user.click(screen.getByRole('button', { name: 'Open Activity' }));
+    await user.click(screen.getByRole('button', { name: 'Open Workflow Detail' }));
+
+    expect(screen.getByTestId('current-view').textContent).toBe('workflows');
+    expect(window.location.pathname).toBe('/workflows/workflow-route-context');
+    expect(window.history.state.veritasKanbanNavigation.originView).toBe('activity');
+    expect(window.history.state.veritasWorkflowNavigation).toEqual({ from: '/activity' });
   });
 
   it('maps Cmd+[ to in-app browser Back semantics', async () => {

--- a/web/src/components/digest/AdmissionQueuePanel.tsx
+++ b/web/src/components/digest/AdmissionQueuePanel.tsx
@@ -1,0 +1,680 @@
+import { useMemo, type ReactNode } from 'react';
+import { Alert, Badge, Button, Group, Loader, Text } from '@mantine/core';
+import {
+  AlertTriangle,
+  ArrowUpRight,
+  Clock3,
+  Gauge,
+  GitBranch,
+  Layers3,
+  RefreshCw,
+  Route,
+} from 'lucide-react';
+import type {
+  AdmissionQueueInspectionEntry,
+  AdmissionQueueListResponse,
+  AdmissionScope,
+} from '@veritas-kanban/shared';
+import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
+import { useAdmissionQueue } from '@/hooks/useAdmissionQueue';
+import { cn } from '@/lib/utils';
+
+interface AdmissionQueuePanelProps {
+  onTaskClick?: (taskId: string, target?: TaskDetailNavigationTarget) => void;
+  onWorkflowClick?: (workflowId: string) => void;
+}
+
+interface QueueSummary {
+  waiting: number;
+  leased: number;
+  oldestWaitingMs: number;
+  readiness: Array<[AdmissionQueueInspectionEntry['readiness'], number]>;
+  limitingScopes: Array<[AdmissionScope, number]>;
+}
+
+export function AdmissionQueuePanel({ onTaskClick, onWorkflowClick }: AdmissionQueuePanelProps) {
+  const queue = useAdmissionQueue();
+  const data = queue.data;
+  const summary = useMemo(() => summarizeQueue(data), [data]);
+
+  if (queue.isLoading && !data) {
+    return (
+      <section
+        className="rounded-xl border border-slate-700/70 bg-slate-950/60 p-5"
+        aria-labelledby="admission-queue-heading"
+        aria-busy="true"
+      >
+        <PanelHeading />
+        <div className="mt-5 flex min-h-28 items-center justify-center gap-3 rounded-lg border border-dashed border-slate-700 text-sm text-slate-400">
+          <Loader size="sm" />
+          Loading bounded admission queue…
+        </div>
+      </section>
+    );
+  }
+
+  if (!data) {
+    return (
+      <section
+        className="rounded-xl border border-red-900/60 bg-slate-950/60 p-5"
+        aria-labelledby="admission-queue-heading"
+      >
+        <PanelHeading />
+        <Alert
+          mt="md"
+          color="red"
+          variant="light"
+          icon={<AlertTriangle className="h-4 w-4" />}
+          title="Admission queue unavailable"
+        >
+          <Group justify="space-between" align="center" wrap="wrap">
+            <Text size="sm">{errorMessage(queue.error)}</Text>
+            <Button
+              size="compact-sm"
+              variant="light"
+              color="red"
+              onClick={() => void queue.refetch()}
+            >
+              Retry
+            </Button>
+          </Group>
+        </Alert>
+      </section>
+    );
+  }
+
+  const isPartial = data.pagination.hasMore || data.pagination.snapshotTruncated;
+  const isSaturated = data.depth.global.current >= data.depth.global.limit;
+  const isStale = queue.isStale || Boolean(queue.error);
+
+  return (
+    <section
+      className={cn(
+        'overflow-hidden rounded-xl border bg-slate-950/60 shadow-sm',
+        isSaturated ? 'border-amber-500/50' : 'border-slate-700/70'
+      )}
+      aria-labelledby="admission-queue-heading"
+    >
+      <div className="border-b border-slate-800 bg-[radial-gradient(circle_at_top_right,rgba(56,189,248,0.12),transparent_42%)] p-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <PanelHeading />
+          <Group gap="xs" wrap="wrap" aria-live="polite">
+            <Badge variant="light" color={isStale ? 'yellow' : 'cyan'} tt="none">
+              {isStale ? 'Stale snapshot' : 'Live snapshot'}
+            </Badge>
+            {isSaturated ? (
+              <Badge variant="light" color="orange" tt="none">
+                Saturated
+              </Badge>
+            ) : null}
+            {isPartial ? (
+              <Badge variant="light" color="violet" tt="none">
+                Partial view
+              </Badge>
+            ) : null}
+            <Badge variant="outline" color="gray" tt="none">
+              Conditional, no start-time promise
+            </Badge>
+            <Button
+              variant="subtle"
+              color="gray"
+              size="compact-sm"
+              onClick={() => void queue.refetch()}
+              leftSection={
+                <RefreshCw className={cn('h-3.5 w-3.5', queue.isFetching && 'animate-spin')} />
+              }
+            >
+              Refresh queue
+            </Button>
+          </Group>
+        </div>
+
+        {queue.error ? (
+          <Alert
+            mt="md"
+            color="yellow"
+            variant="light"
+            icon={<AlertTriangle className="h-4 w-4" />}
+          >
+            Showing the last available bounded snapshot. Refresh failed: {errorMessage(queue.error)}
+          </Alert>
+        ) : null}
+
+        <div className="mt-5 grid gap-3 lg:grid-cols-[minmax(0,1.7fr)_repeat(3,minmax(130px,0.55fr))]">
+          <CapacityRail
+            current={data.depth.global.current}
+            limit={data.depth.global.limit}
+            saturated={isSaturated}
+          />
+          <Signal
+            icon={<Layers3 className="h-4 w-4 text-cyan-300" />}
+            label="Visible waiting"
+            value={String(summary.waiting)}
+            detail={isPartial ? 'bounded subset' : 'complete snapshot'}
+          />
+          <Signal
+            icon={<Route className="h-4 w-4 text-violet-300" />}
+            label="Visible leased"
+            value={String(summary.leased)}
+            detail={isPartial ? 'bounded subset' : 'reserved for dispatch'}
+          />
+          <Signal
+            icon={<Clock3 className="h-4 w-4 text-amber-300" />}
+            label="Oldest visible wait"
+            value={formatAge(summary.oldestWaitingMs)}
+            detail={`${data.pagination.limit}-row bound`}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-5 p-5">
+        <WorkspacePressure data={data} />
+
+        <div className="grid gap-3 lg:grid-cols-2">
+          <SignalStrip
+            label="Readiness"
+            empty="No active readiness signals"
+            values={summary.readiness.map(([readiness, count]) => ({
+              label: readableLabel(readiness),
+              value: count,
+            }))}
+          />
+          <SignalStrip
+            label="Limiting scopes"
+            empty="No limiting scope is reported"
+            values={summary.limitingScopes.map(([scope, count]) => ({
+              label: readableLabel(scope),
+              value: count,
+            }))}
+          />
+        </div>
+
+        {data.entries.length === 0 ? (
+          <div
+            className="rounded-lg border border-dashed border-slate-700 px-4 py-10 text-center"
+            role="status"
+          >
+            <Text fw={600}>Admission runway is clear</Text>
+            <Text size="sm" c="dimmed" mt={4}>
+              No queued, requeued, or leased work is visible in this bounded snapshot.
+            </Text>
+          </div>
+        ) : (
+          <QueueTable data={data} onTaskClick={onTaskClick} onWorkflowClick={onWorkflowClick} />
+        )}
+
+        <div className="flex flex-col gap-1 border-t border-slate-800 pt-3 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+          <span>
+            Snapshot {formatDateTime(data.generatedAt)} · {data.pagination.total} matching entries
+          </span>
+          <span>
+            Position can change with arrivals, capacity, policy checks, retries, and lease expiry.
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PanelHeading() {
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        <Gauge className="h-5 w-5 text-cyan-300" aria-hidden="true" />
+        <h2 id="admission-queue-heading" className="text-lg font-semibold text-slate-100">
+          Admission Runway
+        </h2>
+      </div>
+      <p className="mt-1 max-w-2xl text-sm text-slate-400">
+        Bounded queue pressure, readiness, and waiting work from the durable admission scheduler.
+      </p>
+    </div>
+  );
+}
+
+function CapacityRail({
+  current,
+  limit,
+  saturated,
+}: {
+  current: number;
+  limit: number;
+  saturated: boolean;
+}) {
+  const percentage = limit > 0 ? Math.min(100, Math.round((current / limit) * 100)) : 0;
+  return (
+    <div className="rounded-lg border border-slate-700/80 bg-slate-900/75 p-4">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <div className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500">
+            Global queue depth
+          </div>
+          <div className="mt-1 text-2xl font-semibold tabular-nums text-slate-100">
+            {current}
+            <span className="ml-1 text-sm font-normal text-slate-500">/ {limit}</span>
+          </div>
+        </div>
+        <span
+          className={cn(
+            'text-xs font-semibold uppercase tracking-wide',
+            saturated ? 'text-amber-300' : 'text-cyan-300'
+          )}
+        >
+          {percentage}% occupied
+        </span>
+      </div>
+      <div
+        className="mt-3 h-2 overflow-hidden rounded-full bg-slate-800"
+        role="progressbar"
+        aria-label="Global admission queue capacity"
+        aria-valuemin={0}
+        aria-valuemax={limit}
+        aria-valuenow={current}
+      >
+        <div
+          className={cn(
+            'h-full rounded-full transition-[width]',
+            saturated
+              ? 'bg-gradient-to-r from-amber-500 to-orange-400'
+              : 'bg-gradient-to-r from-cyan-500 to-sky-300'
+          )}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Signal({
+  icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-700/80 bg-slate-900/75 p-4">
+      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-2 text-xl font-semibold tabular-nums text-slate-100">{value}</div>
+      <div className="mt-0.5 text-xs text-slate-500">{detail}</div>
+    </div>
+  );
+}
+
+function WorkspacePressure({ data }: { data: AdmissionQueueListResponse }) {
+  const workspaceRows = [...data.depth.workspaces].sort((left, right) => {
+    const leftRatio = left.limit > 0 ? left.current / left.limit : 0;
+    const rightRatio = right.limit > 0 ? right.current / right.limit : 0;
+    return rightRatio - leftRatio || left.workspaceId.localeCompare(right.workspaceId);
+  });
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-slate-200">Workspace pressure</h3>
+        <span className="text-xs text-slate-500">{workspaceRows.length} active workspaces</span>
+      </div>
+      {workspaceRows.length ? (
+        <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+          {workspaceRows.map((workspace) => {
+            const percentage =
+              workspace.limit > 0
+                ? Math.min(100, Math.round((workspace.current / workspace.limit) * 100))
+                : 0;
+            const saturated = workspace.current >= workspace.limit;
+            return (
+              <div
+                key={workspace.workspaceKey}
+                className="rounded-lg border border-slate-800 bg-slate-900/40 px-3 py-2.5"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span
+                    className="truncate text-sm font-medium text-slate-300"
+                    title={workspace.workspaceId}
+                  >
+                    {workspace.workspaceId}
+                  </span>
+                  <span
+                    className={cn(
+                      'shrink-0 text-xs tabular-nums',
+                      saturated ? 'text-amber-300' : 'text-slate-500'
+                    )}
+                  >
+                    {workspace.current}/{workspace.limit}
+                  </span>
+                </div>
+                <div className="mt-2 h-1 overflow-hidden rounded-full bg-slate-800">
+                  <div
+                    className={saturated ? 'h-full bg-amber-400' : 'h-full bg-cyan-500/80'}
+                    style={{ width: `${percentage}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <Text size="sm" c="dimmed">
+          No per-workspace depth is currently reported.
+        </Text>
+      )}
+    </div>
+  );
+}
+
+function SignalStrip({
+  label,
+  values,
+  empty,
+}: {
+  label: string;
+  values: Array<{ label: string; value: number }>;
+  empty: string;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/35 p-3">
+      <div className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</div>
+      <div className="mt-2 flex min-h-6 flex-wrap gap-1.5">
+        {values.length ? (
+          values.map((value) => (
+            <Badge key={value.label} variant="light" color="gray" tt="none">
+              {value.label} · {value.value}
+            </Badge>
+          ))
+        ) : (
+          <span className="text-sm text-slate-500">{empty}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function QueueTable({
+  data,
+  onTaskClick,
+  onWorkflowClick,
+}: {
+  data: AdmissionQueueListResponse;
+  onTaskClick?: AdmissionQueuePanelProps['onTaskClick'];
+  onWorkflowClick?: AdmissionQueuePanelProps['onWorkflowClick'];
+}) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-slate-800">
+      <table className="w-full min-w-[1040px] border-collapse text-left text-sm">
+        <caption className="sr-only">
+          Bounded admission queue. Start timing is conditional and positions may change.
+        </caption>
+        <thead className="bg-slate-900/90 text-xs uppercase tracking-wide text-slate-500">
+          <tr>
+            <th className="px-3 py-3 font-medium" scope="col">
+              Position
+            </th>
+            <th className="px-3 py-3 font-medium" scope="col">
+              Work
+            </th>
+            <th className="px-3 py-3 font-medium" scope="col">
+              Workspace / source
+            </th>
+            <th className="px-3 py-3 font-medium" scope="col">
+              Priority
+            </th>
+            <th className="px-3 py-3 font-medium" scope="col">
+              Age
+            </th>
+            <th className="px-3 py-3 font-medium" scope="col">
+              Readiness
+            </th>
+            <th className="px-3 py-3 font-medium" scope="col">
+              Lease / limits
+            </th>
+            <th className="px-3 py-3 text-right font-medium" scope="col">
+              Open
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-800">
+          {data.entries.map((entry) => (
+            <QueueRow
+              key={entry.id}
+              entry={entry}
+              onTaskClick={onTaskClick}
+              onWorkflowClick={onWorkflowClick}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function QueueRow({
+  entry,
+  onTaskClick,
+  onWorkflowClick,
+}: {
+  entry: AdmissionQueueInspectionEntry;
+  onTaskClick?: AdmissionQueuePanelProps['onTaskClick'];
+  onWorkflowClick?: AdmissionQueuePanelProps['onWorkflowClick'];
+}) {
+  const tree = entry.navigation.executionTree;
+  const taskId = entry.navigation.taskId;
+  const workflowId = entry.navigation.workflowId;
+  const treeLabel = tree
+    ? tree.depth === 0
+      ? 'Root'
+      : `Descendant · depth ${tree.depth}`
+    : 'Direct';
+  const scopeLabels = Array.from(new Set(entry.limitingPolicies.map((policy) => policy.scope)));
+
+  return (
+    <tr className="bg-slate-950/25 align-top transition-colors hover:bg-slate-900/55">
+      <td className="px-3 py-3">
+        <span className="font-mono text-base font-semibold text-slate-200">
+          {entry.position ?? '—'}
+        </span>
+        <div className="mt-1 text-xs text-slate-500">{readableLabel(entry.state)}</div>
+      </td>
+      <td className="px-3 py-3">
+        <Badge
+          variant="light"
+          color={tree?.depth === 0 ? 'cyan' : tree ? 'violet' : 'gray'}
+          tt="none"
+          leftSection={tree ? <GitBranch className="h-3 w-3" /> : undefined}
+        >
+          {treeLabel}
+        </Badge>
+        <div className="mt-1.5 text-xs text-slate-500">{readableLabel(entry.launch.target)}</div>
+      </td>
+      <td className="max-w-64 px-3 py-3">
+        <div className="truncate font-medium text-slate-300" title={entry.launch.workspaceId}>
+          {entry.launch.workspaceId}
+        </div>
+        <div className="mt-1 text-xs text-slate-500">
+          {readableLabel(entry.launch.source)} · {readableLabel(entry.launch.provider)}
+        </div>
+      </td>
+      <td className="px-3 py-3">
+        <span className="font-medium tabular-nums text-slate-200">
+          {entry.rawPriority} → {entry.effectivePriority}
+        </span>
+        <div className="mt-1 text-xs text-slate-500">
+          {entry.agePromotion > 0 ? `+${entry.agePromotion} age promotion` : 'No age promotion'}
+        </div>
+      </td>
+      <td className="px-3 py-3 tabular-nums text-slate-300">{formatAge(entry.ageMs)}</td>
+      <td className="px-3 py-3">
+        <Badge variant="outline" color={readinessColor(entry.readiness)} tt="none">
+          {readableLabel(entry.readiness)}
+        </Badge>
+        <div className="mt-1.5 max-w-44 text-xs text-slate-500">
+          {entry.conditionalStartFactors.length
+            ? entry.conditionalStartFactors.map(readableLabel).join(', ')
+            : 'No conditional factors reported'}
+        </div>
+      </td>
+      <td className="px-3 py-3">
+        <div className="text-slate-300">{readableLabel(entry.lease.posture)}</div>
+        {entry.lease.expiresAt ? (
+          <div className="mt-1 text-xs text-slate-500">
+            Expires {formatDateTime(entry.lease.expiresAt)}
+          </div>
+        ) : null}
+        <div className="mt-1.5 flex max-w-48 flex-wrap gap-1">
+          {scopeLabels.length ? (
+            scopeLabels.map((scope) => (
+              <Badge key={scope} size="xs" variant="light" color="orange" tt="none">
+                {readableLabel(scope)}
+              </Badge>
+            ))
+          ) : (
+            <span className="text-xs text-slate-500">No limiting scope</span>
+          )}
+        </div>
+      </td>
+      <td className="px-3 py-3">
+        <div className="flex justify-end gap-1">
+          {taskId && onTaskClick ? (
+            <Button
+              size="compact-xs"
+              variant="subtle"
+              color="cyan"
+              onClick={() => onTaskClick(taskId)}
+              aria-label={`Open task at queue position ${entry.position ?? 'reserved'}`}
+              rightSection={<ArrowUpRight className="h-3 w-3" />}
+            >
+              Task
+            </Button>
+          ) : null}
+          {taskId && onTaskClick ? (
+            <Button
+              size="compact-xs"
+              variant="subtle"
+              color="cyan"
+              onClick={() =>
+                onTaskClick(taskId, {
+                  tab: 'timeline',
+                  timelineAttemptId: entry.navigation.attemptId,
+                })
+              }
+              aria-label={`Open attempt at queue position ${entry.position ?? 'reserved'}`}
+              rightSection={<ArrowUpRight className="h-3 w-3" />}
+            >
+              Attempt
+            </Button>
+          ) : null}
+          {tree && taskId && onTaskClick ? (
+            <Button
+              size="compact-xs"
+              variant="subtle"
+              color="violet"
+              onClick={() => onTaskClick(taskId, { tab: 'timeline' })}
+              aria-label={`Open execution tree context at queue position ${entry.position ?? 'reserved'}`}
+              rightSection={<ArrowUpRight className="h-3 w-3" />}
+            >
+              Tree
+            </Button>
+          ) : null}
+          {workflowId && onWorkflowClick ? (
+            <Button
+              size="compact-xs"
+              variant="subtle"
+              color="violet"
+              onClick={() => onWorkflowClick(workflowId)}
+              aria-label={`Open workflow for queue position ${entry.position ?? 'reserved'}`}
+              rightSection={<ArrowUpRight className="h-3 w-3" />}
+            >
+              Workflow
+            </Button>
+          ) : null}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function summarizeQueue(data?: AdmissionQueueListResponse): QueueSummary {
+  if (!data) {
+    return {
+      waiting: 0,
+      leased: 0,
+      oldestWaitingMs: 0,
+      readiness: [],
+      limitingScopes: [],
+    };
+  }
+
+  const waitingEntries = data.entries.filter(
+    (entry) => entry.state === 'queued' || entry.state === 'requeued'
+  );
+  const readiness = new Map<AdmissionQueueInspectionEntry['readiness'], number>();
+  const scopes = new Map<AdmissionScope, number>();
+  for (const entry of data.entries) {
+    readiness.set(entry.readiness, (readiness.get(entry.readiness) ?? 0) + 1);
+    for (const scope of new Set(entry.limitingPolicies.map((policy) => policy.scope))) {
+      scopes.set(scope, (scopes.get(scope) ?? 0) + 1);
+    }
+  }
+
+  return {
+    waiting: waitingEntries.length,
+    leased: data.entries.filter((entry) => entry.state === 'leased').length,
+    oldestWaitingMs: waitingEntries.reduce((oldest, entry) => Math.max(oldest, entry.ageMs), 0),
+    readiness: [...readiness.entries()].sort((left, right) => right[1] - left[1]),
+    limitingScopes: [...scopes.entries()].sort((left, right) => right[1] - left[1]),
+  };
+}
+
+function readabilityParts(value: string): string[] {
+  return value.split('-').filter(Boolean);
+}
+
+function readableLabel(value: string): string {
+  return readabilityParts(value)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function readinessColor(
+  readiness: AdmissionQueueInspectionEntry['readiness']
+): 'cyan' | 'yellow' | 'violet' | 'green' | 'gray' {
+  switch (readiness) {
+    case 'conditional':
+      return 'yellow';
+    case 'delayed':
+      return 'violet';
+    case 'reserved':
+      return 'cyan';
+    case 'dispatched':
+      return 'green';
+    case 'terminal':
+      return 'gray';
+  }
+}
+
+function formatAge(ms: number): string {
+  if (!ms || ms <= 0) return '0m';
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${Math.max(1, minutes)}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 24) return remainingMinutes ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours ? `${days}d ${remainingHours}h` : `${days}d`;
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'The queue snapshot could not be loaded.';
+}

--- a/web/src/components/digest/OperationsDigestPage.tsx
+++ b/web/src/components/digest/OperationsDigestPage.tsx
@@ -25,6 +25,8 @@ import {
   Search,
 } from 'lucide-react';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
+import { AdmissionQueuePanel } from '@/components/digest/AdmissionQueuePanel';
+import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
 import { useProjects } from '@/hooks/useProjects';
 import {
   normalizeOperationsDigestFilters,
@@ -45,7 +47,8 @@ import { cn } from '@/lib/utils';
 
 interface OperationsDigestPageProps {
   onBack: () => void;
-  onTaskClick?: (taskId: string) => void;
+  onTaskClick?: (taskId: string, target?: TaskDetailNavigationTarget) => void;
+  onWorkflowClick?: (workflowId: string) => void;
 }
 
 type WindowPreset = '24' | '72' | '168' | 'custom';
@@ -59,7 +62,11 @@ const WINDOW_OPTIONS: Array<{ value: WindowPreset; label: string }> = [
 
 const SOURCE_COLLECTIONS: SearchCollection[] = ['tasks-active', 'agent-runs', 'scheduled-runs'];
 
-export function OperationsDigestPage({ onBack, onTaskClick }: OperationsDigestPageProps) {
+export function OperationsDigestPage({
+  onBack,
+  onTaskClick,
+  onWorkflowClick,
+}: OperationsDigestPageProps) {
   const [windowPreset, setWindowPreset] = useState<WindowPreset>('24');
   const [from, setFrom] = useState(() => toLocalDateTimeInput(hoursAgo(24)));
   const [to, setTo] = useState(() => toLocalDateTimeInput(new Date()));
@@ -307,6 +314,8 @@ export function OperationsDigestPage({ onBack, onTaskClick }: OperationsDigestPa
             'Failed to load operations digest.'}
         </Alert>
       ) : null}
+
+      <AdmissionQueuePanel onTaskClick={onTaskClick} onWorkflowClick={onWorkflowClick} />
 
       {digest ? <InventoryReconciliation digest={digest} onOpenSources={openSources} /> : null}
 

--- a/web/src/contexts/ViewContext.tsx
+++ b/web/src/contexts/ViewContext.tsx
@@ -81,6 +81,8 @@ interface ViewContextValue {
   setView: (view: AppView) => void;
   /** Navigate to a specific task by opening the board and setting selectedTaskId. */
   navigateToTask: (taskId: string, target?: TaskDetailNavigationTarget) => void;
+  /** Navigate to a specific workflow while preserving the originating full-page view. */
+  navigateToWorkflow: (workflowId: string) => void;
   /** The task ID requested by view navigation (consumed once by the board). */
   pendingTaskId: string | null;
   /** Optional tab/run target for the pending task navigation. */
@@ -96,6 +98,7 @@ const ViewContext = createContext<ViewContextValue>({
   view: 'board',
   setView: () => {},
   navigateToTask: () => {},
+  navigateToWorkflow: () => {},
   pendingTaskId: null,
   pendingTaskTarget: null,
   clearPendingTask: () => {},
@@ -189,6 +192,24 @@ export function ViewProvider({ children }: { children: ReactNode }) {
     [setView, view]
   );
 
+  const navigateToWorkflow = useCallback(
+    (workflowId: string) => {
+      const originPath = typeof window === 'undefined' ? '' : window.location.pathname;
+      setView('workflows');
+      if (typeof window === 'undefined') return;
+
+      const workflowPath =
+        `${basePath}${VIEW_PATHS.workflows}/${encodeURIComponent(workflowId)}`.replace(/\/+/g, '/');
+      const currentState =
+        window.history.state && typeof window.history.state === 'object'
+          ? { ...(window.history.state as Record<string, unknown>) }
+          : {};
+      currentState.veritasWorkflowNavigation = { from: originPath };
+      window.history.replaceState(currentState, '', workflowPath);
+    },
+    [setView]
+  );
+
   const clearPendingTask = useCallback(() => {
     setPendingTaskId(null);
     setPendingTaskTarget(null);
@@ -205,6 +226,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       view,
       setView,
       navigateToTask,
+      navigateToWorkflow,
       pendingTaskId,
       pendingTaskTarget,
       clearPendingTask,
@@ -215,6 +237,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       view,
       setView,
       navigateToTask,
+      navigateToWorkflow,
       pendingTaskId,
       pendingTaskTarget,
       clearPendingTask,

--- a/web/src/hooks/useAdmissionQueue.ts
+++ b/web/src/hooks/useAdmissionQueue.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import type { AdmissionQueueInspectionQuery } from '@veritas-kanban/shared';
+import { useWebSocketStatus } from '@/contexts/WebSocketContext';
+import { api } from '@/lib/api';
+
+export const ADMISSION_QUEUE_QUERY_KEY = ['admission-queue'] as const;
+
+const DEFAULT_QUEUE_QUERY: AdmissionQueueInspectionQuery = {
+  states: ['queued', 'requeued', 'leased'],
+  page: 1,
+  limit: 100,
+};
+
+export function useAdmissionQueue(query: AdmissionQueueInspectionQuery = DEFAULT_QUEUE_QUERY) {
+  const { isConnected } = useWebSocketStatus();
+
+  return useQuery({
+    queryKey: [...ADMISSION_QUEUE_QUERY_KEY, query],
+    queryFn: () => api.admission.queue(query),
+    placeholderData: (previousData) => previousData,
+    refetchInterval: isConnected ? 120_000 : 30_000,
+    staleTime: isConnected ? 60_000 : 10_000,
+  });
+}

--- a/web/src/hooks/useTaskSync.ts
+++ b/web/src/hooks/useTaskSync.ts
@@ -91,6 +91,7 @@ export function useTaskSync(): {
         // Invalidate metrics and trends (derived from task data)
         queryClient.invalidateQueries({ queryKey: ['metrics'] });
         queryClient.invalidateQueries({ queryKey: ['trends'] });
+        queryClient.invalidateQueries({ queryKey: ['admission-queue'] });
       }
 
       // Handle telemetry events (run.started, run.completed, run.tokens)
@@ -98,6 +99,11 @@ export function useTaskSync(): {
         // Telemetry events update metrics and trends data
         queryClient.invalidateQueries({ queryKey: ['metrics'] });
         queryClient.invalidateQueries({ queryKey: ['trends'] });
+        queryClient.invalidateQueries({ queryKey: ['admission-queue'] });
+      }
+
+      if (message.type === 'workflow:status') {
+        queryClient.invalidateQueries({ queryKey: ['admission-queue'] });
       }
     },
     [queryClient]

--- a/web/src/lib/api/admission.ts
+++ b/web/src/lib/api/admission.ts
@@ -1,0 +1,31 @@
+import type {
+  AdmissionQueueGetResponse,
+  AdmissionQueueInspectionQuery,
+  AdmissionQueueListResponse,
+} from '@veritas-kanban/shared';
+import { API_BASE, apiFetch } from './helpers';
+
+function queueQuery(query: AdmissionQueueInspectionQuery): string {
+  const params = new URLSearchParams();
+  if (query.workspaceId) params.set('workspaceId', query.workspaceId);
+  if (query.rootObjectiveId) params.set('rootObjectiveId', query.rootObjectiveId);
+  if (query.nodeId) params.set('nodeId', query.nodeId);
+  for (const source of query.sources ?? []) params.append('source', source);
+  for (const state of query.states ?? []) params.append('state', state);
+  if (query.priority !== undefined) params.set('priority', String(query.priority));
+  for (const scope of query.limitingScopes ?? []) params.append('limitingScope', scope);
+  if (query.minAgeMs !== undefined) params.set('minAgeMs', String(query.minAgeMs));
+  if (query.maxAgeMs !== undefined) params.set('maxAgeMs', String(query.maxAgeMs));
+  if (query.page !== undefined) params.set('page', String(query.page));
+  if (query.limit !== undefined) params.set('limit', String(query.limit));
+  const suffix = params.toString();
+  return `${API_BASE}/admission/queue${suffix ? `?${suffix}` : ''}`;
+}
+
+export const admissionApi = {
+  queue: (query: AdmissionQueueInspectionQuery = {}): Promise<AdmissionQueueListResponse> =>
+    apiFetch<AdmissionQueueListResponse>(queueQuery(query)),
+
+  queueEntry: (id: string): Promise<AdmissionQueueGetResponse> =>
+    apiFetch<AdmissionQueueGetResponse>(`${API_BASE}/admission/queue/${encodeURIComponent(id)}`),
+};

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -34,6 +34,7 @@ import { schedulerApi } from './scheduler';
 import { queueMonitorsApi } from './queue-monitors';
 import { ceremoniesApi } from './ceremonies';
 import { reflectionsApi } from './reflections';
+import { admissionApi } from './admission';
 
 // Assemble the full API object (matches original structure exactly)
 export const api = {
@@ -79,6 +80,7 @@ export const api = {
   queueMonitors: queueMonitorsApi,
   ceremonies: ceremoniesApi,
   reflections: reflectionsApi,
+  admission: admissionApi,
 };
 
 export type {
@@ -94,6 +96,12 @@ export type {
 export type { WorkProductExportFormat, WorkProductExportOptions } from './work-products';
 export type { CeremonyListFilters } from './ceremonies';
 export type { ReflectionListFilters } from './reflections';
+export type {
+  AdmissionQueueGetResponse,
+  AdmissionQueueInspectionEntry,
+  AdmissionQueueInspectionQuery,
+  AdmissionQueueListResponse,
+} from '@veritas-kanban/shared';
 export type { TraceStatus } from './traces';
 export type { SqlitePortabilityReport } from './maintenance';
 export type {

--- a/web/src/lib/views.ts
+++ b/web/src/lib/views.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react';
+import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
 
 export type AppView =
   | 'board'
@@ -33,7 +34,8 @@ export type ViewIcon =
 
 export interface ViewComponentProps {
   onBack: () => void;
-  onTaskClick?: (taskId: string) => void;
+  onTaskClick?: (taskId: string, target?: TaskDetailNavigationTarget) => void;
+  onWorkflowClick?: (workflowId: string) => void;
 }
 
 export interface ViewDefinition {


### PR DESCRIPTION
Closes #1065

## Summary

- Add admission capacity, runway, workspace pressure, and waiting-work visibility to Operations
- Show queue state, readiness, retry posture, launch source, and safe drill-down navigation
- Refresh from admission WebSocket events with bounded fallback polling
- Preserve the redacted API projection and accessible status semantics

## Verification

- 15 focused web tests
- Web typecheck
- Production web build
- Focused lint, security, and cadence checks

## Note

The managed local runtime blocks temporary listener and file URL browser smoke checks. CI owns the route and browser gate for this PR.