### PR TITLE
feat: route provider egress through run gateway

### DIFF
--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -65,7 +65,7 @@ Readiness runs bounded `claude --version`, `claude auth status`, and
 `claude agents --json` probes without a shell. The auth status probe is useful
 diagnostic evidence, but only the explicit bare-mode environment satisfies
 launch authentication. The runtime profile requires an exact
-`2.1.218 (Claude Code)` version match and probe revision 15; version or build
+`2.1.218 (Claude Code)` version match and probe revision 16; version or build
 drift invalidates conformance evidence.
 
 Claude's stream is consumed as bounded JSONL. Partial text/thinking, tool
@@ -192,7 +192,7 @@ starts it without a shell in the assigned task worktree.
 Before changing attempt state, Veritas starts a bounded probe process and sends
 ACP `initialize` with protocol version `1`. The returned agent name, version,
 capabilities, and a deterministic capability digest become
-`provider-runtime-manifest/v1` evidence at probe revision 15. Launch starts a
+`provider-runtime-manifest/v1` evidence at probe revision 16. Launch starts a
 fresh process and rejects capability drift before opening or prompting a
 session.
 
@@ -813,6 +813,14 @@ host cannot support them. Advisory controls continue with warnings and a
 governance trace. Settings also includes a dry-run panel that shows effective
 sandbox mode, network access, environment allowlist, unsupported controls, and
 the trace ID.
+
+Selective network policies for local task and workflow providers start an
+authenticated, run-scoped loopback gateway before dispatch. Durable launch and
+gateway evidence records only the injected proxy key names and policy digest;
+tokens and proxy URLs are never persisted. HTTP, HTTPS CONNECT, and plaintext WebSocket
+transports use the evaluated DNS address, and the gateway is stopped during
+terminal cleanup. OpenClaw is provider-managed and cannot receive this local
+boundary, so a required fine-grained policy blocks its launch.
 
 Local ACP, Claude Code, Codex app-server, Codex CLI, and Hermes processes use a
 version-bound `codex sandbox` wrapper when its credential-free conformance

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -469,7 +469,7 @@ Implemented:
   successful provider result fails closed.
 - **Session continuity evidence** — Claude `session_id` is stored on the attempt
   and separately from turn/item identity in the event schema.
-- **Versioned readiness** — The exact v2.1.218 runtime, probe revision 15,
+- **Versioned readiness** — The exact v2.1.218 runtime, probe revision 16,
   authentication posture, and safe agent-discovery summary determine support
   status.
 - **Capability truth** — The shared approval broker is available, but this
@@ -1176,6 +1176,11 @@ Reusable launch-time sandbox presets for provider execution guardrails.
 - Dry-runs also compile `run-egress-policy/v1`: host rules are normalized, deny
   rules take precedence, unsafe global allow wildcards fail validation, and a
   deterministic policy digest binds later gateway launch evidence.
+- Selective local-provider policies start an authenticated loopback gateway
+  before provider dispatch. Veritas injects HTTP, HTTPS, and all-proxy variables,
+  clears proxy bypass variables, pins the evaluated DNS address for transport,
+  and stops the gateway with the run. Remote OpenClaw execution fails closed
+  when the preset requires this local gateway.
 
 **Enforcement:**
 
@@ -1201,7 +1206,9 @@ Reusable launch-time sandbox presets for provider execution guardrails.
   catalogs. Existing provider authentication and explicit environment
   passthrough are not mislabeled as brokered.
 - Provider capability checks currently distinguish Codex CLI, Codex SDK,
-  Codex app-server, Claude Code, Hermes, and OpenClaw execution behavior.
+  Codex app-server, Claude Code, ACP stdio harnesses, Hermes, and OpenClaw
+  execution behavior. Gateway capability evidence is invalidated by provider
+  runtime probe revision 16.
 
 ### Session Isolation
 

