### PR TITLE
feat: pause runaway execution-tree fan-out

### DIFF
--- a/cli/src/__tests__/admission.test.ts
+++ b/cli/src/__tests__/admission.test.ts
@@ -238,6 +238,45 @@ describe('vk admission commands', () => {
     output.mockRestore();
   });
 
+  it('resumes an eligible execution tree with a stable idempotency identity', async () => {
+    api.mockResolvedValue({
+      schemaVersion: 'execution-tree-control/v1',
+      rootObjectiveId: 'objective-a',
+      state: 'resumed',
+      resumedAt: '2026-07-25T12:00:00.000Z',
+      resumeReason: 'Operator confirmed pressure cleared.',
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerAdmissionCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'admission',
+      'resume-tree',
+      'objective-a',
+      '--reason',
+      'Operator confirmed pressure cleared.',
+      '--idempotency-key',
+      'resume-execution-tree-123',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith('/api/admission/tree/objective-a/resume', {
+      method: 'POST',
+      body: JSON.stringify({
+        reason: 'Operator confirmed pressure cleared.',
+        idempotencyKey: 'resume-execution-tree-123',
+      }),
+    });
+    expect(JSON.parse(String(output.mock.calls[0][0]))).toMatchObject({
+      state: 'resumed',
+      rootObjectiveId: 'objective-a',
+    });
+    output.mockRestore();
+  });
+
   it('lists the admission queue as JSON with all operator filters preserved', async () => {
     api.mockResolvedValue({
       schemaVersion: 'admission-queue-list/v1',

--- a/cli/src/commands/admission.ts
+++ b/cli/src/commands/admission.ts
@@ -13,6 +13,7 @@ import type {
   AdmissionReservationState,
   AdmissionScope,
   ExecutionTreeBudgetSummary,
+  ExecutionTreeControl,
 } from '@veritas-kanban/shared';
 import { api } from '../utils/api.js';
 
@@ -248,6 +249,36 @@ export function registerAdmissionCommands(program: Command): void {
     });
 
   admission
+    .command('resume-tree <root-objective-id>')
+    .description('Resume an eligible execution tree after its fan-out breaker pauses')
+    .requiredOption('--reason <text>', 'Operator reason for resuming expansion')
+    .option('--idempotency-key <key>', 'Stable identity for safe retries')
+    .option('--json', 'Output as JSON')
+    .action(async (rootObjectiveId, options) => {
+      try {
+        const result = await api<ExecutionTreeControl>(
+          `/api/admission/tree/${encodeURIComponent(rootObjectiveId)}/resume`,
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              reason: options.reason,
+              idempotencyKey:
+                options.idempotencyKey ?? `vk-cli:tree-resume:${rootObjectiveId}:${randomUUID()}`,
+            }),
+          }
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(chalk.green(`✓ Resumed execution tree ${result.rootObjectiveId}`));
+        console.log(chalk.dim(`Recorded: ${result.resumedAt}; reason: ${result.resumeReason}`));
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  admission
     .command('get <id>')
     .description('Inspect one admission reservation')
     .option('--json', 'Output as JSON')
@@ -337,12 +368,20 @@ function printReservation(reservation: AdmissionReservation, verbose = false): v
 function printExecutionTreeSummary(summary: ExecutionTreeBudgetSummary): void {
   console.log(chalk.bold(`Execution tree ${summary.rootObjectiveId}`));
   if (summary.control) {
+    const color = summary.control.state === 'resumed' ? chalk.green : chalk.red;
     console.log(
-      chalk.red(
+      color(
         `  control=${summary.control.state} trigger=${summary.control.trigger} recorded=${summary.control.recordedAt}`
       )
     );
     console.log(chalk.dim(`  reason=${summary.control.reason}`));
+    if (summary.control.resumedAt) {
+      console.log(
+        chalk.dim(
+          `  resumed=${summary.control.resumedAt} resume-reason=${summary.control.resumeReason}`
+        )
+      );
+    }
   }
   console.log(
     `  committed tokens=${summary.committed.totalTokens} cost=$${summary.committed.costUsd.toFixed(4)} tools=${summary.committed.toolCalls} runtime=${summary.committed.runtimeSeconds}s retries=${summary.committed.retries} fan-out=${summary.committed.fanOut}`

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -1073,6 +1073,24 @@ child-agent launches fail closed before any provider adapter runs. The command
 reports verified running attempts that the local supervisor could not
 interrupt; those require explicit operator reconciliation.
 
+Veritas also applies one provider-neutral fan-out circuit breaker before every
+tree expansion. The default guard pauses a root at 256 descendants, depth 16,
+64 active reservations, 64 queued descendants, or 95 percent capacity/budget
+pressure once the tree has eight descendants. A paused decision includes
+bounded `execution-tree-breaker-evidence/v1` signals and returns
+`EXECUTION_TREE_EXPANSION_PAUSED`. Codex, Claude Code, Buzz, Grok Build, GitHub
+Copilot, Hermes, OpenClaw, and custom harnesses must treat that outcome as a
+durable stop signal, not transient provider throttling: do not start a local
+retry storm, change providers, or create a fresh root to evade it.
+
+Inspect the root with `vk admission tree <root-objective-id>` or Operations.
+After the reported active, queued, capacity, or budget pressure clears, an
+administrator can run `vk admission resume-tree <root-objective-id> --reason
+<text>`. Veritas re-evaluates the same durable evidence after restart and
+rejects unsafe resumes with `EXECUTION_TREE_RESUME_BLOCKED`. A successful
+resume preserves the breaker history for audit and allows subsequent launches;
+tree cancellation remains terminal.
+
 ## Local And Cloud Profiles
 
 | Profile            | Provider           | Default command                               | Auth / readiness                                             |

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -4249,9 +4249,32 @@ not be interrupted so operators can reconcile them explicitly. Reusing the
 same idempotency key is safe; a different key conflicts with existing terminal
 ownership. Veritas stores and returns only the key's SHA-256 identity.
 
-Once the root control is recorded, late resume, retry, fallback, workflow-step,
-and child-agent launches fail closed before provider dispatch. The durable
-control survives restart and is visible through the tree summary and
+The fan-out circuit breaker is enabled by default under
+`features.admission.fanOutBreaker`. It evaluates durable descendant count,
+depth, active reservations, queued descendants, capacity pressure, and budget
+pressure before a new tree node is admitted. Defaults are 256 descendants,
+depth 16, 64 active reservations, 64 queued descendants, and 95 percent
+capacity or budget pressure after a tree reaches eight descendants. When a
+threshold is reached, Veritas atomically records a durable paused control on
+the root and returns retryable `EXECUTION_TREE_EXPANSION_PAUSED` evidence.
+Harnesses must stop expanding that root; retrying the same launch cannot bypass
+the control.
+
+Operators can inspect the bounded evidence through the tree summary or
+Operations, clear the reported pressure, and resume with the same strict body:
+
+```http
+POST /api/v1/admission/tree/:rootObjectiveId/resume
+```
+
+Resume returns `409 Conflict` with
+`details.code: "EXECUTION_TREE_RESUME_BLOCKED"` while a breaker signal remains
+unsafe. A successful resume records a durable `resumed` control and accepts new
+nodes without discarding the earlier breaker evidence. Cancellation remains
+terminal: once the root cancellation is recorded, late resume, retry, fallback,
+workflow-step, and child-agent launches fail closed before provider dispatch.
+Paused, resumed, and cancelled controls survive restart and are visible through
+the tree summary, Operations, support bundles, telemetry, and
 `vk admission tree`.
 
 Direct `POST /api/v1/agents/:taskId/start` callers may send an opaque

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -615,6 +615,9 @@ vk admission queue cancel admission_queue_0123456789abcdef \
 vk admission cancel-tree objective_0123456789abcdef \
   --reason "Operator stopped runaway child-agent expansion." \
   --idempotency-key operator-tree-cancel-20260725
+vk admission resume-tree objective_0123456789abcdef \
+  --reason "Operator confirmed fan-out pressure cleared." \
+  --idempotency-key operator-tree-resume-20260725
 ```
 
 `admission list` filters by workspace, task, root task, provider, host, state,
@@ -642,11 +645,20 @@ an ETA or exact start time. Use `--json` for the complete versioned REST shape.
 dispatch and releases its reservation. `admission cancel-tree` records
 cancellation on the root first, drains queued descendants, releases unbound
 reservations, and asks the local supervisor to interrupt verified running
-attempts. Both commands require `admin:manage`, require an operator reason, and
-accept a stable `--idempotency-key` for safe retries. If omitted, the CLI
-generates a new key. Use `--json` to inspect any verified running attempts that
-still require reconciliation. A cancelled root rejects late resume, retry,
-fallback, workflow-step, and child-agent launches before provider dispatch.
+attempts. `admission resume-tree` re-evaluates durable breaker evidence and
+resumes a paused tree only after every blocking signal clears. All three
+commands require `admin:manage`, require an operator reason, and accept a stable
+`--idempotency-key` for safe retries. If omitted, the CLI generates a new key.
+Use `--json` to inspect the complete control or any verified running attempts
+that still require reconciliation. A blocked resume returns
+`EXECUTION_TREE_RESUME_BLOCKED`; do not retry it in a loop without changing the
+reported pressure. A cancelled root rejects late resume, retry, fallback,
+workflow-step, and child-agent launches before provider dispatch.
+
+The Operations admission panel exposes the same controls. Queue rows can cancel
+one pending launch or its entire tree. Durable tree-control cards show bounded
+breaker signals and observed descendant/depth evidence, then allow an
+administrator to resume or cancel the tree with an audited reason.
 
 ---
 

--- a/server/src/__tests__/admission-control-service.test.ts
+++ b/server/src/__tests__/admission-control-service.test.ts
@@ -10,7 +10,10 @@ import {
   type ExecutionTreeBudgetPolicy,
   ZERO_AGENT_BUDGET_USAGE,
 } from '@veritas-kanban/shared';
-import { AdmissionControlService } from '../services/admission-control-service.js';
+import {
+  AdmissionControlService,
+  type AdmissionControlServiceOptions,
+} from '../services/admission-control-service.js';
 import { FileAdmissionReservationRepository } from '../storage/admission-reservation-repository.js';
 import { SqliteDatabase } from '../storage/sqlite/database.js';
 import { SqliteAdmissionReservationRepository } from '../storage/sqlite/admission-reservation-repository.js';
@@ -34,6 +37,7 @@ function configuredSettings(
     global?: AdmissionCapacityLimit;
     providers?: AdmissionSettings['providers'];
     queue?: Partial<AdmissionSettings['queue']>;
+    fanOutBreaker?: Partial<AdmissionSettings['fanOutBreaker']>;
   } = {}
 ): AdmissionSettings {
   return {
@@ -44,6 +48,10 @@ function configuredSettings(
       ...DEFAULT_FEATURE_SETTINGS.admission.queue,
       ...overrides.queue,
     },
+    fanOutBreaker: {
+      ...DEFAULT_FEATURE_SETTINGS.admission.fanOutBreaker,
+      ...overrides.fanOutBreaker,
+    },
     heartbeatMs: 20_000,
   };
 }
@@ -51,7 +59,11 @@ function configuredSettings(
 function createService(
   repository: AdmissionReservationRepository,
   settings: AdmissionSettings,
-  options: { now?: () => Date; ownerId?: string } = {}
+  options: {
+    now?: () => Date;
+    ownerId?: string;
+    treeControlTelemetry?: AdmissionControlServiceOptions['treeControlTelemetry'];
+  } = {}
 ): AdmissionControlService {
   const service = new AdmissionControlService({
     repository,
@@ -60,6 +72,7 @@ function createService(
     ownerId: options.ownerId ?? 'owner-a',
     processId: 101,
     now: options.now,
+    treeControlTelemetry: options.treeControlTelemetry,
   });
   services.push(service);
   return service;
@@ -636,6 +649,252 @@ describe.each(['file', 'sqlite'] as const)('%s admission reservation parity', (b
       state: 'dispatched',
       dispatchedAttemptId: 'attempt-tree-drain-child',
     });
+  });
+
+  it('pauses wide trees before the configured descendant boundary can grow', async () => {
+    const repository = await repositoryFor(backend);
+    const treeControlTelemetry = vi.fn().mockResolvedValue(undefined);
+    const service = createService(
+      repository,
+      configuredSettings({
+        fanOutBreaker: {
+          maxDescendants: 2,
+          pressureActivationDescendants: 100,
+        },
+      }),
+      { treeControlTelemetry }
+    );
+    const wideRequest = (taskId: string, nodeId: string, parentNodeId?: string) => ({
+      ...treeRequest(taskId, nodeId, parentNodeId),
+      budgetPolicies: [
+        {
+          ...treePolicy,
+          id: 'budget_wide_breaker',
+          limits: { fanOut: 100 },
+        },
+      ],
+    });
+    await service.admit(wideRequest('task-wide-root', 'node-wide-root'));
+    await service.admit(wideRequest('task-wide-left', 'node-wide-left', 'node-wide-root'));
+    await service.admit(wideRequest('task-wide-right', 'node-wide-right', 'node-wide-root'));
+
+    await expect(
+      service.admit(wideRequest('task-wide-overflow', 'node-wide-overflow', 'node-wide-root'))
+    ).resolves.toMatchObject({
+      outcome: 'retryable-overload',
+      executionTreeControl: {
+        state: 'paused',
+        trigger: 'fan-out-breaker',
+        evidence: {
+          signals: expect.arrayContaining(['descendant-limit']),
+          observed: { descendants: 3 },
+          thresholds: { maxDescendants: 2 },
+        },
+      },
+    });
+    await expect(service.getExecutionTreeSummary('objective-a')).resolves.toMatchObject({
+      control: {
+        state: 'paused',
+        evidence: { observed: { descendants: 3 } },
+      },
+    });
+    expect(treeControlTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'admission.tree_control',
+        action: 'paused',
+        trigger: 'fan-out-breaker',
+        rootObjectiveKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        signals: expect.arrayContaining(['descendant-limit']),
+      })
+    );
+    expect(JSON.stringify(treeControlTelemetry.mock.calls)).not.toContain('objective-a');
+  });
+
+  it('pauses recursive expansion beyond the configured depth', async () => {
+    const repository = await repositoryFor(backend);
+    const service = createService(
+      repository,
+      configuredSettings({
+        fanOutBreaker: {
+          maxDepth: 2,
+          pressureActivationDescendants: 100,
+        },
+      })
+    );
+    await service.admit(treeRequest('task-deep-root', 'node-deep-root'));
+    await service.admit(treeRequest('task-deep-child', 'node-deep-child', 'node-deep-root'));
+    await service.admit(
+      treeRequest('task-deep-grandchild', 'node-deep-grandchild', 'node-deep-child', undefined, {
+        depth: 2,
+      })
+    );
+
+    await expect(
+      service.admit(
+        treeRequest('task-deep-overflow', 'node-deep-overflow', 'node-deep-grandchild', undefined, {
+          depth: 3,
+        })
+      )
+    ).resolves.toMatchObject({
+      outcome: 'retryable-overload',
+      executionTreeControl: {
+        state: 'paused',
+        evidence: {
+          signals: expect.arrayContaining(['depth-limit']),
+          observed: { maxDepth: 3 },
+        },
+      },
+    });
+  });
+
+  it('serializes concurrent children at the atomic fan-out boundary', async () => {
+    const repository = await repositoryFor(backend);
+    const settings = configuredSettings({
+      fanOutBreaker: {
+        maxDescendants: 1,
+        pressureActivationDescendants: 100,
+      },
+    });
+    const left = createService(repository, settings, { ownerId: 'owner-fanout-left' });
+    const right = createService(repository, settings, { ownerId: 'owner-fanout-right' });
+    await left.admit(treeRequest('task-concurrent-root', 'node-concurrent-root'));
+
+    const decisions = await Promise.all([
+      left.admit(
+        treeRequest('task-concurrent-left', 'node-concurrent-left', 'node-concurrent-root')
+      ),
+      right.admit(
+        treeRequest('task-concurrent-right', 'node-concurrent-right', 'node-concurrent-root')
+      ),
+    ]);
+
+    expect(decisions.map((decision) => decision.outcome).sort()).toEqual([
+      'admitted',
+      'retryable-overload',
+    ]);
+    expect(decisions.find((decision) => decision.outcome !== 'admitted')).toMatchObject({
+      executionTreeControl: {
+        state: 'paused',
+        evidence: { signals: expect.arrayContaining(['descendant-limit']) },
+      },
+    });
+    await expect(
+      repository.list({ rootObjectiveId: 'objective-a', states: ['active'] })
+    ).resolves.toHaveLength(2);
+  });
+
+  it('resumes expansion only after recoverable reservation pressure clears', async () => {
+    const repository = await repositoryFor(backend);
+    const settings = configuredSettings({
+      fanOutBreaker: {
+        maxActiveReservations: 2,
+        pressureActivationDescendants: 100,
+      },
+    });
+    const service = createService(repository, settings);
+    const root = await service.admit(treeRequest('task-resume-root', 'node-resume-root'));
+    const child = await service.admit(
+      treeRequest('task-resume-child', 'node-resume-child', 'node-resume-root')
+    );
+    await expect(
+      service.admit(treeRequest('task-resume-paused', 'node-resume-paused', 'node-resume-root'))
+    ).resolves.toMatchObject({
+      outcome: 'retryable-overload',
+      executionTreeControl: {
+        state: 'paused',
+        evidence: { signals: expect.arrayContaining(['active-reservation-limit']) },
+      },
+    });
+
+    const restarted = createService(repository, settings, {
+      ownerId: 'owner-resume-after-restart',
+    });
+    await expect(restarted.getExecutionTreeSummary('objective-a')).resolves.toMatchObject({
+      control: {
+        state: 'paused',
+        evidence: { signals: expect.arrayContaining(['active-reservation-limit']) },
+      },
+    });
+    await expect(
+      restarted.resumeExecutionTree('objective-a', {
+        idempotencyKey: 'resume-pressure-tree-123',
+        reason: 'Operator reviewed the still-active descendants.',
+      })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      details: {
+        code: 'EXECUTION_TREE_RESUME_BLOCKED',
+      },
+    });
+
+    await service.release(
+      child.reservation?.id as string,
+      'completed',
+      'complete-resume-pressure-child'
+    );
+    const resumed = await restarted.resumeExecutionTree('objective-a', {
+      idempotencyKey: 'resume-pressure-tree-123',
+      reason: 'Operator confirmed reservation pressure cleared.',
+    });
+    expect(resumed).toMatchObject({
+      state: 'resumed',
+      resumeIdempotencyKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      resumeReason: 'Operator confirmed reservation pressure cleared.',
+    });
+    expect(JSON.stringify(resumed)).not.toContain('resume-pressure-tree-123');
+    await expect(
+      restarted.admit(treeRequest('task-resume-next', 'node-resume-next', 'node-resume-root'))
+    ).resolves.toMatchObject({ outcome: 'admitted' });
+    await service.release(
+      root.reservation?.id as string,
+      'completed',
+      'complete-resume-pressure-root'
+    );
+  });
+
+  it('bounds sustained concurrent fan-out without growing durable queues or control events', async () => {
+    const repository = await repositoryFor(backend);
+    const treeControlTelemetry = vi.fn().mockResolvedValue(undefined);
+    const service = createService(
+      repository,
+      configuredSettings({
+        fanOutBreaker: {
+          maxDescendants: 16,
+          pressureActivationDescendants: 100,
+        },
+      }),
+      { treeControlTelemetry }
+    );
+    const loadRequest = (taskId: string, nodeId: string, parentNodeId?: string) => ({
+      ...treeRequest(taskId, nodeId, parentNodeId),
+      budgetPolicies: [
+        {
+          ...treePolicy,
+          id: 'budget_bounded_fanout_load',
+          limits: { fanOut: 1_000 },
+        },
+      ],
+    });
+    await service.admit(loadRequest('task-load-root', 'node-load-root'));
+
+    const decisions = await Promise.all(
+      Array.from({ length: 64 }, (_, index) =>
+        service.admit(
+          loadRequest(`task-load-child-${index}`, `node-load-child-${index}`, 'node-load-root')
+        )
+      )
+    );
+
+    expect(decisions.filter((decision) => decision.outcome === 'admitted')).toHaveLength(16);
+    expect(decisions.filter((decision) => decision.outcome === 'retryable-overload')).toHaveLength(
+      48
+    );
+    await expect(repository.list({ rootObjectiveId: 'objective-a' })).resolves.toHaveLength(17);
+    await expect(
+      repository.list({ rootObjectiveId: 'objective-a', states: ['active'] })
+    ).resolves.toHaveLength(17);
+    await expect(repository.listQueue({ limit: 1_000 })).resolves.toHaveLength(0);
+    expect(treeControlTelemetry).toHaveBeenCalledTimes(1);
   });
 
   it('durably queues and atomically claims a saturated direct launch', async () => {

--- a/server/src/__tests__/maintenance-service.test.ts
+++ b/server/src/__tests__/maintenance-service.test.ts
@@ -209,6 +209,18 @@ describe('MaintenanceService', () => {
             updatedAt: '2026-07-25T00:00:00.000Z',
           },
         ],
+        treeControls: [
+          {
+            rootObjectiveKey: `sha256:${'e'.repeat(64)}`,
+            state: 'paused',
+            trigger: 'fan-out-breaker',
+            recordedAt: '2026-07-25T00:00:00.000Z',
+            signals: ['descendant-limit'],
+            observed: { descendants: 257 },
+            thresholds: { maxDescendants: 256 },
+            recoveryGuidance: ['Inspect the tree before resuming.'],
+          },
+        ],
       })
     );
 
@@ -226,7 +238,10 @@ describe('MaintenanceService', () => {
     ) as { records: Array<Record<string, unknown>> };
     const admissionQueue = JSON.parse(
       await fs.readFile(path.join(bundle.outputPath, 'admission-queue.json'), 'utf-8')
-    ) as { entries: Array<Record<string, unknown>> };
+    ) as {
+      entries: Array<Record<string, unknown>>;
+      treeControls: Array<Record<string, unknown>>;
+    };
     const bundleText = await readDirectoryText(bundle.outputPath);
 
     expect(bundle.redacted).toBe(true);
@@ -252,6 +267,15 @@ describe('MaintenanceService', () => {
       })
     );
     expect(JSON.stringify(admissionQueue)).not.toContain('options');
+    expect(admissionQueue.treeControls).toContainEqual(
+      expect.objectContaining({
+        state: 'paused',
+        trigger: 'fan-out-breaker',
+        signals: ['descendant-limit'],
+      })
+    );
+    expect(JSON.stringify(admissionQueue.treeControls)).not.toContain('objective-a');
+    expect(JSON.stringify(admissionQueue.treeControls)).not.toContain('idempotencyKey');
     expect(manifest.files.find((file) => file.id === 'server')?.path).toContain('[redacted-logs]');
     expect(serverLog).not.toContain('sk_supersecret1234567890');
     expect(summary).not.toContain(root);

--- a/server/src/__tests__/routes/admission.test.ts
+++ b/server/src/__tests__/routes/admission.test.ts
@@ -9,6 +9,7 @@ const admission = vi.hoisted(() => ({
   inspectQueue: vi.fn(),
   inspectQueueEntry: vi.fn(),
   cancelQueuedLaunch: vi.fn(),
+  resumeExecutionTree: vi.fn(),
 }));
 
 const cancelExecutionTree = vi.hoisted(() => vi.fn());
@@ -170,6 +171,25 @@ describe('admission routes', () => {
       .send({ idempotencyKey: 'short', reason: 'too short' });
     expect(invalid.status).toBe(400);
     expect(cancelExecutionTree).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes an eligible execution tree with stable operator identity', async () => {
+    admission.resumeExecutionTree.mockResolvedValue({
+      schemaVersion: 'execution-tree-control/v1',
+      rootObjectiveId: 'objective-a',
+      state: 'resumed',
+    });
+    const app = createApp();
+    const response = await request(app).post('/api/admission/tree/objective-a/resume').send({
+      idempotencyKey: 'resume-execution-tree-123',
+      reason: 'Operator confirmed pressure cleared.',
+    });
+
+    expect(response.status).toBe(200);
+    expect(admission.resumeExecutionTree).toHaveBeenCalledWith('objective-a', {
+      idempotencyKey: 'resume-execution-tree-123',
+      reason: 'Operator confirmed pressure cleared.',
+    });
   });
 
   it('returns a validation error for an invalid reservation identifier', async () => {

--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -430,6 +430,16 @@ describe('Feature Settings Schema', () => {
             evaluationLimit: 32,
           },
         },
+        fanOutBreaker: {
+          enabled: true,
+          maxDescendants: 256,
+          maxDepth: 16,
+          maxActiveReservations: 64,
+          maxQueuedDescendants: 64,
+          pressureActivationDescendants: 8,
+          capacityPressurePercent: 95,
+          budgetPressurePercent: 95,
+        },
       },
     });
     expect(result.admission?.global?.concurrentRuns).toBe(8);
@@ -437,6 +447,7 @@ describe('Feature Settings Schema', () => {
     expect(result.admission?.providers?.['workflow-control']?.concurrentRuns).toBe(3);
     expect(result.admission?.queue?.workspaceLimit).toBe(100);
     expect(result.admission?.queue?.scheduler?.evaluationLimit).toBe(32);
+    expect(result.admission?.fanOutBreaker?.maxDescendants).toBe(256);
     expect(() =>
       FeatureSettingsPatchSchema.parse({
         admission: { leaseMs: 10_000, heartbeatMs: 10_000 },
@@ -482,6 +493,15 @@ describe('Feature Settings Schema', () => {
               defaultPriority: 1,
               maxAgePromotion: 2,
             },
+          },
+        },
+      })
+    ).toThrow();
+    expect(() =>
+      FeatureSettingsPatchSchema.parse({
+        admission: {
+          fanOutBreaker: {
+            capacityPressurePercent: 101,
           },
         },
       })

--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -187,6 +187,7 @@ describe('Common Schemas', () => {
         'run.completed',
         'run.error',
         'run.tokens',
+        'admission.tree_control',
       ];
       for (const type of validTypes) {
         expect(TelemetryEventTypeSchema.parse(type)).toBe(type);

--- a/server/src/routes/admission.ts
+++ b/server/src/routes/admission.ts
@@ -169,6 +169,22 @@ router.post(
   })
 );
 
+router.post(
+  '/tree/:rootObjectiveId/resume',
+  asyncHandler(async (req, res) => {
+    try {
+      const rootObjectiveId = z.string().trim().min(1).max(240).parse(req.params.rootObjectiveId);
+      const input = cancellationSchema.parse(req.body);
+      res.json(await admission.resumeExecutionTree(rootObjectiveId, input));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+  })
+);
+
 router.get(
   '/',
   asyncHandler(async (req, res) => {

--- a/server/src/schemas/admission-control-schemas.ts
+++ b/server/src/schemas/admission-control-schemas.ts
@@ -13,6 +13,7 @@ import {
   ADMISSION_SCOPES,
   CONVERSATION_LAUNCH_INTENTS,
   CONVERSATION_LAUNCH_MODES,
+  EXECUTION_TREE_BREAKER_EVIDENCE_SCHEMA_VERSION,
   EXECUTION_TREE_BUDGET_EVENT_SCHEMA_VERSION,
   EXECUTION_TREE_EDGE_KINDS,
   EXECUTION_TREE_IDENTITY_SCHEMA_VERSION,
@@ -73,13 +74,75 @@ export const ExecutionTreeControlSchema = z
   .object({
     schemaVersion: z.literal(EXECUTION_TREE_CONTROL_SCHEMA_VERSION),
     rootObjectiveId: identifier,
-    state: z.enum(['paused', 'cancelled']),
+    state: z.enum(['paused', 'resumed', 'cancelled']),
     trigger: z.enum(['operator', 'fan-out-breaker']),
     reason: z.string().trim().min(1).max(1_000),
     idempotencyKey: digest,
     recordedAt: z.string().datetime(),
+    evidence: z
+      .object({
+        schemaVersion: z.literal(EXECUTION_TREE_BREAKER_EVIDENCE_SCHEMA_VERSION),
+        rootObjectiveId: identifier,
+        evaluatedAt: z.string().datetime(),
+        signals: z
+          .array(
+            z.enum([
+              'descendant-limit',
+              'depth-limit',
+              'active-reservation-limit',
+              'queued-descendant-limit',
+              'capacity-pressure',
+              'budget-pressure',
+            ])
+          )
+          .min(1)
+          .max(6),
+        observed: z
+          .object({
+            descendants: z.number().int().min(0).max(100_000),
+            maxDepth: z.number().int().min(0).max(10_000),
+            activeReservations: z.number().int().min(0).max(100_000),
+            queuedDescendants: z.number().int().min(0).max(100_000),
+            capacityPressurePercent: z.number().min(0).max(100_000),
+            budgetPressurePercent: z.number().min(0).max(100_000),
+          })
+          .strict(),
+        thresholds: z
+          .object({
+            maxDescendants: z.number().int().min(1).max(100_000),
+            maxDepth: z.number().int().min(1).max(1_000),
+            maxActiveReservations: z.number().int().min(1).max(100_000),
+            maxQueuedDescendants: z.number().int().min(1).max(100_000),
+            pressureActivationDescendants: z.number().int().min(1).max(100_000),
+            capacityPressurePercent: z.number().min(1).max(100),
+            budgetPressurePercent: z.number().min(1).max(100),
+          })
+          .strict(),
+        recoveryGuidance: z.array(z.string().trim().min(1).max(240)).min(1).max(5),
+      })
+      .strict()
+      .optional(),
+    resumedAt: z.string().datetime().optional(),
+    resumeReason: z.string().trim().min(1).max(1_000).optional(),
+    resumeIdempotencyKey: digest.optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((control, ctx) => {
+    const hasResumeEvidence = Boolean(
+      control.resumedAt || control.resumeReason || control.resumeIdempotencyKey
+    );
+    if (
+      (control.state === 'resumed' &&
+        (!control.resumedAt || !control.resumeReason || !control.resumeIdempotencyKey)) ||
+      (control.state !== 'resumed' && hasResumeEvidence)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Resumed execution-tree control requires complete resume evidence.',
+        path: ['state'],
+      });
+    }
+  });
 
 export const ExecutionTreeBudgetPolicySchema = z
   .object({

--- a/server/src/schemas/common.ts
+++ b/server/src/schemas/common.ts
@@ -81,6 +81,7 @@ export const TelemetryEventTypeSchema = z.enum([
   'run.completed',
   'run.error',
   'run.tokens',
+  'admission.tree_control',
 ]);
 
 export type ValidTelemetryEventType = z.infer<typeof TelemetryEventTypeSchema>;

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -291,6 +291,19 @@ const AdmissionSettingsSchema = z
       })
       .strict()
       .optional(),
+    fanOutBreaker: z
+      .object({
+        enabled: z.boolean().optional(),
+        maxDescendants: z.number().int().min(1).max(100_000).optional(),
+        maxDepth: z.number().int().min(1).max(1_000).optional(),
+        maxActiveReservations: z.number().int().min(1).max(100_000).optional(),
+        maxQueuedDescendants: z.number().int().min(1).max(100_000).optional(),
+        pressureActivationDescendants: z.number().int().min(1).max(100_000).optional(),
+        capacityPressurePercent: z.number().min(1).max(100).optional(),
+        budgetPressurePercent: z.number().min(1).max(100).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -20,6 +20,7 @@ import type {
   AdmissionQueueSelectionEvidence,
   AdmissionQueueTarget,
   AdmissionQueuedCancellationResult,
+  AdmissionRequest,
   AdmissionReservation,
   AdmissionReservationClaimOrQueueResult,
   AdmissionReservationListQuery,
@@ -29,6 +30,8 @@ import type {
   ExecutionTreeBudgetPolicy,
   ExecutionTreeBudgetSummary,
   ExecutionTreeBudgetUsageEvent,
+  ExecutionTreeBreakerEvidence,
+  ExecutionTreeBreakerSignal,
   ExecutionTreeIdentity,
   ExecutionTreeControl,
   AgentType,
@@ -42,6 +45,7 @@ import {
   ADMISSION_REQUEST_SCHEMA_VERSION,
   ADMISSION_RESERVATION_SCHEMA_VERSION,
   DEFAULT_FEATURE_SETTINGS,
+  EXECUTION_TREE_BREAKER_EVIDENCE_SCHEMA_VERSION,
   EXECUTION_TREE_CANCELLATION_SCHEMA_VERSION,
   EXECUTION_TREE_CONTROL_SCHEMA_VERSION,
   ZERO_AGENT_BUDGET_USAGE,
@@ -163,6 +167,11 @@ function idempotencyIdentity(idempotencyKey: string): string {
   return `sha256:${createHash('sha256').update(idempotencyKey).digest('hex')}`;
 }
 
+function percentage(used: number, limit: number | undefined): number {
+  if (limit === undefined || limit <= 0) return 0;
+  return Math.round((used / limit) * 10_000) / 100;
+}
+
 export class AdmissionControlService {
   private readonly repositoryOverride?: AdmissionReservationRepository;
   private readonly settingsOverride?: () => Promise<AdmissionSettings>;
@@ -193,10 +202,17 @@ export class AdmissionControlService {
   }
 
   private async settings(): Promise<AdmissionSettings> {
-    const settings = this.settingsOverride
+    const loaded = this.settingsOverride
       ? await this.settingsOverride()
       : ((await this.configService.getFeatureSettings()).admission ??
         DEFAULT_FEATURE_SETTINGS.admission);
+    const settings: AdmissionSettings = {
+      ...loaded,
+      fanOutBreaker: {
+        ...DEFAULT_FEATURE_SETTINGS.admission.fanOutBreaker,
+        ...(loaded as Partial<AdmissionSettings>).fanOutBreaker,
+      },
+    };
     if (settings.heartbeatMs >= settings.leaseMs) {
       throw new ConflictError('Admission heartbeat must be shorter than its lease.', {
         heartbeatMs: settings.heartbeatMs,
@@ -244,9 +260,13 @@ export class AdmissionControlService {
     return (await this.executionTreeRootReservation(rootObjectiveId))?.executionTreeControl ?? null;
   }
 
+  private blocksExecutionTree(control: ExecutionTreeControl | null): control is ExecutionTreeControl {
+    return control?.state === 'paused' || control?.state === 'cancelled';
+  }
+
   async assertExecutionTreeLaunchAllowed(rootObjectiveId: string): Promise<void> {
     const control = await this.getExecutionTreeControl(rootObjectiveId);
-    if (!control) return;
+    if (!this.blocksExecutionTree(control)) return;
     throw new ConflictError(
       control.state === 'cancelled'
         ? 'Execution tree was cancelled before provider dispatch.'
@@ -259,6 +279,323 @@ export class AdmissionControlService {
         executionTreeControl: control,
       }
     );
+  }
+
+  private fanOutBreakerPolicy(
+    rootObjectiveId: string,
+    settings: AdmissionSettings
+  ): ExecutionTreeBudgetPolicy {
+    return {
+      id: `fan-out-breaker:${createHash('sha256').update(rootObjectiveId).digest('hex').slice(0, 32)}`,
+      scope: 'root-objective',
+      scopeId: rootObjectiveId,
+      name: 'Execution-tree fan-out circuit breaker',
+      limits: { fanOut: settings.fanOutBreaker.maxDescendants + 1 },
+      hardAction: 'pause',
+    };
+  }
+
+  private withFanOutBreakerPolicy(
+    input: AdmissionRequestInput,
+    settings: AdmissionSettings
+  ): ExecutionTreeBudgetPolicy[] | undefined {
+    if (!settings.fanOutBreaker.enabled || !input.executionTree) return input.budgetPolicies;
+    const breaker = this.fanOutBreakerPolicy(input.executionTree.rootObjectiveId, settings);
+    return [...(input.budgetPolicies ?? []).filter((policy) => policy.id !== breaker.id), breaker];
+  }
+
+  private async executionTreeBreakerEvidence(
+    request: AdmissionRequest,
+    settings: AdmissionSettings,
+    prospective: 'active' | 'queued' | 'none'
+  ): Promise<ExecutionTreeBreakerEvidence> {
+    const identity = request.executionTree;
+    if (!identity) throw new Error('Execution-tree breaker evidence requires a tree identity.');
+    const [treeRecords, activeRecords, queueEntries] = await Promise.all([
+      this.repository.list({ rootObjectiveId: identity.rootObjectiveId, limit: 10_000 }),
+      this.repository.list({ states: ['active'], limit: 10_000 }),
+      this.repository.listQueue({
+        states: [...ACTIVE_QUEUE_STATES],
+        limit: ACTIVE_INSPECTION_SNAPSHOT_LIMIT,
+      }),
+    ]);
+    const treeQueueEntries = queueEntries.filter(
+      (entry) =>
+        entry.request.executionTree?.rootObjectiveId === identity.rootObjectiveId &&
+        entry.request.executionTree.edge !== 'root'
+    );
+    const existingNode = treeRecords.some(
+      (record) => record.request.executionTree?.nodeId === identity.nodeId
+    );
+    const existingQueueNode = treeQueueEntries.some(
+      (entry) => entry.request.executionTree?.nodeId === identity.nodeId
+    );
+    const includeCandidate =
+      prospective !== 'none' && !existingNode && !existingQueueNode && identity.edge !== 'root';
+    const prospectiveUsage =
+      includeCandidate
+        ? { ...ZERO_AGENT_BUDGET_USAGE, ...request.budgetRequest }
+        : ZERO_AGENT_BUDGET_USAGE;
+    const descendants =
+      treeRecords
+        .filter((record) => record.request.executionTree?.edge !== 'root')
+        .reduce(
+          (total, record) => total + Math.max(1, record.executionBudget?.requested.fanOut ?? 1),
+          0
+        ) +
+      treeQueueEntries
+        .filter(
+          (entry) =>
+            !treeRecords.some(
+              (record) =>
+                record.request.executionTree?.nodeId === entry.request.executionTree?.nodeId
+            )
+        )
+        .reduce(
+          (total, entry) => total + Math.max(1, entry.request.budgetRequest?.fanOut ?? 1),
+          0
+        ) +
+      (includeCandidate ? Math.max(1, prospectiveUsage.fanOut) : 0);
+    const maxDepth = Math.max(
+      identity.depth,
+      ...treeRecords.map((record) => record.request.executionTree?.depth ?? 0),
+      ...treeQueueEntries.map((entry) => entry.request.executionTree?.depth ?? 0)
+    );
+    const activeReservations =
+      treeRecords.filter((record) => record.state === 'active').length +
+      (prospective === 'active' && !existingNode ? 1 : 0);
+    const queuedDescendants =
+      treeQueueEntries.filter((entry) => entry.state !== 'dispatched').length +
+      (prospective === 'queued' && !existingQueueNode ? 1 : 0);
+
+    const candidatePolicies = this.policiesFor(request, settings).filter(
+      (policy) => policy.scope !== 'task'
+    );
+    let capacityPressurePercent = 0;
+    for (const policy of candidatePolicies) {
+      const matching = activeRecords.filter((record) =>
+        record.policies.some((candidate) => candidate.id === policy.id)
+      );
+      const used = matching.reduce(
+        (total, record) => ({
+          runSlots: total.runSlots + record.request.requested.runSlots,
+          processSlots: total.processSlots + record.request.requested.processSlots,
+          estimatedMemoryMb:
+            total.estimatedMemoryMb + record.request.requested.estimatedMemoryMb,
+        }),
+        { runSlots: 0, processSlots: 0, estimatedMemoryMb: 0 }
+      );
+      if (prospective === 'active' && !existingNode) {
+        used.runSlots += request.requested.runSlots;
+        used.processSlots += request.requested.processSlots;
+        used.estimatedMemoryMb += request.requested.estimatedMemoryMb;
+      }
+      capacityPressurePercent = Math.max(
+        capacityPressurePercent,
+        percentage(used.runSlots, policy.limits.concurrentRuns),
+        percentage(used.processSlots, policy.limits.processSlots),
+        percentage(used.estimatedMemoryMb, policy.limits.estimatedMemoryMb)
+      );
+    }
+
+    const summary = summarizeExecutionTreeBudget(
+      identity.rootObjectiveId,
+      treeRecords,
+      1,
+      this.now().toISOString()
+    );
+    let budgetPressurePercent = 0;
+    for (const status of summary.policies) {
+      for (const metric of [
+        'inputTokens',
+        'outputTokens',
+        'totalTokens',
+        'costUsd',
+        'toolCalls',
+        'runtimeSeconds',
+        'idleRuntimeSeconds',
+        'retries',
+        'fanOut',
+      ] as const) {
+        const limit = status.policy.limits[metric];
+        budgetPressurePercent = Math.max(
+          budgetPressurePercent,
+          percentage(status.used[metric] + status.reserved[metric] + prospectiveUsage[metric], limit)
+        );
+      }
+    }
+
+    const thresholds = settings.fanOutBreaker;
+    const pressureActive = descendants >= thresholds.pressureActivationDescendants;
+    const signals: ExecutionTreeBreakerSignal[] = [];
+    if (descendants > thresholds.maxDescendants) signals.push('descendant-limit');
+    if (maxDepth > thresholds.maxDepth) signals.push('depth-limit');
+    if (activeReservations > thresholds.maxActiveReservations) {
+      signals.push('active-reservation-limit');
+    }
+    if (queuedDescendants > thresholds.maxQueuedDescendants) {
+      signals.push('queued-descendant-limit');
+    }
+    if (pressureActive && capacityPressurePercent >= thresholds.capacityPressurePercent) {
+      signals.push('capacity-pressure');
+    }
+    if (pressureActive && budgetPressurePercent >= thresholds.budgetPressurePercent) {
+      signals.push('budget-pressure');
+    }
+    const recoveryGuidance = [
+      ...(signals.some((signal) =>
+        ['active-reservation-limit', 'capacity-pressure'].includes(signal)
+      )
+        ? ['Wait for verified running descendants to finish or cancel the execution tree.']
+        : []),
+      ...(signals.some((signal) =>
+        ['queued-descendant-limit', 'budget-pressure'].includes(signal)
+      )
+        ? ['Drain or cancel queued descendants, then inspect the tree before resuming.']
+        : []),
+      ...(signals.some((signal) => ['descendant-limit', 'depth-limit'].includes(signal))
+        ? ['Raise the configured tree limit only after reviewing the expansion plan.']
+        : []),
+      'Resume explicitly after the triggering evidence is below configured thresholds.',
+    ].slice(0, 5);
+    return {
+      schemaVersion: EXECUTION_TREE_BREAKER_EVIDENCE_SCHEMA_VERSION,
+      rootObjectiveId: identity.rootObjectiveId,
+      evaluatedAt: this.now().toISOString(),
+      signals,
+      observed: {
+        descendants,
+        maxDepth,
+        activeReservations,
+        queuedDescendants,
+        capacityPressurePercent,
+        budgetPressurePercent,
+      },
+      thresholds: {
+        maxDescendants: thresholds.maxDescendants,
+        maxDepth: thresholds.maxDepth,
+        maxActiveReservations: thresholds.maxActiveReservations,
+        maxQueuedDescendants: thresholds.maxQueuedDescendants,
+        pressureActivationDescendants: thresholds.pressureActivationDescendants,
+        capacityPressurePercent: thresholds.capacityPressurePercent,
+        budgetPressurePercent: thresholds.budgetPressurePercent,
+      },
+      recoveryGuidance,
+    };
+  }
+
+  private async pauseExecutionTree(
+    rootObjectiveId: string,
+    evidence: ExecutionTreeBreakerEvidence
+  ): Promise<ExecutionTreeControl> {
+    const root = await this.executionTreeRootReservation(rootObjectiveId);
+    if (!root) throw new NotFoundError('Execution tree root reservation not found.');
+    const evidenceIdentity = idempotencyIdentity(
+      `fan-out-breaker:${rootObjectiveId}:${JSON.stringify(evidence.observed)}`
+    );
+    const updated = await this.mutate(root.id, (current, now) => {
+      const control = current.executionTreeControl;
+      if (control?.state === 'cancelled' || control?.state === 'paused') return current;
+      return {
+        ...current,
+        executionTreeControl: {
+          schemaVersion: EXECUTION_TREE_CONTROL_SCHEMA_VERSION,
+          rootObjectiveId,
+          state: 'paused',
+          trigger: 'fan-out-breaker',
+          reason: `Fan-out circuit breaker tripped: ${evidence.signals.join(', ')}.`,
+          idempotencyKey: evidenceIdentity,
+          recordedAt: now.toISOString(),
+          evidence,
+        },
+        updatedAt: now.toISOString(),
+      };
+    });
+    if (!updated.executionTreeControl) {
+      throw new Error('Execution-tree breaker state was not persisted.');
+    }
+    return updated.executionTreeControl;
+  }
+
+  async resumeExecutionTree(
+    rootObjectiveId: string,
+    input: AdmissionCancellationInput
+  ): Promise<ExecutionTreeControl> {
+    const root = await this.executionTreeRootReservation(rootObjectiveId);
+    if (!root) throw new NotFoundError('Execution tree root reservation not found.');
+    const resumeIdempotencyKey = idempotencyIdentity(input.idempotencyKey.trim());
+    const existing = root.executionTreeControl;
+    if (!existing) {
+      throw new ConflictError('Execution tree does not have a paused circuit breaker.', {
+        rootObjectiveId,
+      });
+    }
+    if (existing.state === 'cancelled') {
+      throw new ConflictError('Cancelled execution trees cannot be resumed.', {
+        rootObjectiveId,
+        executionTreeControl: existing,
+      });
+    }
+    if (existing.state === 'resumed') {
+      if (existing.resumeIdempotencyKey !== resumeIdempotencyKey) {
+        throw new ConflictError('Execution tree resume already has different ownership.', {
+          rootObjectiveId,
+          executionTreeControl: existing,
+        });
+      }
+      return existing;
+    }
+    const settings = await this.settings();
+    const evidence = settings.fanOutBreaker.enabled
+      ? await this.executionTreeBreakerEvidence(root.request, settings, 'none')
+      : null;
+    if (evidence?.signals.length) {
+      throw new ConflictError(
+        'Execution tree still exceeds configured fan-out breaker thresholds.',
+        {
+          code: 'EXECUTION_TREE_RESUME_BLOCKED',
+          evidence,
+        }
+      );
+    }
+    const resumed = await this.mutate(root.id, (current, now) => {
+      const control = current.executionTreeControl;
+      if (!control) {
+        throw new ConflictError('Execution tree control disappeared during resume.', {
+          rootObjectiveId,
+        });
+      }
+      if (control.state === 'cancelled') {
+        throw new ConflictError('Cancelled execution trees cannot be resumed.', {
+          rootObjectiveId,
+          executionTreeControl: control,
+        });
+      }
+      if (control.state === 'resumed') {
+        if (control.resumeIdempotencyKey !== resumeIdempotencyKey) {
+          throw new ConflictError('Execution tree resume already has different ownership.', {
+            rootObjectiveId,
+            executionTreeControl: control,
+          });
+        }
+        return current;
+      }
+      return {
+        ...current,
+        executionTreeControl: {
+          ...control,
+          state: 'resumed',
+          resumedAt: now.toISOString(),
+          resumeReason: input.reason.trim().slice(0, 1_000),
+          resumeIdempotencyKey,
+        },
+        updatedAt: now.toISOString(),
+      };
+    });
+    if (!resumed.executionTreeControl) {
+      throw new Error('Execution-tree resume evidence was not persisted.');
+    }
+    return resumed.executionTreeControl;
   }
 
   private blockedTreeDecision(
@@ -296,6 +633,7 @@ export class AdmissionControlService {
       ...settings.defaultRequest,
       ...input.requested,
     };
+    const budgetPolicies = this.withFanOutBreakerPolicy(input, settings);
     const request = {
       schemaVersion: ADMISSION_REQUEST_SCHEMA_VERSION,
       idempotencyKey,
@@ -309,7 +647,7 @@ export class AdmissionControlService {
       ...(input.workflowStepId ? { workflowStepId: input.workflowStepId } : {}),
       ...(input.rootReservationId ? { rootReservationId: input.rootReservationId } : {}),
       ...(input.executionTree ? { executionTree: input.executionTree } : {}),
-      ...(input.budgetPolicies ? { budgetPolicies: input.budgetPolicies } : {}),
+      ...(budgetPolicies ? { budgetPolicies } : {}),
       ...(input.executionTree
         ? {
             budgetRequest: {
@@ -327,8 +665,22 @@ export class AdmissionControlService {
     const initialTreeControl = request.executionTree
       ? await this.getExecutionTreeControl(request.executionTree.rootObjectiveId)
       : null;
-    if (initialTreeControl) {
+    if (this.blocksExecutionTree(initialTreeControl)) {
       return this.blockedTreeDecision(request, initialTreeControl, settings, now);
+    }
+    if (
+      settings.fanOutBreaker.enabled &&
+      request.executionTree &&
+      request.executionTree.edge !== 'root'
+    ) {
+      const evidence = await this.executionTreeBreakerEvidence(request, settings, 'active');
+      if (evidence.signals.length > 0) {
+        const control = await this.pauseExecutionTree(
+          request.executionTree.rootObjectiveId,
+          evidence
+        );
+        return this.blockedTreeDecision(request, control, settings, now);
+      }
     }
     const policies = this.policiesFor(request, settings);
     const impossible = requestExceedsPolicies(request.requested, policies);
@@ -408,7 +760,7 @@ export class AdmissionControlService {
     const currentTreeControl = request.executionTree
       ? await this.getExecutionTreeControl(request.executionTree.rootObjectiveId)
       : null;
-    if (currentTreeControl) {
+    if (this.blocksExecutionTree(currentTreeControl)) {
       if (claimed.queueEntry && claimed.queueEntry.state !== 'terminal') {
         const reservationId = claimed.queueEntry.reservationId;
         await this.terminateQueueEntry(
@@ -435,6 +787,44 @@ export class AdmissionControlService {
         );
       }
       return this.blockedTreeDecision(request, currentTreeControl, settings, now);
+    }
+    const breakerPolicyId = request.executionTree
+      ? this.fanOutBreakerPolicy(request.executionTree.rootObjectiveId, settings).id
+      : undefined;
+    if (
+      settings.fanOutBreaker.enabled &&
+      request.executionTree?.edge !== 'root' &&
+      breakerPolicyId &&
+      claimed.limitingBudgetPolicies?.some((policy) => policy.id === breakerPolicyId)
+    ) {
+      const evidence = await this.executionTreeBreakerEvidence(
+        request,
+        settings,
+        claimed.queueEntry ? 'queued' : 'active'
+      );
+      if (!evidence.signals.includes('descendant-limit')) {
+        evidence.signals.unshift('descendant-limit');
+      }
+      const control = await this.pauseExecutionTree(
+        request.executionTree.rootObjectiveId,
+        evidence
+      );
+      if (claimed.queueEntry && claimed.queueEntry.state !== 'terminal') {
+        await this.terminateQueueEntry(
+          claimed.queueEntry.id,
+          'EXECUTION_TREE_EXPANSION_PAUSED',
+          control.reason,
+          control.idempotencyKey
+        );
+      }
+      if (claimed.record?.state === 'active') {
+        await this.release(
+          claimed.record.id,
+          'reconciled',
+          `fan-out-breaker:${control.idempotencyKey}:${claimed.record.id}`
+        );
+      }
+      return this.blockedTreeDecision(request, control, settings, now);
     }
     if (claimed.queueConflict) {
       return this.decision(

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -76,6 +76,7 @@ import {
   scoreAdmissionQueueEntry,
   workspaceKey,
 } from './admission-queue-scheduler.js';
+import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
 
 const MAX_CAS_ATTEMPTS = 8;
 const ACTIVE_INSPECTION_SNAPSHOT_LIMIT = 100_000;
@@ -785,12 +786,19 @@ export class AdmissionControlService {
       createdAt: now.toISOString(),
       updatedAt: now.toISOString(),
     });
-    const queueTarget: AdmissionQueueTarget | null =
+    const suppliedQueueTarget: AdmissionQueueTarget | null =
       queue && 'target' in queue
         ? queue.target
         : queue
           ? { kind: 'direct', agent: queue.agent }
           : null;
+    const queueTarget: AdmissionQueueTarget | null =
+      suppliedQueueTarget?.kind === 'workflow-root'
+        ? {
+            ...suppliedQueueTarget,
+            budgetPolicyDigest: digestRunLaunchValue(request.budgetPolicies ?? []),
+          }
+        : suppliedQueueTarget;
     const queueable = Boolean(
       queue &&
       queueTarget &&

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -26,6 +26,7 @@ import type {
   AdmissionReservationListQuery,
   AdmissionReservationRelease,
   AdmissionSettings,
+  AdmissionTreeControlTelemetryEvent,
   AgentBudgetUsage,
   ExecutionTreeBudgetPolicy,
   ExecutionTreeBudgetSummary,
@@ -140,6 +141,9 @@ export interface AdmissionControlServiceOptions {
   ownerId?: string;
   hostId?: string;
   processId?: number;
+  treeControlTelemetry?: (
+    event: Omit<AdmissionTreeControlTelemetryEvent, 'id' | 'timestamp'>
+  ) => Promise<void>;
 }
 
 let fileRepository: FileAdmissionReservationRepository | undefined;
@@ -169,7 +173,7 @@ function idempotencyIdentity(idempotencyKey: string): string {
 
 function percentage(used: number, limit: number | undefined): number {
   if (limit === undefined || limit <= 0) return 0;
-  return Math.round((used / limit) * 10_000) / 100;
+  return Math.min(100_000, Math.round((used / limit) * 10_000) / 100);
 }
 
 export class AdmissionControlService {
@@ -180,6 +184,7 @@ export class AdmissionControlService {
   private readonly ownerId: string;
   private readonly executionHostId: string;
   private readonly processId: number;
+  private readonly treeControlTelemetry?: AdmissionControlServiceOptions['treeControlTelemetry'];
   private readonly heartbeatTimers = new Map<string, NodeJS.Timeout>();
   private readonly heartbeatEligible = new Set<string>();
   private readonly queueHeartbeatTimers = new Map<string, NodeJS.Timeout>();
@@ -193,6 +198,7 @@ export class AdmissionControlService {
     this.now = options.now ?? (() => new Date());
     this.processId = options.processId ?? process.pid;
     this.executionHostId = options.hostId ?? defaultExecutionHostId();
+    this.treeControlTelemetry = options.treeControlTelemetry;
     this.ownerId =
       options.ownerId ?? `admission-${this.processId}-${randomUUID().replaceAll('-', '')}`;
   }
@@ -260,7 +266,9 @@ export class AdmissionControlService {
     return (await this.executionTreeRootReservation(rootObjectiveId))?.executionTreeControl ?? null;
   }
 
-  private blocksExecutionTree(control: ExecutionTreeControl | null): control is ExecutionTreeControl {
+  private blocksExecutionTree(
+    control: ExecutionTreeControl | null
+  ): control is ExecutionTreeControl {
     return control?.state === 'paused' || control?.state === 'cancelled';
   }
 
@@ -332,41 +340,46 @@ export class AdmissionControlService {
     );
     const includeCandidate =
       prospective !== 'none' && !existingNode && !existingQueueNode && identity.edge !== 'root';
-    const prospectiveUsage =
-      includeCandidate
-        ? { ...ZERO_AGENT_BUDGET_USAGE, ...request.budgetRequest }
-        : ZERO_AGENT_BUDGET_USAGE;
-    const descendants =
+    const prospectiveUsage = includeCandidate
+      ? { ...ZERO_AGENT_BUDGET_USAGE, ...request.budgetRequest }
+      : ZERO_AGENT_BUDGET_USAGE;
+    const descendants = Math.min(
+      100_000,
       treeRecords
         .filter((record) => record.request.executionTree?.edge !== 'root')
         .reduce(
           (total, record) => total + Math.max(1, record.executionBudget?.requested.fanOut ?? 1),
           0
         ) +
-      treeQueueEntries
-        .filter(
-          (entry) =>
-            !treeRecords.some(
-              (record) =>
-                record.request.executionTree?.nodeId === entry.request.executionTree?.nodeId
-            )
-        )
-        .reduce(
-          (total, entry) => total + Math.max(1, entry.request.budgetRequest?.fanOut ?? 1),
-          0
-        ) +
-      (includeCandidate ? Math.max(1, prospectiveUsage.fanOut) : 0);
+        treeQueueEntries
+          .filter(
+            (entry) =>
+              !treeRecords.some(
+                (record) =>
+                  record.request.executionTree?.nodeId === entry.request.executionTree?.nodeId
+              )
+          )
+          .reduce(
+            (total, entry) => total + Math.max(1, entry.request.budgetRequest?.fanOut ?? 1),
+            0
+          ) +
+        (includeCandidate ? Math.max(1, prospectiveUsage.fanOut) : 0)
+    );
     const maxDepth = Math.max(
       identity.depth,
       ...treeRecords.map((record) => record.request.executionTree?.depth ?? 0),
       ...treeQueueEntries.map((entry) => entry.request.executionTree?.depth ?? 0)
     );
-    const activeReservations =
+    const activeReservations = Math.min(
+      100_000,
       treeRecords.filter((record) => record.state === 'active').length +
-      (prospective === 'active' && !existingNode ? 1 : 0);
-    const queuedDescendants =
+        (prospective === 'active' && !existingNode ? 1 : 0)
+    );
+    const queuedDescendants = Math.min(
+      100_000,
       treeQueueEntries.filter((entry) => entry.state !== 'dispatched').length +
-      (prospective === 'queued' && !existingQueueNode ? 1 : 0);
+        (prospective === 'queued' && !existingQueueNode ? 1 : 0)
+    );
 
     const candidatePolicies = this.policiesFor(request, settings).filter(
       (policy) => policy.scope !== 'task'
@@ -380,8 +393,7 @@ export class AdmissionControlService {
         (total, record) => ({
           runSlots: total.runSlots + record.request.requested.runSlots,
           processSlots: total.processSlots + record.request.requested.processSlots,
-          estimatedMemoryMb:
-            total.estimatedMemoryMb + record.request.requested.estimatedMemoryMb,
+          estimatedMemoryMb: total.estimatedMemoryMb + record.request.requested.estimatedMemoryMb,
         }),
         { runSlots: 0, processSlots: 0, estimatedMemoryMb: 0 }
       );
@@ -420,20 +432,40 @@ export class AdmissionControlService {
         const limit = status.policy.limits[metric];
         budgetPressurePercent = Math.max(
           budgetPressurePercent,
-          percentage(status.used[metric] + status.reserved[metric] + prospectiveUsage[metric], limit)
+          percentage(
+            status.used[metric] + status.reserved[metric] + prospectiveUsage[metric],
+            limit
+          )
         );
       }
     }
 
     const thresholds = settings.fanOutBreaker;
     const pressureActive = descendants >= thresholds.pressureActivationDescendants;
+    const resumeEvaluation = prospective === 'none';
     const signals: ExecutionTreeBreakerSignal[] = [];
-    if (descendants > thresholds.maxDescendants) signals.push('descendant-limit');
-    if (maxDepth > thresholds.maxDepth) signals.push('depth-limit');
-    if (activeReservations > thresholds.maxActiveReservations) {
+    if (
+      resumeEvaluation
+        ? descendants >= thresholds.maxDescendants
+        : descendants > thresholds.maxDescendants
+    ) {
+      signals.push('descendant-limit');
+    }
+    if (resumeEvaluation ? maxDepth >= thresholds.maxDepth : maxDepth > thresholds.maxDepth) {
+      signals.push('depth-limit');
+    }
+    if (
+      resumeEvaluation
+        ? activeReservations >= thresholds.maxActiveReservations
+        : activeReservations > thresholds.maxActiveReservations
+    ) {
       signals.push('active-reservation-limit');
     }
-    if (queuedDescendants > thresholds.maxQueuedDescendants) {
+    if (
+      resumeEvaluation
+        ? queuedDescendants >= thresholds.maxQueuedDescendants
+        : queuedDescendants > thresholds.maxQueuedDescendants
+    ) {
       signals.push('queued-descendant-limit');
     }
     if (pressureActive && capacityPressurePercent >= thresholds.capacityPressurePercent) {
@@ -448,9 +480,7 @@ export class AdmissionControlService {
       )
         ? ['Wait for verified running descendants to finish or cancel the execution tree.']
         : []),
-      ...(signals.some((signal) =>
-        ['queued-descendant-limit', 'budget-pressure'].includes(signal)
-      )
+      ...(signals.some((signal) => ['queued-descendant-limit', 'budget-pressure'].includes(signal))
         ? ['Drain or cancel queued descendants, then inspect the tree before resuming.']
         : []),
       ...(signals.some((signal) => ['descendant-limit', 'depth-limit'].includes(signal))
@@ -493,9 +523,14 @@ export class AdmissionControlService {
     const evidenceIdentity = idempotencyIdentity(
       `fan-out-breaker:${rootObjectiveId}:${JSON.stringify(evidence.observed)}`
     );
+    let didPause = false;
     const updated = await this.mutate(root.id, (current, now) => {
       const control = current.executionTreeControl;
-      if (control?.state === 'cancelled' || control?.state === 'paused') return current;
+      if (control?.state === 'cancelled' || control?.state === 'paused') {
+        didPause = false;
+        return current;
+      }
+      didPause = true;
       return {
         ...current,
         executionTreeControl: {
@@ -513,6 +548,9 @@ export class AdmissionControlService {
     });
     if (!updated.executionTreeControl) {
       throw new Error('Execution-tree breaker state was not persisted.');
+    }
+    if (didPause && updated.executionTreeControl.state === 'paused') {
+      await this.emitTreeControlTelemetry(updated.executionTreeControl, 'paused');
     }
     return updated.executionTreeControl;
   }
@@ -558,6 +596,7 @@ export class AdmissionControlService {
         }
       );
     }
+    let didResume = false;
     const resumed = await this.mutate(root.id, (current, now) => {
       const control = current.executionTreeControl;
       if (!control) {
@@ -572,6 +611,7 @@ export class AdmissionControlService {
         });
       }
       if (control.state === 'resumed') {
+        didResume = false;
         if (control.resumeIdempotencyKey !== resumeIdempotencyKey) {
           throw new ConflictError('Execution tree resume already has different ownership.', {
             rootObjectiveId,
@@ -580,6 +620,7 @@ export class AdmissionControlService {
         }
         return current;
       }
+      didResume = true;
       return {
         ...current,
         executionTreeControl: {
@@ -595,7 +636,40 @@ export class AdmissionControlService {
     if (!resumed.executionTreeControl) {
       throw new Error('Execution-tree resume evidence was not persisted.');
     }
+    if (didResume) {
+      await this.emitTreeControlTelemetry(resumed.executionTreeControl, 'resumed');
+    }
     return resumed.executionTreeControl;
+  }
+
+  private async emitTreeControlTelemetry(
+    control: ExecutionTreeControl,
+    action: AdmissionTreeControlTelemetryEvent['action'],
+    counts: Pick<
+      AdmissionTreeControlTelemetryEvent,
+      'queueEntriesCancelled' | 'interruptedAttempts' | 'unresolvedAttempts'
+    > = {}
+  ): Promise<void> {
+    try {
+      const event: Omit<AdmissionTreeControlTelemetryEvent, 'id' | 'timestamp'> = {
+        type: 'admission.tree_control',
+        action,
+        trigger: control.trigger,
+        rootObjectiveKey: idempotencyIdentity(control.rootObjectiveId),
+        signals: control.evidence?.signals ?? [],
+        ...(control.evidence ? { observed: control.evidence.observed } : {}),
+        ...counts,
+      };
+      if (this.treeControlTelemetry) {
+        await this.treeControlTelemetry(event);
+        return;
+      }
+      if (this.repositoryOverride) return;
+      const { getTelemetryService } = await import('./telemetry-service.js');
+      await getTelemetryService().emit<AdmissionTreeControlTelemetryEvent>(event);
+    } catch {
+      // Durable tree control remains authoritative when optional telemetry is unavailable.
+    }
   }
 
   private blockedTreeDecision(
@@ -793,7 +867,8 @@ export class AdmissionControlService {
       : undefined;
     if (
       settings.fanOutBreaker.enabled &&
-      request.executionTree?.edge !== 'root' &&
+      request.executionTree &&
+      request.executionTree.edge !== 'root' &&
       breakerPolicyId &&
       claimed.limitingBudgetPolicies?.some((policy) => policy.id === breakerPolicyId)
     ) {
@@ -1507,6 +1582,7 @@ export class AdmissionControlService {
       });
     }
 
+    let didCancel = false;
     const control =
       existing?.state === 'cancelled'
         ? existing
@@ -1514,6 +1590,7 @@ export class AdmissionControlService {
             await this.mutate(root.id, (current, now) => {
               const currentControl = current.executionTreeControl;
               if (currentControl?.state === 'cancelled') {
+                didCancel = false;
                 if (currentControl.idempotencyKey !== idempotencyKey) {
                   throw new ConflictError(
                     'Execution tree cancellation already has different ownership.',
@@ -1525,6 +1602,7 @@ export class AdmissionControlService {
                 }
                 return current;
               }
+              didCancel = true;
               return {
                 ...current,
                 executionTreeControl: {
@@ -1591,7 +1669,7 @@ export class AdmissionControlService {
       reservationsReleased += 1;
     }
 
-    return {
+    const result: AdmissionExecutionTreeCancellationResult = {
       schemaVersion: EXECUTION_TREE_CANCELLATION_SCHEMA_VERSION,
       scope: 'execution-tree',
       idempotencyKey,
@@ -1602,6 +1680,14 @@ export class AdmissionControlService {
       interruptedAttempts: 0,
       runningAttempts,
     };
+    if (didCancel) {
+      await this.emitTreeControlTelemetry(control, 'cancelled', {
+        queueEntriesCancelled,
+        interruptedAttempts: 0,
+        unresolvedAttempts: runningAttempts.length,
+      });
+    }
+    return result;
   }
 
   async bindAttempt(id: string, attemptId: string): Promise<AdmissionReservation> {

--- a/server/src/services/evidence-timeline-service.ts
+++ b/server/src/services/evidence-timeline-service.ts
@@ -5,7 +5,6 @@ import type {
   Deliverable,
   EvidenceTimelineCitation,
   EvidenceTimelineEvent,
-  EvidenceTimelineEventSource,
   EvidenceTimelineEventType,
   EvidenceTimelineFilters,
   EvidenceTimelineRecap,
@@ -591,6 +590,8 @@ function telemetryTitle(event: AnyTelemetryEvent): string {
       return `Agent run error from ${event.agent}`;
     case 'run.tokens':
       return `Token usage recorded for ${event.agent}`;
+    case 'admission.tree_control':
+      return `Execution tree ${event.action}`;
     case 'task.status_changed':
       return 'Task status changed';
     case 'task.created':
@@ -611,6 +612,11 @@ function telemetryDetail(event: AnyTelemetryEvent): string | undefined {
   if (event.type === 'task.status_changed') {
     return `${event.previousStatus ?? 'unknown'} -> ${event.status ?? 'unknown'}`;
   }
+  if (event.type === 'admission.tree_control') {
+    return event.signals.length > 0
+      ? `${event.trigger}: ${event.signals.join(', ')}`
+      : event.trigger;
+  }
   return undefined;
 }
 
@@ -624,6 +630,12 @@ function telemetryMetadata(
   if ('durationMs' in event) metadata.durationMs = event.durationMs ?? null;
   if ('totalTokens' in event) metadata.totalTokens = event.totalTokens ?? null;
   if ('cost' in event) metadata.cost = event.cost ?? null;
+  if (event.type === 'admission.tree_control') {
+    metadata.action = event.action;
+    metadata.trigger = event.trigger;
+    metadata.rootObjectiveKey = event.rootObjectiveKey;
+    metadata.unresolvedAttempts = event.unresolvedAttempts ?? null;
+  }
   return metadata;
 }
 

--- a/server/src/services/maintenance-service.ts
+++ b/server/src/services/maintenance-service.ts
@@ -1,9 +1,11 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { createHash } from 'node:crypto';
 import {
   PHASE_AUTHORITY_DIMENSIONS,
   type AdmissionQueueDepth,
   type AdmissionQueueInspectionEntry,
+  type ExecutionTreeBreakerEvidence,
   type PhaseCapabilityEvidence,
   type MaintenanceCleanupPreviewItem,
   type MaintenanceDebugBundle,
@@ -65,6 +67,17 @@ interface AdmissionQueueDiagnosticExport {
   truncated: boolean;
   depth?: AdmissionQueueDepth;
   entries: AdmissionQueueInspectionEntry[];
+  treeControls?: Array<{
+    rootObjectiveKey: string;
+    state: 'paused' | 'resumed' | 'cancelled';
+    trigger: 'operator' | 'fan-out-breaker';
+    recordedAt: string;
+    resumedAt?: string;
+    signals: string[];
+    observed?: ExecutionTreeBreakerEvidence['observed'];
+    thresholds?: ExecutionTreeBreakerEvidence['thresholds'];
+    recoveryGuidance: string[];
+  }>;
 }
 
 type AdmissionQueueDiagnosticCollector = () => Promise<AdmissionQueueDiagnosticExport>;
@@ -683,15 +696,45 @@ export class MaintenanceService {
 
 async function collectAdmissionQueueDiagnostics(): Promise<AdmissionQueueDiagnosticExport> {
   try {
-    const queue = await getAdmissionControlService().inspectQueue({
-      limit: MAX_ADMISSION_QUEUE_DIAGNOSTICS,
-    });
+    const admission = getAdmissionControlService();
+    const [queue, reservations] = await Promise.all([
+      admission.inspectQueue({
+        limit: MAX_ADMISSION_QUEUE_DIAGNOSTICS,
+      }),
+      admission.list({ limit: 10_000 }),
+    ]);
+    const controls = reservations
+      .filter(
+        (reservation) =>
+          reservation.request.executionTree?.edge === 'root' && reservation.executionTreeControl
+      )
+      .flatMap((reservation) => {
+        const control = reservation.executionTreeControl;
+        if (!control) return [];
+        return {
+          rootObjectiveKey: `sha256:${createHash('sha256')
+            .update(control.rootObjectiveId)
+            .digest('hex')}`,
+          state: control.state,
+          trigger: control.trigger,
+          recordedAt: control.recordedAt,
+          ...(control.resumedAt ? { resumedAt: control.resumedAt } : {}),
+          signals: control.evidence?.signals ?? [],
+          ...(control.evidence ? { observed: control.evidence.observed } : {}),
+          ...(control.evidence ? { thresholds: control.evidence.thresholds } : {}),
+          recoveryGuidance: control.evidence?.recoveryGuidance ?? [],
+        };
+      });
     return {
       generatedAt: queue.generatedAt,
       status: 'ok',
-      truncated: queue.pagination.hasMore || queue.pagination.snapshotTruncated,
+      truncated:
+        queue.pagination.hasMore ||
+        queue.pagination.snapshotTruncated ||
+        controls.length > MAX_ADMISSION_QUEUE_DIAGNOSTICS,
       depth: queue.depth,
       entries: queue.entries,
+      treeControls: controls.slice(0, MAX_ADMISSION_QUEUE_DIAGNOSTICS),
     };
   } catch {
     return {

--- a/shared/src/types/admission-control.types.ts
+++ b/shared/src/types/admission-control.types.ts
@@ -588,6 +588,16 @@ export interface AdmissionSettings {
     maxRetries: number;
     scheduler: AdmissionQueueSchedulerSettings;
   };
+  fanOutBreaker: {
+    enabled: boolean;
+    maxDescendants: number;
+    maxDepth: number;
+    maxActiveReservations: number;
+    maxQueuedDescendants: number;
+    pressureActivationDescendants: number;
+    capacityPressurePercent: number;
+    budgetPressurePercent: number;
+  };
 }
 
 export type AdmissionQueuePriority = number | TaskPriority;

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -582,6 +582,16 @@ export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
         evaluationLimit: 32,
       },
     },
+    fanOutBreaker: {
+      enabled: true,
+      maxDescendants: 256,
+      maxDepth: 16,
+      maxActiveReservations: 64,
+      maxQueuedDescendants: 64,
+      pressureActivationDescendants: 8,
+      capacityPressurePercent: 95,
+      budgetPressurePercent: 95,
+    },
   },
   enforcement: {
     squadChat: false,

--- a/shared/src/types/execution-tree-budget.types.ts
+++ b/shared/src/types/execution-tree-budget.types.ts
@@ -9,6 +9,8 @@ export const EXECUTION_TREE_BUDGET_EVENT_SCHEMA_VERSION = 'execution-tree-budget
 export const EXECUTION_TREE_BUDGET_SUMMARY_SCHEMA_VERSION =
   'execution-tree-budget-summary/v1' as const;
 export const EXECUTION_TREE_CONTROL_SCHEMA_VERSION = 'execution-tree-control/v1' as const;
+export const EXECUTION_TREE_BREAKER_EVIDENCE_SCHEMA_VERSION =
+  'execution-tree-breaker-evidence/v1' as const;
 
 export const EXECUTION_TREE_EDGE_KINDS = [
   'root',
@@ -84,11 +86,48 @@ export interface ExecutionTreeBudgetContributor {
 export interface ExecutionTreeControl {
   schemaVersion: typeof EXECUTION_TREE_CONTROL_SCHEMA_VERSION;
   rootObjectiveId: string;
-  state: 'paused' | 'cancelled';
+  state: 'paused' | 'resumed' | 'cancelled';
   trigger: 'operator' | 'fan-out-breaker';
   reason: string;
   idempotencyKey: string;
   recordedAt: string;
+  evidence?: ExecutionTreeBreakerEvidence;
+  resumedAt?: string;
+  resumeReason?: string;
+  resumeIdempotencyKey?: string;
+}
+
+export type ExecutionTreeBreakerSignal =
+  | 'descendant-limit'
+  | 'depth-limit'
+  | 'active-reservation-limit'
+  | 'queued-descendant-limit'
+  | 'capacity-pressure'
+  | 'budget-pressure';
+
+export interface ExecutionTreeBreakerEvidence {
+  schemaVersion: typeof EXECUTION_TREE_BREAKER_EVIDENCE_SCHEMA_VERSION;
+  rootObjectiveId: string;
+  evaluatedAt: string;
+  signals: ExecutionTreeBreakerSignal[];
+  observed: {
+    descendants: number;
+    maxDepth: number;
+    activeReservations: number;
+    queuedDescendants: number;
+    capacityPressurePercent: number;
+    budgetPressurePercent: number;
+  };
+  thresholds: {
+    maxDescendants: number;
+    maxDepth: number;
+    maxActiveReservations: number;
+    maxQueuedDescendants: number;
+    pressureActivationDescendants: number;
+    capacityPressurePercent: number;
+    budgetPressurePercent: number;
+  };
+  recoveryGuidance: string[];
 }
 
 export interface ExecutionTreeBudgetSummary {

--- a/shared/src/types/telemetry.types.ts
+++ b/shared/src/types/telemetry.types.ts
@@ -3,6 +3,7 @@
 import type { TaskStatus, AgentType } from './task.types.js';
 import type { HarnessSupportFailureClass, HarnessSupportTier } from './provider-runtime.types.js';
 import type { AdmissionLaunchSource } from './admission-control.types.js';
+import type { ExecutionTreeBreakerEvidence } from './execution-tree-budget.types.js';
 
 export type TelemetryEventType =
   | 'task.created'
@@ -12,7 +13,8 @@ export type TelemetryEventType =
   | 'run.started'
   | 'run.completed'
   | 'run.error'
-  | 'run.tokens';
+  | 'run.tokens'
+  | 'admission.tree_control';
 
 /** Base telemetry event - all events extend this */
 export interface TelemetryEvent {
@@ -111,6 +113,18 @@ export interface TokenTelemetryEvent extends TelemetryEvent {
   attemptId?: string;
 }
 
+export interface AdmissionTreeControlTelemetryEvent extends TelemetryEvent {
+  type: 'admission.tree_control';
+  action: 'paused' | 'resumed' | 'cancelled';
+  trigger: 'operator' | 'fan-out-breaker';
+  rootObjectiveKey: string;
+  signals: string[];
+  observed?: ExecutionTreeBreakerEvidence['observed'];
+  queueEntriesCancelled?: number;
+  interruptedAttempts?: number;
+  unresolvedAttempts?: number;
+}
+
 /** Union type for all telemetry events */
 export type AnyTelemetryEvent =
   | TaskTelemetryEvent
@@ -118,7 +132,8 @@ export type AnyTelemetryEvent =
   | RunStartedEvent
   | RunCompletedEvent
   | RunErrorEvent
-  | TokenTelemetryEvent;
+  | TokenTelemetryEvent
+  | AdmissionTreeControlTelemetryEvent;
 
 /** Telemetry configuration */
 export interface TelemetryConfig {

--- a/web/src/__tests__/admission-queue-panel.test.tsx
+++ b/web/src/__tests__/admission-queue-panel.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION,
@@ -13,11 +13,22 @@ import { renderWithProviders } from './test-utils';
 
 const mocks = vi.hoisted(() => ({
   useAdmissionQueue: vi.fn(),
+  useAdmissionReservations: vi.fn(),
+  useAdmissionQueueCancel: vi.fn(),
+  useAdmissionTreeCancel: vi.fn(),
+  useAdmissionTreeResume: vi.fn(),
+  cancelQueue: vi.fn(),
+  cancelTree: vi.fn(),
+  resumeTree: vi.fn(),
   refetch: vi.fn(),
 }));
 
 vi.mock('@/hooks/useAdmissionQueue', () => ({
   useAdmissionQueue: mocks.useAdmissionQueue,
+  useAdmissionReservations: mocks.useAdmissionReservations,
+  useAdmissionQueueCancel: mocks.useAdmissionQueueCancel,
+  useAdmissionTreeCancel: mocks.useAdmissionTreeCancel,
+  useAdmissionTreeResume: mocks.useAdmissionTreeResume,
 }));
 
 const entries: AdmissionQueueInspectionEntry[] = [
@@ -180,6 +191,25 @@ describe('AdmissionQueuePanel', () => {
     vi.clearAllMocks();
     mocks.refetch.mockResolvedValue({});
     mocks.useAdmissionQueue.mockReturnValue(queueResult());
+    mocks.useAdmissionReservations.mockReturnValue({
+      data: { generatedAt: '2026-07-25T20:00:00.000Z', reservations: [] },
+      isLoading: false,
+    });
+    mocks.useAdmissionQueueCancel.mockReturnValue({
+      isPending: false,
+      mutateAsync: mocks.cancelQueue,
+    });
+    mocks.useAdmissionTreeCancel.mockReturnValue({
+      isPending: false,
+      mutateAsync: mocks.cancelTree,
+    });
+    mocks.useAdmissionTreeResume.mockReturnValue({
+      isPending: false,
+      mutateAsync: mocks.resumeTree,
+    });
+    mocks.cancelQueue.mockResolvedValue({});
+    mocks.cancelTree.mockResolvedValue({});
+    mocks.resumeTree.mockResolvedValue({});
   });
 
   afterEach(() => cleanup());
@@ -224,6 +254,85 @@ describe('AdmissionQueuePanel', () => {
     );
     renderWithProviders(<AdmissionQueuePanel />);
     expect(screen.getByText('Loading bounded admission queue…')).toBeDefined();
+  });
+
+  it('shows breaker evidence and resumes through a reasoned operator action', async () => {
+    const user = userEvent.setup();
+    mocks.resumeTree.mockRejectedValueOnce(new Error('Ambiguous network failure.'));
+    mocks.useAdmissionReservations.mockReturnValue({
+      data: {
+        generatedAt: '2026-07-25T20:00:00.000Z',
+        reservations: [
+          {
+            id: 'admission-root',
+            request: {
+              executionTree: {
+                rootObjectiveId: 'objective-breaker-1234567890',
+                edge: 'root',
+              },
+            },
+            executionTreeControl: {
+              schemaVersion: 'execution-tree-control/v1',
+              rootObjectiveId: 'objective-breaker-1234567890',
+              state: 'paused',
+              trigger: 'fan-out-breaker',
+              reason: 'Fan-out circuit breaker tripped.',
+              idempotencyKey: `sha256:${'a'.repeat(64)}`,
+              recordedAt: '2026-07-25T20:00:00.000Z',
+              evidence: {
+                schemaVersion: 'execution-tree-breaker-evidence/v1',
+                rootObjectiveId: 'objective-breaker-1234567890',
+                evaluatedAt: '2026-07-25T20:00:00.000Z',
+                signals: ['descendant-limit'],
+                observed: {
+                  descendants: 257,
+                  maxDepth: 8,
+                  activeReservations: 32,
+                  queuedDescendants: 12,
+                  capacityPressurePercent: 80,
+                  budgetPressurePercent: 88,
+                },
+                thresholds: {
+                  maxDescendants: 256,
+                  maxDepth: 16,
+                  maxActiveReservations: 64,
+                  maxQueuedDescendants: 64,
+                  pressureActivationDescendants: 8,
+                  capacityPressurePercent: 95,
+                  budgetPressurePercent: 95,
+                },
+                recoveryGuidance: ['Inspect the tree before resuming.'],
+              },
+            },
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    renderWithProviders(<AdmissionQueuePanel />);
+
+    expect(screen.getByText('Execution-tree controls')).toBeDefined();
+    expect(screen.getByText('Descendant Limit')).toBeDefined();
+    await user.click(screen.getByRole('button', { name: 'Resume' }));
+    await user.type(
+      screen.getByRole('textbox', { name: 'Operator reason' }),
+      'Pressure cleared after descendants completed.'
+    );
+    await user.click(screen.getByRole('button', { name: 'Resume expansion' }));
+
+    await waitFor(() => expect(mocks.resumeTree).toHaveBeenCalledTimes(1));
+    const firstRequest = mocks.resumeTree.mock.calls[0]?.[0];
+    expect(firstRequest).toEqual({
+      rootObjectiveId: 'objective-breaker-1234567890',
+      idempotencyKey: expect.stringContaining(
+        'operations:resume-tree:objective-breaker-1234567890:'
+      ),
+      reason: 'Pressure cleared after descendants completed.',
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Resume expansion' }));
+    await waitFor(() => expect(mocks.resumeTree).toHaveBeenCalledTimes(2));
+    expect(mocks.resumeTree.mock.calls[1]?.[0]?.idempotencyKey).toBe(firstRequest.idempotencyKey);
   });
 
   it('renders an explicit empty state', () => {

--- a/web/src/components/digest/AdmissionQueuePanel.tsx
+++ b/web/src/components/digest/AdmissionQueuePanel.tsx
@@ -1,22 +1,32 @@
-import { useMemo, type ReactNode } from 'react';
-import { Alert, Badge, Button, Group, Loader, Text } from '@mantine/core';
+import { useMemo, useState, type ReactNode } from 'react';
+import { Alert, Badge, Button, Group, Loader, Modal, Stack, Text, Textarea } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
 import {
   AlertTriangle,
   ArrowUpRight,
+  Ban,
   Clock3,
   Gauge,
   GitBranch,
   Layers3,
+  Play,
   RefreshCw,
   Route,
 } from 'lucide-react';
 import type {
   AdmissionQueueInspectionEntry,
   AdmissionQueueListResponse,
+  AdmissionReservation,
   AdmissionScope,
 } from '@veritas-kanban/shared';
 import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
-import { useAdmissionQueue } from '@/hooks/useAdmissionQueue';
+import {
+  useAdmissionQueue,
+  useAdmissionQueueCancel,
+  useAdmissionReservations,
+  useAdmissionTreeCancel,
+  useAdmissionTreeResume,
+} from '@/hooks/useAdmissionQueue';
 import { cn } from '@/lib/utils';
 
 interface AdmissionQueuePanelProps {
@@ -32,10 +42,88 @@ interface QueueSummary {
   limitingScopes: Array<[AdmissionScope, number]>;
 }
 
+type AdmissionControlAction = 'cancel-queue' | 'cancel-tree' | 'resume-tree';
+
+interface AdmissionControlTarget {
+  action: AdmissionControlAction;
+  id: string;
+  label: string;
+}
+
+interface AdmissionControlRequest extends AdmissionControlTarget {
+  idempotencyKey: string;
+}
+
 export function AdmissionQueuePanel({ onTaskClick, onWorkflowClick }: AdmissionQueuePanelProps) {
   const queue = useAdmissionQueue();
+  const reservations = useAdmissionReservations();
+  const cancelQueue = useAdmissionQueueCancel();
+  const cancelTree = useAdmissionTreeCancel();
+  const resumeTree = useAdmissionTreeResume();
+  const [controlRequest, setControlRequest] = useState<AdmissionControlRequest | null>(null);
+  const [controlReason, setControlReason] = useState('');
   const data = queue.data;
   const summary = useMemo(() => summarizeQueue(data), [data]);
+  const treeControls = useMemo(
+    () =>
+      (reservations.data?.reservations ?? [])
+        .filter(
+          (reservation) =>
+            reservation.request.executionTree?.edge === 'root' && reservation.executionTreeControl
+        )
+        .sort((left, right) =>
+          (right.executionTreeControl?.recordedAt ?? '').localeCompare(
+            left.executionTreeControl?.recordedAt ?? ''
+          )
+        )
+        .slice(0, 12),
+    [reservations.data]
+  );
+
+  const openControl = (request: AdmissionControlTarget) => {
+    setControlReason('');
+    setControlRequest({
+      ...request,
+      idempotencyKey: `operations:${request.action}:${request.id}:${crypto.randomUUID()}`,
+    });
+  };
+
+  const closeControl = () => {
+    if (cancelQueue.isPending || cancelTree.isPending || resumeTree.isPending) return;
+    setControlRequest(null);
+    setControlReason('');
+  };
+
+  const submitControl = async () => {
+    if (!controlRequest || controlReason.trim().length < 8) return;
+    const input = {
+      idempotencyKey: controlRequest.idempotencyKey,
+      reason: controlReason.trim(),
+    };
+    try {
+      if (controlRequest.action === 'cancel-queue') {
+        await cancelQueue.mutateAsync({ id: controlRequest.id, ...input });
+      } else if (controlRequest.action === 'cancel-tree') {
+        await cancelTree.mutateAsync({ rootObjectiveId: controlRequest.id, ...input });
+      } else {
+        await resumeTree.mutateAsync({ rootObjectiveId: controlRequest.id, ...input });
+      }
+      notifications.show({
+        color: controlRequest.action === 'resume-tree' ? 'teal' : 'orange',
+        title:
+          controlRequest.action === 'resume-tree' ? 'Execution tree resumed' : 'Control recorded',
+        message: controlRequest.label,
+      });
+      setControlRequest(null);
+      setControlReason('');
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        title: 'Admission control failed',
+        message: errorMessage(error),
+      });
+    }
+  };
 
   if (queue.isLoading && !data) {
     return (
@@ -86,133 +174,188 @@ export function AdmissionQueuePanel({ onTaskClick, onWorkflowClick }: AdmissionQ
   const isPartial = data.pagination.hasMore || data.pagination.snapshotTruncated;
   const isSaturated = data.depth.global.current >= data.depth.global.limit;
   const isStale = queue.isStale || Boolean(queue.error);
+  const controlPending = cancelQueue.isPending || cancelTree.isPending || resumeTree.isPending;
 
   return (
-    <section
-      className={cn(
-        'overflow-hidden rounded-xl border bg-slate-950/60 shadow-sm',
-        isSaturated ? 'border-amber-500/50' : 'border-slate-700/70'
-      )}
-      aria-labelledby="admission-queue-heading"
-    >
-      <div className="border-b border-slate-800 bg-[radial-gradient(circle_at_top_right,rgba(56,189,248,0.12),transparent_42%)] p-5">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <PanelHeading />
-          <Group gap="xs" wrap="wrap" aria-live="polite">
-            <Badge variant="light" color={isStale ? 'yellow' : 'cyan'} tt="none">
-              {isStale ? 'Stale snapshot' : 'Live snapshot'}
-            </Badge>
-            {isSaturated ? (
-              <Badge variant="light" color="orange" tt="none">
-                Saturated
+    <>
+      <section
+        className={cn(
+          'overflow-hidden rounded-xl border bg-slate-950/60 shadow-sm',
+          isSaturated ? 'border-amber-500/50' : 'border-slate-700/70'
+        )}
+        aria-labelledby="admission-queue-heading"
+      >
+        <div className="border-b border-slate-800 bg-[radial-gradient(circle_at_top_right,rgba(56,189,248,0.12),transparent_42%)] p-5">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <PanelHeading />
+            <Group gap="xs" wrap="wrap" aria-live="polite">
+              <Badge variant="light" color={isStale ? 'yellow' : 'cyan'} tt="none">
+                {isStale ? 'Stale snapshot' : 'Live snapshot'}
               </Badge>
-            ) : null}
-            {isPartial ? (
-              <Badge variant="light" color="violet" tt="none">
-                Partial view
+              {isSaturated ? (
+                <Badge variant="light" color="orange" tt="none">
+                  Saturated
+                </Badge>
+              ) : null}
+              {isPartial ? (
+                <Badge variant="light" color="violet" tt="none">
+                  Partial view
+                </Badge>
+              ) : null}
+              <Badge variant="outline" color="gray" tt="none">
+                Conditional, no start-time promise
               </Badge>
-            ) : null}
-            <Badge variant="outline" color="gray" tt="none">
-              Conditional, no start-time promise
-            </Badge>
-            <Button
-              variant="subtle"
-              color="gray"
-              size="compact-sm"
-              onClick={() => void queue.refetch()}
-              leftSection={
-                <RefreshCw className={cn('h-3.5 w-3.5', queue.isFetching && 'animate-spin')} />
-              }
+              <Button
+                variant="subtle"
+                color="gray"
+                size="compact-sm"
+                onClick={() => void queue.refetch()}
+                leftSection={
+                  <RefreshCw className={cn('h-3.5 w-3.5', queue.isFetching && 'animate-spin')} />
+                }
+              >
+                Refresh queue
+              </Button>
+            </Group>
+          </div>
+
+          {queue.error ? (
+            <Alert
+              mt="md"
+              color="yellow"
+              variant="light"
+              icon={<AlertTriangle className="h-4 w-4" />}
             >
-              Refresh queue
+              Showing the last available bounded snapshot. Refresh failed:{' '}
+              {errorMessage(queue.error)}
+            </Alert>
+          ) : null}
+
+          <div className="mt-5 grid gap-3 lg:grid-cols-[minmax(0,1.7fr)_repeat(3,minmax(130px,0.55fr))]">
+            <CapacityRail
+              current={data.depth.global.current}
+              limit={data.depth.global.limit}
+              saturated={isSaturated}
+            />
+            <Signal
+              icon={<Layers3 className="h-4 w-4 text-cyan-300" />}
+              label="Visible waiting"
+              value={String(summary.waiting)}
+              detail={isPartial ? 'bounded subset' : 'complete snapshot'}
+            />
+            <Signal
+              icon={<Route className="h-4 w-4 text-violet-300" />}
+              label="Visible leased"
+              value={String(summary.leased)}
+              detail={isPartial ? 'bounded subset' : 'reserved for dispatch'}
+            />
+            <Signal
+              icon={<Clock3 className="h-4 w-4 text-amber-300" />}
+              label="Oldest visible wait"
+              value={formatAge(summary.oldestWaitingMs)}
+              detail={`${data.pagination.limit}-row bound`}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-5 p-5">
+          <TreeControlPanel
+            reservations={treeControls}
+            loading={reservations.isLoading}
+            onControl={openControl}
+          />
+          <WorkspacePressure data={data} />
+
+          <div className="grid gap-3 lg:grid-cols-2">
+            <SignalStrip
+              label="Readiness"
+              empty="No active readiness signals"
+              values={summary.readiness.map(([readiness, count]) => ({
+                label: readableLabel(readiness),
+                value: count,
+              }))}
+            />
+            <SignalStrip
+              label="Limiting scopes"
+              empty="No limiting scope is reported"
+              values={summary.limitingScopes.map(([scope, count]) => ({
+                label: readableLabel(scope),
+                value: count,
+              }))}
+            />
+          </div>
+
+          {data.entries.length === 0 ? (
+            <div
+              className="rounded-lg border border-dashed border-slate-700 px-4 py-10 text-center"
+              role="status"
+            >
+              <Text fw={600}>Admission runway is clear</Text>
+              <Text size="sm" c="dimmed" mt={4}>
+                No queued, requeued, or leased work is visible in this bounded snapshot.
+              </Text>
+            </div>
+          ) : (
+            <QueueTable
+              data={data}
+              onTaskClick={onTaskClick}
+              onWorkflowClick={onWorkflowClick}
+              onControl={openControl}
+            />
+          )}
+
+          <div className="flex flex-col gap-1 border-t border-slate-800 pt-3 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+            <span>
+              Snapshot {formatDateTime(data.generatedAt)} · {data.pagination.total} matching entries
+            </span>
+            <span>
+              Position can change with arrivals, capacity, policy checks, retries, and lease expiry.
+            </span>
+          </div>
+        </div>
+      </section>
+      <Modal
+        opened={Boolean(controlRequest)}
+        onClose={closeControl}
+        title={controlTitle(controlRequest?.action)}
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            {controlRequest?.label}
+          </Text>
+          <Textarea
+            label="Operator reason"
+            description="Stored as durable control evidence. Minimum 8 characters."
+            value={controlReason}
+            onChange={(event) => setControlReason(event.currentTarget.value)}
+            minRows={3}
+            maxLength={1_000}
+            autoFocus
+          />
+          <Group justify="flex-end">
+            <Button variant="subtle" color="gray" onClick={closeControl} disabled={controlPending}>
+              Keep running
+            </Button>
+            <Button
+              color={controlRequest?.action === 'resume-tree' ? 'teal' : 'orange'}
+              leftSection={
+                controlRequest?.action === 'resume-tree' ? (
+                  <Play className="h-4 w-4" />
+                ) : (
+                  <Ban className="h-4 w-4" />
+                )
+              }
+              loading={controlPending}
+              disabled={controlReason.trim().length < 8}
+              onClick={() => void submitControl()}
+            >
+              {controlRequest?.action === 'resume-tree' ? 'Resume expansion' : 'Record control'}
             </Button>
           </Group>
-        </div>
-
-        {queue.error ? (
-          <Alert
-            mt="md"
-            color="yellow"
-            variant="light"
-            icon={<AlertTriangle className="h-4 w-4" />}
-          >
-            Showing the last available bounded snapshot. Refresh failed: {errorMessage(queue.error)}
-          </Alert>
-        ) : null}
-
-        <div className="mt-5 grid gap-3 lg:grid-cols-[minmax(0,1.7fr)_repeat(3,minmax(130px,0.55fr))]">
-          <CapacityRail
-            current={data.depth.global.current}
-            limit={data.depth.global.limit}
-            saturated={isSaturated}
-          />
-          <Signal
-            icon={<Layers3 className="h-4 w-4 text-cyan-300" />}
-            label="Visible waiting"
-            value={String(summary.waiting)}
-            detail={isPartial ? 'bounded subset' : 'complete snapshot'}
-          />
-          <Signal
-            icon={<Route className="h-4 w-4 text-violet-300" />}
-            label="Visible leased"
-            value={String(summary.leased)}
-            detail={isPartial ? 'bounded subset' : 'reserved for dispatch'}
-          />
-          <Signal
-            icon={<Clock3 className="h-4 w-4 text-amber-300" />}
-            label="Oldest visible wait"
-            value={formatAge(summary.oldestWaitingMs)}
-            detail={`${data.pagination.limit}-row bound`}
-          />
-        </div>
-      </div>
-
-      <div className="space-y-5 p-5">
-        <WorkspacePressure data={data} />
-
-        <div className="grid gap-3 lg:grid-cols-2">
-          <SignalStrip
-            label="Readiness"
-            empty="No active readiness signals"
-            values={summary.readiness.map(([readiness, count]) => ({
-              label: readableLabel(readiness),
-              value: count,
-            }))}
-          />
-          <SignalStrip
-            label="Limiting scopes"
-            empty="No limiting scope is reported"
-            values={summary.limitingScopes.map(([scope, count]) => ({
-              label: readableLabel(scope),
-              value: count,
-            }))}
-          />
-        </div>
-
-        {data.entries.length === 0 ? (
-          <div
-            className="rounded-lg border border-dashed border-slate-700 px-4 py-10 text-center"
-            role="status"
-          >
-            <Text fw={600}>Admission runway is clear</Text>
-            <Text size="sm" c="dimmed" mt={4}>
-              No queued, requeued, or leased work is visible in this bounded snapshot.
-            </Text>
-          </div>
-        ) : (
-          <QueueTable data={data} onTaskClick={onTaskClick} onWorkflowClick={onWorkflowClick} />
-        )}
-
-        <div className="flex flex-col gap-1 border-t border-slate-800 pt-3 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-between">
-          <span>
-            Snapshot {formatDateTime(data.generatedAt)} · {data.pagination.total} matching entries
-          </span>
-          <span>
-            Position can change with arrivals, capacity, policy checks, retries, and lease expiry.
-          </span>
-        </div>
-      </div>
-    </section>
+        </Stack>
+      </Modal>
+    </>
   );
 }
 
@@ -304,6 +447,139 @@ function Signal({
       </div>
       <div className="mt-2 text-xl font-semibold tabular-nums text-slate-100">{value}</div>
       <div className="mt-0.5 text-xs text-slate-500">{detail}</div>
+    </div>
+  );
+}
+
+function TreeControlPanel({
+  reservations,
+  loading,
+  onControl,
+}: {
+  reservations: AdmissionReservation[];
+  loading: boolean;
+  onControl: (request: AdmissionControlTarget) => void;
+}) {
+  if (loading && reservations.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-slate-800 bg-slate-900/35 px-3 py-2 text-sm text-slate-500">
+        <Loader size="xs" />
+        Loading execution-tree controls…
+      </div>
+    );
+  }
+  if (reservations.length === 0) return null;
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-slate-200">Execution-tree controls</h3>
+        <span className="text-xs text-slate-500">
+          Latest {reservations.length} durable controls
+        </span>
+      </div>
+      <div className="grid gap-2 xl:grid-cols-2">
+        {reservations.map((reservation) => {
+          const control = reservation.executionTreeControl;
+          if (!control) return null;
+          const rootObjectiveId =
+            reservation.request.executionTree?.rootObjectiveId ?? control.rootObjectiveId;
+          const evidence = control.evidence;
+          return (
+            <div
+              key={reservation.id}
+              className={cn(
+                'rounded-lg border bg-slate-900/45 p-3',
+                control.state === 'paused'
+                  ? 'border-amber-700/60'
+                  : control.state === 'cancelled'
+                    ? 'border-red-900/60'
+                    : 'border-emerald-900/60'
+              )}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <GitBranch className="h-4 w-4 text-violet-300" />
+                    <span className="font-mono text-sm text-slate-200">
+                      {shortIdentity(rootObjectiveId)}
+                    </span>
+                    <Badge
+                      size="xs"
+                      variant="light"
+                      color={
+                        control.state === 'paused'
+                          ? 'orange'
+                          : control.state === 'cancelled'
+                            ? 'red'
+                            : 'teal'
+                      }
+                      tt="none"
+                    >
+                      {control.state}
+                    </Badge>
+                  </div>
+                  <div className="mt-1 text-xs text-slate-500">
+                    {readableLabel(control.trigger)} · {formatDateTime(control.recordedAt)}
+                  </div>
+                </div>
+                <Group gap={4}>
+                  {control.state === 'paused' ? (
+                    <Button
+                      size="compact-xs"
+                      variant="light"
+                      color="teal"
+                      onClick={() =>
+                        onControl({
+                          action: 'resume-tree',
+                          id: rootObjectiveId,
+                          label: `Resume execution tree ${shortIdentity(rootObjectiveId)}`,
+                        })
+                      }
+                      leftSection={<Play className="h-3 w-3" />}
+                    >
+                      Resume
+                    </Button>
+                  ) : null}
+                  {control.state !== 'cancelled' ? (
+                    <Button
+                      size="compact-xs"
+                      variant="light"
+                      color="red"
+                      onClick={() =>
+                        onControl({
+                          action: 'cancel-tree',
+                          id: rootObjectiveId,
+                          label: `Cancel execution tree ${shortIdentity(rootObjectiveId)}`,
+                        })
+                      }
+                      leftSection={<Ban className="h-3 w-3" />}
+                    >
+                      Cancel tree
+                    </Button>
+                  ) : null}
+                </Group>
+              </div>
+              {evidence ? (
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <div className="rounded-md bg-slate-950/55 p-2 text-xs text-slate-400">
+                    <div className="font-medium text-slate-300">Trigger evidence</div>
+                    <div className="mt-1">{evidence.signals.map(readableLabel).join(', ')}</div>
+                  </div>
+                  <div className="rounded-md bg-slate-950/55 p-2 text-xs text-slate-400">
+                    <div className="font-medium text-slate-300">Tree pressure</div>
+                    <div className="mt-1">
+                      {evidence.observed.descendants}/{evidence.thresholds.maxDescendants}{' '}
+                      descendants · depth {evidence.observed.maxDepth}/
+                      {evidence.thresholds.maxDepth}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -400,10 +676,12 @@ function QueueTable({
   data,
   onTaskClick,
   onWorkflowClick,
+  onControl,
 }: {
   data: AdmissionQueueListResponse;
   onTaskClick?: AdmissionQueuePanelProps['onTaskClick'];
   onWorkflowClick?: AdmissionQueuePanelProps['onWorkflowClick'];
+  onControl: (request: AdmissionControlTarget) => void;
 }) {
   return (
     <div className="overflow-x-auto rounded-lg border border-slate-800">
@@ -435,7 +713,7 @@ function QueueTable({
               Lease / limits
             </th>
             <th className="px-3 py-3 text-right font-medium" scope="col">
-              Open
+              Actions
             </th>
           </tr>
         </thead>
@@ -446,6 +724,7 @@ function QueueTable({
               entry={entry}
               onTaskClick={onTaskClick}
               onWorkflowClick={onWorkflowClick}
+              onControl={onControl}
             />
           ))}
         </tbody>
@@ -458,10 +737,12 @@ function QueueRow({
   entry,
   onTaskClick,
   onWorkflowClick,
+  onControl,
 }: {
   entry: AdmissionQueueInspectionEntry;
   onTaskClick?: AdmissionQueuePanelProps['onTaskClick'];
   onWorkflowClick?: AdmissionQueuePanelProps['onWorkflowClick'];
+  onControl: (request: AdmissionControlTarget) => void;
 }) {
   const tree = entry.navigation.executionTree;
   const taskId = entry.navigation.taskId;
@@ -539,7 +820,39 @@ function QueueRow({
         </div>
       </td>
       <td className="px-3 py-3">
-        <div className="flex justify-end gap-1">
+        <div className="flex max-w-64 flex-wrap justify-end gap-1">
+          <Button
+            size="compact-xs"
+            variant="light"
+            color="orange"
+            onClick={() =>
+              onControl({
+                action: 'cancel-queue',
+                id: entry.id,
+                label: `Cancel queued launch ${entry.id}`,
+              })
+            }
+            leftSection={<Ban className="h-3 w-3" />}
+          >
+            Cancel queue
+          </Button>
+          {tree ? (
+            <Button
+              size="compact-xs"
+              variant="light"
+              color="red"
+              onClick={() =>
+                onControl({
+                  action: 'cancel-tree',
+                  id: tree.rootObjectiveId,
+                  label: `Cancel execution tree ${shortIdentity(tree.rootObjectiveId)}`,
+                })
+              }
+              leftSection={<Ban className="h-3 w-3" />}
+            >
+              Cancel tree
+            </Button>
+          ) : null}
           {taskId && onTaskClick ? (
             <Button
               size="compact-xs"
@@ -675,6 +988,23 @@ function formatDateTime(value: string): string {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 }
 
+function shortIdentity(value: string): string {
+  return value.length <= 24 ? value : `${value.slice(0, 12)}…${value.slice(-8)}`;
+}
+
+function controlTitle(action?: AdmissionControlAction): string {
+  switch (action) {
+    case 'cancel-queue':
+      return 'Cancel queued launch';
+    case 'cancel-tree':
+      return 'Cancel execution tree';
+    case 'resume-tree':
+      return 'Resume execution tree';
+    default:
+      return 'Execution control';
+  }
+}
+
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : 'The queue snapshot could not be loaded.';
+  return error instanceof Error ? error.message : 'The admission operation could not be completed.';
 }

--- a/web/src/hooks/useAdmissionQueue.ts
+++ b/web/src/hooks/useAdmissionQueue.ts
@@ -1,9 +1,21 @@
-import { useQuery } from '@tanstack/react-query';
-import type { AdmissionQueueInspectionQuery } from '@veritas-kanban/shared';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  AdmissionCancellationInput,
+  AdmissionQueueInspectionQuery,
+} from '@veritas-kanban/shared';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 import { api } from '@/lib/api';
 
 export const ADMISSION_QUEUE_QUERY_KEY = ['admission-queue'] as const;
+export const ADMISSION_RESERVATIONS_QUERY_KEY = ['admission-reservations'] as const;
+
+interface QueueControlInput extends AdmissionCancellationInput {
+  id: string;
+}
+
+interface TreeControlInput extends AdmissionCancellationInput {
+  rootObjectiveId: string;
+}
 
 const DEFAULT_QUEUE_QUERY: AdmissionQueueInspectionQuery = {
   states: ['queued', 'requeued', 'leased'],
@@ -20,5 +32,50 @@ export function useAdmissionQueue(query: AdmissionQueueInspectionQuery = DEFAULT
     placeholderData: (previousData) => previousData,
     refetchInterval: isConnected ? 120_000 : 30_000,
     staleTime: isConnected ? 60_000 : 10_000,
+  });
+}
+
+export function useAdmissionReservations() {
+  const { isConnected } = useWebSocketStatus();
+  return useQuery({
+    queryKey: ADMISSION_RESERVATIONS_QUERY_KEY,
+    queryFn: api.admission.reservations,
+    refetchInterval: isConnected ? 120_000 : 30_000,
+    staleTime: isConnected ? 60_000 : 10_000,
+  });
+}
+
+function useAdmissionControlInvalidation() {
+  const queryClient = useQueryClient();
+  return () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: ADMISSION_QUEUE_QUERY_KEY }),
+      queryClient.invalidateQueries({ queryKey: ADMISSION_RESERVATIONS_QUERY_KEY }),
+    ]);
+}
+
+export function useAdmissionQueueCancel() {
+  const invalidate = useAdmissionControlInvalidation();
+  return useMutation({
+    mutationFn: ({ id, ...input }: QueueControlInput) => api.admission.cancelQueueEntry(id, input),
+    onSuccess: invalidate,
+  });
+}
+
+export function useAdmissionTreeCancel() {
+  const invalidate = useAdmissionControlInvalidation();
+  return useMutation({
+    mutationFn: ({ rootObjectiveId, ...input }: TreeControlInput) =>
+      api.admission.cancelTree(rootObjectiveId, input),
+    onSuccess: invalidate,
+  });
+}
+
+export function useAdmissionTreeResume() {
+  const invalidate = useAdmissionControlInvalidation();
+  return useMutation({
+    mutationFn: ({ rootObjectiveId, ...input }: TreeControlInput) =>
+      api.admission.resumeTree(rootObjectiveId, input),
+    onSuccess: invalidate,
   });
 }

--- a/web/src/lib/api/admission.ts
+++ b/web/src/lib/api/admission.ts
@@ -1,7 +1,12 @@
 import type {
+  AdmissionCancellationInput,
+  AdmissionExecutionTreeCancellationResult,
   AdmissionQueueGetResponse,
   AdmissionQueueInspectionQuery,
   AdmissionQueueListResponse,
+  AdmissionQueuedCancellationResult,
+  AdmissionReservation,
+  ExecutionTreeControl,
 } from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
 
@@ -28,4 +33,37 @@ export const admissionApi = {
 
   queueEntry: (id: string): Promise<AdmissionQueueGetResponse> =>
     apiFetch<AdmissionQueueGetResponse>(`${API_BASE}/admission/queue/${encodeURIComponent(id)}`),
+
+  reservations: (): Promise<{ generatedAt: string; reservations: AdmissionReservation[] }> =>
+    apiFetch(`${API_BASE}/admission?limit=1000`),
+
+  cancelQueueEntry: (
+    id: string,
+    input: AdmissionCancellationInput
+  ): Promise<AdmissionQueuedCancellationResult> =>
+    apiFetch(`${API_BASE}/admission/queue/${encodeURIComponent(id)}/cancel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
+
+  cancelTree: (
+    rootObjectiveId: string,
+    input: AdmissionCancellationInput
+  ): Promise<AdmissionExecutionTreeCancellationResult> =>
+    apiFetch(`${API_BASE}/admission/tree/${encodeURIComponent(rootObjectiveId)}/cancel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
+
+  resumeTree: (
+    rootObjectiveId: string,
+    input: AdmissionCancellationInput
+  ): Promise<ExecutionTreeControl> =>
+    apiFetch(`${API_BASE}/admission/tree/${encodeURIComponent(rootObjectiveId)}/resume`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
 };


### PR DESCRIPTION
## Summary

- add a durable, provider-neutral fan-out circuit breaker with atomic descendant limits
- pause wide, deep, reservation-heavy, queue-heavy, capacity-heavy, and budget-heavy trees with bounded recovery evidence
- add policy-checked tree resume through REST, CLI, and Operations while keeping cancellation terminal
- expose queue and tree controls in Operations with stable idempotency across ambiguous retries
- add redacted tree-control telemetry and support-bundle evidence
- document the stop/resume contract for Codex, Claude Code, Buzz, Grok Build, GitHub Copilot, Hermes, OpenClaw, and custom harnesses

## Verification

- admission control service: 48 tests passed across file/SQLite parameterized paths
- admission schemas: 130 tests passed
- maintenance support bundle: 4 tests passed
- CLI admission: 10 tests passed
- Operations admission panel: 6 tests passed
- web and CLI typechecks passed
- targeted ESLint passed with no warnings
- Prettier and `git diff --check` passed

The focused suite includes wide and deep expansion, concurrent boundary claims, cancellation/dequeue races, restart persistence, blocked and successful resume, telemetry redaction, support redaction, and a 64-child bounded load smoke test. The full workspace matrix remains delegated to CI.

Closes #1055
