### PR TITLE
feat: compile run-scoped egress policy

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -3017,11 +3017,14 @@ POST /api/sandbox-policies
   "network": {
     "defaultEgress": "deny",
     "allowedHosts": [],
+    "deniedHosts": ["metadata.example.internal"],
     "allowedMethods": [],
     "allowedPathPrefixes": [],
     "blockPrivateNetwork": true,
     "blockMetadataEndpoints": true,
-    "blockLoopback": false
+    "blockLoopback": false,
+    "allowApprovals": false,
+    "dangerouslyAllowGlobalWildcard": false
   },
   "environment": {
     "passthrough": ["CODEX_HOME", "OPENAI_API_KEY"],
@@ -3069,7 +3072,26 @@ the immutable manifest already selected and persisted for the attempt.
     "sandboxMode": "workspace-write",
     "networkAccessEnabled": false,
     "envPassthrough": ["CODEX_HOME", "OPENAI_API_KEY"],
-    "credentialRefs": ["openai-api-key"]
+    "credentialRefs": ["openai-api-key"],
+    "networkPolicy": {
+      "schemaVersion": "run-egress-policy/v1",
+      "policyHash": "sha256:<64 lowercase hex characters>",
+      "defaultEgress": "deny",
+      "allowedHosts": [],
+      "deniedHosts": [
+        {
+          "kind": "exact",
+          "value": "metadata.example.internal"
+        }
+      ],
+      "allowedMethods": [],
+      "allowedPathPrefixes": [],
+      "blockPrivateNetwork": true,
+      "blockMetadataEndpoints": true,
+      "blockLoopback": false,
+      "allowApprovals": false,
+      "tlsInspection": "disabled"
+    }
   },
   "unsupportedRules": [],
   "warnings": [],
@@ -3081,6 +3103,13 @@ the immutable manifest already selected and persisted for the attempt.
 launches before execution. Advisory unsupported controls continue with warnings.
 Credential references and environment-style `name=value` values are redacted in
 responses and governance traces.
+
+Network host rules are normalized to exact or scoped `*.example.com` entries.
+Explicit deny rules take precedence. A global allow wildcard is rejected unless
+`dangerouslyAllowGlobalWildcard` is set on the preset. The compiled policy has a
+stable digest and is the input to the run-scoped gateway; it does not by itself
+prove that a provider launch is using that gateway. Until gateway launch
+evidence is present, required fine-grained egress rules continue to fail closed.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1168,8 +1168,14 @@ Reusable launch-time sandbox presets for provider execution guardrails.
 
 - Create, edit, enable, disable, and delete custom presets in **Settings -> Agents -> Sandbox Policies**.
 - Assign presets to agent profiles or workflow agents; one-off agent starts can pass `sandboxPresetId` to override the profile default.
-- Presets declare filesystem read/write paths, denied paths, dotfile masking, network default egress, allowed hosts and paths, environment passthrough keys, credential mode, and broker references.
+- Presets declare filesystem read/write paths, denied paths, dotfile masking,
+  network default egress, allowed and denied hosts, methods and paths,
+  private/loopback/metadata protection, scoped approval eligibility, environment
+  passthrough keys, credential mode, and broker references.
 - Dry-runs compare a preset against provider capabilities before execution and show the effective sandbox mode, network state, environment allowlist, unsupported controls, and governance trace ID.
+- Dry-runs also compile `run-egress-policy/v1`: host rules are normalized, deny
+  rules take precedence, unsafe global allow wildcards fail validation, and a
+  deterministic policy digest binds later gateway launch evidence.
 
 **Enforcement:**
 