--- a/server/src/__tests__/__snapshots__/provider-task-envelope-renderer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/provider-task-envelope-renderer.test.ts.snap
@@ -6,10 +6,10 @@ exports[`provider task-envelope renderers > renders a callback-free Claude Code 
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:7d9c175d883fbd1ea63c00e4bf7301e41835886942f3fa58103f8f011042f286\`
+- Digest: \`sha256:ef4bde56bd2a3ab7f14ab2fcbfe034092ea8dfae37927adc11ba2bfce3f06f86\`
 - Provider: \`claude-code\`
 - Adapter: \`claude-code\`
-- Runtime manifest: \`sha256:82a911fb183a8d0485edbe2983acedadc61a9fd78c0cdaae654bf56fef5349a9\`
+- Runtime manifest: \`sha256:88e24bd4e81c1188c99ba752fa246b15e2cbe1610d8c7ebeb435a983e66dc348\`
 - Protocol: \`fixture-runtime/v1\`
 - Task: \`task_transport\`
 - Attempt: \`attempt_transport\`
@@ -97,10 +97,10 @@ exports[`provider task-envelope renderers > renders a callback-free Codex CLI tr
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:35af227ade918170ee3456ee27310ef098fd7dba1b10b88f9739ce958df590fb\`
+- Digest: \`sha256:0655dd8724d872681c78ded660e839f8fc4e15aad3028a64196b807c73f987e5\`
 - Provider: \`codex-cli\`
 - Adapter: \`codex-cli\`
-- Runtime manifest: \`sha256:3c6fc26242ea1b32aebf454356ef66d16c8a4f45a2629d1827676e1cdeb0eca6\`
+- Runtime manifest: \`sha256:d8ad6b2c4913ff3b21f6ce902b77cb362401ef86f32aa4f3f28cbbd9d88082c9\`
 - Protocol: \`fixture-runtime/v1\`
 - Task: \`task_transport\`
 - Attempt: \`attempt_transport\`
@@ -185,10 +185,10 @@ exports[`provider task-envelope renderers > renders a callback-free Codex SDK tr
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:954122d11522feeb54c1622134ceaad889f576fe7ff2d0abfc1ab70947cc52b8\`
+- Digest: \`sha256:9e8bd5c917431107ec21f6f4836b1f9f7077f4a2201cf6afb031d5eeec657920\`
 - Provider: \`codex-sdk\`
 - Adapter: \`codex-sdk\`
-- Runtime manifest: \`sha256:f4c2bcc5c01bb569405dd1be9c1cfc5fe91573ebee93ea6b256e09b5459b4d37\`
+- Runtime manifest: \`sha256:a0d6c0f07b4c24419c37b4526f183951db10d5c6ec9bf3451f2daa1ef7cf368a\`
 - Protocol: \`fixture-runtime/v1\`
 - Task: \`task_transport\`
 - Attempt: \`attempt_transport\`
@@ -274,10 +274,10 @@ exports[`provider task-envelope renderers > renders a callback-free Codex app-se
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:c1417ad3a6d68f811d6e9af3f268137abef42a6741e794c7f8f1785560f53673\`
+- Digest: \`sha256:6c2fa8ebc32e978a3a8fda910471429b26e93be9afe346311d0a80c97680658a\`
 - Provider: \`codex-app-server\`
 - Adapter: \`codex-app-server\`
-- Runtime manifest: \`sha256:f1c80cd954bf05b190f6f8612110d58b03ce8a17f981b7c298b157f6814aa32f\`
+- Runtime manifest: \`sha256:d5a32f42bfe25fc1a2d4e93a35b31f1cded947bfbf24041b8fd96ebd86c299a3\`
 - Protocol: \`fixture-runtime/v1\`
 - Task: \`task_transport\`
 - Attempt: \`attempt_transport\`
@@ -365,10 +365,10 @@ exports[`provider task-envelope renderers > renders a callback-free Hermes scrip
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:e76d0f50368c587eb3c5427bc7900bddcc49c7c6c7e7633ac52a682717f90890\`
+- Digest: \`sha256:f4943d64435f9a418eb648d3a309ffa22cf7bf488db3cfac471e6a779beb29a5\`
 - Provider: \`hermes-cli\`
 - Adapter: \`hermes-cli\`
-- Runtime manifest: \`sha256:620745ce1c045e69e0c092b123c583363946f2cad033320b657a354cc3a99ed2\`
+- Runtime manifest: \`sha256:105fc11b1236086a7d0181f73ac7201e519ef667c27ad7f7b71d44a28ee4360c\`
 - Protocol: \`fixture-runtime/v1\`
 - Task: \`task_transport\`
 - Attempt: \`attempt_transport\`
@@ -456,10 +456,10 @@ exports[`provider task-envelope renderers > renders an OpenClaw callback transpo
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:effaba7e3c3427d5bf35d60aff09a265f46be1dc845d66eac391a2df5d104999\`
+- Digest: \`sha256:43adb348cbb7ad4322b6b4ff1ca9a24091ddb7319a4e690602efe34e5caafbfd\`
 - Provider: \`openclaw\`
 - Adapter: \`openclaw\`
-- Runtime manifest: \`sha256:064a08bbbea37347f7422087b7c293c3ec81884dc5a540e1eb14d61d16517489\`
+- Runtime manifest: \`sha256:be3844c45a6aef384fb2c6d8dd0e15365b9cd06170272607396278beb052db68\`
 - Protocol: \`fixture-runtime/v1\`
 - Task: \`task_transport\`
 - Attempt: \`attempt_transport\`
@@ -558,7 +558,7 @@ When the work reaches a terminal state, report it to Veritas.
 \`\`\`bash
 curl -X POST http://localhost:3001/api/agents/task_transport/complete \\
   -H "Content-Type: application/json" \\
-  -d '{"attemptId":"attempt_transport","providerRuntimeManifestDigest":"sha256:064a08bbbea37347f7422087b7c293c3ec81884dc5a540e1eb14d61d16517489","success":true,"summary":"Brief description of what was done"}'
+  -d '{"attemptId":"attempt_transport","providerRuntimeManifestDigest":"sha256:be3844c45a6aef384fb2c6d8dd0e15365b9cd06170272607396278beb052db68","success":true,"summary":"Brief description of what was done"}'
 \`\`\`
 
 For failure, send \`success: false\` and include an \`error\` message.

--- a/server/src/__tests__/acp-stdio-provider.test.ts
+++ b/server/src/__tests__/acp-stdio-provider.test.ts
@@ -80,7 +80,7 @@ describe('ACP v1 stdio provider adapter', () => {
       protocolVersion: 'acp/v1',
       providerVersion: 'VK ACP fixture 1.3.0',
       providerBuild: expect.stringMatching(/^acp-v1:sha256:[a-f0-9]{64}$/),
-      probeRevision: 15,
+      probeRevision: 16,
     });
     expect(manifest.capabilities.find((capability) => capability.id === 'run.resume')?.state).toBe(
       'supported'
@@ -133,7 +133,7 @@ describe('ACP v1 stdio provider adapter', () => {
       adapter: 'acp-stdio',
       providerVersion: 'buzz-agent 0.1.0',
       providerBuild: expect.stringMatching(/profile:buzz-agent@1:sha256:/),
-      probeRevision: 15,
+      probeRevision: 16,
       probe: {
         diagnostics: expect.arrayContaining([
           expect.stringContaining(BUZZ_AGENT_TESTED_RELEASE),
@@ -356,7 +356,7 @@ describe('ACP v1 stdio provider adapter', () => {
       adapter: 'acp-stdio',
       providerVersion: 'Copilot 1.0.74',
       providerBuild: expect.stringMatching(/profile:github-copilot-cli@1:sha256:/),
-      probeRevision: 15,
+      probeRevision: 16,
       probe: {
         diagnostics: expect.arrayContaining([
           expect.stringContaining(COPILOT_ACP_TESTED_RELEASE),
@@ -515,7 +515,7 @@ describe('ACP v1 stdio provider adapter', () => {
       adapter: 'acp-stdio',
       providerVersion: `Grok Build ${GROK_BUILD_ACP_VERSION}`,
       providerBuild: expect.stringMatching(/profile:grok-build@1:sha256:/),
-      probeRevision: 15,
+      probeRevision: 16,
       probe: {
         diagnostics: expect.arrayContaining([
           expect.stringContaining(GROK_BUILD_TESTED_RELEASE),

--- a/server/src/__tests__/harness-compatibility-matrix-service.test.ts
+++ b/server/src/__tests__/harness-compatibility-matrix-service.test.ts
@@ -14,7 +14,7 @@ describe('HarnessCompatibilityMatrixService', () => {
     expect(matrix).toMatchObject({
       schemaVersion: 'harness-compatibility-matrix/v1',
       generatedAt: NOW.toISOString(),
-      probeRevision: 15,
+      probeRevision: 16,
     });
     expect(matrix.records.map((record) => record.agentType)).toEqual([
       'buzz-agent',

--- a/server/src/__tests__/run-egress-gateway-service.test.ts
+++ b/server/src/__tests__/run-egress-gateway-service.test.ts
@@ -83,6 +83,7 @@ describe('RunEgressGatewayService', () => {
       protocols: ['http', 'connect', 'ws'],
     });
     expect(JSON.stringify(gateway.evidence)).not.toContain(proxy.password);
+    expect(gateway.environment.ALL_PROXY).toBe(gateway.environment.HTTP_PROXY);
     expect(gateway.environment.NO_PROXY).toBe('');
 
     await expect(gateway.stop()).resolves.toMatchObject({

--- a/server/src/__tests__/run-egress-launch-policy.test.ts
+++ b/server/src/__tests__/run-egress-launch-policy.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { PROVIDER_RUNTIME_PROBE_REVISION } from '@veritas-kanban/shared';
+import { EgressPolicyService } from '../services/egress-policy-service.js';
+import { getProviderRuntimeAdapterDefinition } from '../services/provider-runtime-adapter-registry.js';
+import { runEgressPolicyRequiresGateway } from '../services/run-egress-gateway-service.js';
+
+const policyService = new EgressPolicyService();
+
+describe('run egress launch policy', () => {
+  it('starts the gateway only when a policy needs selective transport enforcement', () => {
+    expect(
+      runEgressPolicyRequiresGateway(
+        policyService.compile({
+          defaultEgress: 'deny',
+          allowedHosts: [],
+          allowedMethods: [],
+          allowedPathPrefixes: [],
+          blockPrivateNetwork: true,
+          blockMetadataEndpoints: true,
+          blockLoopback: true,
+        })
+      )
+    ).toBe(false);
+
+    expect(
+      runEgressPolicyRequiresGateway(
+        policyService.compile({
+          defaultEgress: 'deny',
+          allowedHosts: ['api.example.com'],
+          allowedMethods: [],
+          allowedPathPrefixes: [],
+          blockPrivateNetwork: true,
+          blockMetadataEndpoints: true,
+          blockLoopback: true,
+        })
+      )
+    ).toBe(true);
+
+    expect(
+      runEgressPolicyRequiresGateway(
+        policyService.compile({
+          defaultEgress: 'allow',
+          allowedHosts: [],
+          allowedMethods: [],
+          allowedPathPrefixes: [],
+          blockPrivateNetwork: false,
+          blockMetadataEndpoints: false,
+          blockLoopback: false,
+        })
+      )
+    ).toBe(false);
+
+    expect(
+      runEgressPolicyRequiresGateway(
+        policyService.compile({
+          defaultEgress: 'allow',
+          allowedHosts: [],
+          deniedHosts: ['metadata.google.internal'],
+          allowedMethods: [],
+          allowedPathPrefixes: [],
+          blockPrivateNetwork: true,
+          blockMetadataEndpoints: true,
+          blockLoopback: false,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('reports local gateway injection as host-enforced and remote OpenClaw as advisory', () => {
+    expect(PROVIDER_RUNTIME_PROBE_REVISION).toBe(16);
+
+    for (const provider of [
+      'codex-cli',
+      'codex-sdk',
+      'codex-app-server',
+      'claude-code',
+      'acp-stdio',
+      'hermes-cli',
+    ] as const) {
+      const capability = getProviderRuntimeAdapterDefinition(provider).capabilities.find(
+        (candidate) => candidate.id === 'network.allowlist'
+      );
+      expect(capability).toMatchObject({
+        state: 'supported',
+        source: 'host-enforced',
+      });
+    }
+
+    expect(
+      getProviderRuntimeAdapterDefinition('openclaw').capabilities.find(
+        (candidate) => candidate.id === 'network.allowlist'
+      )
+    ).toMatchObject({
+      state: 'advisory',
+    });
+  });
+});

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -22,6 +22,13 @@ import { getTelemetryService } from './telemetry-service.js';
 import { getAgentRoutingService } from './agent-routing-service.js';
 import { getGovernanceTraceService } from './governance-trace-service.js';
 import { getSandboxPolicyService, type SandboxPolicyService } from './sandbox-policy-service.js';
+import {
+  getRunEgressGatewayService,
+  RUN_EGRESS_PROXY_ENVIRONMENT_KEYS,
+  runEgressPolicyRequiresGateway,
+  type RunEgressGatewayHandle,
+  type RunEgressGatewayService,
+} from './run-egress-gateway-service.js';
 import { getAgentBudgetService } from './agent-budget-service.js';
 import {
   AgentHealthService,
@@ -462,6 +469,7 @@ interface PendingAgent {
   acpControl?: AcpStdioControl;
   runToolBridge?: RunToolBridgeLaunch;
   filesystemSandboxPlan?: FilesystemSandboxLaunchPlan;
+  egressGateway?: RunEgressGatewayHandle;
   /** Durable session key returned by OpenClaw sessions_spawn (openclaw provider only) */
   openclawSessionKey?: string;
   /** Hermes session identity captured from process output (hermes-cli provider only) */
@@ -565,6 +573,7 @@ export class ClawdbotAgentService {
     'compile' | 'activate' | 'cleanup' | 'wrap'
   >;
   private sandboxPolicies: Pick<SandboxPolicyService, 'dryRunWithTrace'>;
+  private runEgressGateway: Pick<RunEgressGatewayService, 'start' | 'stopRun'>;
   private workspaceExecutionTrust: Pick<
     WorkspaceExecutionTrustService,
     'scan' | 'evaluateForLaunch' | 'assertFresh'
@@ -602,7 +611,11 @@ export class ClawdbotAgentService {
     phaseAuthority = new PhaseLaunchAuthorityService(),
     phaseTransitions?: Pick<PhaseTransitionService, 'getCurrent'> &
       Partial<Pick<PhaseTransitionService, 'list'>>,
-    admission: AdmissionControlService = getAdmissionControlService()
+    admission: AdmissionControlService = getAdmissionControlService(),
+    runEgressGateway: Pick<
+      RunEgressGatewayService,
+      'start' | 'stopRun'
+    > = getRunEgressGatewayService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -629,6 +642,7 @@ export class ClawdbotAgentService {
     this.runRecoveryPolicy = runRecoveryPolicy;
     this.filesystemSandbox = filesystemSandbox;
     this.sandboxPolicies = sandboxPolicies;
+    this.runEgressGateway = runEgressGateway;
     this.workspaceExecutionTrust = workspaceExecutionTrust;
     this.phaseAuthority = phaseAuthority;
     this.phaseTransitions = phaseTransitions;
@@ -2920,6 +2934,62 @@ export class ClawdbotAgentService {
         runLaunchManifest.workspaceTrust
       );
       await this.filesystemSandbox.activate(filesystemSandboxPlan);
+      const egressPolicy = trustSandbox.policy.effective.networkPolicy;
+      if (egressPolicy && runEgressPolicyRequiresGateway(egressPolicy)) {
+        if (provider === 'openclaw' && trustSandbox.policy.preset.enforcement === 'required') {
+          throw new ConflictError(
+            'OpenClaw cannot enforce a Veritas run-scoped egress gateway for this preset.',
+            {
+              provider,
+              presetId: trustSandbox.policy.preset.id,
+              policyHash: egressPolicy.policyHash,
+              remediation:
+                'Use a local provider adapter with gateway enforcement or select a preset that does not require fine-grained egress controls.',
+            }
+          );
+        }
+        if (provider === 'openclaw') {
+          this.recordTraceStep(attemptId, 'execute', {
+            eventType: 'network.egress.gateway-bypass-advisory',
+            policyHash: egressPolicy.policyHash,
+            provider,
+            presetId: trustSandbox.policy.preset.id,
+          });
+        } else {
+          const pending = pendingAgents.get(taskId);
+          if (!pending || pending.attemptId !== attemptId) {
+            throw new ConflictError('Run egress gateway no longer matches the pending launch.', {
+              taskId,
+              attemptId,
+            });
+          }
+          pending.egressGateway = await this.runEgressGateway.start({
+            runId: attemptId,
+            policy: egressPolicy,
+            onDecision: (event) => {
+              this.recordTraceStep(attemptId, 'execute', {
+                eventType: 'network.egress.decision',
+                gatewayId: event.gatewayId,
+                runKey: event.runKey,
+                occurredAt: event.occurredAt,
+                policyHash: event.decision.policyHash,
+                protocol: event.decision.protocol,
+                hostKey: event.decision.hostKey,
+                port: event.decision.port,
+                method: event.decision.method,
+                decision: event.decision.decision,
+                reason: event.decision.reason,
+                blockedAddressClass: event.decision.blockedAddressClass,
+                approvalEligible: event.decision.approvalEligible,
+              });
+            },
+          });
+          this.recordTraceStep(attemptId, 'execute', {
+            eventType: 'network.egress.gateway-started',
+            evidence: pending.egressGateway.evidence,
+          });
+        }
+      }
       const providerAdmission: AgentProviderAdmissionEvidence = {
         schemaVersion: 'provider-admission-evidence/v1',
         source: admissionSource,
@@ -2939,7 +3009,7 @@ export class ClawdbotAgentService {
         startedAt,
         emitter,
         attempt,
-        sandboxPolicy: sandboxPolicy.result,
+        sandboxPolicy: trustSandbox.policy,
         runLaunchManifest,
         conversation,
         admission: providerAdmission,
@@ -4093,6 +4163,7 @@ export class ClawdbotAgentService {
       });
     } finally {
       this.runToolBridge.revokeRun(taskId, attemptId);
+      await this.runEgressGateway.stopRun(attemptId);
     }
   }
 
@@ -5653,13 +5724,17 @@ export class ClawdbotAgentService {
       command: launch.command,
       args: launch.args,
       cwd: launch.cwd,
-      environment: { ...process.env, ...launch.environment },
+      environment: this.withRunEgressEnvironment(pending, {
+        ...process.env,
+        ...launch.environment,
+      }),
       environmentKeys: [
         ...(sandboxPolicy?.effective.envPassthrough ?? []),
         ...toolEnvironmentKeys,
         ...supportProfile.launch.environmentAllowlist,
         ...supportProfile.launch.credentialAllowlist,
         ...Object.keys(launch.environment),
+        ...Object.keys(pending.egressGateway?.environment ?? {}),
       ],
       runtimeProfileId: supportProfile.id,
       onSpawn: async (child) => {
@@ -5979,7 +6054,10 @@ export class ClawdbotAgentService {
     );
     const child = spawn(launch.command, launch.args, {
       cwd: launch.cwd,
-      env: { ...launchEnvironment, ...launch.environment },
+      env: this.withRunEgressEnvironment(pending, {
+        ...launchEnvironment,
+        ...launch.environment,
+      }),
       shell: false,
       detached: process.platform !== 'win32',
     });
@@ -6838,13 +6916,13 @@ export class ClawdbotAgentService {
     const launch = this.filesystemSandboxLaunch(pending, command, args, worktreePath);
     const child = spawn(launch.command, launch.args, {
       cwd: launch.cwd,
-      env: {
+      env: this.withRunEgressEnvironment(pending, {
         ...buildSafeClaudeCodeEnv(process.env, [
           ...(sandboxPolicy?.effective.envPassthrough ?? []),
           ...toolEnvironmentKeys,
         ]),
         ...launch.environment,
-      },
+      }),
       shell: false,
       detached: process.platform !== 'win32',
     });
@@ -7261,10 +7339,10 @@ export class ClawdbotAgentService {
     const launch = this.filesystemSandboxLaunch(pending, command, args, worktreePath);
     const child = spawn(launch.command, launch.args, {
       cwd: launch.cwd,
-      env: {
+      env: this.withRunEgressEnvironment(pending, {
         ...buildSafeHermesEnv(process.env, sandboxPolicy?.effective.envPassthrough),
         ...launch.environment,
-      },
+      }),
       shell: false,
       detached: process.platform !== 'win32',
     });
@@ -7449,7 +7527,10 @@ export class ClawdbotAgentService {
     );
     const child = spawn(launch.command, launch.args, {
       cwd: launch.cwd,
-      env: { ...launchEnvironment, ...launch.environment },
+      env: this.withRunEgressEnvironment(pending, {
+        ...launchEnvironment,
+        ...launch.environment,
+      }),
       shell: false,
       detached: process.platform !== 'win32',
     });
@@ -7708,13 +7789,13 @@ export class ClawdbotAgentService {
     const { Codex } = await import('@openai/codex-sdk');
     const codex = new Codex({
       codexPathOverride: sdkExecutable.codexPathOverride,
-      env: {
+      env: this.withRunEgressEnvironment(pending, {
         ...this.runToolBridge.launchEnvironment(
           buildSafeCodexEnv(process.env, sandboxPolicy?.effective.envPassthrough),
           pending.runToolBridge
         ),
         ...pending.filesystemSandboxPlan?.environment,
-      },
+      }),
       ...(pending.runToolBridge
         ? {
             config: this.runToolBridge.codexConfig(pending.runToolBridge) as NonNullable<
@@ -9972,17 +10053,38 @@ export class ClawdbotAgentService {
     };
   }
 
+  private withRunEgressEnvironment(
+    pending: PendingAgent,
+    environment: NodeJS.ProcessEnv
+  ): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries({
+        ...environment,
+        ...pending.egressGateway?.environment,
+      }).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+    );
+  }
+
   private buildRunLaunchEnvironment(
     provider: ExecutableAgentProvider,
     sandboxPolicy: SandboxPolicyDryRunResult,
     agentConfig?: AgentConfig
   ): Pick<RunLaunchRuntime, 'environmentKeys' | 'credentialReferences'> {
+    const egressEnvironmentKeys =
+      provider !== 'openclaw' &&
+      sandboxPolicy.effective.networkPolicy &&
+      runEgressPolicyRequiresGateway(sandboxPolicy.effective.networkPolicy)
+        ? [...RUN_EGRESS_PROXY_ENVIRONMENT_KEYS]
+        : [];
     if (provider === 'codex-cli' || provider === 'codex-sdk' || provider === 'codex-app-server') {
-      const environmentKeys = Object.keys(
-        provider === 'codex-app-server'
-          ? buildSafeCodexAppServerEnv(process.env, sandboxPolicy.effective.envPassthrough)
-          : buildSafeCodexEnv(process.env, sandboxPolicy.effective.envPassthrough)
-      );
+      const environmentKeys = [
+        ...Object.keys(
+          provider === 'codex-app-server'
+            ? buildSafeCodexAppServerEnv(process.env, sandboxPolicy.effective.envPassthrough)
+            : buildSafeCodexEnv(process.env, sandboxPolicy.effective.envPassthrough)
+        ),
+        ...egressEnvironmentKeys,
+      ];
       return {
         environmentKeys,
         credentialReferences: [
@@ -9994,9 +10096,10 @@ export class ClawdbotAgentService {
       };
     }
     if (provider === 'hermes-cli') {
-      const environmentKeys = Object.keys(
-        buildSafeHermesEnv(process.env, sandboxPolicy.effective.envPassthrough)
-      );
+      const environmentKeys = [
+        ...Object.keys(buildSafeHermesEnv(process.env, sandboxPolicy.effective.envPassthrough)),
+        ...egressEnvironmentKeys,
+      ];
       return {
         environmentKeys,
         credentialReferences: [
@@ -10008,9 +10111,10 @@ export class ClawdbotAgentService {
       };
     }
     if (provider === 'claude-code') {
-      const environmentKeys = Object.keys(
-        buildSafeClaudeCodeEnv(process.env, sandboxPolicy.effective.envPassthrough)
-      );
+      const environmentKeys = [
+        ...Object.keys(buildSafeClaudeCodeEnv(process.env, sandboxPolicy.effective.envPassthrough)),
+        ...egressEnvironmentKeys,
+      ];
       const credentialKeys = new Set<string>(CLAUDE_CODE_CREDENTIAL_ENV_KEYS);
       return {
         environmentKeys,
@@ -10026,12 +10130,15 @@ export class ClawdbotAgentService {
         ...(supportProfile?.launch.environmentAllowlist ?? []),
         ...(supportProfile?.launch.credentialAllowlist ?? []),
       ];
-      const environmentKeys = Object.keys(
-        buildSafeAcpEnv(process.env, [
-          ...sandboxPolicy.effective.envPassthrough,
-          ...profileEnvironmentKeys,
-        ])
-      );
+      const environmentKeys = [
+        ...Object.keys(
+          buildSafeAcpEnv(process.env, [
+            ...sandboxPolicy.effective.envPassthrough,
+            ...profileEnvironmentKeys,
+          ])
+        ),
+        ...egressEnvironmentKeys,
+      ];
       const credentialKeys = new Set(supportProfile?.launch.credentialAllowlist ?? []);
       return {
         environmentKeys,

--- a/server/src/services/provider-runtime-adapter-registry.ts
+++ b/server/src/services/provider-runtime-adapter-registry.ts
@@ -33,6 +33,18 @@ const CLI_SANDBOX: ProviderRuntimeCapabilityOverrides = {
   'environment.allowlist': supported('The adapter receives an allowlisted environment.'),
 };
 
+const RUN_EGRESS_GATEWAY: ProviderRuntimeCapabilityOverrides = {
+  'network.allowlist': hostEnforced(
+    'Veritas injects the authenticated run-scoped gateway and blocks local provider startup if the gateway is unavailable.'
+  ),
+  'network.block-private': hostEnforced(
+    'The run-scoped gateway resolves destinations and enforces private, link-local, and loopback policy before opening the transport.'
+  ),
+  'network.block-metadata': hostEnforced(
+    'The run-scoped gateway blocks metadata hostnames and resolved metadata addresses before opening the transport.'
+  ),
+};
+
 const NOT_YET_IMPLEMENTED: ProviderRuntimeCapabilityOverrides = {
   'run.follow-up': unsupported('The adapter does not expose provider-native follow-up turns.'),
   'run.steer': unsupported('The adapter does not expose provider-native steering.'),
@@ -50,6 +62,7 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
     ...COMMON_SUPPORTED,
     ...CLI_SANDBOX,
     ...NOT_YET_IMPLEMENTED,
+    ...RUN_EGRESS_GATEWAY,
     'run.stop': supported('The adapter terminates the supervised Codex process.'),
     'run.reattach': supported(
       'The durable run supervisor validates and reattaches the original Codex process group.'
@@ -77,6 +90,7 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
     ...COMMON_SUPPORTED,
     ...CLI_SANDBOX,
     ...NOT_YET_IMPLEMENTED,
+    ...RUN_EGRESS_GATEWAY,
     'run.stop': supported('The adapter aborts the active Codex SDK run.'),
     'run.streaming': supported('Codex SDK thread events are streamed into run events.'),
     'run.structured-events': supported('Codex SDK emits typed thread events.'),
@@ -106,6 +120,7 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
       ...COMMON_SUPPORTED,
       ...CLI_SANDBOX,
       ...NOT_YET_IMPLEMENTED,
+      ...RUN_EGRESS_GATEWAY,
       'run.stop': supported(
         'The adapter requests turn/interrupt, closes the supervised stdio connection, and retains a bounded process-kill fallback.'
       ),
@@ -171,6 +186,7 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
   'claude-code': definition('claude-code', 'Claude Code', 'claude-code-stream-json/v1', {
     ...COMMON_SUPPORTED,
     ...NOT_YET_IMPLEMENTED,
+    ...RUN_EGRESS_GATEWAY,
     'run.stop': supported(
       'The adapter sends SIGTERM to the supervised Claude Code process with a bounded SIGKILL fallback.'
     ),
@@ -229,6 +245,7 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
   'acp-stdio': definition('acp-stdio', 'ACP stdio', 'acp/v1', {
     ...COMMON_SUPPORTED,
     ...NOT_YET_IMPLEMENTED,
+    ...RUN_EGRESS_GATEWAY,
     'run.stop': supported(
       'The adapter sends session/cancel and closes the supervised ACP process with a bounded kill fallback.'
     ),
@@ -278,6 +295,7 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
     ...COMMON_SUPPORTED,
     ...CLI_SANDBOX,
     ...NOT_YET_IMPLEMENTED,
+    ...RUN_EGRESS_GATEWAY,
     'run.stop': supported('The adapter terminates the supervised Hermes process.'),
     'run.reattach': supported(
       'The durable run supervisor validates and reattaches the original Hermes process group.'
@@ -372,6 +390,10 @@ function definition(
 
 function supported(reason: string) {
   return posture('supported', reason);
+}
+
+function hostEnforced(reason: string) {
+  return { state: 'supported' as const, reason, source: 'host-enforced' as const };
 }
 
 function advisory(reason: string) {

--- a/server/src/services/run-egress-gateway-service.ts
+++ b/server/src/services/run-egress-gateway-service.ts
@@ -19,11 +19,13 @@ const LOOPBACK_HOST = '127.0.0.1';
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
 const DEFAULT_MAX_CONNECTIONS = 64;
-const PROXY_ENVIRONMENT_KEYS = [
+export const RUN_EGRESS_PROXY_ENVIRONMENT_KEYS = [
   'HTTP_PROXY',
   'HTTPS_PROXY',
+  'ALL_PROXY',
   'http_proxy',
   'https_proxy',
+  'all_proxy',
   'NO_PROXY',
   'no_proxy',
 ] as const;
@@ -57,7 +59,7 @@ export interface StartRunEgressGatewayInput {
 
 export interface RunEgressGatewayHandle {
   gatewayId: string;
-  environment: Record<(typeof PROXY_ENVIRONMENT_KEYS)[number], string>;
+  environment: Record<(typeof RUN_EGRESS_PROXY_ENVIRONMENT_KEYS)[number], string>;
   evidence: RunEgressGatewayEvidence;
   stop(): Promise<RunEgressGatewayEvidence>;
 }
@@ -177,8 +179,10 @@ export class RunEgressGatewayService {
     const environment: ActiveGateway['environment'] = {
       HTTP_PROXY: proxyUrl,
       HTTPS_PROXY: proxyUrl,
+      ALL_PROXY: proxyUrl,
       http_proxy: proxyUrl,
       https_proxy: proxyUrl,
+      all_proxy: proxyUrl,
       NO_PROXY: '',
       no_proxy: '',
     };
@@ -190,7 +194,7 @@ export class RunEgressGatewayService {
       policyHash: input.policy.policyHash,
       state: 'enforced',
       protocols: ['http', 'connect', 'ws'],
-      proxyEnvironmentKeys: [...PROXY_ENVIRONMENT_KEYS],
+      proxyEnvironmentKeys: [...RUN_EGRESS_PROXY_ENVIRONMENT_KEYS],
       startedAt: this.now().toISOString(),
     };
     let stopPromise: Promise<RunEgressGatewayEvidence> | undefined;
@@ -244,8 +248,10 @@ export class RunEgressGatewayService {
     active.environment = {
       HTTP_PROXY: '',
       HTTPS_PROXY: '',
+      ALL_PROXY: '',
       http_proxy: '',
       https_proxy: '',
+      all_proxy: '',
       NO_PROXY: '',
       no_proxy: '',
     };
@@ -569,4 +575,26 @@ let service: RunEgressGatewayService | undefined;
 export function getRunEgressGatewayService(): RunEgressGatewayService {
   service ??= new RunEgressGatewayService();
   return service;
+}
+
+export function runEgressPolicyRequiresGateway(policy: RunEgressPolicy): boolean {
+  if (
+    policy.defaultEgress === 'deny' &&
+    policy.allowedHosts.length === 0 &&
+    !policy.allowApprovals
+  ) {
+    return false;
+  }
+  if (
+    policy.defaultEgress === 'allow' &&
+    policy.deniedHosts.length === 0 &&
+    policy.allowedMethods.length === 0 &&
+    policy.allowedPathPrefixes.length === 0 &&
+    !policy.blockPrivateNetwork &&
+    !policy.blockMetadataEndpoints &&
+    !policy.blockLoopback
+  ) {
+    return false;
+  }
+  return true;
 }

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -42,6 +42,11 @@ import { getToolPolicyService } from './tool-policy-service.js';
 import { getAgentHostService } from './agent-host-service.js';
 import { getSandboxPolicyService } from './sandbox-policy-service.js';
 import {
+  getRunEgressGatewayService,
+  runEgressPolicyRequiresGateway,
+  type RunEgressGatewayService,
+} from './run-egress-gateway-service.js';
+import {
   assertProviderRuntimeCapabilities,
   assertProviderRuntimeControl,
   BASELINE_LAUNCH_CAPABILITIES,
@@ -80,6 +85,7 @@ interface WorkflowStepExecutorOptions {
   runtimeManifestResolver?: (agent: AgentConfig) => Promise<ProviderRuntimeManifest>;
   persistRun?: (run: WorkflowRun) => Promise<void>;
   phaseAuthority?: PhaseLaunchAuthorityService;
+  runEgressGateway?: Pick<RunEgressGatewayService, 'start'>;
 }
 
 type WorkflowExecutableProvider = Extract<ExecutableAgentProvider, 'codex-sdk' | 'openclaw'>;
@@ -122,6 +128,7 @@ export class WorkflowStepExecutor {
   private runtimeManifestResolver: (agent: AgentConfig) => Promise<ProviderRuntimeManifest>;
   private persistRun: (run: WorkflowRun) => Promise<void>;
   private phaseAuthority: PhaseLaunchAuthorityService;
+  private runEgressGateway: Pick<RunEgressGatewayService, 'start'>;
   private appendCountCache?: Map<string, number>; // Performance: Track append counts to reduce stat() calls
 
   constructor(runsDir?: string, options: WorkflowStepExecutorOptions = {}) {
@@ -135,6 +142,7 @@ export class WorkflowStepExecutor {
       });
     this.persistRun = options.persistRun ?? (async () => undefined);
     this.phaseAuthority = options.phaseAuthority ?? new PhaseLaunchAuthorityService();
+    this.runEgressGateway = options.runEgressGateway ?? getRunEgressGatewayService();
   }
 
   /**
@@ -391,6 +399,17 @@ export class WorkflowStepExecutor {
     preparation: WorkflowAgentStepPreparation,
     run: WorkflowRun
   ): Promise<StepExecutionResult> {
+    const egressPolicy = preparation.sandboxPolicy.effective.networkPolicy;
+    if (
+      preparation.runtimeProvider === 'openclaw' &&
+      egressPolicy &&
+      preparation.sandboxPolicy.preset.enforcement === 'required' &&
+      runEgressPolicyRequiresGateway(egressPolicy)
+    ) {
+      throw new Error(
+        `OpenClaw workflow step ${preparation.step.id} cannot enforce the required run-scoped egress gateway`
+      );
+    }
     if (preparation.runtimeProvider === 'codex-sdk') {
       return this.executeCodexAgentStep(
         preparation.step,
@@ -843,125 +862,177 @@ export class WorkflowStepExecutor {
       agentDef?.command,
       `Workflow agent ${agentDef?.id || step.agent || step.id}`
     );
-    const { Codex } = await import('@openai/codex-sdk');
-    const workingDirectory = this.expandPath(this.getWorkflowWorkingDirectory(run));
-    const codex = new Codex({
-      codexPathOverride,
-      env: buildSafeCodexEnv(process.env, sandboxPolicy.effective.envPassthrough),
-    });
-
-    const sessionKey = step.agent || agentDef?.id || step.id;
-    const existingThreadId =
-      sessionConfig.mode === 'reuse'
-        ? (run.context._sessions as Record<string, string> | undefined)?.[sessionKey]
+    const egressPolicy = sandboxPolicy.effective.networkPolicy;
+    const egressGateway =
+      egressPolicy && runEgressPolicyRequiresGateway(egressPolicy)
+        ? await this.runEgressGateway.start({
+            runId: this.workflowStepAttemptId(run, step.id),
+            policy: egressPolicy,
+            onDecision: async (event) => {
+              await getGovernanceTraceService().record({
+                kind: 'policy',
+                outcome: event.decision.decision === 'allow' ? 'allowed' : 'blocked',
+                title: 'Workflow egress decision',
+                summary: `${event.decision.protocol} request ${event.decision.decision}: ${event.decision.reason}`,
+                subject: {
+                  taskId: run.taskId,
+                  agentId: step.agent,
+                  actionType: 'workflow.network-egress',
+                },
+                evaluatedRules: [
+                  {
+                    id: event.decision.reason,
+                    label: 'Run-scoped egress gateway',
+                    type: 'policy',
+                    status: 'matched',
+                    outcome: event.decision.decision === 'allow' ? 'allowed' : 'blocked',
+                    message: event.decision.reason,
+                  },
+                ],
+                raw: {
+                  gatewayId: event.gatewayId,
+                  runKey: event.runKey,
+                  occurredAt: event.occurredAt,
+                  policyHash: event.decision.policyHash,
+                  protocol: event.decision.protocol,
+                  hostKey: event.decision.hostKey,
+                  port: event.decision.port,
+                  method: event.decision.method,
+                  decision: event.decision.decision,
+                  reason: event.decision.reason,
+                  blockedAddressClass: event.decision.blockedAddressClass,
+                  approvalEligible: event.decision.approvalEligible,
+                },
+              });
+            },
+          })
         : undefined;
-    const thread = existingThreadId
-      ? codex.resumeThread(existingThreadId, {
-          workingDirectory,
-          sandboxMode: sandboxPolicy.effective.sandboxMode,
-          approvalPolicy: 'never',
-          networkAccessEnabled: sandboxPolicy.effective.networkAccessEnabled,
-          model: agentDef?.model,
-        })
-      : codex.startThread({
-          workingDirectory,
-          skipGitRepoCheck: true,
-          sandboxMode: sandboxPolicy.effective.sandboxMode,
-          approvalPolicy: 'never',
-          networkAccessEnabled: sandboxPolicy.effective.networkAccessEnabled,
-          model: agentDef?.model,
-        });
+    try {
+      const { Codex } = await import('@openai/codex-sdk');
+      const workingDirectory = this.expandPath(this.getWorkflowWorkingDirectory(run));
+      const codex = new Codex({
+        codexPathOverride,
+        env: {
+          ...buildSafeCodexEnv(process.env, sandboxPolicy.effective.envPassthrough),
+          ...egressGateway?.environment,
+        },
+      });
 
-    const streamed = await thread.runStreamed(prompt);
-    const events: unknown[] = [];
-    let threadId = existingThreadId || '';
-    let finalResponse = '';
-    let failureMessage = '';
-    let toolCalls = 0;
-    let tokenUsage:
-      | {
-          inputTokens: number;
-          outputTokens: number;
-          totalTokens?: number;
-          cost?: number;
+      const sessionKey = step.agent || agentDef?.id || step.id;
+      const existingThreadId =
+        sessionConfig.mode === 'reuse'
+          ? (run.context._sessions as Record<string, string> | undefined)?.[sessionKey]
+          : undefined;
+      const thread = existingThreadId
+        ? codex.resumeThread(existingThreadId, {
+            workingDirectory,
+            sandboxMode: sandboxPolicy.effective.sandboxMode,
+            approvalPolicy: 'never',
+            networkAccessEnabled: sandboxPolicy.effective.networkAccessEnabled,
+            model: agentDef?.model,
+          })
+        : codex.startThread({
+            workingDirectory,
+            skipGitRepoCheck: true,
+            sandboxMode: sandboxPolicy.effective.sandboxMode,
+            approvalPolicy: 'never',
+            networkAccessEnabled: sandboxPolicy.effective.networkAccessEnabled,
+            model: agentDef?.model,
+          });
+
+      const streamed = await thread.runStreamed(prompt);
+      const events: unknown[] = [];
+      let threadId = existingThreadId || '';
+      let finalResponse = '';
+      let failureMessage = '';
+      let toolCalls = 0;
+      let tokenUsage:
+        | {
+            inputTokens: number;
+            outputTokens: number;
+            totalTokens?: number;
+            cost?: number;
+          }
+        | undefined;
+
+      for await (const event of streamed.events) {
+        events.push(event);
+        if (this.isCodexToolEvent(event)) {
+          assertProviderRuntimeControl(runtimeManifest, 'tool-calls');
+          toolCalls++;
         }
-      | undefined;
+        const eventUsage = this.extractCodexBudgetUsage(event);
+        if (eventUsage) {
+          assertProviderRuntimeControl(runtimeManifest, 'token-usage');
+          tokenUsage = eventUsage;
+        }
+        if (event.type === 'thread.started') {
+          threadId = event.thread_id;
+          this.recordWorkflowSession(run, step, sessionKey, threadId);
+        }
+        if (event.type === 'item.completed' && event.item.type === 'agent_message') {
+          finalResponse = event.item.text;
+        }
+        if (event.type === 'turn.failed') failureMessage = event.error.message;
+        if (event.type === 'error') failureMessage = event.message;
+      }
 
-    for await (const event of streamed.events) {
-      events.push(event);
-      if (this.isCodexToolEvent(event)) {
-        assertProviderRuntimeControl(runtimeManifest, 'tool-calls');
-        toolCalls++;
+      if (failureMessage) {
+        throw new Error(`Codex workflow step failed: ${failureMessage}`);
       }
-      const eventUsage = this.extractCodexBudgetUsage(event);
-      if (eventUsage) {
-        assertProviderRuntimeControl(runtimeManifest, 'token-usage');
-        tokenUsage = eventUsage;
-      }
-      if (event.type === 'thread.started') {
-        threadId = event.thread_id;
-        this.recordWorkflowSession(run, step, sessionKey, threadId);
-      }
-      if (event.type === 'item.completed' && event.item.type === 'agent_message') {
-        finalResponse = event.item.text;
-      }
-      if (event.type === 'turn.failed') failureMessage = event.error.message;
-      if (event.type === 'error') failureMessage = event.message;
+
+      const result = [
+        `# Codex Workflow Step: ${step.name || step.id}`,
+        '',
+        `Agent: ${agentDef?.name || step.agent}`,
+        `Provider: ${agentDef?.provider || 'codex-sdk'}`,
+        `Model: ${agentDef?.model || 'default'}`,
+        `Thread: ${threadId || 'unknown'}`,
+        `Working directory: ${workingDirectory}`,
+        `Host routing: ${hostRouting.policy}`,
+        `Selected host: ${hostRouting.selectedHostName || hostRouting.selectedHostId || 'none'}`,
+        `Routing reason: ${hostRouting.reason}`,
+        '',
+        '## Prompt',
+        '',
+        prompt,
+        '',
+        '## Final Response',
+        '',
+        finalResponse || 'Codex completed without a final response.',
+        '',
+        'STATUS: done',
+        `OUTPUT: ${finalResponse || 'Codex completed without a final response.'}`,
+        '',
+        '<details><summary>Codex events</summary>',
+        '',
+        '```json',
+        JSON.stringify(events, null, 2),
+        '```',
+        '',
+        '</details>',
+      ].join('\n');
+
+      const parsed = this.parseStepOutput(result, step);
+      await this.validateAcceptanceCriteria(step, result, parsed);
+      const outputPath = await this.saveStepOutput(run.id, step.id, result, step.output?.file);
+      await this.appendProgressFile(run.id, step.id, result);
+
+      return {
+        output: parsed,
+        outputPath,
+        budgetUsage: {
+          inputTokens: tokenUsage?.inputTokens,
+          outputTokens: tokenUsage?.outputTokens,
+          totalTokens: tokenUsage?.totalTokens,
+          costUsd: tokenUsage?.cost,
+          toolCalls,
+        },
+        providerRuntimeManifest: runtimeManifest,
+      };
+    } finally {
+      await egressGateway?.stop();
     }
