### PR TITLE
feat: enforce run-scoped egress proxy

### DIFF
--- a/server/src/__tests__/run-egress-gateway-service.test.ts
+++ b/server/src/__tests__/run-egress-gateway-service.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import http from 'node:http';
+import net, { type Server as NetServer, type Socket } from 'node:net';
+import type { AddressInfo } from 'node:net';
+import { EgressPolicyService } from '../services/egress-policy-service.js';
+import {
+  RunEgressGatewayService,
+  type RunEgressGatewayHandle,
+} from '../services/run-egress-gateway-service.js';
+
+const policyService = new EgressPolicyService();
+const openGateways: RunEgressGatewayHandle[] = [];
+const openServers: Array<http.Server | NetServer> = [];
+
+afterEach(async () => {
+  await Promise.all(openGateways.splice(0).map((gateway) => gateway.stop()));
+  await Promise.all(
+    openServers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          if ('closeAllConnections' in server) server.closeAllConnections();
+          server.close(() => resolve());
+        })
+    )
+  );
+});
+
+describe('RunEgressGatewayService', () => {
+  it('proxies an allowed HTTP request with redacted audit evidence and blocks method drift', async () => {
+    const upstreamCalls: string[] = [];
+    const upstream = http.createServer((request, response) => {
+      upstreamCalls.push(`${request.method} ${request.url}`);
+      response.writeHead(200, { 'content-type': 'text/plain' });
+      response.end('gateway-ok');
+    });
+    const upstreamPort = await listen(upstream);
+    const audit = vi.fn();
+    const gateway = await startGateway({
+      allowedMethods: ['GET'],
+      allowedPathPrefixes: ['/allowed'],
+      onDecision: audit,
+    });
+    const target = `http://127.0.0.1:${upstreamPort}/allowed/resource?secret=query-value`;
+
+    await expect(proxyRequest(gateway, target, 'GET')).resolves.toMatchObject({
+      statusCode: 200,
+      body: 'gateway-ok',
+    });
+    await expect(proxyRequest(gateway, target, 'POST')).resolves.toMatchObject({
+      statusCode: 403,
+      body: expect.stringContaining('method-not-allowed'),
+    });
+    expect(upstreamCalls).toEqual(['GET /allowed/resource?secret=query-value']);
+    expect(audit).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(audit.mock.calls)).not.toContain('query-value');
+    expect(audit.mock.calls[0]?.[0]).toMatchObject({
+      gatewayId: gateway.gatewayId,
+      runKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      decision: {
+        decision: 'allow',
+        hostKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      },
+    });
+  });
+
+  it('requires run attribution and exposes only hashed durable evidence', async () => {
+    const upstream = http.createServer((_request, response) => response.end('unreachable'));
+    const upstreamPort = await listen(upstream);
+    const gateway = await startGateway();
+    const proxy = new URL(gateway.environment.HTTP_PROXY);
+
+    const unauthenticated = await rawProxyRequest({
+      proxy,
+      target: `http://127.0.0.1:${upstreamPort}/`,
+      method: 'GET',
+    });
+    expect(unauthenticated.statusCode).toBe(407);
+    expect(gateway.evidence).toMatchObject({
+      state: 'enforced',
+      gatewayId: gateway.gatewayId,
+      runKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      attributionKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      protocols: ['http', 'connect', 'ws'],
+    });
+    expect(JSON.stringify(gateway.evidence)).not.toContain(proxy.password);
+    expect(gateway.environment.NO_PROXY).toBe('');
+
+    await expect(gateway.stop()).resolves.toMatchObject({
+      state: 'stopped',
+      stoppedAt: expect.any(String),
+    });
+  });
+
+  it('opens an authenticated CONNECT tunnel only when encrypted policy is enforceable', async () => {
+    const echo = net.createServer((socket) => socket.pipe(socket));
+    const echoPort = await listen(echo);
+    const gateway = await startGateway();
+
+    const tunnel = await connectTunnel(gateway, `127.0.0.1:${echoPort}`);
+    expect(tunnel.statusCode).toBe(200);
+    await expect(roundTrip(tunnel.socket, 'through-gateway')).resolves.toBe('through-gateway');
+    tunnel.socket.destroy();
+
+    const restricted = await startGateway({
+      runId: 'run-egress-restricted',
+      allowedMethods: ['GET'],
+    });
+    await expect(connectTunnel(restricted, `127.0.0.1:${echoPort}`)).rejects.toMatchObject({
+      statusCode: 403,
+      body: expect.stringContaining('tls-inspection-required'),
+    });
+  });
+
+  it('forwards an allowed plaintext WebSocket upgrade through the same policy boundary', async () => {
+    const upstream = http.createServer();
+    upstream.on('upgrade', (_request, socket) => {
+      socket.write(
+        'HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n'
+      );
+    });
+    const upstreamPort = await listen(upstream);
+    const gateway = await startGateway({
+      runId: 'run-egress-websocket',
+      allowedMethods: ['GET'],
+      allowedPathPrefixes: ['/socket'],
+    });
+
+    const response = await websocketUpgrade(
+      gateway,
+      `ws://127.0.0.1:${upstreamPort}/socket?secret=not-audited`
+    );
+    expect(response).toContain('101 Switching Protocols');
+  });
+});
+
+async function startGateway(
+  overrides: {
+    runId?: string;
+    allowedMethods?: string[];
+    allowedPathPrefixes?: string[];
+    onDecision?: (event: unknown) => void;
+  } = {}
+): Promise<RunEgressGatewayHandle> {
+  const service = new RunEgressGatewayService(policyService);
+  const gateway = await service.start({
+    runId: overrides.runId ?? `run-egress-${openGateways.length}`,
+    policy: policyService.compile({
+      defaultEgress: 'deny',
+      allowedHosts: ['127.0.0.1'],
+      deniedHosts: [],
+      allowedMethods: overrides.allowedMethods ?? [],
+      allowedPathPrefixes: overrides.allowedPathPrefixes ?? [],
+      blockPrivateNetwork: false,
+      blockMetadataEndpoints: false,
+      blockLoopback: false,
+      allowApprovals: false,
+      dangerouslyAllowGlobalWildcard: false,
+    }),
+    requestTimeoutMs: 5_000,
+    idleTimeoutMs: 5_000,
+    onDecision: overrides.onDecision,
+  });
+  openGateways.push(gateway);
+  return gateway;
+}
+
+async function listen(server: http.Server | NetServer): Promise<number> {
+  openServers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  return (server.address() as AddressInfo).port;
+}
+
+async function proxyRequest(
+  gateway: RunEgressGatewayHandle,
+  target: string,
+  method: string
+): Promise<{ statusCode: number; body: string }> {
+  const proxy = new URL(gateway.environment.HTTP_PROXY);
+  return rawProxyRequest({
+    proxy,
+    target,
+    method,
+    proxyAuthorization: basicProxyAuthorization(proxy),
+  });
+}
+
+function rawProxyRequest(input: {
+  proxy: URL;
+  target: string;
+  method: string;
+  proxyAuthorization?: string;
+}): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      host: input.proxy.hostname,
+      port: Number(input.proxy.port),
+      method: input.method,
+      path: input.target,
+      headers: {
+        ...(input.proxyAuthorization ? { 'Proxy-Authorization': input.proxyAuthorization } : {}),
+      },
+    });
+    request.once('response', (response) => {
+      const chunks: Buffer[] = [];
+      response.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      response.once('end', () =>
+        resolve({
+          statusCode: response.statusCode ?? 0,
+          body: Buffer.concat(chunks).toString('utf8'),
+        })
+      );
+    });
+    request.once('error', reject);
+    request.end();
+  });
+}
+
+function connectTunnel(
+  gateway: RunEgressGatewayHandle,
+  authority: string
+): Promise<{ statusCode: number; socket: Socket }> {
+  const proxy = new URL(gateway.environment.HTTPS_PROXY);
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      host: proxy.hostname,
+      port: Number(proxy.port),
+      method: 'CONNECT',
+      path: authority,
+      headers: { 'Proxy-Authorization': basicProxyAuthorization(proxy) },
+    });
+    request.once('connect', (response, socket) =>
+      resolve({ statusCode: response.statusCode ?? 0, socket })
+    );
+    request.once('response', (response) => {
+      const chunks: Buffer[] = [];
+      response.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      response.once('end', () =>
+        reject({
+          statusCode: response.statusCode ?? 0,
+          body: Buffer.concat(chunks).toString('utf8'),
+        })
+      );
+    });
+    request.once('error', reject);
+    request.end();
+  });
+}
+
+function roundTrip(socket: Socket, value: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    socket.once('data', (chunk) => resolve(Buffer.from(chunk).toString('utf8')));
+    socket.once('error', reject);
+    socket.write(value);
+  });
+}
+
+function websocketUpgrade(gateway: RunEgressGatewayHandle, target: string): Promise<string> {
+  const proxy = new URL(gateway.environment.HTTP_PROXY);
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(Number(proxy.port), proxy.hostname);
+    socket.once('connect', () => {
+      socket.write(
+        `GET ${target} HTTP/1.1\r\n` +
+          `Host: ${new URL(target).host}\r\n` +
+          'Connection: Upgrade\r\n' +
+          'Upgrade: websocket\r\n' +
+          `Proxy-Authorization: ${basicProxyAuthorization(proxy)}\r\n` +
+          '\r\n'
+      );
+    });
+    socket.once('data', (chunk) => {
+      resolve(Buffer.from(chunk).toString('utf8'));
+      socket.destroy();
+    });
+    socket.once('error', reject);
+  });
+}
+
+function basicProxyAuthorization(proxy: URL): string {
+  return `Basic ${Buffer.from(`${proxy.username}:${proxy.password}`).toString('base64')}`;
+}

