### PR TITLE
feat: add durable execution tree cancellation

### DIFF
--- a/cli/src/__tests__/admission.test.ts
+++ b/cli/src/__tests__/admission.test.ts
@@ -103,6 +103,141 @@ describe('vk admission commands', () => {
     output.mockRestore();
   });
 
+  it('shows durable execution-tree control in human output', async () => {
+    api.mockResolvedValue({
+      schemaVersion: 'execution-tree-budget-summary/v1',
+      rootObjectiveId: 'objective-a',
+      control: {
+        schemaVersion: 'execution-tree-control/v1',
+        rootObjectiveId: 'objective-a',
+        state: 'cancelled',
+        trigger: 'operator',
+        reason: 'Operator stopped runaway expansion.',
+        idempotencyKey: 'sha256:cancelled',
+        recordedAt: '2026-07-25T12:00:00.000Z',
+      },
+      committed: {
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        toolCalls: 0,
+        runtimeSeconds: 0,
+        idleRuntimeSeconds: 0,
+        costUsd: 0,
+        retries: 0,
+        fanOut: 0,
+      },
+      reserved: {
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        toolCalls: 0,
+        runtimeSeconds: 0,
+        idleRuntimeSeconds: 0,
+        costUsd: 0,
+        retries: 0,
+        fanOut: 0,
+      },
+      policies: [],
+      contributors: [],
+      contributorCount: 0,
+      truncated: false,
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerAdmissionCommands(program);
+
+    await program.parseAsync(['node', 'vk', 'admission', 'tree', 'objective-a']);
+
+    expect(output.mock.calls.map(([line]) => String(line)).join('\n')).toContain(
+      'control=cancelled trigger=operator'
+    );
+    expect(output.mock.calls.map(([line]) => String(line)).join('\n')).toContain(
+      'Operator stopped runaway expansion.'
+    );
+    output.mockRestore();
+  });
+
+  it('cancels one queued launch with a stable idempotency identity', async () => {
+    api.mockResolvedValue({
+      schemaVersion: 'execution-tree-cancellation/v1',
+      scope: 'queued-launch',
+      queueEntry: { id: 'admission_queue_1', state: 'terminal' },
+      reservationReleased: true,
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerAdmissionCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'admission',
+      'queue',
+      'cancel',
+      'admission_queue_1',
+      '--reason',
+      'Operator cancelled the queued launch.',
+      '--idempotency-key',
+      'cancel-queue-entry-123',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith('/api/admission/queue/admission_queue_1/cancel', {
+      method: 'POST',
+      body: JSON.stringify({
+        reason: 'Operator cancelled the queued launch.',
+        idempotencyKey: 'cancel-queue-entry-123',
+      }),
+    });
+    expect(JSON.parse(String(output.mock.calls[0][0]))).toMatchObject({
+      scope: 'queued-launch',
+      queueEntry: { state: 'terminal' },
+    });
+    output.mockRestore();
+  });
+
+  it('cancels an execution tree and reports remaining verified runs', async () => {
+    api.mockResolvedValue({
+      schemaVersion: 'execution-tree-cancellation/v1',
+      scope: 'execution-tree',
+      rootObjectiveId: 'objective-a',
+      queueEntriesCancelled: 2,
+      interruptedAttempts: 1,
+      runningAttempts: [],
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerAdmissionCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'admission',
+      'cancel-tree',
+      'objective-a',
+      '--reason',
+      'Operator cancelled runaway expansion.',
+      '--idempotency-key',
+      'cancel-execution-tree-123',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith('/api/admission/tree/objective-a/cancel', {
+      method: 'POST',
+      body: JSON.stringify({
+        reason: 'Operator cancelled runaway expansion.',
+        idempotencyKey: 'cancel-execution-tree-123',
+      }),
+    });
+    expect(JSON.parse(String(output.mock.calls[0][0]))).toMatchObject({
+      scope: 'execution-tree',
+      queueEntriesCancelled: 2,
+      interruptedAttempts: 1,
+    });
+    output.mockRestore();
+  });
+
   it('lists the admission queue as JSON with all operator filters preserved', async () => {
     api.mockResolvedValue({
       schemaVersion: 'admission-queue-list/v1',
@@ -253,15 +388,7 @@ describe('vk admission commands', () => {
     const program = new Command().exitOverride();
     registerAdmissionCommands(program);
 
-    await program.parseAsync([
-      'node',
-      'vk',
-      'admission',
-      'queue',
-      'list',
-      '--limit',
-      '1',
-    ]);
+    await program.parseAsync(['node', 'vk', 'admission', 'queue', 'list', '--limit', '1']);
 
     const rendered = output.mock.calls.map(([line]) => String(line)).join('\n');
     expect(rendered).toContain('priority=1->2 readiness=conditional');

--- a/cli/src/commands/admission.ts
+++ b/cli/src/commands/admission.ts
@@ -1,11 +1,14 @@
 import { Command } from 'commander';
+import { randomUUID } from 'node:crypto';
 import chalk from 'chalk';
 import type {
+  AdmissionExecutionTreeCancellationResult,
   AdmissionLaunchSource,
   AdmissionQueueGetResponse,
   AdmissionQueueInspectionEntry,
   AdmissionQueueListResponse,
   AdmissionQueueState,
+  AdmissionQueuedCancellationResult,
   AdmissionReservation,
   AdmissionReservationState,
   AdmissionScope,
@@ -75,6 +78,39 @@ export function registerAdmissionCommands(program: Command): void {
         console.log(
           chalk.dim(
             `Conditional snapshot at ${result.generatedAt}; ${result.depth.global.current}/${result.depth.global.limit} global queue slots used.`
+          )
+        );
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  queue
+    .command('cancel <id>')
+    .description('Cancel one queued launch before provider dispatch')
+    .requiredOption('--reason <text>', 'Operator reason for cancellation')
+    .option('--idempotency-key <key>', 'Stable identity for safe retries')
+    .option('--json', 'Output as JSON')
+    .action(async (id, options) => {
+      try {
+        const result = await api<AdmissionQueuedCancellationResult>(
+          `/api/admission/queue/${encodeURIComponent(id)}/cancel`,
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              reason: options.reason,
+              idempotencyKey: options.idempotencyKey ?? `vk-cli:queue-cancel:${id}:${randomUUID()}`,
+            }),
+          }
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(chalk.green(`✓ Cancelled queued launch ${result.queueEntry.id}`));
+        console.log(
+          chalk.dim(
+            `State: ${result.queueEntry.state}; reservation released: ${result.reservationReleased}`
           )
         );
       } catch (error) {
@@ -178,6 +214,40 @@ export function registerAdmissionCommands(program: Command): void {
     });
 
   admission
+    .command('cancel-tree <root-objective-id>')
+    .description('Cancel queued and verified running work for one execution tree')
+    .requiredOption('--reason <text>', 'Operator reason for cancellation')
+    .option('--idempotency-key <key>', 'Stable identity for safe retries')
+    .option('--json', 'Output as JSON')
+    .action(async (rootObjectiveId, options) => {
+      try {
+        const result = await api<AdmissionExecutionTreeCancellationResult>(
+          `/api/admission/tree/${encodeURIComponent(rootObjectiveId)}/cancel`,
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              reason: options.reason,
+              idempotencyKey:
+                options.idempotencyKey ?? `vk-cli:tree-cancel:${rootObjectiveId}:${randomUUID()}`,
+            }),
+          }
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(chalk.green(`✓ Cancelled execution tree ${result.rootObjectiveId}`));
+        console.log(
+          chalk.dim(
+            `Queued: ${result.queueEntriesCancelled}; interrupted: ${result.interruptedAttempts}; remaining verified runs: ${result.runningAttempts.length}`
+          )
+        );
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  admission
     .command('get <id>')
     .description('Inspect one admission reservation')
     .option('--json', 'Output as JSON')
@@ -266,6 +336,14 @@ function printReservation(reservation: AdmissionReservation, verbose = false): v
 
 function printExecutionTreeSummary(summary: ExecutionTreeBudgetSummary): void {
   console.log(chalk.bold(`Execution tree ${summary.rootObjectiveId}`));
+  if (summary.control) {
+    console.log(
+      chalk.red(
+        `  control=${summary.control.state} trigger=${summary.control.trigger} recorded=${summary.control.recordedAt}`
+      )
+    );
+    console.log(chalk.dim(`  reason=${summary.control.reason}`));
+  }
   console.log(
     `  committed tokens=${summary.committed.totalTokens} cost=$${summary.committed.costUsd.toFixed(4)} tools=${summary.committed.toolCalls} runtime=${summary.committed.runtimeSeconds}s retries=${summary.committed.retries} fan-out=${summary.committed.fanOut}`
   );

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -1054,13 +1054,24 @@ Inspect reservations with `vk admission list`, `vk admission get <id>`, or the
 matching read-only REST endpoints. Use `--workflow-run`, `--workflow-step`,
 `--root-reservation`, or `--root-objective` to follow a tree. Use
 `vk admission tree <root-objective-id>` for aggregate totals, remaining policy
-capacity, blocking policies, and bounded contributors. Machine consumers
-should use `--json`. Inspect the conditional, redacted queue view with
+capacity, blocking policies, bounded contributors, and durable cancellation
+or circuit-breaker control. Machine consumers should use `--json`. Inspect the
+conditional, redacted queue view with
 `vk admission queue list`, `vk admission queue get <queue-id>`, or the matching
 `/api/v1/admission/queue` endpoints. Queue position is evidence at the response
 generation time, never an exact start-time promise. Machine consumers may use
 the safe `navigation` identifiers to open related task, attempt, workflow, and
 execution-tree views without accessing the redacted launch payload.
+
+Operators can stop a queued launch with `vk admission queue cancel <queue-id>
+--reason <text>` or cancel an entire execution tree with `vk admission
+cancel-tree <root-objective-id> --reason <text>`. Supply
+`--idempotency-key <key>` when an automation may retry the request. Tree
+cancellation is recorded on the root reservation before descendants are
+drained, so harness-driven resume, retry, fallback, workflow-step, and
+child-agent launches fail closed before any provider adapter runs. The command
+reports verified running attempts that the local supervisor could not
+interrupt; those require explicit operator reconciliation.
 
 ## Local And Cloud Profiles
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -4154,13 +4154,15 @@ before attempt persistence or provider dispatch. Workflow roots use the
 `workflow-control` admission provider; child steps use the resolved execution
 provider and selected host. Inspection requires `agent:read`.
 
-| Method | Path                                   | Description                                             |
-| ------ | -------------------------------------- | ------------------------------------------------------- |
-| `GET`  | `/api/admission`                       | List reservations with optional scope and state filters |
-| `GET`  | `/api/admission/queue`                 | List the bounded, redacted admission queue view         |
-| `GET`  | `/api/admission/queue/:id`             | Inspect one redacted queue entry                        |
-| `GET`  | `/api/admission/tree/:rootObjectiveId` | Summarize one aggregate execution tree                  |
-| `GET`  | `/api/admission/:id`                   | Inspect one durable reservation                         |
+| Method | Path                                          | Description                                                    |
+| ------ | --------------------------------------------- | -------------------------------------------------------------- |
+| `GET`  | `/api/admission`                              | List reservations with optional scope and state filters        |
+| `GET`  | `/api/admission/queue`                        | List the bounded, redacted admission queue view                |
+| `GET`  | `/api/admission/queue/:id`                    | Inspect one redacted queue entry                               |
+| `POST` | `/api/admission/queue/:id/cancel`             | Cancel one queued launch before provider dispatch              |
+| `GET`  | `/api/admission/tree/:rootObjectiveId`        | Summarize one aggregate execution tree and its control state   |
+| `POST` | `/api/admission/tree/:rootObjectiveId/cancel` | Cancel queued and verified running work for one execution tree |
+| `GET`  | `/api/admission/:id`                          | Inspect one durable reservation                                |
 
 List filters are `workspaceId`, `taskId`, `rootTaskId`, `provider`, `hostId`,
 `workflowRunId`, `workflowStepId`, `rootReservationId`, `rootObjectiveId`,
@@ -4223,8 +4225,34 @@ Execution-tree reservations include `execution-tree-identity/v1` and durable
 requested, remaining, committed, released-unused, and idempotent usage-event
 state. The tree summary aggregates each node once and returns committed and
 active reserved usage, per-policy remaining limits, the policy that blocks the
-next launch, bounded contributors, and truncation evidence. Committed usage is
-retained after release; only unused reservation returns to the tree.
+next launch, bounded contributors, truncation evidence, and any durable
+`execution-tree-control/v1` cancellation or circuit-breaker state. Committed
+usage is retained after release; only unused reservation returns to the tree.
+
+Cancellation requests require `admin:manage` and a strict JSON body:
+
+```json
+{
+  "idempotencyKey": "operator-request-20260725-001",
+  "reason": "Operator stopped runaway child-agent expansion."
+}
+```
+
+`POST /api/v1/admission/queue/:id/cancel` terminalizes a queued or leased
+launch before dispatch and releases its reservation. A dispatched entry must
+be controlled through its verified run instead. `POST
+/api/v1/admission/tree/:rootObjectiveId/cancel` first records cancellation on
+the root reservation, then drains queued descendants, releases unbound
+reservations, and interrupts verified running attempts owned by the local
+agent supervisor. The response lists any verified running attempts that could
+not be interrupted so operators can reconcile them explicitly. Reusing the
+same idempotency key is safe; a different key conflicts with existing terminal
+ownership. Veritas stores and returns only the key's SHA-256 identity.
+
+Once the root control is recorded, late resume, retry, fallback, workflow-step,
+and child-agent launches fail closed before provider dispatch. The durable
+control survives restart and is visible through the tree summary and
+`vk admission tree`.
 
 Direct `POST /api/v1/agents/:taskId/start` callers may send an opaque
 `X-Idempotency-Key` header (8-240 characters). The header takes precedence

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -609,6 +609,12 @@ vk admission queue list
 vk admission queue list --state queued requeued --source workflow --min-age 60000 --json
 vk admission queue get admission_queue_0123456789abcdef
 vk admission queue get admission_queue_0123456789abcdef --json
+vk admission queue cancel admission_queue_0123456789abcdef \
+  --reason "Operator cancelled the queued launch." \
+  --idempotency-key operator-queue-cancel-20260725
+vk admission cancel-tree objective_0123456789abcdef \
+  --reason "Operator stopped runaway child-agent expansion." \
+  --idempotency-key operator-tree-cancel-20260725
 ```
 
 `admission list` filters by workspace, task, root task, provider, host, state,
@@ -620,8 +626,9 @@ steps show their resolved provider, selected host, and root reservation.
 Released records retain the terminal reason and idempotency identity for
 operator diagnosis. `admission tree` reports committed and reserved tokens,
 cost, tool calls, runtime, retries, fan-out, policy availability, and bounded
-contributors without double counting descendant totals. These are read-only
-commands and require `agent:read`.
+contributors without double counting descendant totals. It also shows durable
+cancellation or circuit-breaker control state when present. Inspection
+commands are read-only and require `agent:read`.
 
 `admission queue list` filters by workspace, root objective, node, launch
 source, queue state, raw numeric priority, limiting scope, age window, page,
@@ -630,6 +637,16 @@ priority aging, readiness, lease posture, redacted launch identity, limiting
 policy, conditional start factors, selection evidence, and safe navigation
 identifiers. Human output labels the snapshot as conditional and never presents
 an ETA or exact start time. Use `--json` for the complete versioned REST shape.
+
+`admission queue cancel` stops one queued or leased launch before provider
+dispatch and releases its reservation. `admission cancel-tree` records
+cancellation on the root first, drains queued descendants, releases unbound
+reservations, and asks the local supervisor to interrupt verified running
+attempts. Both commands require `admin:manage`, require an operator reason, and
+accept a stable `--idempotency-key` for safe retries. If omitted, the CLI
+generates a new key. Use `--json` to inspect any verified running attempts that
+still require reconciliation. A cancelled root rejects late resume, retry,
+fallback, workflow-step, and child-agent launches before provider dispatch.
 
 ---
 

--- a/server/src/__tests__/admission-control-service.test.ts
+++ b/server/src/__tests__/admission-control-service.test.ts
@@ -408,6 +408,236 @@ describe('AdmissionControlService', () => {
 });
 
 describe.each(['file', 'sqlite'] as const)('%s admission reservation parity', (backend) => {
+  it('cancels a leased queue entry and releases its reservation idempotently', async () => {
+    const repository = await repositoryFor(backend);
+    const service = createService(
+      repository,
+      configuredSettings({ global: { concurrentRuns: 1 } })
+    );
+    const root = await service.admit(treeRequest('task-cancel-queue-root', 'node-cancel-root'));
+    await service.bindAttempt(root.reservation?.id as string, 'attempt-cancel-root');
+    const queued = await service.admitOrQueue(
+      {
+        ...treeRequest('task-cancel-queue-child', 'node-cancel-child', 'node-cancel-root'),
+        source: 'child-agent',
+      },
+      {
+        attemptId: 'attempt-cancel-child',
+        target: {
+          kind: 'agent-launch',
+          agent: 'codex',
+          source: 'child-agent',
+          options: {},
+        },
+      }
+    );
+    await service.release(root.reservation?.id as string, 'completed', 'release-cancel-queue-root');
+    const claim = await service.claimNextQueued();
+    expect(claim?.entry.id).toBe(queued.queueEntry?.id);
+
+    const cancelled = await service.cancelQueuedLaunch(claim?.entry.id as string, {
+      idempotencyKey: 'cancel-queue-entry-123',
+      reason: 'Operator cancelled this queued descendant.',
+    });
+    expect(cancelled).toMatchObject({
+      scope: 'queued-launch',
+      reservationReleased: true,
+      queueEntry: {
+        state: 'terminal',
+        terminal: {
+          code: 'QUEUE_CANCELLED',
+          idempotencyKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
+      },
+    });
+    expect(JSON.stringify(cancelled)).not.toContain('cancel-queue-entry-123');
+    await expect(
+      service.cancelQueuedLaunch(claim?.entry.id as string, {
+        idempotencyKey: 'cancel-queue-entry-123',
+        reason: 'Operator cancelled this queued descendant.',
+      })
+    ).resolves.toMatchObject({ queueEntry: { state: 'terminal' } });
+    await expect(
+      service.cancelQueuedLaunch(claim?.entry.id as string, {
+        idempotencyKey: 'different-cancel-queue-entry',
+        reason: 'A conflicting cancellation identity.',
+      })
+    ).rejects.toMatchObject({ statusCode: 409 });
+    await expect(service.get(claim?.reservation.id as string)).resolves.toMatchObject({
+      state: 'released',
+      release: { reason: 'cancelled' },
+    });
+  });
+
+  it('marks a tree cancelled before draining descendants and rejects late expansion', async () => {
+    const repository = await repositoryFor(backend);
+    const service = createService(
+      repository,
+      configuredSettings({ global: { concurrentRuns: 2 } })
+    );
+    const root = await service.admit(treeRequest('task-tree-cancel-root', 'node-tree-root'));
+    await service.bindAttempt(root.reservation?.id as string, 'attempt-tree-root');
+    const child = await service.admit(
+      treeRequest('task-tree-cancel-child', 'node-tree-child', 'node-tree-root')
+    );
+    await service.bindAttempt(child.reservation?.id as string, 'attempt-tree-child');
+    const queued = await service.admitOrQueue(
+      {
+        ...treeRequest('task-tree-cancel-queued', 'node-tree-queued', 'node-tree-root'),
+        source: 'child-agent',
+      },
+      {
+        attemptId: 'attempt-tree-queued',
+        target: {
+          kind: 'agent-launch',
+          agent: 'codex',
+          source: 'child-agent',
+          options: {},
+        },
+      }
+    );
+
+    const cancelled = await service.cancelExecutionTree('objective-a', {
+      idempotencyKey: 'cancel-execution-tree-123',
+      reason: 'Operator stopped runaway expansion.',
+    });
+    expect(cancelled).toMatchObject({
+      scope: 'execution-tree',
+      rootObjectiveId: 'objective-a',
+      control: {
+        state: 'cancelled',
+        trigger: 'operator',
+        idempotencyKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      },
+      queueEntriesCancelled: 1,
+      runningAttempts: expect.arrayContaining([
+        expect.objectContaining({ attemptId: 'attempt-tree-root' }),
+        expect.objectContaining({ attemptId: 'attempt-tree-child' }),
+      ]),
+    });
+    await expect(service.getQueueEntry(queued.queueEntry?.id as string)).resolves.toMatchObject({
+      state: 'terminal',
+      terminal: { code: 'QUEUE_CANCELLED' },
+    });
+    await expect(service.getExecutionTreeControl('objective-a')).resolves.toMatchObject({
+      state: 'cancelled',
+    });
+    await expect(service.getExecutionTreeSummary('objective-a')).resolves.toMatchObject({
+      control: {
+        state: 'cancelled',
+        trigger: 'operator',
+        idempotencyKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      },
+    });
+    await expect(
+      service.admit(
+        treeRequest('task-tree-cancel-late', 'node-tree-late', 'node-tree-child', undefined, {
+          depth: 2,
+        })
+      )
+    ).resolves.toMatchObject({
+      outcome: 'terminal-policy-denial',
+      executionTreeControl: { state: 'cancelled' },
+      reservation: undefined,
+    });
+    await expect(
+      service.cancelExecutionTree('objective-a', {
+        idempotencyKey: 'different-tree-cancellation',
+        reason: 'Conflicting operator identity.',
+      })
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it('serializes competing execution-tree cancellation ownership', async () => {
+    const repository = await repositoryFor(backend);
+    const settings = configuredSettings();
+    const left = createService(repository, settings, { ownerId: 'owner-cancel-left' });
+    const right = createService(repository, settings, { ownerId: 'owner-cancel-right' });
+    await left.admit(treeRequest('task-tree-cancel-race-root', 'node-tree-cancel-race-root'));
+
+    const results = await Promise.allSettled([
+      left.cancelExecutionTree('objective-a', {
+        idempotencyKey: 'cancel-tree-race-left',
+        reason: 'Left operator cancellation request.',
+      }),
+      right.cancelExecutionTree('objective-a', {
+        idempotencyKey: 'cancel-tree-race-right',
+        reason: 'Right operator cancellation request.',
+      }),
+    ]);
+
+    const fulfilled = results.filter(
+      (
+        result
+      ): result is PromiseFulfilledResult<Awaited<ReturnType<typeof left.cancelExecutionTree>>> =>
+        result.status === 'fulfilled'
+    );
+    const rejected = results.filter((result) => result.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]).toMatchObject({ reason: { statusCode: 409 } });
+    await expect(right.getExecutionTreeControl('objective-a')).resolves.toMatchObject({
+      state: 'cancelled',
+      idempotencyKey: fulfilled[0]?.value.idempotencyKey,
+    });
+  });
+
+  it('continues tree cancellation when queue dispatch wins the drain race', async () => {
+    const repository = await repositoryFor(backend);
+    const service = createService(
+      repository,
+      configuredSettings({ global: { concurrentRuns: 1 } })
+    );
+    const root = await service.admit(treeRequest('task-tree-drain-root', 'node-tree-drain-root'));
+    await service.bindAttempt(root.reservation?.id as string, 'attempt-tree-drain-root');
+    const queued = await service.admitOrQueue(
+      {
+        ...treeRequest('task-tree-drain-child', 'node-tree-drain-child', 'node-tree-drain-root'),
+        source: 'child-agent',
+      },
+      {
+        attemptId: 'attempt-tree-drain-child',
+        target: {
+          kind: 'agent-launch',
+          agent: 'codex',
+          source: 'child-agent',
+          options: {},
+        },
+      }
+    );
+    await service.release(root.reservation?.id as string, 'completed', 'release-tree-drain-root');
+    const claim = await service.claimNextQueued();
+    await service.bindQueuedAttempt(
+      claim?.entry.id as string,
+      claim?.reservation.id as string,
+      claim?.entry.attemptId as string
+    );
+    const cancelQueuedLaunch = service.cancelQueuedLaunch.bind(service);
+    vi.spyOn(service, 'cancelQueuedLaunch').mockImplementationOnce(async (id, input) => {
+      await service.markQueueDispatched(id, claim?.entry.attemptId as string);
+      return cancelQueuedLaunch(id, input);
+    });
+
+    await expect(
+      service.cancelExecutionTree('objective-a', {
+        idempotencyKey: 'cancel-tree-drain-race',
+        reason: 'Operator cancelled during queue dispatch.',
+      })
+    ).resolves.toMatchObject({
+      queueEntriesCancelled: 0,
+      runningAttempts: [
+        expect.objectContaining({
+          attemptId: 'attempt-tree-drain-child',
+          reservationId: claim?.reservation.id,
+        }),
+      ],
+    });
+    await expect(service.getQueueEntry(queued.queueEntry?.id as string)).resolves.toMatchObject({
+      state: 'dispatched',
+      dispatchedAttemptId: 'attempt-tree-drain-child',
+    });
+  });
+
   it('durably queues and atomically claims a saturated direct launch', async () => {
     const repository = await repositoryFor(backend);
     const settings = configuredSettings({ global: { concurrentRuns: 1 } });

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -305,6 +305,8 @@ function testAdmissionControl(): AdmissionControlService {
     expireAbandoned: vi.fn(async () => []),
     recoverVerifiedRun: vi.fn(async () => null),
     claimNextQueued: vi.fn(async () => null),
+    assertExecutionTreeLaunchAllowed: vi.fn(async () => undefined),
+    cancelExecutionTree: vi.fn(),
   } as unknown as AdmissionControlService;
 }
 
@@ -838,6 +840,66 @@ describe('ClawdbotAgentService Codex providers', () => {
         executionTree,
       } as TaskAttempt)
     ).toThrow('Provider launch is missing required admission evidence.');
+  });
+
+  it('marks tree cancellation before interrupting each verified running attempt', async () => {
+    const admission = testAdmissionControl();
+    vi.mocked(admission.cancelExecutionTree).mockResolvedValue({
+      schemaVersion: 'execution-tree-cancellation/v1',
+      scope: 'execution-tree',
+      idempotencyKey: `sha256:${'a'.repeat(64)}`,
+      rootObjectiveId: 'objective-cancel',
+      control: {
+        schemaVersion: 'execution-tree-control/v1',
+        rootObjectiveId: 'objective-cancel',
+        state: 'cancelled',
+        trigger: 'operator',
+        reason: 'Stop runaway expansion.',
+        idempotencyKey: `sha256:${'a'.repeat(64)}`,
+        recordedAt: '2026-07-25T12:00:00.000Z',
+      },
+      queueEntriesCancelled: 2,
+      reservationsReleased: 1,
+      interruptedAttempts: 0,
+      runningAttempts: [
+        {
+          taskId: 'task-running',
+          attemptId: 'attempt-running',
+          reservationId: 'reservation-running',
+        },
+        {
+          taskId: 'task-detached',
+          attemptId: 'attempt-detached',
+          reservationId: 'reservation-detached',
+        },
+      ],
+    });
+    const service = testableService(
+      tmpDir,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      testWorkspaceExecutionTrust(),
+      admission
+    );
+    const stop = vi.spyOn(service, 'stopAgent').mockImplementation(async (taskId) => {
+      if (taskId === 'task-detached') throw new Error('Verified control unavailable');
+    });
+
+    const result = await service.cancelExecutionTree('objective-cancel', {
+      idempotencyKey: 'cancel-execution-tree-123',
+      reason: 'Stop runaway expansion.',
+    });
+
+    expect(admission.cancelExecutionTree).toHaveBeenCalledBefore(stop);
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      interruptedAttempts: 1,
+      reservationsReleased: 2,
+      runningAttempts: [{ taskId: 'task-detached', attemptId: 'attempt-detached' }],
+    });
   });
 
   it('queues a versioned agent launch and replays its exact options exactly once', async () => {
@@ -3807,7 +3869,10 @@ describe('ClawdbotAgentService Codex providers', () => {
       reason: 'Active reservations currently consume the configured capacity.',
       decidedAt: '2026-07-25T10:00:00.000Z',
     });
-    const admission = { admitOrQueue: admit } as unknown as AdmissionControlService;
+    const admission = {
+      admitOrQueue: admit,
+      assertExecutionTreeLaunchAllowed: vi.fn(async () => undefined),
+    } as unknown as AdmissionControlService;
     const service = testableService(
       tmpDir,
       undefined,

--- a/server/src/__tests__/routes/admission.test.ts
+++ b/server/src/__tests__/routes/admission.test.ts
@@ -8,10 +8,17 @@ const admission = vi.hoisted(() => ({
   get: vi.fn(),
   inspectQueue: vi.fn(),
   inspectQueueEntry: vi.fn(),
+  cancelQueuedLaunch: vi.fn(),
 }));
+
+const cancelExecutionTree = vi.hoisted(() => vi.fn());
 
 vi.mock('../../services/admission-control-service.js', () => ({
   getAdmissionControlService: () => admission,
+}));
+
+vi.mock('../../services/clawdbot-agent-service.js', () => ({
+  clawdbotAgentService: { cancelExecutionTree },
 }));
 
 import { admissionRoutes } from '../../routes/admission.js';
@@ -121,6 +128,48 @@ describe('admission routes', () => {
     expect(admission.inspectQueueEntry).toHaveBeenCalledWith('admission_queue_1');
     expect(invalid.status).toBe(400);
     expect(admission.inspectQueue).not.toHaveBeenCalled();
+  });
+
+  it('cancels queued launches and execution trees with stable operator identity', async () => {
+    admission.cancelQueuedLaunch.mockResolvedValue({
+      schemaVersion: 'execution-tree-cancellation/v1',
+      scope: 'queued-launch',
+      queueEntry: { id: 'admission_queue_1', state: 'terminal' },
+    });
+    cancelExecutionTree.mockResolvedValue({
+      schemaVersion: 'execution-tree-cancellation/v1',
+      scope: 'execution-tree',
+      rootObjectiveId: 'objective-a',
+      queueEntriesCancelled: 2,
+      interruptedAttempts: 1,
+      runningAttempts: [],
+    });
+    const app = createApp();
+    const queued = await request(app).post('/api/admission/queue/admission_queue_1/cancel').send({
+      idempotencyKey: 'cancel-queue-entry-123',
+      reason: 'Operator cancelled the queued launch.',
+    });
+    const tree = await request(app).post('/api/admission/tree/objective-a/cancel').send({
+      idempotencyKey: 'cancel-execution-tree-123',
+      reason: 'Operator cancelled runaway expansion.',
+    });
+
+    expect(queued.status).toBe(200);
+    expect(admission.cancelQueuedLaunch).toHaveBeenCalledWith('admission_queue_1', {
+      idempotencyKey: 'cancel-queue-entry-123',
+      reason: 'Operator cancelled the queued launch.',
+    });
+    expect(tree.status).toBe(200);
+    expect(cancelExecutionTree).toHaveBeenCalledWith('objective-a', {
+      idempotencyKey: 'cancel-execution-tree-123',
+      reason: 'Operator cancelled runaway expansion.',
+    });
+
+    const invalid = await request(app)
+      .post('/api/admission/tree/objective-a/cancel')
+      .send({ idempotencyKey: 'short', reason: 'too short' });
+    expect(invalid.status).toBe(400);
+    expect(cancelExecutionTree).toHaveBeenCalledTimes(1);
   });
 
   it('returns a validation error for an invalid reservation identifier', async () => {

--- a/server/src/routes/admission.ts
+++ b/server/src/routes/admission.ts
@@ -9,9 +9,17 @@ import { asyncHandler } from '../middleware/async-handler.js';
 import { ValidationError } from '../middleware/error-handler.js';
 import { AdmissionReservationListQuerySchema } from '../schemas/admission-control-schemas.js';
 import { getAdmissionControlService } from '../services/admission-control-service.js';
+import { clawdbotAgentService } from '../services/clawdbot-agent-service.js';
 
 const router: RouterType = Router();
 const admission = getAdmissionControlService();
+
+const cancellationSchema = z
+  .object({
+    idempotencyKey: z.string().trim().min(8).max(240),
+    reason: z.string().trim().min(8).max(1_000),
+  })
+  .strict();
 
 const listQuerySchema = z
   .object({
@@ -120,6 +128,38 @@ router.get(
     try {
       const id = z.string().trim().min(1).max(240).parse(req.params.id);
       res.json(await admission.inspectQueueEntry(id));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+  })
+);
+
+router.post(
+  '/queue/:id/cancel',
+  asyncHandler(async (req, res) => {
+    try {
+      const id = z.string().trim().min(1).max(240).parse(req.params.id);
+      const input = cancellationSchema.parse(req.body);
+      res.json(await admission.cancelQueuedLaunch(id, input));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+  })
+);
+
+router.post(
+  '/tree/:rootObjectiveId/cancel',
+  asyncHandler(async (req, res) => {
+    try {
+      const rootObjectiveId = z.string().trim().min(1).max(240).parse(req.params.rootObjectiveId);
+      const input = cancellationSchema.parse(req.body);
+      res.json(await clawdbotAgentService.cancelExecutionTree(rootObjectiveId, input));
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new ValidationError('Validation failed', error.issues);

--- a/server/src/schemas/admission-control-schemas.ts
+++ b/server/src/schemas/admission-control-schemas.ts
@@ -16,6 +16,7 @@ import {
   EXECUTION_TREE_BUDGET_EVENT_SCHEMA_VERSION,
   EXECUTION_TREE_EDGE_KINDS,
   EXECUTION_TREE_IDENTITY_SCHEMA_VERSION,
+  EXECUTION_TREE_CONTROL_SCHEMA_VERSION,
   EXECUTABLE_AGENT_PROVIDERS,
   PHASE_NAMES,
   RUN_FAILURE_CLASSES,
@@ -67,6 +68,18 @@ export const ExecutionTreeIdentitySchema = z
       });
     }
   });
+
+export const ExecutionTreeControlSchema = z
+  .object({
+    schemaVersion: z.literal(EXECUTION_TREE_CONTROL_SCHEMA_VERSION),
+    rootObjectiveId: identifier,
+    state: z.enum(['paused', 'cancelled']),
+    trigger: z.enum(['operator', 'fan-out-breaker']),
+    reason: z.string().trim().min(1).max(1_000),
+    idempotencyKey: digest,
+    recordedAt: z.string().datetime(),
+  })
+  .strict();
 
 export const ExecutionTreeBudgetPolicySchema = z
   .object({
@@ -201,6 +214,7 @@ export const AdmissionReservationSchema = z
       .strict()
       .optional(),
     executionBudget: ExecutionTreeBudgetStateSchema.optional(),
+    executionTreeControl: ExecutionTreeControlSchema.optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
   })
@@ -225,6 +239,18 @@ export const AdmissionReservationSchema = z
         code: z.ZodIssueCode.custom,
         message: 'Execution-tree reservations require durable budget state.',
         path: ['executionBudget'],
+      });
+    }
+    if (
+      record.executionTreeControl &&
+      (record.request.executionTree?.edge !== 'root' ||
+        record.request.executionTree.rootObjectiveId !==
+          record.executionTreeControl.rootObjectiveId)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Execution-tree control must be stored on its matching root reservation.',
+        path: ['executionTreeControl'],
       });
     }
   });
@@ -429,6 +455,7 @@ export const AdmissionQueueEntrySchema = z
       .object({
         code: z.string().trim().min(1).max(160),
         reason: z.string().trim().min(1).max(1_000),
+        idempotencyKey: digest.optional(),
         recordedAt: z.string().datetime(),
       })
       .strict()
@@ -542,6 +569,7 @@ export const AdmissionDecisionSchema = z
     request: AdmissionRequestSchema,
     reservation: AdmissionReservationSchema.optional(),
     queueEntry: AdmissionQueueEntrySchema.optional(),
+    executionTreeControl: ExecutionTreeControlSchema.optional(),
     limitingPolicies: z.array(AdmissionLimitPolicySchema).max(6),
     limitingBudgetPolicies: z.array(ExecutionTreeBudgetPolicySchema).max(16).optional(),
     retryAfterMs: z.number().int().min(250).max(60_000).optional(),

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -2,7 +2,9 @@ import { createHash, randomUUID } from 'node:crypto';
 import { hostname } from 'node:os';
 import type {
   AdmissionCapacityRequest,
+  AdmissionCancellationInput,
   AdmissionDecision,
+  AdmissionExecutionTreeCancellationResult,
   AdmissionLaunchSource,
   AdmissionLimitPolicy,
   AdmissionProvider,
@@ -17,6 +19,7 @@ import type {
   AdmissionQueuePriority,
   AdmissionQueueSelectionEvidence,
   AdmissionQueueTarget,
+  AdmissionQueuedCancellationResult,
   AdmissionReservation,
   AdmissionReservationClaimOrQueueResult,
   AdmissionReservationListQuery,
@@ -27,6 +30,7 @@ import type {
   ExecutionTreeBudgetSummary,
   ExecutionTreeBudgetUsageEvent,
   ExecutionTreeIdentity,
+  ExecutionTreeControl,
   AgentType,
 } from '@veritas-kanban/shared';
 import {
@@ -38,6 +42,8 @@ import {
   ADMISSION_REQUEST_SCHEMA_VERSION,
   ADMISSION_RESERVATION_SCHEMA_VERSION,
   DEFAULT_FEATURE_SETTINGS,
+  EXECUTION_TREE_CANCELLATION_SCHEMA_VERSION,
+  EXECUTION_TREE_CONTROL_SCHEMA_VERSION,
   ZERO_AGENT_BUDGET_USAGE,
 } from '@veritas-kanban/shared';
 import {
@@ -218,6 +224,65 @@ export class AdmissionControlService {
     return this.admitInternal(input, queue);
   }
 
+  private async executionTreeRootReservation(
+    rootObjectiveId: string
+  ): Promise<AdmissionReservation | null> {
+    const records = await this.repository.list({
+      rootObjectiveId,
+      limit: 10_000,
+    });
+    return (
+      records.find(
+        (record) =>
+          record.request.executionTree?.rootObjectiveId === rootObjectiveId &&
+          record.request.executionTree.edge === 'root'
+      ) ?? null
+    );
+  }
+
+  async getExecutionTreeControl(rootObjectiveId: string): Promise<ExecutionTreeControl | null> {
+    return (await this.executionTreeRootReservation(rootObjectiveId))?.executionTreeControl ?? null;
+  }
+
+  async assertExecutionTreeLaunchAllowed(rootObjectiveId: string): Promise<void> {
+    const control = await this.getExecutionTreeControl(rootObjectiveId);
+    if (!control) return;
+    throw new ConflictError(
+      control.state === 'cancelled'
+        ? 'Execution tree was cancelled before provider dispatch.'
+        : 'Execution tree expansion is paused by its fan-out circuit breaker.',
+      {
+        code:
+          control.state === 'cancelled'
+            ? 'EXECUTION_TREE_CANCELLED'
+            : 'EXECUTION_TREE_EXPANSION_PAUSED',
+        executionTreeControl: control,
+      }
+    );
+  }
+
+  private blockedTreeDecision(
+    request: AdmissionDecision['request'],
+    control: ExecutionTreeControl,
+    settings: AdmissionSettings,
+    now: Date
+  ): AdmissionDecision {
+    return this.decision(
+      control.state === 'cancelled' ? 'terminal-policy-denial' : 'retryable-overload',
+      request,
+      [],
+      control.state === 'cancelled'
+        ? 'The root execution tree was cancelled before this launch.'
+        : 'The root execution tree is paused by its fan-out circuit breaker.',
+      now,
+      control.state === 'paused' ? settings.retryAfterMs : undefined,
+      undefined,
+      undefined,
+      undefined,
+      control
+    );
+  }
+
   private async admitInternal(
     input: AdmissionRequestInput,
     queue?: AdmissionQueueInput
@@ -259,6 +324,12 @@ export class AdmissionControlService {
       },
       requestedAt: now.toISOString(),
     } as const;
+    const initialTreeControl = request.executionTree
+      ? await this.getExecutionTreeControl(request.executionTree.rootObjectiveId)
+      : null;
+    if (initialTreeControl) {
+      return this.blockedTreeDecision(request, initialTreeControl, settings, now);
+    }
     const policies = this.policiesFor(request, settings);
     const impossible = requestExceedsPolicies(request.requested, policies);
     if (impossible.length > 0) {
@@ -334,6 +405,37 @@ export class AdmissionControlService {
           workspaceQueueLimit: settings.queue.workspaceLimit,
         })
       : await this.repository.claim({ record, now: now.toISOString() });
+    const currentTreeControl = request.executionTree
+      ? await this.getExecutionTreeControl(request.executionTree.rootObjectiveId)
+      : null;
+    if (currentTreeControl) {
+      if (claimed.queueEntry && claimed.queueEntry.state !== 'terminal') {
+        const reservationId = claimed.queueEntry.reservationId;
+        await this.terminateQueueEntry(
+          claimed.queueEntry.id,
+          currentTreeControl.state === 'cancelled'
+            ? 'EXECUTION_TREE_CANCELLED'
+            : 'EXECUTION_TREE_EXPANSION_PAUSED',
+          currentTreeControl.reason,
+          currentTreeControl.idempotencyKey
+        );
+        if (reservationId) {
+          await this.release(
+            reservationId,
+            currentTreeControl.state === 'cancelled' ? 'cancelled' : 'reconciled',
+            `tree-control:${currentTreeControl.idempotencyKey}:${reservationId}`
+          );
+        }
+      }
+      if (claimed.record?.state === 'active') {
+        await this.release(
+          claimed.record.id,
+          currentTreeControl.state === 'cancelled' ? 'cancelled' : 'reconciled',
+          `tree-control:${currentTreeControl.idempotencyKey}:${claimed.record.id}`
+        );
+      }
+      return this.blockedTreeDecision(request, currentTreeControl, settings, now);
+    }
     if (claimed.queueConflict) {
       return this.decision(
         'terminal-policy-denial',
@@ -913,7 +1015,8 @@ export class AdmissionControlService {
   async terminateQueueEntry(
     id: string,
     code: string,
-    reason: string
+    reason: string,
+    idempotencyKey?: string
   ): Promise<AdmissionQueueEntry> {
     this.stopQueueHeartbeat(id);
     return this.mutateQueue(id, (current, now) => {
@@ -932,11 +1035,183 @@ export class AdmissionControlService {
         terminal: {
           code: code.trim().slice(0, 160) || 'QUEUE_TERMINAL',
           reason: reason.trim().slice(0, 1_000) || 'Queued launch terminated.',
+          ...(idempotencyKey ? { idempotencyKey } : {}),
           recordedAt: now.toISOString(),
         },
         updatedAt: now.toISOString(),
       };
     });
+  }
+
+  async cancelQueuedLaunch(
+    id: string,
+    input: AdmissionCancellationInput
+  ): Promise<AdmissionQueuedCancellationResult> {
+    const idempotencyKey = idempotencyIdentity(input.idempotencyKey.trim());
+    const current = await this.getQueueEntry(id);
+    if (current.state === 'terminal') {
+      if (
+        current.terminal?.code !== 'QUEUE_CANCELLED' ||
+        current.terminal.idempotencyKey !== idempotencyKey
+      ) {
+        throw new ConflictError('Queue entry already has different terminal ownership.', {
+          queueId: id,
+          terminal: current.terminal,
+        });
+      }
+      return {
+        schemaVersion: EXECUTION_TREE_CANCELLATION_SCHEMA_VERSION,
+        scope: 'queued-launch',
+        idempotencyKey,
+        queueEntry: current,
+        reservationReleased: false,
+      };
+    }
+    if (current.state === 'dispatched') {
+      throw new ConflictError('Dispatched work must be interrupted through its verified run.', {
+        queueId: id,
+        dispatchedAttemptId: current.dispatchedAttemptId,
+      });
+    }
+
+    const reservationId = current.reservationId;
+    const queueEntry = await this.terminateQueueEntry(
+      id,
+      'QUEUE_CANCELLED',
+      input.reason,
+      idempotencyKey
+    );
+    let reservationReleased = false;
+    if (reservationId) {
+      const reservation = await this.repository.get(reservationId);
+      if (reservation?.state === 'active') {
+        await this.release(
+          reservationId,
+          'cancelled',
+          `queue-cancel:${idempotencyKey}:${reservationId}`
+        );
+        reservationReleased = true;
+      }
+    }
+    return {
+      schemaVersion: EXECUTION_TREE_CANCELLATION_SCHEMA_VERSION,
+      scope: 'queued-launch',
+      idempotencyKey,
+      queueEntry,
+      reservationReleased,
+    };
+  }
+
+  async cancelExecutionTree(
+    rootObjectiveId: string,
+    input: AdmissionCancellationInput
+  ): Promise<AdmissionExecutionTreeCancellationResult> {
+    const idempotencyKey = idempotencyIdentity(input.idempotencyKey.trim());
+    const root = await this.executionTreeRootReservation(rootObjectiveId);
+    if (!root) throw new NotFoundError('Execution tree root reservation not found.');
+    const existing = root.executionTreeControl;
+    if (existing?.state === 'cancelled' && existing.idempotencyKey !== idempotencyKey) {
+      throw new ConflictError('Execution tree cancellation already has different ownership.', {
+        rootObjectiveId,
+        executionTreeControl: existing,
+      });
+    }
+
+    const control =
+      existing?.state === 'cancelled'
+        ? existing
+        : (
+            await this.mutate(root.id, (current, now) => {
+              const currentControl = current.executionTreeControl;
+              if (currentControl?.state === 'cancelled') {
+                if (currentControl.idempotencyKey !== idempotencyKey) {
+                  throw new ConflictError(
+                    'Execution tree cancellation already has different ownership.',
+                    {
+                      rootObjectiveId,
+                      executionTreeControl: currentControl,
+                    }
+                  );
+                }
+                return current;
+              }
+              return {
+                ...current,
+                executionTreeControl: {
+                  schemaVersion: EXECUTION_TREE_CONTROL_SCHEMA_VERSION,
+                  rootObjectiveId,
+                  state: 'cancelled',
+                  trigger: 'operator',
+                  reason: input.reason.trim().slice(0, 1_000),
+                  idempotencyKey,
+                  recordedAt: now.toISOString(),
+                },
+                updatedAt: now.toISOString(),
+              };
+            })
+          ).executionTreeControl;
+    if (!control) throw new Error('Execution tree cancellation was not persisted.');
+
+    const queued = await this.repository.listQueue({
+      states: [...ACTIVE_QUEUE_STATES],
+      limit: ACTIVE_INSPECTION_SNAPSHOT_LIMIT,
+    });
+    let queueEntriesCancelled = 0;
+    for (const entry of queued) {
+      if (
+        entry.request.executionTree?.rootObjectiveId !== rootObjectiveId ||
+        entry.state === 'dispatched'
+      ) {
+        continue;
+      }
+      try {
+        await this.cancelQueuedLaunch(entry.id, {
+          idempotencyKey: input.idempotencyKey,
+          reason: input.reason,
+        });
+        queueEntriesCancelled += 1;
+      } catch (error) {
+        const latest =
+          error instanceof ConflictError ? await this.repository.getQueueEntry(entry.id) : null;
+        if (latest?.state !== 'dispatched') throw error;
+      }
+    }
+
+    const reservations = await this.repository.list({
+      rootObjectiveId,
+      states: ['active'],
+      limit: 10_000,
+    });
+    const runningAttempts: AdmissionExecutionTreeCancellationResult['runningAttempts'] = [];
+    let reservationsReleased = 0;
+    for (const reservation of reservations) {
+      if (reservation.attemptId) {
+        runningAttempts.push({
+          taskId: reservation.request.taskId,
+          attemptId: reservation.attemptId,
+          reservationId: reservation.id,
+        });
+        continue;
+      }
+      await this.release(
+        reservation.id,
+        'cancelled',
+        `tree-cancel:${idempotencyKey}:${reservation.id}`
+      );
+      reservationsReleased += 1;
+    }
+
+    return {
+      schemaVersion: EXECUTION_TREE_CANCELLATION_SCHEMA_VERSION,
+      scope: 'execution-tree',
+      idempotencyKey,
+      rootObjectiveId,
+      control,
+      queueEntriesCancelled,
+      reservationsReleased,
+      interruptedAttempts: 0,
+      runningAttempts,
+    };
   }
 
   async bindAttempt(id: string, attemptId: string): Promise<AdmissionReservation> {
@@ -1171,12 +1446,18 @@ export class AdmissionControlService {
       rootObjectiveId,
       limit: 10_000,
     });
-    return summarizeExecutionTreeBudget(
+    const summary = summarizeExecutionTreeBudget(
       rootObjectiveId,
       records,
       Math.min(Math.max(1, limit), 1_000),
       this.now().toISOString()
     );
+    const control = records.find(
+      (record) =>
+        record.request.executionTree?.rootObjectiveId === rootObjectiveId &&
+        record.request.executionTree.edge === 'root'
+    )?.executionTreeControl;
+    return control ? { ...summary, control } : summary;
   }
 
   async findByAttempt(
@@ -1260,7 +1541,8 @@ export class AdmissionControlService {
     retryAfterMs?: number,
     reservation?: AdmissionReservation,
     limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[],
-    queueEntry?: AdmissionQueueEntry
+    queueEntry?: AdmissionQueueEntry,
+    executionTreeControl?: ExecutionTreeControl
   ): AdmissionDecision {
     return AdmissionDecisionSchema.parse({
       schemaVersion: ADMISSION_DECISION_SCHEMA_VERSION,
@@ -1268,6 +1550,7 @@ export class AdmissionControlService {
       request,
       reservation,
       queueEntry,
+      executionTreeControl,
       limitingPolicies,
       limitingBudgetPolicies,
       retryAfterMs,

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -129,6 +129,8 @@ import type {
   WorkspaceExecutionTrustEvaluation,
   WorkspaceExecutionTrustScanResult,
   AdmissionReservationRelease,
+  AdmissionCancellationInput,
+  AdmissionExecutionTreeCancellationResult,
   AdmissionAgentLaunchOptions,
   AdmissionLaunchSource,
   AdmissionQueueClaim,
@@ -2401,6 +2403,7 @@ export class ClawdbotAgentService {
         recoveryAction: options.recovery?.action,
         rootIdempotencyKey: options.admissionIdempotencyKey,
       });
+    await this.admission.assertExecutionTreeLaunchAllowed(executionTree.rootObjectiveId);
     const inheritedBudgetPolicies = parentAttempt?.admissionReservationId
       ? ((await this.admission.get(parentAttempt.admissionReservationId)).request.budgetPolicies ??
         [])
@@ -2925,6 +2928,7 @@ export class ClawdbotAgentService {
         ...(queuedClaim ? { queueEntryId: queuedClaim.entry.id } : {}),
         executionTree,
       };
+      await this.admission.assertExecutionTreeLaunchAllowed(executionTree.rootObjectiveId);
       this.assertProviderAdmissionEvidence(providerAdmission, attempt);
       await adapter.start({
         task,
@@ -4221,6 +4225,29 @@ export class ClawdbotAgentService {
         error: 'Stopped by user',
       };
     });
+  }
+
+  async cancelExecutionTree(
+    rootObjectiveId: string,
+    input: AdmissionCancellationInput
+  ): Promise<AdmissionExecutionTreeCancellationResult> {
+    const cancellation = await this.admission.cancelExecutionTree(rootObjectiveId, input);
+    const runningAttempts: AdmissionExecutionTreeCancellationResult['runningAttempts'] = [];
+    let interruptedAttempts = 0;
+    for (const attempt of cancellation.runningAttempts) {
+      try {
+        await this.stopAgent(attempt.taskId, attempt.attemptId);
+        interruptedAttempts += 1;
+      } catch {
+        runningAttempts.push(attempt);
+      }
+    }
+    return {
+      ...cancellation,
+      interruptedAttempts,
+      reservationsReleased: cancellation.reservationsReleased + interruptedAttempts,
+      runningAttempts,
+    };
   }
 
   private async stopPendingProvider(pending: PendingAgent): Promise<void> {

--- a/shared/src/types/admission-control.types.ts
+++ b/shared/src/types/admission-control.types.ts
@@ -11,6 +11,7 @@ import type {
   ExecutionTreeBudgetState,
   ExecutionTreeBudgetSummary,
   ExecutionTreeBudgetUsageEvent,
+  ExecutionTreeControl,
   ExecutionTreeIdentity,
 } from './execution-tree-budget.types.js';
 import type { AgentBudgetUsage } from './agent-budget.types.js';
@@ -23,6 +24,7 @@ export const ADMISSION_QUEUE_SELECTION_SCHEMA_VERSION = 'admission-queue-selecti
 export const ADMISSION_QUEUE_SCHEDULER_POLICY_VERSION = 'admission-queue-scheduler/v1' as const;
 export const ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION = 'admission-queue-inspection/v1' as const;
 export const ADMISSION_QUEUE_LIST_SCHEMA_VERSION = 'admission-queue-list/v1' as const;
+export const EXECUTION_TREE_CANCELLATION_SCHEMA_VERSION = 'execution-tree-cancellation/v1' as const;
 export const ADMISSION_CONTROL_PROVIDER = 'workflow-control' as const;
 export type AdmissionProvider = ExecutableAgentProvider | typeof ADMISSION_CONTROL_PROVIDER;
 
@@ -135,6 +137,8 @@ export interface AdmissionReservation {
   lease: AdmissionReservationLease;
   release?: AdmissionReservationRelease;
   executionBudget?: ExecutionTreeBudgetState;
+  /** Root-reservation authority that blocks later descendant admission. */
+  executionTreeControl?: ExecutionTreeControl;
   createdAt: string;
   updatedAt: string;
 }
@@ -142,6 +146,7 @@ export interface AdmissionReservation {
 export interface AdmissionQueueTerminalEvidence {
   code: string;
   reason: string;
+  idempotencyKey?: string;
   recordedAt: string;
 }
 
@@ -286,11 +291,41 @@ export interface AdmissionDecision {
   request: AdmissionRequest;
   reservation?: AdmissionReservation;
   queueEntry?: AdmissionQueueEntry;
+  executionTreeControl?: ExecutionTreeControl;
   limitingPolicies: AdmissionLimitPolicy[];
   limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[];
   retryAfterMs?: number;
   reason: string;
   decidedAt: string;
+}
+
+export interface AdmissionCancellationInput {
+  idempotencyKey: string;
+  reason: string;
+}
+
+export interface AdmissionQueuedCancellationResult {
+  schemaVersion: typeof EXECUTION_TREE_CANCELLATION_SCHEMA_VERSION;
+  scope: 'queued-launch';
+  idempotencyKey: string;
+  queueEntry: AdmissionQueueEntry;
+  reservationReleased: boolean;
+}
+
+export interface AdmissionExecutionTreeCancellationResult {
+  schemaVersion: typeof EXECUTION_TREE_CANCELLATION_SCHEMA_VERSION;
+  scope: 'execution-tree';
+  idempotencyKey: string;
+  rootObjectiveId: string;
+  control: ExecutionTreeControl;
+  queueEntriesCancelled: number;
+  reservationsReleased: number;
+  interruptedAttempts: number;
+  runningAttempts: Array<{
+    taskId: string;
+    attemptId: string;
+    reservationId: string;
+  }>;
 }
 
 export interface AdmissionQueueListQuery {

--- a/shared/src/types/execution-tree-budget.types.ts
+++ b/shared/src/types/execution-tree-budget.types.ts
@@ -8,6 +8,7 @@ export const EXECUTION_TREE_IDENTITY_SCHEMA_VERSION = 'execution-tree-identity/v
 export const EXECUTION_TREE_BUDGET_EVENT_SCHEMA_VERSION = 'execution-tree-budget-event/v1' as const;
 export const EXECUTION_TREE_BUDGET_SUMMARY_SCHEMA_VERSION =
   'execution-tree-budget-summary/v1' as const;
+export const EXECUTION_TREE_CONTROL_SCHEMA_VERSION = 'execution-tree-control/v1' as const;
 
 export const EXECUTION_TREE_EDGE_KINDS = [
   'root',
@@ -80,9 +81,20 @@ export interface ExecutionTreeBudgetContributor {
   updatedAt: string;
 }
 
+export interface ExecutionTreeControl {
+  schemaVersion: typeof EXECUTION_TREE_CONTROL_SCHEMA_VERSION;
+  rootObjectiveId: string;
+  state: 'paused' | 'cancelled';
+  trigger: 'operator' | 'fan-out-breaker';
+  reason: string;
+  idempotencyKey: string;
+  recordedAt: string;
+}
+
 export interface ExecutionTreeBudgetSummary {
   schemaVersion: typeof EXECUTION_TREE_BUDGET_SUMMARY_SCHEMA_VERSION;
   rootObjectiveId: string;
+  control?: ExecutionTreeControl;
   committed: AgentBudgetUsage;
   reserved: AgentBudgetUsage;
   policies: ExecutionTreeBudgetPolicyStatus[];


### PR DESCRIPTION
Part of #1055

## Summary

- Persist versioned cancellation authority on the execution-tree root before draining descendants.
- Reject late direct, conversation, recovery, fallback, workflow, and child-agent launches before provider dispatch.
- Add idempotent REST and CLI cancellation for one queued launch or an entire execution tree.
- Interrupt locally verified running attempts and return unresolved attempts for explicit reconciliation.
- Show durable cancellation state in execution-tree inspection and document the operator and harness workflows.

## Correctness

- Root cancellation ownership uses compare-and-set and rejects competing idempotency identities.
- Tree cancellation tolerates a queue lease crossing into dispatch while the drain is running.
- Raw idempotency keys are never persisted or returned.
- File and SQLite backends cover cancellation, replay, competing ownership, late expansion, and queue-dispatch races.

## Verification

- Shared, server, and CLI typechecks
- 99 focused server tests
- 9 focused CLI tests
- ESLint on changed TypeScript files, no errors
- Prettier and `git diff --check`

The local Supertest route suite cannot bind a listener in the managed workspace (`EPERM`), so CI owns that route-level and broad workspace gate.

## Follow-up

The next vertical under #1055 adds automatic fan-out breaker thresholds, pause/resume controls, Operations UI actions, telemetry, support-bundle projection, and bounded load proof.