-
-    if (failureMessage) {
-      throw new Error(`Codex workflow step failed: ${failureMessage}`);
-    }
-
-    const result = [
-      `# Codex Workflow Step: ${step.name || step.id}`,
-      '',
-      `Agent: ${agentDef?.name || step.agent}`,
-      `Provider: ${agentDef?.provider || 'codex-sdk'}`,
-      `Model: ${agentDef?.model || 'default'}`,
-      `Thread: ${threadId || 'unknown'}`,
-      `Working directory: ${workingDirectory}`,
-      `Host routing: ${hostRouting.policy}`,
-      `Selected host: ${hostRouting.selectedHostName || hostRouting.selectedHostId || 'none'}`,
-      `Routing reason: ${hostRouting.reason}`,
-      '',
-      '## Prompt',
-      '',
-      prompt,
-      '',
-      '## Final Response',
-      '',
-      finalResponse || 'Codex completed without a final response.',
-      '',
-      'STATUS: done',
-      `OUTPUT: ${finalResponse || 'Codex completed without a final response.'}`,
-      '',
-      '<details><summary>Codex events</summary>',
-      '',
-      '```json',
-      JSON.stringify(events, null, 2),
-      '```',
-      '',
-      '</details>',
-    ].join('\n');
-
-    const parsed = this.parseStepOutput(result, step);
-    await this.validateAcceptanceCriteria(step, result, parsed);
-    const outputPath = await this.saveStepOutput(run.id, step.id, result, step.output?.file);
-    await this.appendProgressFile(run.id, step.id, result);
-
-    return {
-      output: parsed,
-      outputPath,
-      budgetUsage: {
-        inputTokens: tokenUsage?.inputTokens,
-        outputTokens: tokenUsage?.outputTokens,
-        totalTokens: tokenUsage?.totalTokens,
-        costUsd: tokenUsage?.cost,
-        toolCalls,
-      },
-      providerRuntimeManifest: runtimeManifest,
-    };
   }
 
   private extractCodexBudgetUsage(event: unknown):

