### PR TITLE
docs: close admission control roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added durable execution-tree cancellation and a provider-neutral fan-out
+  circuit breaker. Operators can cancel one queued launch or an entire root
+  objective through REST, `vk admission`, and Operations; root cancellation is
+  recorded before descendants drain so late resume, retry, fallback,
+  workflow-step, and child-agent launches fail closed. The breaker evaluates
+  durable descendant count, depth, active and queued work, capacity pressure,
+  and aggregate budget pressure before every expansion, persists bounded
+  evidence across restart, and requires a safe operator resume before the tree
+  can grow again (#1055).
+- Routed scheduled workflows, watcher continuations, conversation resume and
+  follow-up, retries, fallbacks, provider handoffs, recovery, and child-agent
+  starts through the same durable admission and queue contract used by direct
+  tasks and workflow steps. Every source preserves its causal execution-tree
+  identity, revalidates immutable launch evidence before dispatch, and rejects
+  hidden adapter-owned queues or bypass launches (#1054).
+- Added one bounded durable admission queue shared by direct tasks and
+  workflows. Atomic dequeue claims both a queue lease and capacity; restart
+  recovery expires abandoned claims without duplicate dispatch. The scheduler
+  combines explicit priority, capped age promotion, workspace fairness, and
+  deterministic tie-breaking while retaining redacted conditional selection
+  evidence. REST, `vk admission`, and Operations expose queue health,
+  readiness, limiting scopes, age, priority, and safe cancellation with file
+  and SQLite parity (#1053).
 - Added versioned execution-tree identities and aggregate budget reservations
   to direct attempts, conversation continuations, retries, fallbacks, provider
   handoffs, child agents, workflow roots, and workflow steps. Capacity and the

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -4177,11 +4177,14 @@ configured.
 
 ## Execution Admission
 
-Direct task starts, workflow roots, and provider-backed workflow steps
-atomically reserve configured run, process, and estimated-memory capacity
-before attempt persistence or provider dispatch. Workflow roots use the
-`workflow-control` admission provider; child steps use the resolved execution
-provider and selected host. Inspection requires `agent:read`.
+Direct starts, scheduled work, watcher continuations, conversation resume and
+follow-up, retries, fallbacks, provider handoffs, recovery, child-agent starts,
+workflow roots, and provider-backed workflow steps all pass through the same
+durable admission and queue contract. Each atomically reserves configured run,
+process, and estimated-memory capacity before attempt persistence or provider
+dispatch. Workflow roots use the `workflow-control` admission provider; child
+steps use the resolved execution provider and selected host. Inspection
+requires `agent:read`.
 
 | Method | Path                                          | Description                                                    |
 | ------ | --------------------------------------------- | -------------------------------------------------------------- |
@@ -4191,6 +4194,7 @@ provider and selected host. Inspection requires `agent:read`.
 | `POST` | `/api/admission/queue/:id/cancel`             | Cancel one queued launch before provider dispatch              |
 | `GET`  | `/api/admission/tree/:rootObjectiveId`        | Summarize one aggregate execution tree and its control state   |
 | `POST` | `/api/admission/tree/:rootObjectiveId/cancel` | Cancel queued and verified running work for one execution tree |
+| `POST` | `/api/admission/tree/:rootObjectiveId/resume` | Safely resume a circuit-breaker-paused execution tree          |
 | `GET`  | `/api/admission/:id`                          | Inspect one durable reservation                                |
 
 List filters are `workspaceId`, `taskId`, `rootTaskId`, `provider`, `hostId`,


### PR DESCRIPTION
## Summary

- records the completed bounded admission queue, launch-source unification, tree cancellation, and fan-out breaker in the Unreleased changelog
- makes the API reference explicit that every recorded launch source uses the same durable admission contract
- documents the existing execution-tree resume endpoint in the admission endpoint table

## Verification

- `prettier --check CHANGELOG.md docs/API-REFERENCE.md`
- `git diff --check`

Closes #864
