### PR TITLE
feat: unify all agent launch admission paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,12 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   whose built-in type and command both identify `codex` or `hermes` may infer a
   provider during migration; provider-less or profile/adapter-mismatched records
   fail closed before an attempt is created.
+- Route direct, profile, conversation, provider-handoff, child-agent, retry,
+  fallback, scheduled, watcher, and workflow launches through the shared
+  admission controller. A `queued` response means Veritas durably accepted
+  ownership; harnesses must not submit a duplicate or create a hidden
+  provider-side queue. Provider adapters require
+  `provider-admission-evidence/v1` before dispatch.
 - Phase authority uses the versioned contracts in
   `shared/src/types/phase-capability.types.ts`. Compile parent, phase, agent
   profile, sandbox, tool-catalog, and launch-policy authority only through

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -147,6 +147,7 @@ function registerConversationTurnCommand(
           phase: options.phase,
           requiredRuntimeCapabilities: options.requireCapability,
           commitPolicy: options.commitPolicy,
+          idempotencyKey: `vk-cli:${taskId}:conversation:${action}:${randomUUID()}`,
         }),
       });
       printConversationResult(action, result, options.json);

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -982,23 +982,26 @@ Configure ceilings through `PATCH /api/settings/features`:
 
 An individual request larger than a ceiling receives a terminal policy denial.
 Queueable temporary exhaustion persists one bounded
-`admission-queue-entry/v1` record. A fresh direct task start with no transient
-operator message or per-request policy override returns `status: "queued"`,
-`queueId`, the reserved `attemptId`, `retryAfterMs`, and redacted limiting
-scopes. Harnesses must treat that response as accepted work, not as a failed
-attempt, and must not submit a duplicate start. Workflow roots and
-provider-backed workflow steps instead persist `state: "waiting"` in their
-admission binding while the run and step remain `pending`.
+`admission-queue-entry/v1` record. Direct, profile, conversation,
+provider-handoff, child-agent, retry, and fallback starts return
+`status: "queued"`, `queueId`, the reserved `attemptId`, `retryAfterMs`, and
+redacted limiting scopes. Harnesses must treat that response as accepted work,
+not as a failed attempt, and must not submit a duplicate start. Workflow roots
+and provider-backed workflow steps instead persist `state: "waiting"` in their
+admission binding while the run and step remain `pending`. Scheduled workflows
+retain `source: "scheduled"`; queue-monitor continuations retain
+`source: "watcher"`.
 
-The queue uses the versioned `admission-queue-scheduler/v1` policy for direct
-tasks, workflow roots, and workflow steps. It ranks the bounded eligible queue
-snapshot by task priority, configured age promotion, workspace turns, enqueue
-sequence, and queue identity. After `workspaceBurstLimit` consecutive
-selections, compatible work from another workspace receives the next turn.
-Age promotion is capped at the highest configured priority, and
-`maxAgePromotion` must let the lowest priority eventually reach that level.
-Provider and host limits only determine capacity readiness; they cannot
-override durable ordering or create a hidden provider queue.
+The queue uses the versioned `admission-queue-scheduler/v1` policy for
+agent-launch, legacy direct, workflow-root, and workflow-step targets. It ranks
+the bounded eligible queue snapshot by task priority, configured age
+promotion, workspace turns, enqueue sequence, and queue identity. After
+`workspaceBurstLimit` consecutive selections, compatible work from another
+workspace receives the next turn. Age promotion is capped at the highest
+configured priority, and `maxAgePromotion` must let the lowest priority
+eventually reach that level. Provider and host limits only determine capacity
+readiness; they cannot override durable ordering or create a hidden provider
+queue.
 
 A worker tries ranked entries until it atomically claims both a queue lease and
 admission capacity. A capacity-blocked entry stays queued while another ready
@@ -1013,9 +1016,19 @@ may restart or finish the work. Abandoned pre-dispatch leases requeue with
 bounded backoff. Terminal drift, retry exhaustion, and queue overflow fail
 closed. Queue records retain task, workspace, agent, execution tree, workflow
 version and revision, retry or fallback sequence, provider, host, immutable
-runtime and phase digests, and limiting-scope evidence. They never retain
-prompts, workflow context, messages, tool arguments, credentials, or raw
-idempotency keys.
+runtime and phase digests, and limiting-scope evidence. Workflow targets never
+retain prompts, workflow context, tool arguments, or credentials. Agent-launch
+targets retain only bounded provider-neutral inputs required for exact replay,
+which may include an operator turn or override reason. Queue inspection,
+telemetry, Operations, and support bundles omit those private inputs. No target
+retains credentials, process handles, leases, or raw idempotency keys.
+
+Every built-in and custom provider adapter receives
+`provider-admission-evidence/v1` immediately before dispatch. The evidence binds
+the shared reservation, launch source, queue-dispatch outcome, and exact
+execution-tree identity to the durable attempt. Missing or inconsistent
+evidence fails before the adapter is called, so an adapter cannot widen
+capacity or substitute an external hidden queue.
 
 Active leases renew while the verified run is live; completion, interruption,
 cancellation, or launch failure releases the reservation idempotently.

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -5497,7 +5497,12 @@ sensitive categories, redaction rules, and redacted file metadata. The
 `phase-authority.json` member includes at most 200 phase-bound runs with phase
 identity, authority scope counts, source kinds, transition expansion counts,
 and completion bindings. Exact authority scopes, paths, credential
-references, and full digests are not exported.
+references, and full digests are not exported. The `admission-queue.json`
+member includes at most 200 entries from the same bounded inspection projection
+used by the API, CLI, and Operations UI. It identifies launch source, queue
+state, readiness, retry posture, and redacted navigation keys without exporting
+the durable replay target, prompts, messages, override text, credentials, or
+raw idempotency keys.
 
 #### SQLite Export and Import
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -2516,7 +2516,8 @@ provider identity:
   "message": "Continue from the verified history",
   "forkTurnId": "turn_7",
   "phase": "verify",
