### PR TITLE
feat: expose durable goal controls

### DIFF
--- a/cli/src/__tests__/goals.test.ts
+++ b/cli/src/__tests__/goals.test.ts
@@ -1,0 +1,175 @@
+import { Command } from 'commander';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const api = vi.hoisted(() => vi.fn());
+
+vi.mock('../utils/api.js', () => ({ api }));
+
+import { registerGoalCommands } from '../commands/goals.js';
+
+const GOAL_ID = 'goal_0123456789abcdef';
+
+describe('vk goals commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+  });
+
+  it('lists goals as JSON with bounded filters', async () => {
+    api.mockResolvedValue({
+      generatedAt: '2026-07-26T02:00:00.000Z',
+      goals: [{ id: GOAL_ID, state: 'blocked' }],
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerGoalCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'goals',
+      'list',
+      '--state',
+      'active',
+      'blocked',
+      '--root-task',
+      'task-865',
+      '--limit',
+      '25',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith(
+      '/api/goals?state=active&state=blocked&rootTaskId=task-865&limit=25'
+    );
+    expect(JSON.parse(String(output.mock.calls[0][0]))).toMatchObject({
+      goals: [{ id: GOAL_ID, state: 'blocked' }],
+    });
+    output.mockRestore();
+  });
+
+  it('creates an evidence-gated task goal', async () => {
+    api.mockResolvedValue({ id: GOAL_ID, state: 'active', revision: 1 });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerGoalCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'goals',
+      'create',
+      '--objective',
+      'Deliver durable controls.',
+      '--acceptance',
+      'REST passes',
+      'CLI passes',
+      '--requirement',
+      'focused-tests|test|Focused tests pass.',
+      '--root-task',
+      'task-865',
+      '--mode',
+      'automatic',
+      '--max-turns',
+      '20',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith('/api/goals', {
+      method: 'POST',
+      body: JSON.stringify({
+        objective: 'Deliver durable controls.',
+        constraints: [],
+        acceptanceCriteria: ['REST passes', 'CLI passes'],
+        root: { kind: 'task', taskId: 'task-865' },
+        continuation: { mode: 'automatic', maxTurns: 20 },
+        completionRequirements: [
+          {
+            id: 'focused-tests',
+            verificationKind: 'test',
+            description: 'Focused tests pass.',
+            required: true,
+          },
+        ],
+      }),
+    });
+    output.mockRestore();
+  });
+
+  it('transitions with exact revision and structured completion evidence', async () => {
+    api.mockResolvedValue({ id: GOAL_ID, state: 'complete', revision: 3 });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerGoalCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'goals',
+      'transition',
+      GOAL_ID,
+      '--revision',
+      '2',
+      '--state',
+      'complete',
+      '--reason',
+      'All verification passed.',
+      '--evidence-json',
+      '[{"requirementId":"focused-tests","evidenceId":"ci-1082","summary":"Passed."}]',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith(`/api/goals/${GOAL_ID}/transition`, {
+      method: 'POST',
+      body: JSON.stringify({
+        expectedRevision: 2,
+        state: 'complete',
+        reason: 'All verification passed.',
+        blocker: undefined,
+        completionEvidence: [
+          {
+            requirementId: 'focused-tests',
+            evidenceId: 'ci-1082',
+            summary: 'Passed.',
+          },
+        ],
+      }),
+    });
+    output.mockRestore();
+  });
+
+  it('links a run to the continuation chain', async () => {
+    api.mockResolvedValue({ id: GOAL_ID, state: 'active', revision: 4 });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerGoalCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'goals',
+      'link-run',
+      GOAL_ID,
+      '--revision',
+      '3',
+      '--task',
+      'task-865',
+      '--attempt',
+      'attempt-3',
+      '--conversation',
+      'conversation-3',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith(`/api/goals/${GOAL_ID}/runs`, {
+      method: 'POST',
+      body: JSON.stringify({
+        expectedRevision: 3,
+        taskId: 'task-865',
+        attemptId: 'attempt-3',
+        conversationId: 'conversation-3',
+      }),
+    });
+    output.mockRestore();
+  });
+});

--- a/cli/src/commands/goals.ts
+++ b/cli/src/commands/goals.ts
@@ -1,0 +1,274 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import type {
+  DurableGoalBlocker,
+  DurableGoalCompletionEvidence,
+  DurableGoalCompletionRequirement,
+  DurableGoalContinuationMode,
+  DurableGoalRecord,
+  DurableGoalState,
+} from '@veritas-kanban/shared';
+import { DURABLE_GOAL_STATES } from '@veritas-kanban/shared';
+import { api } from '../utils/api.js';
+
+interface GoalListResponse {
+  generatedAt: string;
+  goals: DurableGoalRecord[];
+}
+
+type GoalBlockerInput = Omit<DurableGoalBlocker, 'id' | 'recordedAt'> & { id?: string };
+
+const VERIFICATION_KINDS = new Set(['test', 'build', 'artifact', 'operator', 'external', 'other']);
+
+export function registerGoalCommands(program: Command): void {
+  const goals = program
+    .command('goals')
+    .description('Create, inspect, and control durable objectives');
+
+  goals
+    .command('list')
+    .description('List durable goals in the current workspace')
+    .option('--state <states...>', 'Filter by goal state')
+    .option('--root-task <id>', 'Filter by root task')
+    .option('--root-workflow <id>', 'Filter by root workflow')
+    .option('--limit <count>', 'Maximum goals', '100')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const query = new URLSearchParams();
+        for (const state of (options.state ?? []) as DurableGoalState[]) {
+          query.append('state', state);
+        }
+        if (options.rootTask) query.set('rootTaskId', options.rootTask);
+        if (options.rootWorkflow) query.set('rootWorkflowId', options.rootWorkflow);
+        query.set('limit', options.limit);
+        const result = await api<GoalListResponse>(`/api/goals?${query.toString()}`);
+        if (options.json) return printJson(result);
+        if (result.goals.length === 0) {
+          console.log(chalk.dim('No durable goals matched.'));
+          return;
+        }
+        for (const goal of result.goals) printGoal(goal);
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  goals
+    .command('get <id>')
+    .description('Inspect one durable goal')
+    .option('--json', 'Output as JSON')
+    .action(async (id, options) => {
+      try {
+        const goal = await api<DurableGoalRecord>(`/api/goals/${encodeURIComponent(id)}`);
+        if (options.json) return printJson(goal);
+        printGoal(goal, true);
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  goals
+    .command('create')
+    .description('Create an evidence-gated durable goal')
+    .requiredOption('--objective <text>', 'Goal objective')
+    .requiredOption('--acceptance <criteria...>', 'Acceptance criteria')
+    .requiredOption(
+      '--requirement <requirements...>',
+      'Completion requirement as id|kind|description'
+    )
+    .option('--constraint <constraints...>', 'Goal constraints')
+    .option('--root-task <id>', 'Root task identity')
+    .option('--root-workflow <id>', 'Root workflow identity')
+    .option('--task <id>', 'Optional task associated with a root workflow')
+    .option('--mode <mode>', 'Continuation mode: manual or automatic', 'manual')
+    .option('--max-turns <count>', 'Maximum continuation turns')
+    .option('--max-rollovers <count>', 'Maximum conversation rollovers')
+    .option('--compact-after-tokens <count>', 'Compaction threshold')
+    .option('--require-rollover-approval', 'Require approval before rollover')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        if (Boolean(options.rootTask) === Boolean(options.rootWorkflow)) {
+          throw new Error('Specify exactly one of --root-task or --root-workflow.');
+        }
+        if (!['manual', 'automatic'].includes(options.mode)) {
+          throw new Error('--mode must be manual or automatic.');
+        }
+        const completionRequirements = (options.requirement as string[]).map(
+          parseCompletionRequirement
+        );
+        const root = options.rootTask
+          ? { kind: 'task' as const, taskId: options.rootTask }
+          : {
+              kind: 'workflow' as const,
+              workflowId: options.rootWorkflow,
+              ...(options.task ? { taskId: options.task } : {}),
+            };
+        const goal = await api<DurableGoalRecord>('/api/goals', {
+          method: 'POST',
+          body: JSON.stringify({
+            objective: options.objective,
+            constraints: options.constraint ?? [],
+            acceptanceCriteria: options.acceptance,
+            root,
+            continuation: {
+              mode: options.mode as DurableGoalContinuationMode,
+              ...(options.maxTurns ? { maxTurns: parsePositiveInteger(options.maxTurns) } : {}),
+              ...(options.maxRollovers
+                ? { maxRollovers: parseNonnegativeInteger(options.maxRollovers) }
+                : {}),
+              ...(options.compactAfterTokens
+                ? { compactAfterTokens: parsePositiveInteger(options.compactAfterTokens) }
+                : {}),
+              ...(options.requireRolloverApproval ? { requireApprovalForRollover: true } : {}),
+            },
+            completionRequirements,
+          }),
+        });
+        if (options.json) return printJson(goal);
+        console.log(chalk.green(`✓ Created durable goal ${goal.id}`));
+        printGoal(goal);
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  goals
+    .command('transition <id>')
+    .description('Apply one compare-and-set goal state transition')
+    .requiredOption('--revision <number>', 'Expected goal revision')
+    .requiredOption('--state <state>', `New state: ${DURABLE_GOAL_STATES.join(', ')}`)
+    .requiredOption('--reason <text>', 'Operator reason')
+    .option('--blocker-json <json>', 'Actionable blocker JSON for blocked state')
+    .option('--evidence-json <json>', 'Completion evidence JSON array')
+    .option('--json', 'Output as JSON')
+    .action(async (id, options) => {
+      try {
+        if (!DURABLE_GOAL_STATES.includes(options.state as DurableGoalState)) {
+          throw new Error(`Unknown goal state: ${options.state}`);
+        }
+        const blocker = options.blockerJson
+          ? parseJson<GoalBlockerInput>(options.blockerJson, '--blocker-json')
+          : undefined;
+        const completionEvidence = options.evidenceJson
+          ? parseJson<
+              Array<Pick<DurableGoalCompletionEvidence, 'requirementId' | 'evidenceId' | 'summary'>>
+            >(options.evidenceJson, '--evidence-json')
+          : undefined;
+        const goal = await api<DurableGoalRecord>(
+          `/api/goals/${encodeURIComponent(id)}/transition`,
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              expectedRevision: parsePositiveInteger(options.revision),
+              state: options.state,
+              reason: options.reason,
+              blocker,
+              completionEvidence,
+            }),
+          }
+        );
+        if (options.json) return printJson(goal);
+        console.log(chalk.green(`✓ Goal ${goal.id} is ${goal.state} at revision ${goal.revision}`));
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  goals
+    .command('link-run <id>')
+    .description('Link one run or continuation to a durable goal')
+    .requiredOption('--revision <number>', 'Expected goal revision')
+    .requiredOption('--task <id>', 'Run task identity')
+    .option('--attempt <id>', 'Attempt identity')
+    .option('--workflow-run <id>', 'Workflow run identity')
+    .option('--conversation <id>', 'Conversation identity')
+    .option('--parent-attempt <id>', 'Causal parent attempt')
+    .option('--json', 'Output as JSON')
+    .action(async (id, options) => {
+      try {
+        const goal = await api<DurableGoalRecord>(`/api/goals/${encodeURIComponent(id)}/runs`, {
+          method: 'POST',
+          body: JSON.stringify({
+            expectedRevision: parsePositiveInteger(options.revision),
+            taskId: options.task,
+            attemptId: options.attempt,
+            workflowRunId: options.workflowRun,
+            conversationId: options.conversation,
+            parentAttemptId: options.parentAttempt,
+          }),
+        });
+        if (options.json) return printJson(goal);
+        console.log(chalk.green(`✓ Linked run to goal ${goal.id} at revision ${goal.revision}`));
+      } catch (error) {
+        printError(error);
+      }
+    });
+}
+
+function parseCompletionRequirement(value: string): DurableGoalCompletionRequirement {
+  const [id, verificationKind, ...descriptionParts] = value.split('|');
+  const description = descriptionParts.join('|').trim();
+  if (!id?.trim() || !verificationKind?.trim() || !description) {
+    throw new Error(`Invalid requirement "${value}"; expected id|kind|description.`);
+  }
+  if (!VERIFICATION_KINDS.has(verificationKind)) {
+    throw new Error(`Invalid verification kind "${verificationKind}".`);
+  }
+  return {
+    id: id.trim(),
+    verificationKind: verificationKind as DurableGoalCompletionRequirement['verificationKind'],
+    description,
+    required: true,
+  };
+}
+
+function parsePositiveInteger(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`Expected a positive integer.`);
+  return parsed;
+}
+
+function parseNonnegativeInteger(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`Expected a nonnegative integer.`);
+  return parsed;
+}
+
+function parseJson<T>(value: string, option: string): T {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    throw new Error(`${option} must contain valid JSON.`);
+  }
+}
+
+function printGoal(goal: DurableGoalRecord, verbose = false): void {
+  const state =
+    goal.state === 'active'
+      ? chalk.green(goal.state)
+      : ['complete'].includes(goal.state)
+        ? chalk.blue(goal.state)
+        : ['cancelled', 'failed'].includes(goal.state)
+          ? chalk.red(goal.state)
+          : chalk.yellow(goal.state);
+  console.log(`${state} ${chalk.bold(goal.id)} revision=${goal.revision}`);
+  console.log(`  ${goal.objective}`);
+  if (verbose) {
+    console.log(
+      chalk.dim(
+        `  root=${goal.root.kind === 'task' ? goal.root.taskId : goal.root.workflowId} runs=${goal.continuationChain.length} blockers=${goal.blockers.length} evidence=${goal.completionEvidence.length}/${goal.completionRequirements.length}`
+      )
+    );
+  }
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function printError(error: unknown): void {
+  console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
+  process.exitCode = 1;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -26,6 +26,7 @@ import { registerSqliteCommands } from './commands/sqlite.js';
 import { registerToolServerCommands } from './commands/tool-servers.js';
 import { registerAcpCommands } from './commands/acp.js';
 import { registerAdmissionCommands } from './commands/admission.js';
+import { registerGoalCommands } from './commands/goals.js';
 
 const program = new Command();
 const packageJson = JSON.parse(
@@ -63,5 +64,6 @@ registerSqliteCommands(program);
 registerToolServerCommands(program);
 registerAcpCommands(program);
 registerAdmissionCommands(program);
+registerGoalCommands(program);
 
 program.parse();

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -63,6 +63,7 @@
 50. [Rate Limits](#rate-limits)
 51. [Additional Endpoint Groups](#additional-endpoint-groups)
 52. [Execution Admission](#execution-admission)
+53. [Durable Goals](#durable-goals)
 
 ---
 
@@ -4377,6 +4378,67 @@ Once the queue entry is durably `dispatched`, workflow recovery owns the run.
 Startup reconciliation resumes a root or step that stopped at that ownership
 boundary exactly once; already-running provider work continues to use the
 existing operator-reconciliation rules.
+
+## Durable Goals
+
+Durable goals persist an evidence-gated objective independently of any one
+provider run. Reads require `agent:read`; creation and mutation require
+`admin:manage`. Every endpoint is scoped to the authenticated workspace.
+
+| Method | Path                            | Description                                    |
+| ------ | ------------------------------- | ---------------------------------------------- |
+| `GET`  | `/api/goals`                    | List bounded goals with state and root filters |
+| `POST` | `/api/goals`                    | Create one evidence-gated goal at revision 1   |
+| `GET`  | `/api/goals/:goalId`            | Inspect one goal and its continuation chain    |
+| `POST` | `/api/goals/:goalId/transition` | Apply one compare-and-set state transition     |
+| `POST` | `/api/goals/:goalId/runs`       | Link one task, workflow, or conversation run   |
+
+List filters are repeatable `state`, `rootTaskId`, `rootWorkflowId`, and
+`limit` (1-1000). Goal states are `active`, `paused`, `blocked`,
+`awaiting-approval`, `usage-limited`, `budget-limited`, `complete`,
+`cancelled`, and `failed`. Complete, cancelled, and failed goals are terminal.
+
+Creation requires an objective, at least one acceptance criterion, exactly one
+task or workflow root, a manual or automatic continuation policy, and at least
+one required completion-evidence contract. Optional constraints and aggregate
+token, cost, time, tool, retry, and fan-out limits are bounded by the same
+budget metric names used elsewhere in the runtime.
+
+```json
+{
+  "objective": "Deliver the provider migration.",
+  "constraints": ["Do not broaden provider authority."],
+  "acceptanceCriteria": ["Focused provider fixtures pass."],
+  "root": { "kind": "task", "taskId": "task_0123456789abcdef" },
+  "continuation": {
+    "mode": "automatic",
+    "maxTurns": 20,
+    "maxRollovers": 2,
+    "requireApprovalForRollover": true
+  },
+  "completionRequirements": [
+    {
+      "id": "provider-tests",
+      "description": "Focused provider fixtures pass.",
+      "required": true,
+      "verificationKind": "test"
+    }
+  ]
+}
+```
+
+Transitions require `expectedRevision`, `state`, and an operator reason.
+Entering `blocked` also requires an actionable blocker. Completing a goal
+requires evidence for every required completion item. The server derives the
+workspace, actor, verification timestamp, and evidence verifier from
+authenticated context; these identities cannot be supplied by the caller.
+Stale revisions return `409 Conflict`, terminal states cannot reopen, and
+cross-workspace lookups return `404`.
+
+The `durable-goal/v1` record is currently the persistence and operator-control
+contract. Automatic continuation scheduling, usage-event aggregation, and
+conversation rollover build on this record; clients must not create their own
+hidden continuation loop in the meantime.
 
 ---
 

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -20,6 +20,7 @@ Comprehensive guide to the `vk` command-line tool for Veritas Kanban.
   - [Project Management](#project-management)
   - [Agent Commands](#agent-commands)
   - [Admission Commands](#admission-commands)
+  - [Durable Goal Commands](#durable-goal-commands)
   - [Automation Commands](#automation-commands)
   - [Scheduler Commands](#scheduler-commands)
   - [Queue Monitor Commands](#queue-monitor-commands)
@@ -659,6 +660,62 @@ The Operations admission panel exposes the same controls. Queue rows can cancel
 one pending launch or its entire tree. Durable tree-control cards show bounded
 breaker signals and observed descendant/depth evidence, then allow an
 administrator to resume or cancel the tree with an audited reason.
+
+---
+
+### Durable Goal Commands
+
+Create and control one evidence-gated objective across multiple runs:
+
+```bash
+vk goals create \
+  --objective "Deliver the provider migration." \
+  --acceptance "All provider fixtures pass" "Operator docs are current" \
+  --requirement "provider-tests|test|Focused provider fixtures pass." \
+  --requirement "operator-docs|artifact|Operator documentation is reviewed." \
+  --root-task task_0123456789abcdef \
+  --mode automatic \
+  --max-turns 20 \
+  --require-rollover-approval \
+  --json
+
+vk goals list --state active blocked awaiting-approval --json
+vk goals get goal_0123456789abcdef --json
+
+vk goals transition goal_0123456789abcdef \
+  --revision 3 \
+  --state paused \
+  --reason "Operator paused before external coordination." \
+  --json
+
+vk goals transition goal_0123456789abcdef \
+  --revision 4 \
+  --state complete \
+  --reason "All configured evidence is verified." \
+  --evidence-json '[{"requirementId":"provider-tests","evidenceId":"ci-30182450098","summary":"Focused provider fixtures passed."},{"requirementId":"operator-docs","evidenceId":"review-20260726","summary":"Operator docs reviewed."}]' \
+  --json
+
+vk goals link-run goal_0123456789abcdef \
+  --revision 2 \
+  --task task_0123456789abcdef \
+  --attempt attempt_0123456789abcdef \
+  --conversation conversation_0123456789abcdef \
+  --json
+```
+
+`goals create` requires exactly one `--root-task` or `--root-workflow`.
+Completion requirements use `id|kind|description`; supported kinds are
+`test`, `build`, `artifact`, `operator`, `external`, and `other`. At least one
+required evidence item must exist, and a transition to `complete` fails until
+every required item has verified evidence.
+
+Every mutation requires the current `--revision`. A stale revision returns a
+conflict instead of overwriting a newer operator or supervisor decision.
+Blocked transitions use `--blocker-json` for the exact blocker, attempt count,
+next safe action, and required authority or external state change. The server
+derives the transition actor, workspace, verification timestamp, and evidence
+verifier from authenticated context; caller-supplied identity fields are
+rejected. Use `--json` for stable automation output.
 
 ---
 

--- a/server/src/__tests__/routes/goals.test.ts
+++ b/server/src/__tests__/routes/goals.test.ts
@@ -1,0 +1,170 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthenticatedRequest } from '../../middleware/auth.js';
+import { errorHandler } from '../../middleware/error-handler.js';
+
+const goals = vi.hoisted(() => ({
+  create: vi.fn(),
+  get: vi.fn(),
+  list: vi.fn(),
+  transition: vi.fn(),
+  linkRun: vi.fn(),
+}));
+
+vi.mock('../../services/durable-goal-service.js', () => ({
+  getDurableGoalService: () => goals,
+}));
+
+import { goalRoutes } from '../../routes/goals.js';
+
+const GOAL_ID = 'goal_0123456789abcdef';
+
+function createApp(workspaceId = 'workspace-a'): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as AuthenticatedRequest).auth = {
+      role: 'admin',
+      isLocalhost: false,
+      userId: 'user-brad',
+      workspaceId,
+    };
+    next();
+  });
+  app.use('/api/goals', goalRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('durable goal routes', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists bounded goals inside the authenticated workspace', async () => {
+    goals.list.mockResolvedValue([{ id: GOAL_ID, state: 'blocked' }]);
+
+    const response = await request(createApp()).get(
+      '/api/goals?state=active&state=blocked&rootTaskId=task-865&limit=25'
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      generatedAt: expect.any(String),
+      goals: [{ id: GOAL_ID, state: 'blocked' }],
+    });
+    expect(goals.list).toHaveBeenCalledWith({
+      workspaceId: 'workspace-a',
+      states: ['active', 'blocked'],
+      rootTaskId: 'task-865',
+      limit: 25,
+    });
+  });
+
+  it('creates a goal in the authenticated workspace instead of trusting caller identity', async () => {
+    goals.create.mockResolvedValue({ id: GOAL_ID, workspaceId: 'workspace-a', state: 'active' });
+
+    const response = await request(createApp())
+      .post('/api/goals')
+      .send({
+        objective: 'Deliver durable goal controls.',
+        acceptanceCriteria: ['REST is verified.'],
+        root: { kind: 'task', taskId: 'task-865' },
+        continuation: { mode: 'manual' },
+        completionRequirements: [
+          {
+            id: 'route-tests',
+            description: 'Route tests pass.',
+            required: true,
+            verificationKind: 'test',
+          },
+        ],
+      });
+
+    expect(response.status).toBe(201);
+    expect(goals.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'workspace-a',
+        objective: 'Deliver durable goal controls.',
+      })
+    );
+  });
+
+  it('does not expose a goal from another workspace', async () => {
+    goals.get.mockResolvedValue({ id: GOAL_ID, workspaceId: 'workspace-b' });
+
+    const response = await request(createApp('workspace-a')).get(`/api/goals/${GOAL_ID}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('derives transition actor and verification timestamps from the server', async () => {
+    goals.get.mockResolvedValue({ id: GOAL_ID, workspaceId: 'workspace-a' });
+    goals.transition.mockResolvedValue({ id: GOAL_ID, state: 'complete', revision: 2 });
+
+    const response = await request(createApp())
+      .post(`/api/goals/${GOAL_ID}/transition`)
+      .send({
+        expectedRevision: 1,
+        state: 'complete',
+        reason: 'Focused verification passed.',
+        completionEvidence: [
+          {
+            requirementId: 'route-tests',
+            evidenceId: 'ci-1082',
+            summary: 'Route tests passed.',
+          },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(goals.transition).toHaveBeenCalledWith(GOAL_ID, {
+      expectedRevision: 1,
+      to: 'complete',
+      actorId: 'user-brad',
+      reason: 'Focused verification passed.',
+      blocker: undefined,
+      completionEvidence: [
+        {
+          requirementId: 'route-tests',
+          evidenceId: 'ci-1082',
+          summary: 'Route tests passed.',
+          verifier: 'user-brad',
+          verifiedAt: expect.any(String),
+        },
+      ],
+    });
+  });
+
+  it('links a run with exact revision and rejects caller-supplied actor identity', async () => {
+    goals.get.mockResolvedValue({ id: GOAL_ID, workspaceId: 'workspace-a' });
+    goals.linkRun.mockResolvedValue({ id: GOAL_ID, revision: 3 });
+
+    const linked = await request(createApp()).post(`/api/goals/${GOAL_ID}/runs`).send({
+      expectedRevision: 2,
+      taskId: 'task-865',
+      attemptId: 'attempt-2',
+      conversationId: 'conversation-2',
+    });
+    const spoofed = await request(createApp()).post(`/api/goals/${GOAL_ID}/transition`).send({
+      expectedRevision: 3,
+      state: 'paused',
+      reason: 'Caller attempted identity spoofing.',
+      actorId: 'spoofed-admin',
+    });
+
+    expect(linked.status).toBe(200);
+    expect(goals.linkRun).toHaveBeenCalledWith(GOAL_ID, {
+      expectedRevision: 2,
+      run: {
+        taskId: 'task-865',
+        attemptId: 'attempt-2',
+        workflowRunId: undefined,
+        conversationId: 'conversation-2',
+        parentAttemptId: undefined,
+      },
+    });
+    expect(spoofed.status).toBe(400);
+    expect(goals.transition).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/goals.ts
+++ b/server/src/routes/goals.ts
@@ -1,0 +1,268 @@
+import { randomUUID } from 'node:crypto';
+import { Router, type Router as RouterType } from 'express';
+import { z } from 'zod';
+import {
+  DURABLE_GOAL_CONTINUATION_MODES,
+  DURABLE_GOAL_STATES,
+  type DurableGoalRecord,
+} from '@veritas-kanban/shared';
+import { asyncHandler } from '../middleware/async-handler.js';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { getDurableGoalService } from '../services/durable-goal-service.js';
+
+const router: RouterType = Router();
+const IdentifierSchema = z.string().trim().min(1).max(240);
+const BoundedTextSchema = z.string().trim().min(1).max(4_000);
+const VerificationKindSchema = z.enum([
+  'test',
+  'build',
+  'artifact',
+  'operator',
+  'external',
+  'other',
+]);
+
+const paramsSchema = z.object({
+  goalId: z.string().regex(/^goal_[A-Za-z0-9_-]{12,64}$/),
+});
+
+const listQuerySchema = z
+  .object({
+    state: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .transform((value) =>
+        value === undefined ? undefined : Array.isArray(value) ? value : value.split(',')
+      )
+      .pipe(z.array(z.enum(DURABLE_GOAL_STATES)).max(DURABLE_GOAL_STATES.length).optional()),
+    rootTaskId: IdentifierSchema.optional(),
+    rootWorkflowId: IdentifierSchema.optional(),
+    limit: z.coerce.number().int().min(1).max(1_000).default(100),
+  })
+  .strict();
+
+const completionRequirementSchema = z
+  .object({
+    id: IdentifierSchema,
+    description: BoundedTextSchema,
+    required: z.boolean().default(true),
+    verificationKind: VerificationKindSchema,
+  })
+  .strict();
+
+const createSchema = z
+  .object({
+    objective: z.string().trim().min(1).max(50_000),
+    constraints: z.array(BoundedTextSchema).max(200).default([]),
+    acceptanceCriteria: z.array(BoundedTextSchema).min(1).max(200),
+    root: z.discriminatedUnion('kind', [
+      z.object({ kind: z.literal('task'), taskId: IdentifierSchema }).strict(),
+      z
+        .object({
+          kind: z.literal('workflow'),
+          workflowId: IdentifierSchema,
+          taskId: IdentifierSchema.optional(),
+        })
+        .strict(),
+    ]),
+    continuation: z
+      .object({
+        mode: z.enum(DURABLE_GOAL_CONTINUATION_MODES),
+        maxTurns: z.number().int().positive().max(100_000).optional(),
+        maxRollovers: z.number().int().nonnegative().max(10_000).optional(),
+        compactAfterTokens: z.number().int().positive().optional(),
+        requireApprovalForRollover: z.boolean().optional(),
+      })
+      .strict(),
+    budgets: z
+      .object({
+        inputTokens: z.number().nonnegative().optional(),
+        outputTokens: z.number().nonnegative().optional(),
+        totalTokens: z.number().nonnegative().optional(),
+        costUsd: z.number().nonnegative().optional(),
+        toolCalls: z.number().nonnegative().optional(),
+        runtimeSeconds: z.number().nonnegative().optional(),
+        idleRuntimeSeconds: z.number().nonnegative().optional(),
+        retries: z.number().nonnegative().optional(),
+        fanOut: z.number().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
+    completionRequirements: z.array(completionRequirementSchema).min(1).max(200),
+  })
+  .strict();
+
+const transitionSchema = z
+  .object({
+    expectedRevision: z.number().int().positive(),
+    state: z.enum(DURABLE_GOAL_STATES),
+    reason: z.string().trim().min(8).max(4_000),
+    blocker: z
+      .object({
+        id: IdentifierSchema.optional(),
+        code: IdentifierSchema,
+        summary: BoundedTextSchema,
+        attempts: z.number().int().nonnegative().default(0),
+        nextSafeAction: BoundedTextSchema,
+        requiredAuthority: BoundedTextSchema.optional(),
+        externalStateChange: BoundedTextSchema.optional(),
+      })
+      .strict()
+      .optional(),
+    completionEvidence: z
+      .array(
+        z
+          .object({
+            requirementId: IdentifierSchema,
+            evidenceId: IdentifierSchema,
+            summary: BoundedTextSchema,
+          })
+          .strict()
+      )
+      .max(200)
+      .optional(),
+  })
+  .strict();
+
+const runLinkSchema = z
+  .object({
+    expectedRevision: z.number().int().positive(),
+    taskId: IdentifierSchema,
+    attemptId: IdentifierSchema.optional(),
+    workflowRunId: IdentifierSchema.optional(),
+    conversationId: IdentifierSchema.optional(),
+    parentAttemptId: IdentifierSchema.optional(),
+  })
+  .strict();
+
+function parseOrThrow<T>(schema: z.ZodType<T>, value: unknown): T {
+  try {
+    return schema.parse(value);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new ValidationError('Validation failed.', error.issues);
+    }
+    throw error;
+  }
+}
+
+function actorFromRequest(req: AuthenticatedRequest) {
+  const auth = req.auth;
+  return {
+    id:
+      auth?.userId ||
+      auth?.tokenName ||
+      auth?.keyName ||
+      auth?.clientId ||
+      auth?.deviceId ||
+      auth?.role ||
+      'operator',
+    workspaceId: auth?.workspaceId || 'local',
+  };
+}
+
+async function requireWorkspaceGoal(
+  goalId: string,
+  workspaceId: string
+): Promise<DurableGoalRecord> {
+  const goal = await getDurableGoalService().get(goalId);
+  if (goal.workspaceId !== workspaceId) throw new NotFoundError('Durable goal not found.');
+  return goal;
+}
+
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const query = parseOrThrow(listQuerySchema, req.query);
+    const actor = actorFromRequest(req);
+    res.json({
+      generatedAt: new Date().toISOString(),
+      goals: await getDurableGoalService().list({
+        workspaceId: actor.workspaceId,
+        states: query.state,
+        rootTaskId: query.rootTaskId,
+        rootWorkflowId: query.rootWorkflowId,
+        limit: query.limit,
+      }),
+    });
+  })
+);
+
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const input = parseOrThrow(createSchema, req.body);
+    const actor = actorFromRequest(req);
+    res.status(201).json(
+      await getDurableGoalService().create({
+        ...input,
+        workspaceId: actor.workspaceId,
+      })
+    );
+  })
+);
+
+router.get(
+  '/:goalId',
+  asyncHandler(async (req, res) => {
+    const { goalId } = parseOrThrow(paramsSchema, req.params);
+    const actor = actorFromRequest(req);
+    res.json(await requireWorkspaceGoal(goalId, actor.workspaceId));
+  })
+);
+
+router.post(
+  '/:goalId/transition',
+  asyncHandler(async (req, res) => {
+    const { goalId } = parseOrThrow(paramsSchema, req.params);
+    const input = parseOrThrow(transitionSchema, req.body);
+    const actor = actorFromRequest(req);
+    await requireWorkspaceGoal(goalId, actor.workspaceId);
+    const recordedAt = new Date().toISOString();
+    res.json(
+      await getDurableGoalService().transition(goalId, {
+        expectedRevision: input.expectedRevision,
+        to: input.state,
+        actorId: actor.id,
+        reason: input.reason,
+        blocker: input.blocker
+          ? {
+              ...input.blocker,
+              id: input.blocker.id ?? `blocker-${randomUUID()}`,
+              recordedAt,
+            }
+          : undefined,
+        completionEvidence: input.completionEvidence?.map((evidence) => ({
+          ...evidence,
+          verifier: actor.id,
+          verifiedAt: recordedAt,
+        })),
+      })
+    );
+  })
+);
+
+router.post(
+  '/:goalId/runs',
+  asyncHandler(async (req, res) => {
+    const { goalId } = parseOrThrow(paramsSchema, req.params);
+    const input = parseOrThrow(runLinkSchema, req.body);
+    const actor = actorFromRequest(req);
+    await requireWorkspaceGoal(goalId, actor.workspaceId);
+    res.json(
+      await getDurableGoalService().linkRun(goalId, {
+        expectedRevision: input.expectedRevision,
+        run: {
+          taskId: input.taskId,
+          attemptId: input.attemptId,
+          workflowRunId: input.workflowRunId,
+          conversationId: input.conversationId,
+          parentAttemptId: input.parentAttemptId,
+        },
+      })
+    );
+  })
+);
+
+export { router as goalRoutes };

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -32,6 +32,7 @@ import {
   delegationAccess,
   diffAccess,
   feedbackAccess,
+  goalAccess,
   integrationsAccess,
   maintenanceAccess,
   notificationAccess,
@@ -148,6 +149,7 @@ import { schedulerRoutes } from '../scheduler.js';
 import { queueMonitorRoutes } from '../queue-monitors.js';
 import { toolControlPlaneRoutes } from '../tool-control-plane.js';
 import { admissionRoutes } from '../admission.js';
+import { goalRoutes } from '../goals.js';
 
 const v1Router: IRouter = Router();
 
@@ -203,6 +205,7 @@ v1Router.use('/agents/permissions', agentPermissionAccess, agentPermissionRoutes
 v1Router.use('/agents', agentRoutingAccess, agentRoutingRoutes); // Must be before agentRoutes (/:taskId would match "route"/"routing")
 v1Router.use('/agents', agentTaskAccess, agentRoutes);
 v1Router.use('/admission', admissionAccess, admissionRoutes);
+v1Router.use('/goals', goalAccess, goalRoutes);
 v1Router.use('/diff', diffAccess, diffRoutes);
 v1Router.use('/automation', taskAccess, automationRoutes);
 v1Router.use('/summary', reportAccess, summaryRoutes);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -52,6 +52,7 @@ export const agentTaskAccess = routeAccess('agent:read', 'task:write', [
 ]);
 export const agentStatusAccess = routeAccess('agent:read', 'telemetry:write');
 export const admissionAccess = routeAccess('agent:read', 'admin:manage');
+export const goalAccess = routeAccess('agent:read', 'admin:manage');
 export const reportAccess = routeAccess('report:read', 'report:read');
 export const telemetryAccess = routeAccess('telemetry:read', 'telemetry:write');
 export const policyAccess = routeAccess('policy:read', 'policy:read', [

--- a/server/src/schemas/durable-goal-schemas.ts
+++ b/server/src/schemas/durable-goal-schemas.ts
@@ -10,7 +10,7 @@ const IdentifierSchema = z.string().trim().min(1).max(240);
 const IsoTimestampSchema = z.string().datetime();
 const BoundedTextSchema = z.string().trim().min(1).max(4_000);
 
-const BudgetLimitsSchema = z
+export const DurableGoalBudgetLimitsSchema = z
   .object({
     inputTokens: z.number().nonnegative().optional(),
     outputTokens: z.number().nonnegative().optional(),
@@ -38,7 +38,7 @@ const BudgetUsageSchema = z
   })
   .strict();
 
-const RunLinkSchema = z
+export const DurableGoalRunLinkSchema = z
   .object({
     taskId: IdentifierSchema,
     attemptId: IdentifierSchema.optional(),
@@ -49,7 +49,7 @@ const RunLinkSchema = z
   })
   .strict();
 
-const CompletionRequirementSchema = z
+export const DurableGoalCompletionRequirementSchema = z
   .object({
     id: IdentifierSchema,
     description: BoundedTextSchema,
@@ -58,7 +58,7 @@ const CompletionRequirementSchema = z
   })
   .strict();
 
-const CompletionEvidenceSchema = z
+export const DurableGoalCompletionEvidenceSchema = z
   .object({
     requirementId: IdentifierSchema,
     evidenceId: IdentifierSchema,
@@ -97,10 +97,10 @@ export const DurableGoalRecordSchema: z.ZodType<DurableGoalRecord> = z
         requireApprovalForRollover: z.boolean().optional(),
       })
       .strict(),
-    budgets: BudgetLimitsSchema.optional(),
+    budgets: DurableGoalBudgetLimitsSchema.optional(),
     usage: BudgetUsageSchema,
-    currentRun: RunLinkSchema.optional(),
-    continuationChain: z.array(RunLinkSchema).max(10_000),
+    currentRun: DurableGoalRunLinkSchema.optional(),
+    continuationChain: z.array(DurableGoalRunLinkSchema).max(10_000),
     blockers: z
       .array(
         z
@@ -117,8 +117,8 @@ export const DurableGoalRecordSchema: z.ZodType<DurableGoalRecord> = z
           .strict()
       )
       .max(1_000),
-    completionRequirements: z.array(CompletionRequirementSchema).min(1).max(200),
-    completionEvidence: z.array(CompletionEvidenceSchema).max(1_000),
+    completionRequirements: z.array(DurableGoalCompletionRequirementSchema).min(1).max(200),
+    completionEvidence: z.array(DurableGoalCompletionEvidenceSchema).max(1_000),
     transitions: z
       .array(
         z

--- a/server/src/services/durable-goal-service.ts
+++ b/server/src/services/durable-goal-service.ts
@@ -289,3 +289,10 @@ export class DurableGoalService {
     });
   }
 }
+
+let durableGoalService: DurableGoalService | undefined;
+
+export function getDurableGoalService(): DurableGoalService {
+  durableGoalService ??= new DurableGoalService();
+  return durableGoalService;
+}

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -256,6 +256,7 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
   { prefix: '/api/audit', read: 'admin:manage', write: 'admin:manage' },
   { prefix: '/api/lessons', read: 'task:read' },
   { prefix: '/api/delegation', read: 'agent:read', write: 'admin:manage' },
+  { prefix: '/api/goals', read: 'agent:read', write: 'admin:manage' },
   {
     prefix: '/api/workflows',
     read: 'workflow:read',


### PR DESCRIPTION
## Summary

- adds workspace-scoped REST endpoints to create, list, inspect, transition, and link runs to `durable-goal/v1` records
- derives workspace, transition actor, evidence verifier, and verification timestamps from authenticated server context
- exposes `vk goals` create, list, get, transition, and link-run commands with exact revision guards and JSON automation output
- documents the REST and CLI contracts, state model, evidence requirements, blocker input, and current automatic-continuation boundary

## Verification

- shared build
- server and CLI typecheck
- targeted lint, formatting, and `git diff --check`
- 10 non-listener durable-goal service and repository tests
- 4 CLI command tests
- 5 exact REST route tests run in CI because this local sandbox cannot bind Supertest listeners

Part of #865