--- a/shared/src/types/provider-runtime.types.ts
+++ b/shared/src/types/provider-runtime.types.ts
@@ -111,7 +111,7 @@ export interface HarnessSupportStatus {
 
 export const PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION = 'provider-runtime-manifest/v1' as const;
 
-export const PROVIDER_RUNTIME_PROBE_REVISION = 15 as const;
+export const PROVIDER_RUNTIME_PROBE_REVISION = 16 as const;
 
 export const KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS = [
   'run.start',

--- a/shared/src/types/sandbox-policy.types.ts
+++ b/shared/src/types/sandbox-policy.types.ts
@@ -120,7 +120,14 @@ export interface RunEgressGatewayEvidence {
   state: 'enforced' | 'stopped';
   protocols: Array<'http' | 'connect' | 'ws'>;
   proxyEnvironmentKeys: Array<
-    'HTTP_PROXY' | 'HTTPS_PROXY' | 'http_proxy' | 'https_proxy' | 'NO_PROXY' | 'no_proxy'
+    | 'HTTP_PROXY'
+    | 'HTTPS_PROXY'
+    | 'ALL_PROXY'
+    | 'http_proxy'
+    | 'https_proxy'
+    | 'all_proxy'
+    | 'NO_PROXY'
+    | 'no_proxy'
   >;
   startedAt: string;
   stoppedAt?: string;


### PR DESCRIPTION
## Summary

- start an authenticated run-scoped egress gateway before selective local task and workflow launches
- inject HTTP, HTTPS, and all-proxy variables after environment filtering so inherited settings cannot bypass attribution
- fail closed when required remote execution cannot enforce the local gateway, while retaining explicit advisory evidence
- stop gateways during terminal and failed-launch cleanup
- publish host-enforced capability evidence at provider runtime probe revision 16

## Verification

- shared build and server typecheck
- targeted lint, formatting, and diff checks
- 34 focused workflow, sandbox, and launch-policy tests
- 4 ACP revision checks and 3 harness compatibility matrix checks
- 50 focused local-provider adapter tests

Part of #855