-  "commitPolicy": "allowed"
+  "commitPolicy": "allowed",
+  "idempotencyKey": "operator-generated-key"
 }
 ```
 
@@ -2527,6 +2528,12 @@ operation. Unsupported steering fails with an explicit capability error, and
 any recorded-only fallback returns `delivered: false` with a reason. Veritas
 does not claim that recording a message or writing process stdin reached the
 provider.
+
+Fresh, resume, follow-up, and fork launches accept `idempotencyKey` in the JSON
+body or `X-Idempotency-Key` in the request headers; the header takes precedence.
+Veritas hashes the value before persistence. Repeating an admitted or queued
+request with the same key returns the same durable admission outcome instead of
+launching duplicate work.
 
 Resume, follow-up, and fork bind the exact source attempt as the phase parent.
 An optional `phase` may narrow that authority but cannot widen it. Omitting the
@@ -4225,8 +4232,9 @@ over the equivalent JSON `idempotencyKey` field and lets a retry reuse the same
 reservation without launching a second attempt. Veritas persists only its
 SHA-256 identity, never the supplied value.
 
-When capacity is temporarily exhausted, a reconstructable fresh direct start
-returns `201` with `status: "queued"` instead of `ADMISSION_OVERLOAD`:
+When capacity is temporarily exhausted, every provider-neutral agent launch
+returns `201` with `status: "queued"` instead of creating a provider-specific
+queue or a partial attempt:
 
 ```json
 {
@@ -4242,31 +4250,43 @@ returns `201` with `status: "queued"` instead of `ADMISSION_OVERLOAD`:
 ```
 
 The response means Veritas durably accepted ownership. Clients and harnesses
-must not create a second launch. Starts containing a conversation message,
-profile, readiness override, sandbox or budget override, explicit runtime
-capability, commit policy, phase, recovery, or parent attempt are not
-reconstructable from durable task configuration and continue to fail closed
-with `ADMISSION_OVERLOAD`. Queue bounds and retry behavior are configured under
-`features.admission.queue`. Queue inspection is available through
-`GET /api/v1/admission/queue` and `GET /api/v1/admission/queue/:id`;
-reservation inspection remains unchanged.
+must not create a second launch. The versioned `agent-launch` target preserves
+the bounded provider-neutral options required to reconstruct profiles,
+readiness overrides, sandbox and budget overrides, runtime capability
+requirements, commit policy, phase, conversation resume/follow-up/fork,
+provider handoff, child-agent, retry, and fallback launches. It never stores
+credentials, process handles, leases, or raw idempotency keys. Queue
+inspection, telemetry, Operations, and support bundles expose only redacted
+launch-source and admission evidence; prompts, messages, override text, tool
+arguments, and the full durable target remain internal. Queue inspection is
+available through `GET /api/v1/admission/queue` and
+`GET /api/v1/admission/queue/:id`; reservation inspection remains unchanged.
 
-Workflow roots and provider-backed steps use the same durable queue internally.
-Their queue targets preserve the workflow version, run revision, task and step
-identity, retry or fallback sequence, execution-tree edge, selected provider
-and host, and immutable runtime and phase digests. Queue records never copy
-workflow context, prompts, tool arguments, or credentials. Before dispatch,
-Veritas revalidates the persisted run, workflow version, step state, provider
-runtime, host, phase authority, budgets, and reservation evidence. Drift
-terminalizes the queue entry and run without calling the provider.
+Scheduled workflows retain `source: "scheduled"` from the root reservation
+through normal provider steps. Queue-monitor continuations retain
+`source: "watcher"`. Retry and fallback steps use their specific replacement
+source while preserving the same root objective and causal parent edge. Queue
+bounds and retry behavior are configured under `features.admission.queue`.
 
-A single versioned scheduler orders direct, workflow-root, and workflow-step
-entries using explicit task priority, bounded age promotion, workspace turns,
-and stable enqueue identity. Capacity-blocked entries remain queued while the
-next compatible entry is evaluated. The selected entry persists redacted
-priority, fairness, readiness, limiting-scope, and conditional-start evidence;
-provider or host metadata cannot override this ordering. Scheduler bounds live
-under `features.admission.queue.scheduler`.
+Workflow roots, provider-backed steps, and all agent launches use the same
+durable queue internally. Workflow queue targets preserve the workflow version,
+run revision, task and step identity, retry or fallback sequence,
+execution-tree edge, selected provider and host, and immutable runtime and
+phase digests. They never copy workflow context, prompts, tool arguments, or
+credentials. Agent-launch targets may retain the bounded operator input needed
+for exact replay, but public diagnostics always omit it. Before dispatch,
+Veritas revalidates provider, host, phase authority, budgets, root objective,
+parent edge, and reservation evidence. Drift terminalizes the queue entry
+without calling the provider.
+
+A single versioned scheduler orders agent-launch, legacy direct,
+workflow-root, and workflow-step entries using explicit task priority, bounded
+age promotion, workspace turns, and stable enqueue identity. Capacity-blocked
+entries remain queued while the next compatible entry is evaluated. The
+selected entry persists redacted priority, fairness, readiness,
+limiting-scope, and conditional-start evidence; provider or host metadata
+cannot override this ordering. Scheduler bounds live under
+`features.admission.queue.scheduler`.
 
 A pre-dispatch failure releases capacity and may requeue with bounded backoff.
 Once the queue entry is durably `dispatched`, workflow recovery owns the run.

--- a/server/src/__tests__/admission-control-service.test.ts
+++ b/server/src/__tests__/admission-control-service.test.ts
@@ -173,6 +173,18 @@ describe('AdmissionControlService', () => {
 
     const sources = ['direct', 'conversation', 'recovery', 'fallback', 'child-agent'] as const;
     for (const source of sources) {
+      const options =
+        source === 'conversation'
+          ? {
+              overrideReason: 'Private operator justification',
+              conversation: {
+                mode: 'resume' as const,
+                intent: 'follow-up' as const,
+                sourceAttemptId: 'attempt-private-parent',
+                message: 'Private queued conversation message',
+              },
+            }
+          : {};
       const decision = await service.admitOrQueue(
         {
           ...request(`task-source-${source}`),
@@ -184,7 +196,7 @@ describe('AdmissionControlService', () => {
             kind: 'agent-launch',
             agent: 'codex',
             source,
-            options: {},
+            options,
           },
         }
       );
@@ -200,6 +212,22 @@ describe('AdmissionControlService', () => {
         },
       });
     }
+
+    const inspection = await service.inspectQueue({ limit: 10 });
+    expect(inspection.entries).toHaveLength(sources.length);
+    expect(inspection.entries).toEqual(
+      expect.arrayContaining(
+        sources.map((source) =>
+          expect.objectContaining({
+            launch: expect.objectContaining({ source, target: 'agent-launch' }),
+          })
+        )
+      )
+    );
+    const serialized = JSON.stringify(inspection);
+    expect(serialized).not.toContain('Private operator justification');
+    expect(serialized).not.toContain('Private queued conversation message');
+    expect(serialized).not.toContain('attempt-private-parent');
   });
 
   it('admits maximum-length scope identifiers without overflowing generated policy IDs', async () => {

--- a/server/src/__tests__/admission-control-service.test.ts
+++ b/server/src/__tests__/admission-control-service.test.ts
@@ -162,6 +162,46 @@ describe('AdmissionControlService', () => {
     });
   });
 
+  it('queues every provider-neutral agent launch source through one target contract', async () => {
+    const repository = await repositoryFor('file');
+    const service = createService(
+      repository,
+      configuredSettings({ global: { concurrentRuns: 1 } })
+    );
+    const active = await service.admit(request('task-source-blocker'));
+    expect(active.outcome).toBe('admitted');
+
+    const sources = ['direct', 'conversation', 'recovery', 'fallback', 'child-agent'] as const;
+    for (const source of sources) {
+      const decision = await service.admitOrQueue(
+        {
+          ...request(`task-source-${source}`),
+          source,
+        },
+        {
+          attemptId: `attempt-source-${source}`,
+          target: {
+            kind: 'agent-launch',
+            agent: 'codex',
+            source,
+            options: {},
+          },
+        }
+      );
+      expect(decision).toMatchObject({
+        outcome: 'queued',
+        request: { source },
+        queueEntry: {
+          target: {
+            kind: 'agent-launch',
+            agent: 'codex',
+            source,
+          },
+        },
+      });
+    }
+  });
+
   it('admits maximum-length scope identifiers without overflowing generated policy IDs', async () => {
     const repository = await repositoryFor('file');
     const service = createService(repository, configuredSettings());

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -171,6 +171,7 @@ vi.mock('../services/circuit-registry.js', () => ({
 import {
   AgentReadinessError,
   ClawdbotAgentService,
+  type AgentProviderAdmissionEvidence,
   type AgentStatus,
   type CredentialLeaseLifecycle,
 } from '../services/clawdbot-agent-service.js';
@@ -184,6 +185,7 @@ import type {
   TaskAttempt,
   ExecutionTreeIdentity,
   AdmissionQueueClaim,
+  RunRecoveryRecord,
 } from '@veritas-kanban/shared';
 import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
 import {
@@ -771,18 +773,88 @@ describe('ClawdbotAgentService Codex providers', () => {
     });
   });
 
-  it('queues a reconstructable direct launch and dispatches its claim exactly once', async () => {
+  it('classifies every agent execution edge through one admission source contract', () => {
+    const service = testableService(tmpDir);
+    const classify = (
+      service as unknown as {
+        agentAdmissionSource(
+          executionTree: ExecutionTreeIdentity,
+          recovery?: RunRecoveryRecord
+        ): string;
+      }
+    ).agentAdmissionSource.bind(service);
+    const identity = (edge: ExecutionTreeIdentity['edge']): ExecutionTreeIdentity => ({
+      schemaVersion: 'execution-tree-identity/v1',
+      rootObjectiveId: 'objective-source-contract',
+      nodeId: `node-${edge}`,
+      ...(edge === 'root' ? {} : { parentNodeId: 'node-parent' }),
+      edge,
+      depth: edge === 'root' ? 0 : 1,
+    });
+
+    expect(classify(identity('root'))).toBe('direct');
+    expect(classify(identity('resume'))).toBe('conversation');
+    expect(classify(identity('follow-up'))).toBe('conversation');
+    expect(classify(identity('fork'))).toBe('conversation');
+    expect(classify(identity('provider-handoff'))).toBe('conversation');
+    expect(classify(identity('child-agent'))).toBe('child-agent');
+    expect(classify(identity('retry'), { action: 'retry' } as RunRecoveryRecord)).toBe('recovery');
+    expect(classify(identity('fallback'), { action: 'fallback' } as RunRecoveryRecord)).toBe(
+      'fallback'
+    );
+  });
+
+  it('rejects provider dispatch when durable admission evidence is missing', () => {
+    const service = testableService(tmpDir);
+    const executionTree: ExecutionTreeIdentity = {
+      schemaVersion: 'execution-tree-identity/v1',
+      rootObjectiveId: 'objective-admission-guard',
+      nodeId: 'attempt-admission-guard',
+      edge: 'root',
+      depth: 0,
+    };
+    const evidence: AgentProviderAdmissionEvidence = {
+      schemaVersion: 'provider-admission-evidence/v1',
+      source: 'direct',
+      outcome: 'admitted',
+      reservationId: 'admission-expected',
+      executionTree,
+    };
+    const assertEvidence = (
+      service as unknown as {
+        assertProviderAdmissionEvidence(
+          input: AgentProviderAdmissionEvidence,
+          attempt: TaskAttempt
+        ): void;
+      }
+    ).assertProviderAdmissionEvidence.bind(service);
+
+    expect(() =>
+      assertEvidence(evidence, {
+        id: executionTree.nodeId,
+        agent: 'codex',
+        status: 'running',
+        admissionReservationId: 'admission-other',
+        executionTree,
+      } as TaskAttempt)
+    ).toThrow('Provider launch is missing required admission evidence.');
+  });
+
+  it('queues a versioned agent launch and replays its exact options exactly once', async () => {
     const fixture = await fs.readFile(path.join(fixtureDir, 'success.jsonl'), 'utf-8');
     mockSpawn.mockReturnValue(createFakeChild(fixture));
     const admission = testAdmissionControl();
     let claim: AdmissionQueueClaim | undefined;
     let currentEntry: AdmissionQueueClaim['entry'] | undefined;
     vi.mocked(admission.admitOrQueue).mockImplementation(async (input, queue) => {
+      if (!('target' in queue) || queue.target.kind !== 'agent-launch') {
+        throw new Error('Expected a versioned agent launch target');
+      }
       const now = '2026-07-25T12:00:00.000Z';
       const request = {
         schemaVersion: 'admission-request/v1',
         idempotencyKey: `sha256:${'a'.repeat(64)}`,
-        source: 'direct',
+        source: input.source ?? 'direct',
         taskId: input.taskId,
         rootTaskId: input.rootTaskId ?? input.taskId,
         workspaceId: input.workspaceId,
@@ -800,7 +872,7 @@ describe('ClawdbotAgentService Codex providers', () => {
         revision: 1,
         state: 'queued',
         enqueueSequence: 1,
-        agent: queue.agent,
+        target: queue.target,
         attemptId: queue.attemptId,
         request,
         policies: [],
@@ -882,7 +954,9 @@ describe('ClawdbotAgentService Codex providers', () => {
       admission
     );
 
-    const queued = await service.startAgent(task.id, 'codex');
+    const queued = await service.startAgent(task.id, 'codex', {
+      commitPolicy: 'forbidden',
+    });
     expect(queued).toMatchObject({
       taskId: task.id,
       status: 'queued',
@@ -892,6 +966,17 @@ describe('ClawdbotAgentService Codex providers', () => {
     });
     expect(admission.bindAttempt).not.toHaveBeenCalled();
     expect(task.attempt).toBeUndefined();
+    expect(admission.admitOrQueue).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'direct' }),
+      expect.objectContaining({
+        target: expect.objectContaining({
+          kind: 'agent-launch',
+          agent: 'codex',
+          source: 'direct',
+          options: { commitPolicy: 'forbidden' },
+        }),
+      })
+    );
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     vi.mocked(admission.claimNextQueued).mockReset();
@@ -904,7 +989,15 @@ describe('ClawdbotAgentService Codex providers', () => {
     expect(admission.markQueueDispatched).toHaveBeenCalledTimes(1);
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     expect(task.attempt?.id).toBe(claim?.entry.attemptId);
+    expect(task.attempt?.taskEnvelope?.commitPolicy).toBe('forbidden');
     await waitFor(() => expect(task.attempt?.status).toBe('complete'));
+    expect(mockTelemetryEmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'run.started',
+        admissionSource: 'direct',
+        admissionOutcome: 'queued-dispatch',
+      })
+    );
   });
 
   it(
@@ -931,8 +1024,13 @@ describe('ClawdbotAgentService Codex providers', () => {
           budgetRequest: expect.objectContaining({ fanOut: 1, retries: 0 }),
         }),
         expect.objectContaining({
-          agent: 'codex',
           attemptId: status.attemptId,
+          target: expect.objectContaining({
+            kind: 'agent-launch',
+            agent: 'codex',
+            source: 'direct',
+            options: {},
+          }),
         })
       );
       expect(status.runLaunchManifest).toMatchObject({
@@ -1034,6 +1132,8 @@ describe('ClawdbotAgentService Codex providers', () => {
       expect(mockTelemetryEmit).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'run.started',
+          admissionSource: 'direct',
+          admissionOutcome: 'admitted',
           harnessSupport: expect.objectContaining({
             profileId: 'openai-codex-cli',
             adapterId: 'codex-cli',
@@ -3679,7 +3779,7 @@ describe('ClawdbotAgentService Codex providers', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it('blocks a non-reconstructable launch before attempt persistence when admission is overloaded', async () => {
+  it('fails closed before attempt persistence when universal admission returns overload', async () => {
     const admit = vi.fn().mockResolvedValue({
       schemaVersion: 'admission-decision/v1',
       outcome: 'retryable-overload',
@@ -3707,7 +3807,7 @@ describe('ClawdbotAgentService Codex providers', () => {
       reason: 'Active reservations currently consume the configured capacity.',
       decidedAt: '2026-07-25T10:00:00.000Z',
     });
-    const admission = { admit } as unknown as AdmissionControlService;
+    const admission = { admitOrQueue: admit } as unknown as AdmissionControlService;
     const service = testableService(
       tmpDir,
       undefined,

--- a/server/src/__tests__/maintenance-service.test.ts
+++ b/server/src/__tests__/maintenance-service.test.ts
@@ -147,22 +147,70 @@ describe('MaintenanceService', () => {
   });
 
   it('creates a redacted debug bundle manifest and redacted log tails', async () => {
-    const service = new MaintenanceService(async () => ({
-      generatedAt: '2026-07-25T00:00:00.000Z',
-      status: 'ok',
-      truncated: false,
-      records: [
-        {
-          taskId: 'task-phase',
-          attemptId: 'attempt-phase',
-          effective: {
-            identity: { mode: 'profile', phase: 'verify' },
-            digest: 'sha256:123456789012',
+    const service = new MaintenanceService(
+      async () => ({
+        generatedAt: '2026-07-25T00:00:00.000Z',
+        status: 'ok',
+        truncated: false,
+        records: [
+          {
+            taskId: 'task-phase',
+            attemptId: 'attempt-phase',
+            effective: {
+              identity: { mode: 'profile', phase: 'verify' },
+              digest: 'sha256:123456789012',
+            },
+            authorityExpansions: [{ sequence: 2, dimensions: ['filesystem.write'] }],
           },
-          authorityExpansions: [{ sequence: 2, dimensions: ['filesystem.write'] }],
+        ],
+      }),
+      async () => ({
+        generatedAt: '2026-07-25T00:00:00.000Z',
+        status: 'ok',
+        truncated: false,
+        depth: {
+          global: { current: 1, limit: 64 },
+          workspaces: [],
         },
-      ],
-    }));
+        entries: [
+          {
+            schemaVersion: 'admission-queue-inspection/v1',
+            id: 'admission-queue-support',
+            state: 'queued',
+            position: 1,
+            rawPriority: 5,
+            effectivePriority: 5,
+            agePromotion: 0,
+            ageMs: 100,
+            readiness: 'conditional',
+            lease: { posture: 'none' },
+            limitingPolicies: [],
+            conditionalStartFactors: ['capacity-recheck'],
+            launch: {
+              source: 'conversation',
+              target: 'agent-launch',
+              workspaceId: 'workspace-a',
+              taskKey: `sha256:${'a'.repeat(64)}`,
+              rootTaskKey: `sha256:${'b'.repeat(64)}`,
+              workspaceKey: `sha256:${'c'.repeat(64)}`,
+              provider: 'codex-cli',
+              hostKey: `sha256:${'d'.repeat(64)}`,
+            },
+            navigation: {
+              taskId: 'task-support',
+              attemptId: 'attempt-support',
+            },
+            retry: {
+              count: 0,
+              maximum: 3,
+              availableAt: '2026-07-25T00:00:00.000Z',
+            },
+            createdAt: '2026-07-25T00:00:00.000Z',
+            updatedAt: '2026-07-25T00:00:00.000Z',
+          },
+        ],
+      })
+    );
 
     const bundle = await service.createDebugBundle();
     const manifest = JSON.parse(
@@ -176,15 +224,34 @@ describe('MaintenanceService', () => {
     const phaseAuthority = JSON.parse(
       await fs.readFile(path.join(bundle.outputPath, 'phase-authority.json'), 'utf-8')
     ) as { records: Array<Record<string, unknown>> };
+    const admissionQueue = JSON.parse(
+      await fs.readFile(path.join(bundle.outputPath, 'admission-queue.json'), 'utf-8')
+    ) as { entries: Array<Record<string, unknown>> };
     const bundleText = await readDirectoryText(bundle.outputPath);
 
     expect(bundle.redacted).toBe(true);
     expect(manifest.includedCategories).toEqual(
-      expect.arrayContaining(['health', 'storage', 'phase-authority', 'redacted-log-tails'])
+      expect.arrayContaining([
+        'health',
+        'storage',
+        'phase-authority',
+        'admission-queue',
+        'redacted-log-tails',
+      ])
     );
     expect(phaseAuthority.records).toContainEqual(
       expect.objectContaining({ taskId: 'task-phase', attemptId: 'attempt-phase' })
     );
+    expect(admissionQueue.entries).toContainEqual(
+      expect.objectContaining({
+        state: 'queued',
+        launch: expect.objectContaining({
+          source: 'conversation',
+          target: 'agent-launch',
+        }),
+      })
+    );
+    expect(JSON.stringify(admissionQueue)).not.toContain('options');
     expect(manifest.files.find((file) => file.id === 'server')?.path).toContain('[redacted-logs]');
     expect(serverLog).not.toContain('sk_supersecret1234567890');
     expect(summary).not.toContain(root);

--- a/server/src/__tests__/routes/agents-local-capability.test.ts
+++ b/server/src/__tests__/routes/agents-local-capability.test.ts
@@ -472,18 +472,26 @@ describe('agent local capability enforcement', () => {
       })
     );
 
-    const resume = await request(app).post('/api/agents/task_1/conversation/resume').send({
-      sourceAttemptId: 'attempt_parent',
-      message: 'Continue from the durable provider history',
-      commitPolicy: 'forbidden',
-      phase: 'verify',
-    });
+    const resume = await request(app)
+      .post('/api/agents/task_1/conversation/resume')
+      .set('X-Idempotency-Key', 'conversation-resume-123')
+      .send({
+        sourceAttemptId: 'attempt_parent',
+        message: 'Continue from the durable provider history',
+        commitPolicy: 'forbidden',
+        phase: 'verify',
+        idempotencyKey: 'body-conversation-resume-456',
+      });
     expect(resume.status).toBe(201);
     expect(mockResumeConversation).toHaveBeenCalledWith(
       'task_1',
       'attempt_parent',
       'Continue from the durable provider history',
-      expect.objectContaining({ commitPolicy: 'forbidden', phase: 'verify' })
+      expect.objectContaining({
+        commitPolicy: 'forbidden',
+        phase: 'verify',
+        admissionIdempotencyKey: 'conversation-resume-123',
+      })
     );
 
     const fork = await request(app).post('/api/agents/task_1/conversation/fork').send({
@@ -500,6 +508,16 @@ describe('agent local capability enforcement', () => {
       'turn_7',
       expect.objectContaining({ phase: 'explore' })
     );
+
+    const invalidIdempotency = await request(app)
+      .post('/api/agents/task_1/conversation/follow-up')
+      .set('X-Idempotency-Key', 'short')
+      .send({
+        sourceAttemptId: 'attempt_parent',
+        message: 'Retry this turn',
+      });
+    expect(invalidIdempotency.status).toBe(400);
+    expect(mockFollowUpConversation).not.toHaveBeenCalled();
 
     const spoofedSteer = await request(app).post('/api/agents/task_1/conversation/steer').send({
       attemptId: 'attempt_1',
@@ -540,11 +558,14 @@ describe('agent local capability enforcement', () => {
       })
     );
 
-    const response = await request(app).post('/api/agents/task_1/conversation/fresh').send({
-      agent: 'codex',
-      message: 'Start this task through ACP',
-      phase: 'plan',
-    });
+    const response = await request(app)
+      .post('/api/agents/task_1/conversation/fresh')
+      .set('X-Idempotency-Key', 'conversation-fresh-123')
+      .send({
+        agent: 'codex',
+        message: 'Start this task through ACP',
+        phase: 'plan',
+      });
 
     expect(response.status).toBe(201);
     expect(mockStartAgent).toHaveBeenCalledWith(
@@ -552,6 +573,7 @@ describe('agent local capability enforcement', () => {
       'codex',
       expect.objectContaining({
         phase: 'plan',
+        admissionIdempotencyKey: 'conversation-fresh-123',
         conversation: {
           mode: 'fresh',
           intent: 'fresh',

--- a/server/src/__tests__/services/clawdbot-reconcile.test.ts
+++ b/server/src/__tests__/services/clawdbot-reconcile.test.ts
@@ -645,7 +645,7 @@ describe('ClawdbotAgentService.reconcileRunningAttempts (issue #781)', () => {
     ).rejects.toMatchObject({ statusCode: 409 });
   });
 
-  it('launches the exact scheduled task recovery with its causal record', async () => {
+  it('durably queues the exact scheduled recovery before mutating its parent state', async () => {
     const recovery: RunRecoveryRecord = {
       schemaVersion: 'run-recovery/v1',
       rootRunId: 'attempt_root',
@@ -700,9 +700,13 @@ describe('ClawdbotAgentService.reconcileRunningAttempts (issue #781)', () => {
       .mockResolvedValue({} as never);
     const startAgent = vi.spyOn(service, 'startAgent').mockResolvedValue({
       taskId: currentTask.id,
-      attemptId: 'attempt_child',
+      attemptId: 'attempt_queued',
+      queueId: 'admission_queue_recovery',
       agent: 'openclaw',
-      runLaunchManifest: { digest: `sha256:${'b'.repeat(64)}` },
+      status: 'queued',
+      enqueuedAt: '2026-07-25T12:00:00.000Z',
+      retryAfterMs: 250,
+      limitingScopes: [{ scope: 'global', scopeId: 'global' }],
     } as never);
 
     await (
@@ -711,34 +715,44 @@ describe('ClawdbotAgentService.reconcileRunningAttempts (issue #781)', () => {
       }
     ).launchScheduledTaskRecovery(currentTask.id, parentAttempt.id);
 
-    expect(mockUpdateTask).toHaveBeenCalledWith(
-      currentTask.id,
-      expect.objectContaining({
-        expectedRevision: 1,
-        attempt: expect.objectContaining({
-          id: parentAttempt.id,
-          runRetry: expect.objectContaining({ state: 'launching', sequence: 1 }),
-        }),
-      })
-    );
+    expect(mockUpdateTask).not.toHaveBeenCalled();
     expect(startAgent).toHaveBeenCalledWith(
       currentTask.id,
       'openclaw',
       expect.objectContaining({
         parentAttemptId: parentAttempt.id,
+        admissionIdempotencyKey: `recovery:${recovery.rootRunId}:${recovery.parentRunId}:${recovery.sequence}`,
         recovery: expect.objectContaining({
           parentRunId: parentAttempt.id,
-          state: 'launching',
+          state: 'scheduled',
         }),
       })
     );
     expect(appendRunEvent).toHaveBeenCalledWith(
       currentTask.id,
-      'attempt_child',
-      'recovery.launched',
-      expect.objectContaining({ parentAttemptId: parentAttempt.id }),
+      parentAttempt.id,
+      'recovery.queued',
+      expect.objectContaining({ queueId: 'admission_queue_recovery', sequence: 1 }),
       expect.any(Object)
     );
+
+    const claimed = await (
+      service as unknown as {
+        claimTaskRecoveryAfterAdmission(
+          taskId: string,
+          task: Task,
+          options: { parentAttemptId: string; recovery: RunRecoveryRecord }
+        ): Promise<Task>;
+      }
+    ).claimTaskRecoveryAfterAdmission(currentTask.id, currentTask, {
+      parentAttemptId: parentAttempt.id,
+      recovery,
+    });
+    expect(claimed.attempt?.runRetry).toMatchObject({
+      state: 'launching',
+      sequence: recovery.sequence,
+    });
+    expect(mockUpdateTask).toHaveBeenCalledTimes(1);
   });
 
   it('keeps a scheduled task recovery armed when cancellation persistence fails', async () => {

--- a/server/src/__tests__/storage/sqlite-workflow-run-execution.test.ts
+++ b/server/src/__tests__/storage/sqlite-workflow-run-execution.test.ts
@@ -249,13 +249,15 @@ describe('SQLite workflow run execution', () => {
     ]);
 
     expect(executeFirst.mock.calls.length + executeSecond.mock.calls.length).toBe(1);
+    // Universal admission owns the launch boundary, so the recovery remains
+    // scheduled until the mocked executeRun reaches the agent launch itself.
     expect(await first.getRun(run.id)).toMatchObject({
       revision: 3,
       status: 'pending',
       steps: [
         expect.objectContaining({
           runRetry: expect.objectContaining({
-            state: 'launching',
+            state: 'scheduled',
             parentRunId: recovery.parentRunId,
             sequence: recovery.sequence,
           }),

--- a/server/src/__tests__/workflow-admission.test.ts
+++ b/server/src/__tests__/workflow-admission.test.ts
@@ -293,6 +293,11 @@ describe('workflow admission', () => {
 
       const rawContextSecret = `workflow-root-secret-${backend}`;
       const run = await harness.service.startRun(harness.definition.id, undefined, {
+        scheduler: {
+          itemId: 'workflow:scheduled-admission',
+          trigger: 'due-run',
+          runAt: '2026-07-25T12:00:00.000Z',
+        },
         operatorPrompt: `Use ${rawContextSecret}`,
         toolArguments: { credential: rawContextSecret },
       });
@@ -310,6 +315,7 @@ describe('workflow admission', () => {
       });
       expect(queued).toMatchObject({
         state: 'queued',
+        request: { source: 'scheduled' },
         target: {
           kind: 'workflow-root',
           workflowId: harness.definition.id,

--- a/server/src/__tests__/workflow-run-service.test.ts
+++ b/server/src/__tests__/workflow-run-service.test.ts
@@ -100,6 +100,18 @@ describe('WorkflowRunService', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
+  it('preserves interactive, scheduled, and watcher workflow admission sources', () => {
+    const source = (
+      service as unknown as {
+        workflowAdmissionSource(run: { context: Record<string, unknown> }): string;
+      }
+    ).workflowAdmissionSource.bind(service);
+
+    expect(source({ context: {} })).toBe('workflow');
+    expect(source({ context: { scheduler: { itemId: 'workflow:nightly' } } })).toBe('scheduled');
+    expect(source({ context: { queueMonitor: { monitorId: 'backlog' } } })).toBe('watcher');
+  });
+
   it('starts a run, snapshots workflow, merges context, and completes asynchronously', async () => {
     const run = await service.startRun('wf-1', 'task-1', { custom: 42 });
     expect(run.id).toMatch(/^run_\d+_/);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -179,6 +179,7 @@ const conversationTurnSchema = z
     sourceAttemptId: z.string().trim().min(1).max(120),
     message: z.string().trim().min(1).max(20_000),
     forkTurnId: z.string().trim().min(1).max(240).optional(),
+    idempotencyKey: z.string().trim().min(8).max(240).optional(),
     profileId: AgentTypeSchema.optional(),
     overrideReason: z.string().trim().min(8).max(1000).optional(),
     sandboxPresetId: z.string().trim().min(1).max(80).optional(),
@@ -534,7 +535,7 @@ router.post(
   asyncHandler(async (req, res) => {
     let body: z.infer<typeof conversationFreshSchema>;
     try {
-      body = conversationFreshSchema.parse(req.body);
+      body = conversationFreshSchema.parse(withRequestIdempotencyKey(req, req.body));
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new ValidationError('Validation failed', error.issues);
@@ -558,7 +559,7 @@ router.post(
   '/:taskId/conversation/resume',
   requireLocalAgentCapability,
   asyncHandler(async (req, res) => {
-    const body = parseConversationTurn(req.body);
+    const body = parseConversationTurn(withRequestIdempotencyKey(req, req.body));
     if (body.forkTurnId) {
       throw new ValidationError('Resume cannot specify forkTurnId');
     }
@@ -577,7 +578,7 @@ router.post(
   '/:taskId/conversation/follow-up',
   requireLocalAgentCapability,
   asyncHandler(async (req, res) => {
-    const body = parseConversationTurn(req.body);
+    const body = parseConversationTurn(withRequestIdempotencyKey(req, req.body));
     if (body.forkTurnId) {
       throw new ValidationError('Follow-up cannot specify forkTurnId');
     }
@@ -596,7 +597,7 @@ router.post(
   '/:taskId/conversation/fork',
   requireLocalAgentCapability,
   asyncHandler(async (req, res) => {
-    const body = parseConversationTurn(req.body);
+    const body = parseConversationTurn(withRequestIdempotencyKey(req, req.body));
     const status = await clawdbotAgentService.forkConversation(
       req.params.taskId as string,
       body.sourceAttemptId,
@@ -857,6 +858,16 @@ function conversationStartOptions(
       ProviderRuntimeCapabilityId[] | undefined,
     commitPolicy: body.commitPolicy as TaskCommitPolicy | undefined,
     phase: body.phase,
+    admissionIdempotencyKey: body.idempotencyKey,
+  };
+}
+
+function withRequestIdempotencyKey(req: AuthenticatedRequest, input: unknown): unknown {
+  const headerIdempotencyKey = req.get('x-idempotency-key')?.trim();
+  if (!headerIdempotencyKey) return input;
+  return {
+    ...(typeof input === 'object' && input !== null ? input : {}),
+    idempotencyKey: headerIdempotencyKey,
   };
 }
 

--- a/server/src/schemas/admission-control-schemas.ts
+++ b/server/src/schemas/admission-control-schemas.ts
@@ -11,12 +11,25 @@ import {
   ADMISSION_RESERVATION_SCHEMA_VERSION,
   ADMISSION_RESERVATION_STATES,
   ADMISSION_SCOPES,
+  CONVERSATION_LAUNCH_INTENTS,
+  CONVERSATION_LAUNCH_MODES,
   EXECUTION_TREE_BUDGET_EVENT_SCHEMA_VERSION,
   EXECUTION_TREE_EDGE_KINDS,
   EXECUTION_TREE_IDENTITY_SCHEMA_VERSION,
   EXECUTABLE_AGENT_PROVIDERS,
+  PHASE_NAMES,
+  RUN_FAILURE_CLASSES,
+  RUN_RECOVERY_ACTIONS,
+  RUN_RECOVERY_SCHEMA_VERSION,
+  RUN_RECOVERY_STATES,
+  TASK_COMMIT_POLICIES,
 } from '@veritas-kanban/shared';
-import { AgentBudgetLimitsSchema, AgentBudgetUsageSchema } from './agent-budget-schemas.js';
+import {
+  AgentBudgetLimitsSchema,
+  AgentBudgetPolicySchema,
+  AgentBudgetUsageSchema,
+} from './agent-budget-schemas.js';
+import { ProviderRuntimeCapabilityIdSchema } from './provider-runtime-manifest-schemas.js';
 
 const identifier = z.string().trim().min(1).max(240);
 const policyIdentifier = z.string().trim().min(1).max(256);
@@ -216,11 +229,87 @@ export const AdmissionReservationSchema = z
     }
   });
 
+const ConversationLaunchRequestSchema = z
+  .object({
+    mode: z.enum(CONVERSATION_LAUNCH_MODES),
+    intent: z.enum(CONVERSATION_LAUNCH_INTENTS).optional(),
+    sourceAttemptId: identifier.optional(),
+    forkTurnId: z.string().trim().min(1).max(240).optional(),
+    message: z.string().trim().min(1).max(20_000).optional(),
+  })
+  .strict();
+
+const RunRecoveryRecordSchema = z
+  .object({
+    schemaVersion: z.literal(RUN_RECOVERY_SCHEMA_VERSION),
+    rootRunId: identifier,
+    parentRunId: identifier,
+    sequence: z.number().int().nonnegative().max(100),
+    fallbackUsed: z.boolean(),
+    state: z.enum(RUN_RECOVERY_STATES),
+    action: z.enum(RUN_RECOVERY_ACTIONS),
+    failure: z
+      .object({
+        classification: z.enum(RUN_FAILURE_CLASSES),
+        summary: z.string().trim().min(1).max(1_000),
+        retryable: z.boolean(),
+        approvalRequired: z.boolean(),
+        destructiveSideEffects: z.boolean(),
+      })
+      .strict(),
+    reason: z.string().trim().min(1).max(4_000),
+    backoffMs: z.number().int().nonnegative().max(2_147_483_647),
+    scheduledAt: z.string().datetime().optional(),
+    notBefore: z.string().datetime().optional(),
+    launchedAt: z.string().datetime().optional(),
+    launchedRunId: identifier.optional(),
+    cancelledAt: z.string().datetime().optional(),
+    cancelledBy: z.string().trim().min(1).max(240).optional(),
+    selectedAgent: identifier,
+    fallbackAgent: identifier.optional(),
+    routingDecision: z.string().trim().min(1).max(4_000),
+    sourceManifestDigest: digest.optional(),
+    launchedManifestDigest: digest.optional(),
+    requiredRuntimeCapabilities: z.array(ProviderRuntimeCapabilityIdSchema).max(128),
+    cumulativeBudget: AgentBudgetUsageSchema,
+    handoff: z
+      .object({
+        summary: z.string().trim().min(1).max(4_000),
+        nextActions: z.array(z.string().trim().min(1).max(4_000)).max(32),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+const AdmissionAgentLaunchOptionsSchema = z
+  .object({
+    profileId: identifier.optional(),
+    overrideReason: z.string().trim().min(1).max(2_000).optional(),
+    sandboxPresetId: identifier.optional(),
+    budget: AgentBudgetPolicySchema.optional(),
+    requiredRuntimeCapabilities: z.array(ProviderRuntimeCapabilityIdSchema).max(128).optional(),
+    commitPolicy: z.enum(TASK_COMMIT_POLICIES).optional(),
+    phase: z.enum(PHASE_NAMES).optional(),
+    parentAttemptId: identifier.optional(),
+    conversation: ConversationLaunchRequestSchema.optional(),
+    recovery: RunRecoveryRecordSchema.optional(),
+  })
+  .strict();
+
 export const AdmissionQueueTargetSchema = z.discriminatedUnion('kind', [
   z
     .object({
       kind: z.literal('direct'),
       agent: identifier,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('agent-launch'),
+      agent: identifier,
+      source: z.enum(['direct', 'conversation', 'recovery', 'fallback', 'child-agent']),
+      options: AdmissionAgentLaunchOptionsSchema,
     })
     .strict(),
   z
@@ -365,11 +454,24 @@ export const AdmissionQueueEntrySchema = z
         path: ['agent'],
       });
     }
-    if (entry.target && entry.target.kind !== 'direct' && entry.agent) {
+    if (entry.target && !['direct'].includes(entry.target.kind) && entry.agent) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Workflow queue targets cannot contain a direct agent identity.',
+        message: 'Versioned queue targets cannot contain a legacy direct agent identity.',
         path: ['agent'],
+      });
+    }
+    if (
+      entry.target?.kind === 'agent-launch' &&
+      (entry.request.source !== entry.target.source ||
+        entry.request.provider === ADMISSION_CONTROL_PROVIDER ||
+        entry.request.workflowRunId !== undefined ||
+        entry.request.workflowStepId !== undefined)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Agent launch queue target must match its admission request.',
+        path: ['target'],
       });
     }
     if (

--- a/server/src/schemas/telemetry-schemas.ts
+++ b/server/src/schemas/telemetry-schemas.ts
@@ -83,6 +83,19 @@ const RunStartedEventSchema = BaseEventSchema.extend({
   agent: z.string().min(1, 'agent is required'),
   model: z.string().optional(),
   sessionKey: z.string().optional(),
+  admissionSource: z
+    .enum([
+      'direct',
+      'conversation',
+      'recovery',
+      'fallback',
+      'scheduled',
+      'watcher',
+      'workflow',
+      'child-agent',
+    ])
+    .optional(),
+  admissionOutcome: z.enum(['admitted', 'queued-dispatch']).optional(),
 });
 
 /** run.completed event payload */

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -102,13 +102,20 @@ export interface DirectAdmissionQueueInput {
   priority?: AdmissionQueuePriority;
 }
 
-export interface WorkflowAdmissionQueueInput {
-  target: Exclude<AdmissionQueueTarget, { kind: 'direct' }>;
+export interface AgentAdmissionQueueInput {
+  target: Extract<AdmissionQueueTarget, { kind: 'agent-launch' }>;
   attemptId: string;
   priority?: AdmissionQueuePriority;
 }
 
-export type AdmissionQueueInput = DirectAdmissionQueueInput | WorkflowAdmissionQueueInput;
+export interface WorkflowAdmissionQueueInput {
+  target: Extract<AdmissionQueueTarget, { kind: 'workflow-root' | 'workflow-step' }>;
+  attemptId: string;
+  priority?: AdmissionQueuePriority;
+}
+
+export type AdmissionQueueInput =
+  DirectAdmissionQueueInput | AgentAdmissionQueueInput | WorkflowAdmissionQueueInput;
 
 export interface RecoverAdmissionInput {
   workspaceId: string;
@@ -292,12 +299,16 @@ export class AdmissionControlService {
       queueTarget &&
       settings.queue.enabled &&
       ((queueTarget.kind === 'direct' && request.source === 'direct') ||
+        (queueTarget.kind === 'agent-launch' &&
+          request.source === queueTarget.source &&
+          !request.workflowRunId &&
+          !request.workflowStepId) ||
         (queueTarget.kind === 'workflow-root' &&
-          request.source === 'workflow' &&
+          ['workflow', 'scheduled', 'watcher'].includes(request.source) &&
           request.workflowRunId === queueTarget.workflowRunId &&
           !request.workflowStepId) ||
         (queueTarget.kind === 'workflow-step' &&
-          ['workflow', 'recovery', 'fallback'].includes(request.source) &&
+          ['workflow', 'scheduled', 'watcher', 'recovery', 'fallback'].includes(request.source) &&
           request.workflowRunId === queueTarget.workflowRunId &&
           request.workflowStepId === queueTarget.workflowStepId))
     );
@@ -328,7 +339,7 @@ export class AdmissionControlService {
         'terminal-policy-denial',
         request,
         claimed.limitingPolicies,
-        'The task already has a queued launch with a different agent selection.',
+        'The task already has a queued launch with a different durable target.',
         now
       );
     }

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -129,6 +129,8 @@ import type {
   WorkspaceExecutionTrustEvaluation,
   WorkspaceExecutionTrustScanResult,
   AdmissionReservationRelease,
+  AdmissionAgentLaunchOptions,
+  AdmissionLaunchSource,
   AdmissionQueueClaim,
   ExecutionTreeBudgetPolicy,
   ExecutionTreeEdgeKind,
@@ -293,6 +295,16 @@ export interface AgentProviderStartContext {
   sandboxPolicy?: SandboxPolicyDryRunResult;
   runLaunchManifest: RunLaunchManifest;
   conversation: ConversationLifecycleRecord;
+  admission: AgentProviderAdmissionEvidence;
+}
+
+export interface AgentProviderAdmissionEvidence {
+  schemaVersion: 'provider-admission-evidence/v1';
+  source: AdmissionLaunchSource;
+  outcome: 'admitted' | 'queued-dispatch';
+  reservationId: string;
+  queueEntryId?: string;
+  executionTree: ExecutionTreeIdentity;
 }
 
 export interface AgentProviderStopContext {
@@ -677,7 +689,10 @@ export class ClawdbotAgentService {
         await getWorkflowRunService().dispatchQueuedAdmission(claim);
         continue;
       }
-      const queuedAgent = entry.target?.kind === 'direct' ? entry.target.agent : entry.agent;
+      const queuedAgent =
+        entry.target?.kind === 'direct' || entry.target?.kind === 'agent-launch'
+          ? entry.target.agent
+          : entry.agent;
       if (!queuedAgent) {
         await this.admission
           .release(reservation.id, 'start-failed', `queue-target-missing:${entry.id}`)
@@ -703,7 +718,10 @@ export class ClawdbotAgentService {
 
       startingAgents.add(entry.request.taskId);
       try {
+        const queuedOptions =
+          entry.target?.kind === 'agent-launch' ? entry.target.options : undefined;
         const result = await this.startReservedAgent(entry.request.taskId, queuedAgent, {
+          ...queuedOptions,
           rootTaskId: entry.request.rootTaskId,
           admissionQueueClaim: claim,
         });
@@ -745,6 +763,65 @@ export class ClawdbotAgentService {
     return true;
   }
 
+  private agentAdmissionSource(
+    executionTree: ExecutionTreeIdentity,
+    recovery?: RunRecoveryRecord
+  ): Extract<
+    AdmissionLaunchSource,
+    'direct' | 'conversation' | 'recovery' | 'fallback' | 'child-agent'
+  > {
+    if (recovery) return recovery.action === 'fallback' ? 'fallback' : 'recovery';
+    if (executionTree.edge === 'child-agent') return 'child-agent';
+    return executionTree.edge === 'root' ? 'direct' : 'conversation';
+  }
+
+  private admissionAgentLaunchOptions(
+    options: AgentStartOptions,
+    conversation: ConversationLaunchRequest,
+    overrideReason?: string
+  ): AdmissionAgentLaunchOptions {
+    const persistConversation =
+      options.conversation !== undefined ||
+      conversation.mode !== 'fresh' ||
+      conversation.message !== undefined;
+    return {
+      ...(options.profileId ? { profileId: options.profileId } : {}),
+      ...(overrideReason ? { overrideReason } : {}),
+      ...(options.sandboxPresetId ? { sandboxPresetId: options.sandboxPresetId } : {}),
+      ...(options.budget ? { budget: structuredClone(options.budget) } : {}),
+      ...(options.requiredRuntimeCapabilities?.length
+        ? { requiredRuntimeCapabilities: [...options.requiredRuntimeCapabilities] }
+        : {}),
+      ...(options.commitPolicy ? { commitPolicy: options.commitPolicy } : {}),
+      ...(options.phase ? { phase: options.phase } : {}),
+      ...(options.parentAttemptId ? { parentAttemptId: options.parentAttemptId } : {}),
+      ...(persistConversation ? { conversation: structuredClone(conversation) } : {}),
+      ...(options.recovery ? { recovery: structuredClone(options.recovery) } : {}),
+    };
+  }
+
+  private assertProviderAdmissionEvidence(
+    evidence: AgentProviderAdmissionEvidence,
+    attempt: TaskAttempt
+  ): void {
+    const missing = [
+      evidence.schemaVersion !== 'provider-admission-evidence/v1' ? 'schemaVersion' : undefined,
+      attempt.admissionReservationId !== evidence.reservationId ? 'reservationId' : undefined,
+      !attempt.executionTree ||
+      JSON.stringify(attempt.executionTree) !== JSON.stringify(evidence.executionTree)
+        ? 'executionTree'
+        : undefined,
+      evidence.outcome === 'queued-dispatch' && !evidence.queueEntryId ? 'queueEntryId' : undefined,
+      evidence.outcome === 'admitted' && evidence.queueEntryId ? 'queueOutcome' : undefined,
+    ].filter((field): field is string => Boolean(field));
+    if (missing.length > 0) {
+      throw new ConflictError('Provider launch is missing required admission evidence.', {
+        code: 'PROVIDER_ADMISSION_EVIDENCE_INVALID',
+        fields: missing,
+      });
+    }
+  }
+
   private queueDispatchFailure(error: unknown): {
     terminal: boolean;
     code: string;
@@ -780,14 +857,6 @@ export class ClawdbotAgentService {
       ).slice(0, 160),
       reason: redactedReason.trim().slice(0, 1_000) || 'Queued launch failed before dispatch.',
     };
-  }
-
-  private requireRunningLaunch(result: AgentLaunchStatus): AgentStatus {
-    if (result.status !== 'queued') return result;
-    throw new ConflictError('This launch source cannot enter the direct admission queue.', {
-      code: 'ADMISSION_QUEUE_SOURCE_DENIED',
-      queueId: result.queueId,
-    });
   }
 
   /**
@@ -1331,7 +1400,65 @@ export class ClawdbotAgentService {
         : {}),
       parentAttemptId: parentAttempt.id,
       recovery,
+      admissionIdempotencyKey: `recovery:${recovery.rootRunId}:${recovery.parentRunId}:${recovery.sequence}`,
     };
+  }
+
+  private async claimTaskRecoveryAfterAdmission(
+    taskId: string,
+    task: Task,
+    options: AgentStartOptions
+  ): Promise<Task> {
+    const requested = options.recovery;
+    if (!requested) return task;
+    const parentAttempt = task.attempt;
+    const current = parentAttempt?.runRetry;
+    if (
+      !parentAttempt ||
+      parentAttempt.id !== options.parentAttemptId ||
+      !current ||
+      !['scheduled', 'launching'].includes(current.state) ||
+      current.rootRunId !== requested.rootRunId ||
+      current.parentRunId !== requested.parentRunId ||
+      current.sequence !== requested.sequence ||
+      current.action !== requested.action ||
+      current.selectedAgent !== requested.selectedAgent
+    ) {
+      throw new ConflictError('Recovery launch no longer matches the pending parent attempt', {
+        taskId,
+        activeAttemptId: parentAttempt?.id,
+        parentAttemptId: options.parentAttemptId,
+        recoveryState: current?.state,
+        recoverySequence: current?.sequence,
+      });
+    }
+    if (current.state === 'launching') return task;
+
+    const launching: RunRecoveryRecord = { ...current, state: 'launching' };
+    const claimedAttempt = { ...parentAttempt, runRetry: launching };
+    const claimed = await this.taskService.updateTask(taskId, {
+      expectedRevision: normalizedTaskRevision(task),
+      attempt: claimedAttempt,
+      attempts: upsertAttemptHistory(task.attempts, claimedAttempt),
+    });
+    if (!claimed) throw new NotFoundError(`Task "${taskId}" disappeared during recovery launch`);
+    await this.appendRunEvent(
+      taskId,
+      parentAttempt.id,
+      'recovery.launching',
+      {
+        action: launching.action,
+        sequence: launching.sequence,
+        selectedAgent: launching.selectedAgent,
+      },
+      {
+        provider: 'system',
+        adapter: 'run-recovery',
+        agent: launching.selectedAgent,
+        dedupeKey: `recovery.launching:${launching.sequence}`,
+      }
+    );
+    return claimed;
   }
 
   private scheduleTaskRecovery(
@@ -1383,60 +1510,32 @@ export class ClawdbotAgentService {
       return;
     }
 
-    const launching: RunRecoveryRecord = { ...recovery, state: 'launching' };
-    const claimedAttempt = { ...parentAttempt, runRetry: launching };
-    const claimed = await this.taskService.updateTask(taskId, {
-      expectedRevision: normalizedTaskRevision(task),
-      attempt: claimedAttempt,
-      attempts: upsertAttemptHistory(task.attempts, claimedAttempt),
-    });
-    if (!claimed) return;
-    await this.appendRunEvent(
-      taskId,
-      attemptId,
-      'recovery.launching',
-      {
-        action: launching.action,
-        sequence: launching.sequence,
-        selectedAgent: launching.selectedAgent,
-      },
-      {
-        provider: 'system',
-        adapter: 'run-recovery',
-        agent: launching.selectedAgent,
-        dedupeKey: `recovery.launching:${launching.sequence}`,
-      }
-    );
-
     try {
-      const child = this.requireRunningLaunch(
-        await this.startAgent(
-          taskId,
-          launching.selectedAgent,
-          this.recoveryLaunchOptions(claimedAttempt, launching)
-        )
-      );
-      await this.appendRunEvent(
+      const child = await this.startAgent(
         taskId,
-        child.attemptId,
-        'recovery.launched',
-        {
-          action: launching.action,
-          sequence: launching.sequence,
-          parentAttemptId: attemptId,
-          launchedAttemptId: child.attemptId,
-          selectedAgent: child.agent,
-          sourceManifestDigest: launching.sourceManifestDigest,
-          launchedManifestDigest: child.runLaunchManifest.digest,
-          cumulativeBudget: launching.cumulativeBudget,
-        },
-        {
-          provider: 'system',
-          adapter: 'run-recovery',
-          agent: child.agent,
-          dedupeKey: `recovery.launched:${launching.sequence}`,
-        }
+        recovery.selectedAgent,
+        this.recoveryLaunchOptions(parentAttempt, recovery)
       );
+      if (child.status === 'queued') {
+        await this.appendRunEvent(
+          taskId,
+          attemptId,
+          'recovery.queued',
+          {
+            action: recovery.action,
+            sequence: recovery.sequence,
+            queueId: child.queueId,
+            selectedAgent: child.agent,
+            retryAfterMs: child.retryAfterMs,
+          },
+          {
+            provider: 'system',
+            adapter: 'run-recovery',
+            agent: child.agent,
+            dedupeKey: `recovery.queued:${recovery.sequence}`,
+          }
+        );
+      }
     } catch (error) {
       const latest = await this.taskService.getTask(taskId);
       if (latest?.attempt?.id === attemptId) {
@@ -2320,19 +2419,14 @@ export class ClawdbotAgentService {
         isRoot: !parentAttempt,
       }),
     ]);
+    const admissionSource = this.agentAdmissionSource(executionTree, options.recovery);
     const admissionInput = {
       taskId,
       rootTaskId: options.rootTaskId,
       workspaceId: taskEnvelope.workspace.workspaceId,
       provider,
       hostId: runLaunchManifest.routing.selectedHost,
-      source: options.recovery
-        ? options.recovery.action === 'fallback'
-          ? 'fallback'
-          : 'recovery'
-        : conversationRequest.mode === 'fresh'
-          ? 'direct'
-          : 'conversation',
+      source: admissionSource,
       idempotencyKey: options.admissionIdempotencyKey,
       executionTree,
       budgetPolicies: executionBudgetPolicies,
@@ -2341,28 +2435,18 @@ export class ClawdbotAgentService {
         retries: options.recovery ? 1 : 0,
       },
     } as const;
-    const queueableDirectLaunch =
-      !options.admissionQueueClaim &&
-      conversationRequest.mode === 'fresh' &&
-      !conversationRequest.message &&
-      !options.recovery &&
-      !options.parentAttemptId &&
-      !options.profileId &&
-      !options.overrideReason &&
-      !options.sandboxPresetId &&
-      !options.budget &&
-      !options.requiredRuntimeCapabilities?.length &&
-      !options.commitPolicy &&
-      !options.phase;
     const admissionDecision = options.admissionQueueClaim
       ? undefined
-      : queueableDirectLaunch
-        ? await this.admission.admitOrQueue(admissionInput, {
+      : await this.admission.admitOrQueue(admissionInput, {
+          target: {
+            kind: 'agent-launch',
             agent,
-            attemptId,
-            priority: task.priority,
-          })
-        : await this.admission.admit(admissionInput);
+            source: admissionSource,
+            options: this.admissionAgentLaunchOptions(options, conversationRequest, overrideReason),
+          },
+          attemptId,
+          priority: task.priority,
+        });
     if (admissionDecision?.outcome === 'queued' && admissionDecision.queueEntry) {
       try {
         await this.filesystemSandbox.cleanup(filesystemSandboxPlan);
@@ -2411,7 +2495,8 @@ export class ClawdbotAgentService {
       const driftFields = [
         queuedClaim.entry.state !== 'leased' ? 'queueState' : undefined,
         queuedClaim.entry.attemptId !== attemptId ? 'attemptId' : undefined,
-        (queuedClaim.entry.target?.kind === 'direct'
+        (queuedClaim.entry.target?.kind === 'direct' ||
+        queuedClaim.entry.target?.kind === 'agent-launch'
           ? queuedClaim.entry.target.agent
           : queuedClaim.entry.agent) !== agent
           ? 'agent'
@@ -2419,7 +2504,7 @@ export class ClawdbotAgentService {
         queuedClaim.entry.reservationId !== queuedClaim.reservation.id
           ? 'reservationId'
           : undefined,
-        queuedRequest.source !== 'direct' ? 'source' : undefined,
+        queuedRequest.source !== admissionSource ? 'source' : undefined,
         queuedRequest.taskId !== taskId ? 'taskId' : undefined,
         queuedRequest.rootTaskId !== (options.rootTaskId ?? taskId) ? 'rootTaskId' : undefined,
         queuedRequest.workspaceId !== taskEnvelope.workspace.workspaceId
@@ -2479,6 +2564,16 @@ export class ClawdbotAgentService {
           `bind-failed:${attemptId}`
         )
         .catch(() => {});
+      throw error;
+    }
+    try {
+      task = await this.claimTaskRecoveryAfterAdmission(taskId, task, options);
+    } catch (error) {
+      await this.releaseAdmission(
+        admissionReservation.id,
+        'start-failed',
+        `recovery-claim-failed:${attemptId}`
+      );
       throw error;
     }
     // Create event emitter for status updates
@@ -2571,7 +2666,7 @@ export class ClawdbotAgentService {
       executionTree,
     };
 
-    const usesManagedWorktree = Boolean(task.git.worktreeManifestId && task.git.worktreeLeaseId);
+    const usesManagedWorktree = Boolean(task.git?.worktreeManifestId && task.git.worktreeLeaseId);
     if (usesManagedWorktree) {
       try {
         await this.worktrees.claimOwnership(taskId, attemptId);
@@ -2713,6 +2808,29 @@ export class ClawdbotAgentService {
       if (queuedClaim) {
         await this.admission.markQueueDispatched(queuedClaim.entry.id, attemptId);
       }
+      if (options.recovery && runRetry) {
+        await this.appendRunEvent(
+          taskId,
+          attemptId,
+          'recovery.launched',
+          {
+            action: runRetry.action,
+            sequence: runRetry.sequence,
+            parentAttemptId: options.parentAttemptId,
+            launchedAttemptId: attemptId,
+            selectedAgent: agent,
+            sourceManifestDigest: runRetry.sourceManifestDigest,
+            launchedManifestDigest: runRetry.launchedManifestDigest,
+            cumulativeBudget: runRetry.cumulativeBudget,
+          },
+          {
+            provider: 'system',
+            adapter: 'run-recovery',
+            agent,
+            dedupeKey: `recovery.launched:${runRetry.sequence}`,
+          }
+        );
+      }
       const startedEvent = await this.appendRunEvent(
         taskId,
         attemptId,
@@ -2789,6 +2907,8 @@ export class ClawdbotAgentService {
         agent,
         model: launchAgentConfig?.model,
         project: task.project,
+        admissionSource,
+        admissionOutcome: queuedClaim ? 'queued-dispatch' : 'admitted',
         harnessSupport: this.harnessTelemetry(harnessSupport),
       });
 
@@ -2797,6 +2917,15 @@ export class ClawdbotAgentService {
         runLaunchManifest.workspaceTrust
       );
       await this.filesystemSandbox.activate(filesystemSandboxPlan);
+      const providerAdmission: AgentProviderAdmissionEvidence = {
+        schemaVersion: 'provider-admission-evidence/v1',
+        source: admissionSource,
+        outcome: queuedClaim ? 'queued-dispatch' : 'admitted',
+        reservationId: admissionReservation.id,
+        ...(queuedClaim ? { queueEntryId: queuedClaim.entry.id } : {}),
+        executionTree,
+      };
+      this.assertProviderAdmissionEvidence(providerAdmission, attempt);
       await adapter.start({
         task,
         agentConfig: launchAgentConfig,
@@ -2809,6 +2938,7 @@ export class ClawdbotAgentService {
         sandboxPolicy: sandboxPolicy.result,
         runLaunchManifest,
         conversation,
+        admission: providerAdmission,
       });
     } catch (error: unknown) {
       const startError = error instanceof Error ? error : new Error(String(error));
@@ -4220,18 +4350,16 @@ export class ClawdbotAgentService {
     sourceAttemptId: string,
     message: string,
     options: Omit<AgentStartOptions, 'conversation' | 'parentAttemptId'> = {}
-  ): Promise<AgentStatus> {
+  ): Promise<AgentLaunchStatus> {
     const source = this.conversationLifecycle.source(
       await this.findAttempt(sourceAttemptId),
       'resume'
     );
-    return this.requireRunningLaunch(
-      await this.startAgent(taskId, source.attempt.agent, {
-        ...options,
-        parentAttemptId: source.attempt.id,
-        conversation: { mode: 'resume', intent: 'resume', sourceAttemptId, message },
-      })
-    );
+    return this.startAgent(taskId, source.attempt.agent, {
+      ...options,
+      parentAttemptId: source.attempt.id,
+      conversation: { mode: 'resume', intent: 'resume', sourceAttemptId, message },
+    });
   }
 
   async followUpConversation(
@@ -4239,23 +4367,21 @@ export class ClawdbotAgentService {
     sourceAttemptId: string,
     message: string,
     options: Omit<AgentStartOptions, 'conversation' | 'parentAttemptId'> = {}
-  ): Promise<AgentStatus> {
+  ): Promise<AgentLaunchStatus> {
     const source = this.conversationLifecycle.source(
       await this.findAttempt(sourceAttemptId),
       'resume'
     );
-    return this.requireRunningLaunch(
-      await this.startAgent(taskId, source.attempt.agent, {
-        ...options,
-        parentAttemptId: source.attempt.id,
-        conversation: {
-          mode: 'resume',
-          intent: 'follow-up',
-          sourceAttemptId,
-          message,
-        },
-      })
-    );
+    return this.startAgent(taskId, source.attempt.agent, {
+      ...options,
+      parentAttemptId: source.attempt.id,
+      conversation: {
+        mode: 'resume',
+        intent: 'follow-up',
+        sourceAttemptId,
+        message,
+      },
+    });
   }
 
   async forkConversation(
@@ -4264,24 +4390,22 @@ export class ClawdbotAgentService {
     message: string,
     forkTurnId?: string,
     options: Omit<AgentStartOptions, 'conversation' | 'parentAttemptId'> = {}
-  ): Promise<AgentStatus> {
+  ): Promise<AgentLaunchStatus> {
     const source = this.conversationLifecycle.source(
       await this.findAttempt(sourceAttemptId),
       'fork'
     );
-    return this.requireRunningLaunch(
-      await this.startAgent(taskId, source.attempt.agent, {
-        ...options,
-        parentAttemptId: source.attempt.id,
-        conversation: {
-          mode: 'fork',
-          intent: 'fork',
-          sourceAttemptId,
-          message,
-          ...(forkTurnId ? { forkTurnId } : {}),
-        },
-      })
-    );
+    return this.startAgent(taskId, source.attempt.agent, {
+      ...options,
+      parentAttemptId: source.attempt.id,
+      conversation: {
+        mode: 'fork',
+        intent: 'fork',
+        sourceAttemptId,
+        message,
+        ...(forkTurnId ? { forkTurnId } : {}),
+      },
+    });
   }
 
   async compactConversation(

--- a/server/src/services/maintenance-service.ts
+++ b/server/src/services/maintenance-service.ts
@@ -2,6 +2,8 @@ import fs from 'fs/promises';
 import path from 'path';
 import {
   PHASE_AUTHORITY_DIMENSIONS,
+  type AdmissionQueueDepth,
+  type AdmissionQueueInspectionEntry,
   type PhaseCapabilityEvidence,
   type MaintenanceCleanupPreviewItem,
   type MaintenanceDebugBundle,
@@ -30,6 +32,7 @@ import { redactString } from '../lib/redact.js';
 import { getSqliteStorageDiagnostics } from '../storage/sqlite/database.js';
 import { getStorage } from '../storage/index.js';
 import { getRunPhaseAuthorityService } from './run-phase-authority-service.js';
+import { getAdmissionControlService } from './admission-control-service.js';
 
 interface DirectoryStats {
   bytes: number;
@@ -45,6 +48,7 @@ interface LogSourceDefinition {
 
 const MAX_TAIL_LINES = 500;
 const MAX_PHASE_DIAGNOSTIC_RUNS = 200;
+const MAX_ADMISSION_QUEUE_DIAGNOSTICS = 200;
 
 interface PhaseAuthorityDiagnosticExport {
   generatedAt: string;
@@ -54,6 +58,16 @@ interface PhaseAuthorityDiagnosticExport {
 }
 
 type PhaseAuthorityDiagnosticCollector = () => Promise<PhaseAuthorityDiagnosticExport>;
+
+interface AdmissionQueueDiagnosticExport {
+  generatedAt: string;
+  status: 'ok' | 'unavailable';
+  truncated: boolean;
+  depth?: AdmissionQueueDepth;
+  entries: AdmissionQueueInspectionEntry[];
+}
+
+type AdmissionQueueDiagnosticCollector = () => Promise<AdmissionQueueDiagnosticExport>;
 
 const MAINTENANCE_CONTENT_REDACTIONS: [RegExp, string][] = [
   [
@@ -76,7 +90,8 @@ const MAINTENANCE_CONTENT_REDACTIONS: [RegExp, string][] = [
 
 export class MaintenanceService {
   constructor(
-    private readonly collectPhaseAuthority: PhaseAuthorityDiagnosticCollector = collectPhaseAuthorityDiagnostics
+    private readonly collectPhaseAuthority: PhaseAuthorityDiagnosticCollector = collectPhaseAuthorityDiagnostics,
+    private readonly collectAdmissionQueue: AdmissionQueueDiagnosticCollector = collectAdmissionQueueDiagnostics
   ) {}
 
   async buildSummary(): Promise<MaintenanceSummary> {
@@ -261,6 +276,7 @@ export class MaintenanceService {
 
     const summary = await this.buildSummary();
     const phaseAuthority = await this.collectPhaseAuthority();
+    const admissionQueue = await this.collectAdmissionQueue();
     const logTails: MaintenanceLogTail[] = [];
     for (const source of summary.logs.filter((entry) => entry.exists)) {
       const tail = await this.tailLog(source.id, 200);
@@ -279,6 +295,7 @@ export class MaintenanceService {
         'lifecycle',
         'work-products',
         'phase-authority',
+        'admission-queue',
         'redacted-log-tails',
       ],
       excludedCategories: [
@@ -294,6 +311,7 @@ export class MaintenanceService {
         'Bearer tokens, API keys, JWTs, opaque tokens, and long hashes are replaced.',
         'Local home, project, storage, runtime, and log paths are replaced with redacted path labels.',
         'Log files are included as redacted tails only, capped at 200 lines per source.',
+        'Admission queue diagnostics use the bounded inspection projection and never include durable replay targets.',
       ],
       files: summary.logs.map((source) => this.redactLogSource(source)),
     };
@@ -306,6 +324,11 @@ export class MaintenanceService {
     await fs.writeFile(
       path.join(bundleDir, 'phase-authority.json'),
       JSON.stringify(this.redactMaintenanceValue(phaseAuthority), null, 2),
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(bundleDir, 'admission-queue.json'),
+      JSON.stringify(this.redactMaintenanceValue(admissionQueue), null, 2),
       'utf-8'
     );
     await fs.writeFile(
@@ -655,6 +678,28 @@ export class MaintenanceService {
     return redacted
       .replace(/\/Users\/[^/\s]+\/[^\s)]+/g, '[redacted-local-path]')
       .replace(/[A-Z]:\\Users\\[^\\\s]+\\[^\s)]+/g, '[redacted-local-path]');
+  }
+}
+
+async function collectAdmissionQueueDiagnostics(): Promise<AdmissionQueueDiagnosticExport> {
+  try {
+    const queue = await getAdmissionControlService().inspectQueue({
+      limit: MAX_ADMISSION_QUEUE_DIAGNOSTICS,
+    });
+    return {
+      generatedAt: queue.generatedAt,
+      status: 'ok',
+      truncated: queue.pagination.hasMore || queue.pagination.snapshotTruncated,
+      depth: queue.depth,
+      entries: queue.entries,
+    };
+  } catch {
+    return {
+      generatedAt: new Date().toISOString(),
+      status: 'unavailable',
+      truncated: false,
+      entries: [],
+    };
   }
 }
 

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -18,6 +18,7 @@ import {
   type AgentBudgetUsage,
   type AgentType,
   type AdmissionDecision,
+  type AdmissionLaunchSource,
   type AdmissionQueueClaim,
   type AdmissionQueueEntry,
   type AdmissionReservation,
@@ -80,6 +81,10 @@ const RESERVED_CONTEXT_KEYS = new Set([
   '_gateBlock',
   '_gateApproval',
 ]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
 
 class WorkflowStepAdmissionError extends Error {
   readonly decision: AdmissionDecision;
@@ -367,6 +372,14 @@ export class WorkflowRunService {
     return normalizeWorkspaceId(task.project?.trim() || task.git?.repo || task.id);
   }
 
+  private workflowAdmissionSource(
+    run: WorkflowRun
+  ): Extract<AdmissionLaunchSource, 'workflow' | 'scheduled' | 'watcher'> {
+    if (isRecord(run.context.scheduler)) return 'scheduled';
+    if (isRecord(run.context.queueMonitor)) return 'watcher';
+    return 'workflow';
+  }
+
   private admissionConflict(decision: AdmissionDecision, subject: string): ConflictError {
     return new ConflictError(
       decision.outcome === 'retryable-overload'
@@ -435,7 +448,7 @@ export class WorkflowRunService {
       workspaceId,
       provider: ADMISSION_CONTROL_PROVIDER,
       hostId: this.admission.getExecutionHostId(),
-      source: 'workflow',
+      source: this.workflowAdmissionSource(run),
       workflowRunId: run.id,
       idempotencyKey: `workflow-root:${run.id}`,
       requested: {
@@ -584,6 +597,10 @@ export class WorkflowRunService {
     const hostId =
       preparation.hostRouting.selectedHostId ??
       (preparation.runtimeProvider === 'openclaw' ? 'openclaw-gateway' : 'local-process');
+    const rootReservation = await this.admission.get(rootReservationId);
+    const rootSource = ['scheduled', 'watcher'].includes(rootReservation.request.source)
+      ? rootReservation.request.source
+      : 'workflow';
     const admissionInput = {
       taskId: admissionTaskId,
       rootTaskId: run.admission.rootTaskId,
@@ -595,13 +612,13 @@ export class WorkflowRunService {
           ? 'fallback'
           : stepRun.runRetry
             ? 'recovery'
-            : 'workflow',
+            : rootSource,
       workflowRunId: run.id,
       workflowStepId: step.id,
       rootReservationId,
       idempotencyKey: `workflow-step:${run.id}:${step.id}:${sequence}`,
       executionTree,
-      budgetPolicies: (await this.admission.get(rootReservationId)).request.budgetPolicies,
+      budgetPolicies: rootReservation.request.budgetPolicies,
       budgetRequest: {
         fanOut: Math.max(1, step.parallel?.steps.length ?? 1),
         retries: stepRun.runRetry ? 1 : 0,
@@ -761,7 +778,7 @@ export class WorkflowRunService {
     terminalEntry: AdmissionQueueEntry
   ): Promise<void> {
     const target = claim.entry.target;
-    if (!target || target.kind === 'direct') return;
+    if (!target || target.kind === 'direct' || target.kind === 'agent-launch') return;
     const run = await this.getRun(target.workflowRunId);
     if (!run) return;
     const reason = terminalEntry.terminal?.reason ?? 'Workflow queue authority changed.';
@@ -1052,7 +1069,7 @@ export class WorkflowRunService {
 
   private async rollbackWorkflowQueueClaim(claim: AdmissionQueueClaim): Promise<void> {
     const target = claim.entry.target;
-    if (!target || target.kind === 'direct') return;
+    if (!target || target.kind === 'direct' || target.kind === 'agent-launch') return;
     const run = await this.getRun(target.workflowRunId);
     if (!run) return;
     if (
@@ -1594,7 +1611,7 @@ export class WorkflowRunService {
           stepRun.status = 'running';
           stepRun.error = undefined;
           stepRun.startedAt = new Date().toISOString();
-          if (stepRun.runRetry?.state === 'launching') {
+          if (stepRun.runRetry && ['scheduled', 'launching'].includes(stepRun.runRetry.state)) {
             stepRun.runRetry = {
               ...stepRun.runRetry,
               state: 'launched',
@@ -2271,7 +2288,6 @@ export class WorkflowRunService {
     }
     stepRun.runRetry = {
       ...recovery,
-      state: 'launching',
       selectedAgent: stepRun.agent ?? recovery.selectedAgent,
     };
     stepRun.status = 'pending';

--- a/shared/src/types/admission-control.types.ts
+++ b/shared/src/types/admission-control.types.ts
@@ -1,5 +1,11 @@
 import type { ExecutableAgentProvider } from './config.types.js';
+import type { AgentBudgetPolicy } from './agent-budget.types.js';
+import type { ConversationLaunchRequest } from './conversation-lifecycle.types.js';
 import type { AgentType, TaskPriority } from './task.types.js';
+import type { PhaseName } from './phase-capability.types.js';
+import type { ProviderRuntimeCapabilityId } from './provider-runtime.types.js';
+import type { RunRecoveryRecord } from './run-recovery.types.js';
+import type { TaskCommitPolicy } from './task-envelope.types.js';
 import type {
   ExecutionTreeBudgetPolicy,
   ExecutionTreeBudgetState,
@@ -185,10 +191,35 @@ export interface AdmissionQueueSelectionEvidence {
   skipped: AdmissionQueueSkippedCandidateEvidence[];
 }
 
+/**
+ * Durable, provider-neutral inputs required to reconstruct an agent launch.
+ *
+ * Transient authority such as credentials, process handles, leases, and raw
+ * admission idempotency keys must never be stored here.
+ */
+export interface AdmissionAgentLaunchOptions {
+  profileId?: string;
+  overrideReason?: string;
+  sandboxPresetId?: string;
+  budget?: AgentBudgetPolicy;
+  requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
+  commitPolicy?: TaskCommitPolicy;
+  phase?: PhaseName;
+  parentAttemptId?: string;
+  conversation?: ConversationLaunchRequest;
+  recovery?: RunRecoveryRecord;
+}
+
 export type AdmissionQueueTarget =
   | {
       kind: 'direct';
       agent: AgentType;
+    }
+  | {
+      kind: 'agent-launch';
+      agent: AgentType;
+      source: Exclude<AdmissionLaunchSource, 'workflow' | 'scheduled' | 'watcher'>;
+      options: AdmissionAgentLaunchOptions;
     }
   | {
       kind: 'workflow-root';

--- a/shared/src/types/admission-control.types.ts
+++ b/shared/src/types/admission-control.types.ts
@@ -347,7 +347,7 @@ export interface AdmissionQueueInspectionEntry {
   >;
   launch: {
     source: AdmissionLaunchSource;
-    target: 'direct' | 'workflow-root' | 'workflow-step' | 'legacy-direct';
+    target: 'direct' | 'agent-launch' | 'workflow-root' | 'workflow-step' | 'legacy-direct';
     workspaceId: string;
     taskKey: string;
     rootTaskKey: string;

--- a/shared/src/types/telemetry.types.ts
+++ b/shared/src/types/telemetry.types.ts
@@ -2,6 +2,7 @@
 
 import type { TaskStatus, AgentType } from './task.types.js';
 import type { HarnessSupportFailureClass, HarnessSupportTier } from './provider-runtime.types.js';
+import type { AdmissionLaunchSource } from './admission-control.types.js';
 
 export type TelemetryEventType =
   | 'task.created'
@@ -38,6 +39,8 @@ export interface RunStartedEvent extends TelemetryEvent {
   model?: string;
   sessionKey?: string;
   attemptId?: string;
+  admissionSource?: AdmissionLaunchSource;
+  admissionOutcome?: 'admitted' | 'queued-dispatch';
   harnessSupport?: HarnessSupportTelemetry;
 }
 
@@ -89,6 +92,8 @@ export interface RunTelemetryEvent extends TelemetryEvent {
   model?: string;
   sessionKey?: string;
   stackTrace?: string;
+  admissionSource?: AdmissionLaunchSource;
+  admissionOutcome?: 'admitted' | 'queued-dispatch';
   harnessSupport?: HarnessSupportTelemetry;
 }
 

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -37,6 +37,7 @@ export interface StartAgentRequest {
   requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
   commitPolicy?: TaskCommitPolicy;
   parentAttemptId?: string;
+  idempotencyKey?: string;
 }
 
 export interface ConversationTurnRequest {
@@ -49,6 +50,7 @@ export interface ConversationTurnRequest {
   budget?: AgentBudgetPolicy;
   requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
   commitPolicy?: TaskCommitPolicy;
+  idempotencyKey?: string;
 }
 
 export const worktreeApi = {


### PR DESCRIPTION
Closes #1054

## Summary

- Route direct, conversation, recovery, fallback, child-agent, scheduled, watcher, and workflow launches through one durable admission contract
- Preserve root objective, causal edge, bounded replay options, priority, budget, and cancellation evidence across queueing
- Claim recovery state only after admission and prevent partial attempts or adapter calls before capacity ownership
- Require versioned admission evidence immediately before every provider adapter dispatch
- Add stable conversation idempotency, launch-source telemetry, redacted inspection, Operations compatibility, and debug-bundle evidence
- Document the universal admission and replay boundary

## Verification

- Shared, server, web, and CLI typechecks
- 139 focused tests across admission, provider dispatch, recovery, workflows, and maintenance diagnostics
- Focused ESLint with no errors
- Prettier and git diff checks

## Note

The managed local runtime blocks Supertest temporary listeners with EPERM. CI owns the route integration gate; the non-listener focused suites are green.