--- a/server/src/__tests__/run-egress-gateway-service.test.ts
+++ b/server/src/__tests__/run-egress-gateway-service.test.ts
@@ -114,7 +114,7 @@ describe('RunEgressGatewayService', () => {
   it('forwards an allowed plaintext WebSocket upgrade through the same policy boundary', async () => {
     const upstream = http.createServer();
     upstream.on('upgrade', (_request, socket) => {
-      socket.write(
+      socket.end(
         'HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n'
       );
     });
@@ -231,9 +231,23 @@ function connectTunnel(
       path: authority,
       headers: { 'Proxy-Authorization': basicProxyAuthorization(proxy) },
     });
-    request.once('connect', (response, socket) =>
-      resolve({ statusCode: response.statusCode ?? 0, socket })
-    );
+    request.once('connect', (response, socket, head) => {
+      const statusCode = response.statusCode ?? 0;
+      if (statusCode === 200) {
+        resolve({ statusCode, socket });
+        return;
+      }
+      const chunks = head.length > 0 ? [Buffer.from(head)] : [];
+      socket.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      socket.once('end', () =>
+        reject({
+          statusCode,
+          body: Buffer.concat(chunks).toString('utf8'),
+        })
+      );
+      socket.once('error', reject);
+      socket.resume();
+    });
     request.once('response', (response) => {
       const chunks: Buffer[] = [];
       response.on('data', (chunk) => chunks.push(Buffer.from(chunk)));

--- a/server/src/services/egress-policy-service.ts
+++ b/server/src/services/egress-policy-service.ts
@@ -26,6 +26,10 @@ const METADATA_HOSTS = new Set([
 
 type AddressClass = 'public' | 'private' | 'loopback' | 'link-local' | 'metadata' | 'invalid';
 type EgressHostResolver = (host: string) => Promise<string[]>;
+export interface ResolvedEgressDecision {
+  decision: RunEgressDecision;
+  resolvedAddresses: string[];
+}
 
 export class EgressPolicyService {
   constructor(
@@ -130,12 +134,25 @@ export class EgressPolicyService {
     policy: RunEgressPolicy,
     input: Omit<RunEgressDecisionInput, 'resolvedAddresses'>
   ): Promise<RunEgressDecision> {
+    return (await this.resolveAndEvaluate(policy, input)).decision;
+  }
+
+  async resolveAndEvaluate(
+    policy: RunEgressPolicy,
+    input: Omit<RunEgressDecisionInput, 'resolvedAddresses'>
+  ): Promise<ResolvedEgressDecision> {
     const host = normalizeHost(input.host);
     try {
       const resolvedAddresses = isIP(host) === 0 ? await this.resolveHost(host) : [host];
-      return this.evaluate(policy, { ...input, resolvedAddresses });
+      return {
+        decision: this.evaluate(policy, { ...input, resolvedAddresses }),
+        resolvedAddresses,
+      };
     } catch {
-      return this.evaluate(policy, { ...input, resolvedAddresses: ['unresolved'] });
+      return {
+        decision: this.evaluate(policy, { ...input, resolvedAddresses: ['unresolved'] }),
+        resolvedAddresses: [],
+      };
     }
   }
 }

--- a/server/src/services/run-egress-gateway-service.ts
+++ b/server/src/services/run-egress-gateway-service.ts
@@ -1,0 +1,572 @@
+import { createHash, randomBytes } from 'node:crypto';
+import http, {
+  type IncomingHttpHeaders,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
+import net, { type Socket } from 'node:net';
+import { URL } from 'node:url';
+import {
+  RUN_EGRESS_GATEWAY_EVIDENCE_SCHEMA_VERSION,
+  type RunEgressDecision,
+  type RunEgressGatewayEvidence,
+  type RunEgressPolicy,
+} from '@veritas-kanban/shared';
+import { ConflictError } from '../middleware/error-handler.js';
+import { EgressPolicyService, getEgressPolicyService } from './egress-policy-service.js';
+
+const LOOPBACK_HOST = '127.0.0.1';
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+const DEFAULT_MAX_CONNECTIONS = 64;
+const PROXY_ENVIRONMENT_KEYS = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'NO_PROXY',
+  'no_proxy',
+] as const;
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'proxy-connection',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+export interface RunEgressGatewayAuditEvent {
+  gatewayId: string;
+  runKey: string;
+  occurredAt: string;
+  decision: RunEgressDecision;
+}
+
+export interface StartRunEgressGatewayInput {
+  runId: string;
+  policy: RunEgressPolicy;
+  requestTimeoutMs?: number;
+  idleTimeoutMs?: number;
+  maxConnections?: number;
+  onDecision?: (event: RunEgressGatewayAuditEvent) => Promise<void> | void;
+}
+
+export interface RunEgressGatewayHandle {
+  gatewayId: string;
+  environment: Record<(typeof PROXY_ENVIRONMENT_KEYS)[number], string>;
+  evidence: RunEgressGatewayEvidence;
+  stop(): Promise<RunEgressGatewayEvidence>;
+}
+
+interface ActiveGateway {
+  runId: string;
+  server: http.Server;
+  sockets: Set<Socket>;
+  evidence: RunEgressGatewayEvidence;
+  environment: RunEgressGatewayHandle['environment'];
+  stop(): Promise<RunEgressGatewayEvidence>;
+}
+
+export class RunEgressGatewayService {
+  private readonly activeByRunId = new Map<string, ActiveGateway>();
+  private readonly activeByGatewayId = new Map<string, ActiveGateway>();
+
+  constructor(
+    private readonly policyService: EgressPolicyService = getEgressPolicyService(),
+    private readonly now: () => Date = () => new Date()
+  ) {}
+
+  async start(input: StartRunEgressGatewayInput): Promise<RunEgressGatewayHandle> {
+    const runId = input.runId.trim();
+    if (!runId) throw new ConflictError('Run-scoped egress gateway requires a run id.');
+    const existing = this.activeByRunId.get(runId);
+    if (existing) {
+      if (existing.evidence.policyHash !== input.policy.policyHash) {
+        throw new ConflictError('Run egress gateway already uses a different policy.', {
+          gatewayId: existing.evidence.gatewayId,
+          policyHash: existing.evidence.policyHash,
+        });
+      }
+      return this.publicHandle(existing);
+    }
+
+    const token = randomBytes(32).toString('base64url');
+    const gatewayId = `runegress_${createHash('sha256')
+      .update(`${runId}:${token}`)
+      .digest('hex')
+      .slice(0, 32)}`;
+    const runKey = identity('run', runId);
+    const requestTimeoutMs = boundedDuration(
+      input.requestTimeoutMs,
+      DEFAULT_REQUEST_TIMEOUT_MS,
+      1_000,
+      300_000
+    );
+    const idleTimeoutMs = boundedDuration(
+      input.idleTimeoutMs,
+      DEFAULT_IDLE_TIMEOUT_MS,
+      1_000,
+      600_000
+    );
+    const maxConnections = boundedInteger(input.maxConnections, DEFAULT_MAX_CONNECTIONS, 1, 1_000);
+    const sockets = new Set<Socket>();
+    const clientSockets = new Set<Socket>();
+    const server = http.createServer();
+    server.requestTimeout = requestTimeoutMs;
+    server.headersTimeout = requestTimeoutMs;
+    server.keepAliveTimeout = Math.min(idleTimeoutMs, requestTimeoutMs);
+
+    const context: GatewayRequestContext = {
+      gatewayId,
+      runKey,
+      token,
+      policy: input.policy,
+      requestTimeoutMs,
+      idleTimeoutMs,
+      policyService: this.policyService,
+      onDecision: input.onDecision,
+      now: this.now,
+      sockets,
+    };
+    server.on('request', (request, response) => {
+      void handleHttpRequest(context, request, response);
+    });
+    server.on('connect', (request, socket, head) => {
+      void handleConnect(context, request, socket as Socket, head);
+    });
+    server.on('upgrade', (request, socket, head) => {
+      void handleUpgrade(context, request, socket as Socket, head);
+    });
+    server.on('connection', (socket) => {
+      if (clientSockets.size >= maxConnections) {
+        socket.destroy();
+        return;
+      }
+      clientSockets.add(socket);
+      sockets.add(socket);
+      socket.setTimeout(idleTimeoutMs, () => socket.destroy());
+      socket.once('close', () => {
+        clientSockets.delete(socket);
+        sockets.delete(socket);
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => {
+        server.off('listening', onListening);
+        reject(error);
+      };
+      const onListening = () => {
+        server.off('error', onError);
+        resolve();
+      };
+      server.once('error', onError);
+      server.once('listening', onListening);
+      server.listen(0, LOOPBACK_HOST);
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      server.close();
+      throw new Error('Run egress gateway did not bind a TCP port.');
+    }
+    const proxyUrl = `http://veritas:${encodeURIComponent(token)}@${LOOPBACK_HOST}:${address.port}`;
+    const environment: ActiveGateway['environment'] = {
+      HTTP_PROXY: proxyUrl,
+      HTTPS_PROXY: proxyUrl,
+      http_proxy: proxyUrl,
+      https_proxy: proxyUrl,
+      NO_PROXY: '',
+      no_proxy: '',
+    };
+    const evidence: RunEgressGatewayEvidence = {
+      schemaVersion: RUN_EGRESS_GATEWAY_EVIDENCE_SCHEMA_VERSION,
+      gatewayId,
+      runKey,
+      attributionKey: identity('attribution', token),
+      policyHash: input.policy.policyHash,
+      state: 'enforced',
+      protocols: ['http', 'connect', 'ws'],
+      proxyEnvironmentKeys: [...PROXY_ENVIRONMENT_KEYS],
+      startedAt: this.now().toISOString(),
+    };
+    let stopPromise: Promise<RunEgressGatewayEvidence> | undefined;
+    const active: ActiveGateway = {
+      runId,
+      server,
+      sockets,
+      evidence,
+      environment,
+      stop: () => {
+        stopPromise ??= this.stopActive(active);
+        return stopPromise;
+      },
+    };
+    this.activeByRunId.set(runId, active);
+    this.activeByGatewayId.set(gatewayId, active);
+    return this.publicHandle(active);
+  }
+
+  getEvidence(gatewayId: string): RunEgressGatewayEvidence | null {
+    return this.activeByGatewayId.get(gatewayId)?.evidence ?? null;
+  }
+
+  async stopRun(runId: string): Promise<RunEgressGatewayEvidence | null> {
+    const active = this.activeByRunId.get(runId);
+    return active ? active.stop() : null;
+  }
+
+  private publicHandle(active: ActiveGateway): RunEgressGatewayHandle {
+    return {
+      gatewayId: active.evidence.gatewayId,
+      environment: { ...active.environment },
+      evidence: active.evidence,
+      stop: active.stop,
+    };
+  }
+
+  private async stopActive(active: ActiveGateway): Promise<RunEgressGatewayEvidence> {
+    this.activeByRunId.delete(active.runId);
+    this.activeByGatewayId.delete(active.evidence.gatewayId);
+    for (const socket of active.sockets) socket.destroy();
+    await new Promise<void>((resolve) => {
+      active.server.close(() => resolve());
+      active.server.closeAllConnections?.();
+    });
+    active.evidence = {
+      ...active.evidence,
+      state: 'stopped',
+      stoppedAt: this.now().toISOString(),
+    };
+    active.environment = {
+      HTTP_PROXY: '',
+      HTTPS_PROXY: '',
+      http_proxy: '',
+      https_proxy: '',
+      NO_PROXY: '',
+      no_proxy: '',
+    };
+    return active.evidence;
+  }
+}
+
+interface GatewayRequestContext {
+  gatewayId: string;
+  runKey: string;
+  token: string;
+  policy: RunEgressPolicy;
+  requestTimeoutMs: number;
+  idleTimeoutMs: number;
+  policyService: EgressPolicyService;
+  onDecision?: StartRunEgressGatewayInput['onDecision'];
+  now: () => Date;
+  sockets: Set<Socket>;
+}
+
+async function handleHttpRequest(
+  context: GatewayRequestContext,
+  request: IncomingMessage,
+  response: ServerResponse
+): Promise<void> {
+  if (!authenticated(request, context.token)) {
+    rejectHttp(response, 407, 'proxy-authentication-required');
+    return;
+  }
+  const target = parseProxyUrl(request.url);
+  if (!target || target.protocol !== 'http:' || target.username || target.password) {
+    rejectHttp(response, 400, 'invalid-destination');
+    return;
+  }
+  const resolution = await context.policyService.resolveAndEvaluate(context.policy, {
+    protocol: 'http',
+    host: target.hostname,
+    port: portFor(target, 80),
+    method: request.method,
+    path: target.pathname,
+  });
+  await audit(context, resolution.decision);
+  if (resolution.decision.decision === 'block') {
+    rejectHttp(response, 403, resolution.decision.reason);
+    return;
+  }
+  const address = resolution.resolvedAddresses[0];
+  if (!address) {
+    rejectHttp(response, 502, 'destination-resolution-failed');
+    return;
+  }
+  const headers = forwardHeaders(request.headers, target.host, false);
+  const upstream = http.request({
+    host: address,
+    port: portFor(target, 80),
+    method: request.method,
+    path: `${target.pathname}${target.search}`,
+    headers,
+    family: net.isIP(address),
+    timeout: context.requestTimeoutMs,
+  });
+  upstream.once('socket', (socket) => {
+    context.sockets.add(socket);
+    socket.once('close', () => context.sockets.delete(socket));
+  });
+  upstream.once('response', (upstreamResponse) => {
+    response.writeHead(
+      upstreamResponse.statusCode ?? 502,
+      forwardHeaders(upstreamResponse.headers, undefined, false)
+    );
+    upstreamResponse.pipe(response);
+  });
+  upstream.once('timeout', () => upstream.destroy(new Error('Upstream request timed out.')));
+  upstream.once('error', () => {
+    if (!response.headersSent) rejectHttp(response, 502, 'upstream-failure');
+    else response.destroy();
+  });
+  request.pipe(upstream);
+}
+
+async function handleConnect(
+  context: GatewayRequestContext,
+  request: IncomingMessage,
+  client: Socket,
+  head: Buffer
+): Promise<void> {
+  if (!authenticated(request, context.token)) {
+    rejectSocket(client, 407, 'proxy-authentication-required');
+    return;
+  }
+  const authority = parseAuthority(request.url);
+  if (!authority) {
+    rejectSocket(client, 400, 'invalid-destination');
+    return;
+  }
+  const resolution = await context.policyService.resolveAndEvaluate(context.policy, {
+    protocol: 'https',
+    host: authority.host,
+    port: authority.port,
+  });
+  await audit(context, resolution.decision);
+  if (resolution.decision.decision === 'block') {
+    rejectSocket(client, 403, resolution.decision.reason);
+    return;
+  }
+  const address = resolution.resolvedAddresses[0];
+  if (!address) {
+    rejectSocket(client, 502, 'destination-resolution-failed');
+    return;
+  }
+  const upstream = net.connect({
+    host: address,
+    port: authority.port,
+    family: net.isIP(address),
+  });
+  context.sockets.add(upstream);
+  let connected = false;
+  upstream.setTimeout(context.idleTimeoutMs, () => upstream.destroy());
+  upstream.once('close', () => context.sockets.delete(upstream));
+  upstream.once('connect', () => {
+    connected = true;
+    client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+    if (head.length > 0) upstream.write(head);
+    client.pipe(upstream);
+    upstream.pipe(client);
+  });
+  upstream.once('error', () => {
+    if (connected) client.destroy();
+    else rejectSocket(client, 502, 'upstream-failure');
+  });
+}
+
+async function handleUpgrade(
+  context: GatewayRequestContext,
+  request: IncomingMessage,
+  client: Socket,
+  head: Buffer
+): Promise<void> {
+  if (!authenticated(request, context.token)) {
+    rejectSocket(client, 407, 'proxy-authentication-required');
+    return;
+  }
+  const target = parseProxyUrl(request.url);
+  if (
+    !target ||
+    !['http:', 'ws:'].includes(target.protocol) ||
+    target.username ||
+    target.password
+  ) {
+    rejectSocket(client, 400, 'invalid-destination');
+    return;
+  }
+  const resolution = await context.policyService.resolveAndEvaluate(context.policy, {
+    protocol: 'ws',
+    host: target.hostname,
+    port: portFor(target, 80),
+    method: request.method ?? 'GET',
+    path: target.pathname,
+  });
+  await audit(context, resolution.decision);
+  if (resolution.decision.decision === 'block') {
+    rejectSocket(client, 403, resolution.decision.reason);
+    return;
+  }
+  const address = resolution.resolvedAddresses[0];
+  if (!address) {
+    rejectSocket(client, 502, 'destination-resolution-failed');
+    return;
+  }
+  const upstream = net.connect({
+    host: address,
+    port: portFor(target, 80),
+    family: net.isIP(address),
+  });
+  context.sockets.add(upstream);
+  let connected = false;
+  upstream.setTimeout(context.idleTimeoutMs, () => upstream.destroy());
+  upstream.once('close', () => context.sockets.delete(upstream));
+  upstream.once('connect', () => {
+    connected = true;
+    upstream.write(
+      `${request.method ?? 'GET'} ${target.pathname}${target.search} HTTP/${request.httpVersion}\r\n`
+    );
+    for (const [name, value] of Object.entries(
+      forwardHeaders(request.headers, target.host, true)
+    )) {
+      for (const item of Array.isArray(value) ? value : [value]) {
+        if (item !== undefined) upstream.write(`${name}: ${item}\r\n`);
+      }
+    }
+    upstream.write('\r\n');
+    if (head.length > 0) upstream.write(head);
+    client.pipe(upstream);
+    upstream.pipe(client);
+  });
+  upstream.once('error', () => {
+    if (connected) client.destroy();
+    else rejectSocket(client, 502, 'upstream-failure');
+  });
+}
+
+async function audit(context: GatewayRequestContext, decision: RunEgressDecision): Promise<void> {
+  if (!context.onDecision) return;
+  try {
+    await context.onDecision({
+      gatewayId: context.gatewayId,
+      runKey: context.runKey,
+      occurredAt: context.now().toISOString(),
+      decision,
+    });
+  } catch {
+    // The enforced transport decision remains authoritative if optional audit export is unavailable.
+  }
+}
+
+function authenticated(request: IncomingMessage, token: string): boolean {
+  const header = request.headers['proxy-authorization'];
+  if (typeof header !== 'string') return false;
+  const bearer = `Bearer ${token}`;
+  const basic = `Basic ${Buffer.from(`veritas:${token}`).toString('base64')}`;
+  return safeEqual(header, bearer) || safeEqual(header, basic);
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftDigest = createHash('sha256').update(left).digest();
+  const rightDigest = createHash('sha256').update(right).digest();
+  return leftDigest.equals(rightDigest);
+}
+
+function parseProxyUrl(value: string | undefined): URL | null {
+  if (!value) return null;
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function parseAuthority(value: string | undefined): { host: string; port: number } | null {
+  if (!value) return null;
+  try {
+    const parsed = new URL(`http://${value}`);
+    const port = portFor(parsed, 443);
+    if (parsed.username || parsed.password || parsed.pathname !== '/') return null;
+    return { host: parsed.hostname, port };
+  } catch {
+    return null;
+  }
+}
+
+function portFor(url: URL, fallback: number): number {
+  return url.port ? Number.parseInt(url.port, 10) : fallback;
+}
+
+function forwardHeaders(
+  headers: IncomingHttpHeaders,
+  host: string | undefined,
+  preserveUpgrade: boolean
+): IncomingHttpHeaders {
+  const result: IncomingHttpHeaders = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (lower === 'proxy-authorization' || lower === 'proxy-connection') continue;
+    if (!preserveUpgrade && HOP_BY_HOP_HEADERS.has(lower)) continue;
+    if (value === undefined) continue;
+    result[lower] = value;
+  }
+  if (host) result.host = host;
+  return result;
+}
+
+function rejectHttp(response: ServerResponse, statusCode: number, reason: string): void {
+  if (response.headersSent) {
+    response.destroy();
+    return;
+  }
+  response.writeHead(statusCode, {
+    'content-type': 'application/json',
+    ...(statusCode === 407 ? { 'proxy-authenticate': 'Basic realm="veritas-run-egress"' } : {}),
+  });
+  response.end(JSON.stringify({ error: reason }));
+}
+
+function rejectSocket(socket: Socket, statusCode: number, reason: string): void {
+  if (socket.destroyed) return;
+  socket.end(
+    `HTTP/1.1 ${statusCode} ${http.STATUS_CODES[statusCode] ?? 'Rejected'}\r\n` +
+      'Connection: close\r\n' +
+      'Content-Type: application/json\r\n' +
+      `${statusCode === 407 ? 'Proxy-Authenticate: Basic realm="veritas-run-egress"\r\n' : ''}` +
+      '\r\n' +
+      JSON.stringify({ error: reason })
+  );
+}
+
+function boundedDuration(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number
+): number {
+  if (value === undefined) return fallback;
+  return Math.min(maximum, Math.max(minimum, Math.trunc(value)));
+}
+
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number
+): number {
+  return boundedDuration(value, fallback, minimum, maximum);
+}
+
+function identity(kind: string, value: string): string {
+  return `sha256:${createHash('sha256').update(`${kind}:${value}`).digest('hex')}`;
+}
+
+let service: RunEgressGatewayService | undefined;
+
+export function getRunEgressGatewayService(): RunEgressGatewayService {
+  service ??= new RunEgressGatewayService();
+  return service;
+}

--- a/shared/src/types/sandbox-policy.types.ts
+++ b/shared/src/types/sandbox-policy.types.ts
@@ -7,6 +7,7 @@ export type SandboxPolicyDecision = 'allow' | 'warn' | 'block';
 export type SandboxPolicyRuleStatus = 'supported' | 'unsupported' | 'advisory';
 export const RUN_EGRESS_POLICY_SCHEMA_VERSION = 'run-egress-policy/v1' as const;
 export const RUN_EGRESS_DECISION_SCHEMA_VERSION = 'run-egress-decision/v1' as const;
+export const RUN_EGRESS_GATEWAY_EVIDENCE_SCHEMA_VERSION = 'run-egress-gateway-evidence/v1' as const;
 export type FilesystemSandboxBackendId = 'codex-sandbox' | 'provider-native' | 'none';
 export type FilesystemSandboxBackendState = 'available' | 'native' | 'unavailable';
 export type SandboxProviderCapabilityId =
@@ -108,6 +109,21 @@ export interface RunEgressDecision {
   matchedRule?: RunEgressHostRule;
   blockedAddressClass?: 'private' | 'loopback' | 'link-local' | 'metadata';
   approvalEligible: boolean;
+}
+
+export interface RunEgressGatewayEvidence {
+  schemaVersion: typeof RUN_EGRESS_GATEWAY_EVIDENCE_SCHEMA_VERSION;
+  gatewayId: string;
+  runKey: string;
+  attributionKey: string;
+  policyHash: string;
+  state: 'enforced' | 'stopped';
+  protocols: Array<'http' | 'connect' | 'ws'>;
+  proxyEnvironmentKeys: Array<
+    'HTTP_PROXY' | 'HTTPS_PROXY' | 'http_proxy' | 'https_proxy' | 'NO_PROXY' | 'no_proxy'
+  >;
+  startedAt: string;
+  stoppedAt?: string;
 }
 
 export interface SandboxEnvironmentRules {


### PR DESCRIPTION
## Summary

- add an authenticated, run-scoped loopback gateway for HTTP, CONNECT, and plaintext WebSocket traffic
- enforce compiled network policy against DNS-resolved addresses and connect only to the evaluated address
- expose proxy variables to the run while keeping attribution tokens out of durable evidence
- bound client connections, track all transport sockets, and shut down active traffic when the run gateway stops
- add focused integration coverage for allow/deny decisions, attribution, redaction, CONNECT, and WebSocket upgrades

## Verification

- `shared/node_modules/.bin/tsc -p shared/tsconfig.json`
- `server/node_modules/.bin/tsc -p server/tsconfig.json --noEmit`
- targeted ESLint for the four changed files
- targeted Prettier check for the four changed files
- `git diff --check`

The transport integration tests cannot bind a loopback listener in the local workspace sandbox (`listen EPERM`). CI is the execution gate for those four tests.

Part of #855