--- a/server/src/__tests__/egress-policy-service.test.ts
+++ b/server/src/__tests__/egress-policy-service.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest';
+import type { SandboxNetworkRules } from '@veritas-kanban/shared';
+import { EgressPolicyService } from '../services/egress-policy-service.js';
+
+const service = new EgressPolicyService();
+
+function rules(overrides: Partial<SandboxNetworkRules> = {}): SandboxNetworkRules {
+  return {
+    defaultEgress: 'deny',
+    allowedHosts: [],
+    deniedHosts: [],
+    allowedMethods: [],
+    allowedPathPrefixes: [],
+    blockPrivateNetwork: true,
+    blockMetadataEndpoints: true,
+    blockLoopback: true,
+    allowApprovals: false,
+    dangerouslyAllowGlobalWildcard: false,
+    ...overrides,
+  };
+}
+
+describe('EgressPolicyService', () => {
+  it('blocks by default when no allow rule exists', () => {
+    const policy = service.compile(rules());
+
+    expect(
+      service.evaluate(policy, {
+        protocol: 'https',
+        host: 'api.example.com',
+        port: 443,
+        resolvedAddresses: ['93.184.216.34'],
+      })
+    ).toMatchObject({
+      decision: 'block',
+      reason: 'default-deny',
+      approvalEligible: false,
+    });
+  });
+
+  it('normalizes scoped wildcards and rejects an unapproved global allow wildcard', () => {
+    expect(() => service.compile(rules({ allowedHosts: ['*'] }))).toThrow(
+      /dangerouslyAllowGlobalWildcard/
+    );
+
+    const policy = service.compile(
+      rules({
+        allowedHosts: ['*.Example.COM', 'api.example.com', '*.example.com'],
+      })
+    );
+    expect(policy.allowedHosts).toEqual([
+      { kind: 'exact', value: 'api.example.com' },
+      { kind: 'subdomain', value: 'example.com' },
+    ]);
+    expect(
+      service.evaluate(policy, {
+        protocol: 'http',
+        host: 'packages.example.com.',
+        port: 80,
+        resolvedAddresses: ['93.184.216.34'],
+      })
+    ).toMatchObject({ decision: 'allow', reason: 'allowed-by-host-rule' });
+    expect(
+      service.evaluate(policy, {
+        protocol: 'http',
+        host: 'example.com',
+        port: 80,
+        resolvedAddresses: ['93.184.216.34'],
+      })
+    ).toMatchObject({ decision: 'block', reason: 'default-deny' });
+  });
+
+  it('gives explicit deny rules precedence over dangerous global allow', () => {
+    const policy = service.compile(
+      rules({
+        allowedHosts: ['*'],
+        deniedHosts: ['metadata.example.com'],
+        dangerouslyAllowGlobalWildcard: true,
+      })
+    );
+
+    expect(
+      service.evaluate(policy, {
+        protocol: 'http',
+        host: 'metadata.example.com',
+        port: 80,
+        resolvedAddresses: ['93.184.216.34'],
+      })
+    ).toMatchObject({
+      decision: 'block',
+      reason: 'denied-host',
+      matchedRule: { kind: 'exact', value: 'metadata.example.com' },
+      approvalEligible: false,
+    });
+  });
+
+  it('enforces HTTP methods and path prefixes without retaining query strings', () => {
+    const policy = service.compile(
+      rules({
+        allowedHosts: ['api.example.com'],
+        allowedMethods: ['GET'],
+        allowedPathPrefixes: ['/v1/data'],
+        allowApprovals: true,
+      })
+    );
+
+    expect(
+      service.evaluate(policy, {
+        protocol: 'http',
+        host: 'api.example.com',
+        port: 80,
+        method: 'GET',
+        path: '/v1/data/items?secret=value',
+        resolvedAddresses: ['93.184.216.34'],
+      })
+    ).toMatchObject({ decision: 'allow' });
+    expect(
+      service.evaluate(policy, {
+        protocol: 'http',
+        host: 'api.example.com',
+        port: 80,
+        method: 'POST',
+        path: '/v1/data/items',
+        resolvedAddresses: ['93.184.216.34'],
+      })
+    ).toMatchObject({
+      decision: 'block',
+      reason: 'method-not-allowed',
+      approvalEligible: true,
+    });
+    expect(
+      service.evaluate(policy, {
+        protocol: 'http',
+        host: 'api.example.com',
+        port: 80,
+        method: 'GET',
+        path: '/v1/database',
+        resolvedAddresses: ['93.184.216.34'],
+      })
+    ).toMatchObject({ decision: 'block', reason: 'path-not-allowed' });
+  });
+
+  it('fails closed when encrypted traffic cannot satisfy method or path rules', () => {
+    const policy = service.compile(
+      rules({
+        allowedHosts: ['api.example.com'],
+        allowedMethods: ['GET'],
+        allowedPathPrefixes: ['/v1'],
+      })
+    );
+    const input = {
+      protocol: 'https' as const,
+      host: 'api.example.com',
+      port: 443,
+      method: 'GET',
+      path: '/v1/models',
+      resolvedAddresses: ['93.184.216.34'],
+    };
+
+    expect(service.evaluate(policy, input)).toMatchObject({
+      decision: 'block',
+      reason: 'tls-inspection-required',
+    });
+    expect(service.evaluate(policy, { ...input, tlsInspected: true })).toMatchObject({
+      decision: 'allow',
+    });
+  });
+
+  it('blocks private, link-local, loopback, and metadata destinations after resolution', () => {
+    const policy = service.compile(
+      rules({
+        allowedHosts: ['*.example.com', 'metadata.google.internal'],
+      })
+    );
+    const evaluate = (host: string, address: string) =>
+      service.evaluate(policy, {
+        protocol: 'http',
+        host,
+        port: 80,
+        resolvedAddresses: [address],
+      });
+
+    expect(evaluate('private.example.com', '10.20.30.40')).toMatchObject({
+      reason: 'private-network-blocked',
+      blockedAddressClass: 'private',
+    });
+    expect(evaluate('link.example.com', '169.254.10.20')).toMatchObject({
+      reason: 'private-network-blocked',
+      blockedAddressClass: 'link-local',
+    });
+    expect(evaluate('loop.example.com', '::1')).toMatchObject({
+      reason: 'loopback-blocked',
+      blockedAddressClass: 'loopback',
+    });
+    expect(evaluate('metadata.google.internal', '93.184.216.34')).toMatchObject({
+      reason: 'metadata-endpoint-blocked',
+      blockedAddressClass: 'metadata',
+    });
+  });
+
+  it('resolves hostnames before allowing transport and fails closed on lookup errors', async () => {
+    const privateResolver = new EgressPolicyService(async () => ['127.0.0.1']);
+    const failedResolver = new EgressPolicyService(async () => {
+      throw new Error('DNS unavailable');
+    });
+    const policy = service.compile(rules({ allowedHosts: ['api.example.com'] }));
+    const input = {
+      protocol: 'http' as const,
+      host: 'api.example.com',
+      port: 80,
+    };
+
+    await expect(privateResolver.evaluateResolved(policy, input)).resolves.toMatchObject({
+      decision: 'block',
+      reason: 'loopback-blocked',
+    });
+    await expect(failedResolver.evaluateResolved(policy, input)).resolves.toMatchObject({
+      decision: 'block',
+      reason: 'invalid-destination',
+    });
+  });
+
+  it('produces deterministic policy and redacted destination identities', () => {
+    const left = service.compile(
+      rules({ allowedHosts: ['b.example.com', 'a.example.com'], allowedMethods: ['post', 'GET'] })
+    );
+    const right = service.compile(
+      rules({ allowedHosts: ['a.example.com', 'b.example.com'], allowedMethods: ['GET', 'POST'] })
+    );
+    expect(left.policyHash).toBe(right.policyHash);
+
+    const decision = service.evaluate(left, {
+      protocol: 'http',
+      host: 'unlisted.internal.example',
+      port: 80,
+      resolvedAddresses: ['93.184.216.34'],
+    });
+    expect(decision.hostKey).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(JSON.stringify(decision)).not.toContain('unlisted.internal.example');
+  });
+});

--- a/server/src/__tests__/sandbox-policy-service.test.ts
+++ b/server/src/__tests__/sandbox-policy-service.test.ts
@@ -109,6 +109,12 @@ describe('SandboxPolicyService', () => {
     expect(sdkResult.effective).toMatchObject({
       sandboxMode: 'workspace-write',
       networkAccessEnabled: false,
+      networkPolicy: {
+        schemaVersion: 'run-egress-policy/v1',
+        policyHash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        defaultEgress: 'deny',
+        allowedHosts: [],
+      },
     });
 
     const cliResult = await service.dryRun({

--- a/server/src/schemas/sandbox-policy-schemas.ts
+++ b/server/src/schemas/sandbox-policy-schemas.ts
@@ -49,6 +49,7 @@ export const sandboxPolicyPresetSchema = z.object({
   network: z.object({
     defaultEgress: sandboxNetworkDefaultSchema,
     allowedHosts: z.array(z.string().min(1).max(255)).max(100).default([]),
+    deniedHosts: z.array(z.string().min(1).max(255)).max(100).default([]),
     allowedMethods: z
       .array(
         z
@@ -63,6 +64,8 @@ export const sandboxPolicyPresetSchema = z.object({
     blockPrivateNetwork: z.boolean(),
     blockMetadataEndpoints: z.boolean(),
     blockLoopback: z.boolean(),
+    allowApprovals: z.boolean().default(false),
+    dangerouslyAllowGlobalWildcard: z.boolean().default(false),
   }),
   environment: z.object({
     passthrough: z.array(envKeySchema).max(120).default([]),

--- a/server/src/services/egress-policy-service.ts
+++ b/server/src/services/egress-policy-service.ts
@@ -1,0 +1,344 @@
+import { createHash } from 'node:crypto';
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+import { domainToASCII } from 'node:url';
+import {
+  RUN_EGRESS_DECISION_SCHEMA_VERSION,
+  RUN_EGRESS_POLICY_SCHEMA_VERSION,
+  type RunEgressDecision,
+  type RunEgressDecisionInput,
+  type RunEgressDecisionReason,
+  type RunEgressHostRule,
+  type RunEgressPolicy,
+  type SandboxNetworkRules,
+} from '@veritas-kanban/shared';
+import { ValidationError } from '../middleware/error-handler.js';
+import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
+
+const METADATA_HOSTS = new Set([
+  '169.254.169.254',
+  '169.254.170.2',
+  '100.100.100.200',
+  'fd00:ec2::254',
+  'metadata.google.internal',
+  'metadata.goog',
+]);
+
+type AddressClass = 'public' | 'private' | 'loopback' | 'link-local' | 'metadata' | 'invalid';
+type EgressHostResolver = (host: string) => Promise<string[]>;
+
+export class EgressPolicyService {
+  constructor(
+    private readonly resolveHost: EgressHostResolver = async (host) =>
+      (await lookup(host, { all: true, verbatim: true })).map((record) => record.address)
+  ) {}
+
+  compile(rules: SandboxNetworkRules): RunEgressPolicy {
+    const allowedHosts = compileHostRules(
+      rules.allowedHosts,
+      Boolean(rules.dangerouslyAllowGlobalWildcard),
+      'allow'
+    );
+    const deniedHosts = compileHostRules(rules.deniedHosts ?? [], true, 'deny');
+    const payload: Omit<RunEgressPolicy, 'policyHash'> = {
+      schemaVersion: RUN_EGRESS_POLICY_SCHEMA_VERSION,
+      defaultEgress: rules.defaultEgress,
+      allowedHosts,
+      deniedHosts,
+      allowedMethods: uniqueSorted(rules.allowedMethods.map((method) => method.toUpperCase())),
+      allowedPathPrefixes: normalizePathPrefixes(rules.allowedPathPrefixes),
+      blockPrivateNetwork: rules.blockPrivateNetwork,
+      blockMetadataEndpoints: rules.blockMetadataEndpoints,
+      blockLoopback: rules.blockLoopback,
+      allowApprovals: rules.allowApprovals ?? false,
+      tlsInspection: 'disabled',
+    };
+    return {
+      ...payload,
+      policyHash: digestRunLaunchValue(payload),
+    };
+  }
+
+  evaluate(policy: RunEgressPolicy, input: RunEgressDecisionInput): RunEgressDecision {
+    const host = normalizeHost(input.host);
+    const method = input.method?.trim().toUpperCase();
+    const base = {
+      schemaVersion: RUN_EGRESS_DECISION_SCHEMA_VERSION,
+      policyHash: policy.policyHash,
+      protocol: input.protocol,
+      hostKey: identity('egress-host', host || input.host),
+      port: input.port,
+      ...(method ? { method } : {}),
+    } as const;
+    if (!host || !Number.isInteger(input.port) || input.port < 1 || input.port > 65_535) {
+      return blocked(base, policy, 'invalid-destination');
+    }
+    if (input.resolvedAddresses?.some((address) => isIP(address) === 0)) {
+      return blocked(base, policy, 'invalid-destination');
+    }
+
+    const deniedRule = matchingHostRule(policy.deniedHosts, host);
+    if (deniedRule) {
+      return blocked(base, policy, 'denied-host', { matchedRule: deniedRule });
+    }
+    const allowedRule = matchingHostRule(policy.allowedHosts, host);
+    if (policy.defaultEgress === 'deny' && !allowedRule) {
+      return blocked(base, policy, 'default-deny');
+    }
+
+    const addressBlock = destinationAddressBlock(policy, host, input.resolvedAddresses ?? []);
+    if (addressBlock) {
+      return blocked(base, policy, addressBlock.reason, {
+        blockedAddressClass: addressBlock.addressClass,
+        ...(allowedRule ? { matchedRule: allowedRule } : {}),
+      });
+    }
+
+    const inspectionRequired =
+      (input.protocol === 'https' || input.protocol === 'wss' || input.protocol === 'socks') &&
+      !input.tlsInspected &&
+      (policy.allowedMethods.length > 0 || hasPathRestriction(policy.allowedPathPrefixes));
+    if (inspectionRequired) {
+      return blocked(base, policy, 'tls-inspection-required', {
+        ...(allowedRule ? { matchedRule: allowedRule } : {}),
+      });
+    }
+    if (policy.allowedMethods.length > 0 && (!method || !policy.allowedMethods.includes(method))) {
+      return blocked(base, policy, 'method-not-allowed', {
+        ...(allowedRule ? { matchedRule: allowedRule } : {}),
+      });
+    }
+    if (
+      hasPathRestriction(policy.allowedPathPrefixes) &&
+      !pathAllowed(input.path, policy.allowedPathPrefixes)
+    ) {
+      return blocked(base, policy, 'path-not-allowed', {
+        ...(allowedRule ? { matchedRule: allowedRule } : {}),
+      });
+    }
+
+    return {
+      ...base,
+      decision: 'allow',
+      reason: allowedRule ? 'allowed-by-host-rule' : 'allowed-by-default',
+      ...(allowedRule ? { matchedRule: allowedRule } : {}),
+      approvalEligible: false,
+    };
+  }
+
+  async evaluateResolved(
+    policy: RunEgressPolicy,
+    input: Omit<RunEgressDecisionInput, 'resolvedAddresses'>
+  ): Promise<RunEgressDecision> {
+    const host = normalizeHost(input.host);
+    try {
+      const resolvedAddresses = isIP(host) === 0 ? await this.resolveHost(host) : [host];
+      return this.evaluate(policy, { ...input, resolvedAddresses });
+    } catch {
+      return this.evaluate(policy, { ...input, resolvedAddresses: ['unresolved'] });
+    }
+  }
+}
+
+function compileHostRules(
+  values: string[],
+  allowGlobalWildcard: boolean,
+  list: 'allow' | 'deny'
+): RunEgressHostRule[] {
+  const byIdentity = new Map<string, RunEgressHostRule>();
+  for (const rawValue of values) {
+    const value = rawValue.trim().toLowerCase();
+    let rule: RunEgressHostRule;
+    if (value === '*') {
+      if (!allowGlobalWildcard) {
+        throw new ValidationError(
+          'A global egress allow wildcard requires dangerouslyAllowGlobalWildcard.',
+          { list, rule: '*' }
+        );
+      }
+      rule = { kind: 'any', value: '*' };
+    } else if (value.startsWith('*.')) {
+      const base = normalizeHost(value.slice(2));
+      if (!base || isIP(base) !== 0 || !base.includes('.')) {
+        throw invalidHostRule(list, rawValue);
+      }
+      rule = { kind: 'subdomain', value: base };
+    } else {
+      if (value.includes('*')) throw invalidHostRule(list, rawValue);
+      const host = normalizeHost(value);
+      if (!host) throw invalidHostRule(list, rawValue);
+      rule = { kind: 'exact', value: host };
+    }
+    byIdentity.set(`${rule.kind}:${rule.value}`, rule);
+  }
+  return [...byIdentity.values()].sort(
+    (left, right) => left.kind.localeCompare(right.kind) || left.value.localeCompare(right.value)
+  );
+}
+
+function invalidHostRule(list: 'allow' | 'deny', rule: string): ValidationError {
+  return new ValidationError(
+    'Egress host rules must be exact hosts or scoped *.example.com rules.',
+    {
+      list,
+      rule,
+    }
+  );
+}
+
+function normalizeHost(value: string): string {
+  const unwrapped = value
+    .trim()
+    .replace(/^\[|\]$/g, '')
+    .replace(/\.$/, '')
+    .toLowerCase();
+  if (!unwrapped) return '';
+  if (isIP(unwrapped) !== 0) return unwrapped;
+  const ascii = domainToASCII(unwrapped);
+  if (
+    !ascii ||
+    ascii.length > 253 ||
+    ascii.split('.').some((label) => !label || label.length > 63)
+  ) {
+    return '';
+  }
+  return ascii.toLowerCase();
+}
+
+function normalizePathPrefixes(values: string[]): string[] {
+  const normalized = values.map((value) => {
+    const path = value.trim().split(/[?#]/, 1)[0] ?? '';
+    if (!path.startsWith('/')) {
+      throw new ValidationError('Egress path prefixes must start with /.', { path: value });
+    }
+    return path.length > 1 ? path.replace(/\/+$/, '') : path;
+  });
+  return uniqueSorted(normalized);
+}
+
+function matchingHostRule(rules: RunEgressHostRule[], host: string): RunEgressHostRule | undefined {
+  return rules.find(
+    (rule) =>
+      rule.kind === 'any' ||
+      (rule.kind === 'exact' && rule.value === host) ||
+      (rule.kind === 'subdomain' && host.endsWith(`.${rule.value}`))
+  );
+}
+
+function destinationAddressBlock(
+  policy: RunEgressPolicy,
+  host: string,
+  resolvedAddresses: string[]
+):
+  | {
+      reason: 'private-network-blocked' | 'loopback-blocked' | 'metadata-endpoint-blocked';
+      addressClass: Exclude<AddressClass, 'public' | 'invalid'>;
+    }
+  | undefined {
+  const candidates = isIP(host) !== 0 ? [host, ...resolvedAddresses] : resolvedAddresses;
+  if (policy.blockMetadataEndpoints && METADATA_HOSTS.has(host)) {
+    return { reason: 'metadata-endpoint-blocked', addressClass: 'metadata' };
+  }
+  for (const address of candidates) {
+    const addressClass = classifyAddress(address);
+    if (policy.blockMetadataEndpoints && addressClass === 'metadata') {
+      return { reason: 'metadata-endpoint-blocked', addressClass };
+    }
+    if (policy.blockLoopback && addressClass === 'loopback') {
+      return { reason: 'loopback-blocked', addressClass };
+    }
+    if (
+      policy.blockPrivateNetwork &&
+      (addressClass === 'private' || addressClass === 'link-local')
+    ) {
+      return { reason: 'private-network-blocked', addressClass };
+    }
+  }
+  return undefined;
+}
+
+function classifyAddress(value: string): AddressClass {
+  const address = value
+    .trim()
+    .replace(/^\[|\]$/g, '')
+    .toLowerCase();
+  if (METADATA_HOSTS.has(address)) return 'metadata';
+  if (address.startsWith('::ffff:')) return classifyAddress(address.slice('::ffff:'.length));
+  const family = isIP(address);
+  if (family === 4) {
+    const octets = address.split('.').map(Number);
+    const [first = -1, second = -1] = octets;
+    if (first === 127 || first === 0) return 'loopback';
+    if (first === 169 && second === 254) return 'link-local';
+    if (
+      first === 10 ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168) ||
+      (first === 100 && second >= 64 && second <= 127)
+    ) {
+      return 'private';
+    }
+    return 'public';
+  }
+  if (family === 6) {
+    if (address === '::1' || address === '::') return 'loopback';
+    const first = Number.parseInt(address.split(':', 1)[0] || '0', 16);
+    if ((first & 0xfe00) === 0xfc00) return 'private';
+    if ((first & 0xffc0) === 0xfe80) return 'link-local';
+    return 'public';
+  }
+  return 'invalid';
+}
+
+function hasPathRestriction(prefixes: string[]): boolean {
+  return prefixes.length > 0 && !prefixes.includes('/');
+}
+
+function pathAllowed(value: string | undefined, prefixes: string[]): boolean {
+  if (!value) return false;
+  const path = value.split(/[?#]/, 1)[0] || '/';
+  return prefixes.some(
+    (prefix) =>
+      prefix === '/' ||
+      path === prefix ||
+      (path.startsWith(prefix) && (prefix.endsWith('/') || path[prefix.length] === '/'))
+  );
+}
+
+function blocked(
+  base: Pick<
+    RunEgressDecision,
+    'schemaVersion' | 'policyHash' | 'protocol' | 'hostKey' | 'port' | 'method'
+  >,
+  policy: RunEgressPolicy,
+  reason: RunEgressDecisionReason,
+  evidence: Pick<RunEgressDecision, 'matchedRule' | 'blockedAddressClass'> = {}
+): RunEgressDecision {
+  const approvalEligible =
+    policy.allowApprovals &&
+    ['default-deny', 'method-not-allowed', 'path-not-allowed', 'tls-inspection-required'].includes(
+      reason
+    );
+  return {
+    ...base,
+    decision: 'block',
+    reason,
+    ...evidence,
+    approvalEligible,
+  };
+}
+
+function identity(kind: string, value: string): string {
+  return `sha256:${createHash('sha256').update(`${kind}:${value}`).digest('hex')}`;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+let service: EgressPolicyService | undefined;
+
+export function getEgressPolicyService(): EgressPolicyService {
+  service ??= new EgressPolicyService();
+  return service;
+}

--- a/server/src/services/sandbox-policy-service.ts
+++ b/server/src/services/sandbox-policy-service.ts
@@ -16,6 +16,7 @@ import {
   getFilesystemSandboxService,
   type FilesystemSandboxService,
 } from './filesystem-sandbox-service.js';
+import { getEgressPolicyService } from './egress-policy-service.js';
 
 const BUILT_IN_TIMESTAMP = '2026-06-18T00:00:00.000Z';
 
@@ -345,6 +346,7 @@ export class SandboxPolicyService {
         envPassthrough: preset.environment.passthrough.slice().sort(),
         credentialRefs: redactBrokerRefs(preset.credentials.brokerRefs),
         filesystemBackend: effectiveFilesystemBackend,
+        networkPolicy: getEgressPolicyService().compile(preset.network),
       },
       evaluations,
       unsupportedRules,
@@ -417,6 +419,7 @@ export class SandboxPolicyService {
       createdAt: input.createdAt ?? now,
       updatedAt: input.updatedAt ?? now,
     }) as SandboxPolicyPreset;
+    getEgressPolicyService().compile(parsed.network);
     return {
       ...parsed,
       filesystem: {
@@ -428,6 +431,9 @@ export class SandboxPolicyService {
       network: {
         ...parsed.network,
         allowedHosts: uniqueSorted(parsed.network.allowedHosts.map((host) => host.toLowerCase())),
+        deniedHosts: uniqueSorted(
+          (parsed.network.deniedHosts ?? []).map((host) => host.toLowerCase())
+        ),
         allowedMethods: uniqueSorted(
           parsed.network.allowedMethods.map((method) => method.toUpperCase())
         ),

--- a/shared/src/types/sandbox-policy.types.ts
+++ b/shared/src/types/sandbox-policy.types.ts
@@ -5,6 +5,8 @@ export type SandboxNetworkDefault = 'allow' | 'deny';
 export type SandboxCredentialMode = 'none' | 'brokered' | 'env-passthrough';
 export type SandboxPolicyDecision = 'allow' | 'warn' | 'block';
 export type SandboxPolicyRuleStatus = 'supported' | 'unsupported' | 'advisory';
+export const RUN_EGRESS_POLICY_SCHEMA_VERSION = 'run-egress-policy/v1' as const;
+export const RUN_EGRESS_DECISION_SCHEMA_VERSION = 'run-egress-decision/v1' as const;
 export type FilesystemSandboxBackendId = 'codex-sandbox' | 'provider-native' | 'none';
 export type FilesystemSandboxBackendState = 'available' | 'native' | 'unavailable';
 export type SandboxProviderCapabilityId =
@@ -34,11 +36,78 @@ export interface SandboxFilesystemRules {
 export interface SandboxNetworkRules {
   defaultEgress: SandboxNetworkDefault;
   allowedHosts: string[];
+  /** Explicit deny rules take precedence over allow rules. Defaults to empty for legacy presets. */
+  deniedHosts?: string[];
   allowedMethods: string[];
   allowedPathPrefixes: string[];
   blockPrivateNetwork: boolean;
   blockMetadataEndpoints: boolean;
   blockLoopback: boolean;
+  /** Allows a blocked request to enter the scoped run-approval flow. */
+  allowApprovals?: boolean;
+  /** Dangerous compatibility override required before an allow rule may use `*`. */
+  dangerouslyAllowGlobalWildcard?: boolean;
+}
+
+export type RunEgressProtocol = 'http' | 'https' | 'ws' | 'wss' | 'socks';
+export type RunEgressHostRuleKind = 'any' | 'exact' | 'subdomain';
+
+export interface RunEgressHostRule {
+  kind: RunEgressHostRuleKind;
+  value: string;
+}
+
+export interface RunEgressPolicy {
+  schemaVersion: typeof RUN_EGRESS_POLICY_SCHEMA_VERSION;
+  policyHash: string;
+  defaultEgress: SandboxNetworkDefault;
+  allowedHosts: RunEgressHostRule[];
+  deniedHosts: RunEgressHostRule[];
+  allowedMethods: string[];
+  allowedPathPrefixes: string[];
+  blockPrivateNetwork: boolean;
+  blockMetadataEndpoints: boolean;
+  blockLoopback: boolean;
+  allowApprovals: boolean;
+  tlsInspection: 'disabled';
+}
+
+export interface RunEgressDecisionInput {
+  protocol: RunEgressProtocol;
+  host: string;
+  port: number;
+  method?: string;
+  /** Path only. Query strings and fragments must be removed before evaluation. */
+  path?: string;
+  resolvedAddresses?: string[];
+  tlsInspected?: boolean;
+}
+
+export type RunEgressDecisionReason =
+  | 'allowed-by-default'
+  | 'allowed-by-host-rule'
+  | 'default-deny'
+  | 'denied-host'
+  | 'method-not-allowed'
+  | 'path-not-allowed'
+  | 'tls-inspection-required'
+  | 'private-network-blocked'
+  | 'loopback-blocked'
+  | 'metadata-endpoint-blocked'
+  | 'invalid-destination';
+
+export interface RunEgressDecision {
+  schemaVersion: typeof RUN_EGRESS_DECISION_SCHEMA_VERSION;
+  decision: 'allow' | 'block';
+  reason: RunEgressDecisionReason;
+  policyHash: string;
+  protocol: RunEgressProtocol;
+  hostKey: string;
+  port: number;
+  method?: string;
+  matchedRule?: RunEgressHostRule;
+  blockedAddressClass?: 'private' | 'loopback' | 'link-local' | 'metadata';
+  approvalEligible: boolean;
 }
 
 export interface SandboxEnvironmentRules {
@@ -121,6 +190,8 @@ export interface SandboxPolicyDryRunResult {
     envPassthrough: string[];
     credentialRefs: string[];
     filesystemBackend: FilesystemSandboxBackendStatus;
+    /** Compiled harness-owned policy. Provider launch injection lands with the gateway runtime. */
+    networkPolicy?: RunEgressPolicy;
   };
   evaluations: SandboxPolicyRuleEvaluation[];
   unsupportedRules: SandboxPolicyRuleEvaluation[];


### PR DESCRIPTION
## Summary

- compile sandbox network rules into a deterministic `run-egress-policy/v1`
- normalize exact and scoped wildcard hosts while rejecting global allow wildcards without the dangerous override
- add explicit deny rules with precedence over allows and approvals
- evaluate host, method, path, TLS inspection, DNS resolution, private, link-local, loopback, and metadata policy before transport
- return redacted `run-egress-decision/v1` evidence with stable host identities and no URL query data
- expose the compiled policy in sandbox validation responses without claiming gateway launch enforcement yet

## Verification

- egress and sandbox policy tests: 20 passed
- server typecheck passed
- shared typecheck passed
- targeted ESLint passed
- Prettier and `git diff --check` passed

## Scope

This is the policy compiler and decision-engine vertical for #855. The next vertical owns the run-scoped HTTP/CONNECT/SOCKS gateway lifecycle, proxy environment injection, attribution, and launch evidence. Required fine-grained rules continue to fail closed until that runtime evidence exists.

Part of #855
