### PR TITLE
feat: supervise durable goal continuations

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -4440,10 +4440,26 @@ authenticated context; these identities cannot be supplied by the caller.
 Stale revisions return `409 Conflict`, terminal states cannot reopen, and
 cross-workspace lookups return `404`.
 
-The `durable-goal/v1` record is currently the persistence and operator-control
-contract. Automatic continuation scheduling, usage-event aggregation, and
-conversation rollover build on this record; clients must not create their own
-hidden continuation loop in the meantime.
+The `durable-goal/v1` record also exposes `usageEvents` and
+`continuationAttempts`. Each completed provider run contributes one
+idempotency-keyed usage event, verified evidence, and run link. Aggregate goal
+usage is the sum of those deduplicated events.
+
+For an active automatic goal, the supervisor evaluates required evidence,
+blockers, turn limits, and aggregate budgets after the provider completion is
+durable. It persists a `planned` continuation with a stable admission
+idempotency key before calling the normal provider follow-up path. That path
+still enforces runtime capabilities, admission limits, sandbox and phase
+authority, approvals, immutable launch manifests, and the goal's remaining
+budget. The plan becomes `dispatched` only after an attempt or queue identity
+exists.
+
+Startup reconciliation closes the crash window in either direction. If the
+child attempt already exists, the planned continuation is linked without
+launching another provider. Otherwise the same admission idempotency key is
+reused. Failed admission blocks the goal with an actionable reason. Provider
+blockers, missing continuation handles, turn limits, budget limits, and manual
+continuation mode all fail closed instead of creating a hidden retry loop.
 
 ---
 

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -717,6 +717,21 @@ derives the transition actor, workspace, verification timestamp, and evidence
 verifier from authenticated context; caller-supplied identity fields are
 rejected. Use `--json` for stable automation output.
 
+`goals get --json` includes the deduplicated `usageEvents`, full
+`continuationChain`, and restart-safe `continuationAttempts`. Automatic goals
+continue only after the prior completion is durable and required evidence,
+blockers, turn limits, and aggregate budgets are evaluated. A continuation is
+persisted as `planned` before it enters the normal admission path, then becomes
+`dispatched` with its attempt or queue identity. On restart, the same admission
+idempotency key is reused; an already-created child attempt is linked without a
+duplicate launch.
+
+Manual goals pause after an incomplete run. Automatic goals block when the
+provider has no verified continuation handle or admission fails, and enter
+`usage-limited` or `budget-limited` at their configured boundary. Resume those
+states explicitly after addressing the reported condition; do not build a
+second client-side continuation loop.
+
 ---
 
 ### Prompt Commands

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -25,6 +25,8 @@ const {
   mockSdkConstructor,
   mockSdkStartThread,
   mockSdkRunStreamed,
+  mockHandleDurableGoalCompletion,
+  mockReconcileDurableGoalContinuation,
 } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
   mockGetConfig: vi.fn(),
@@ -44,6 +46,8 @@ const {
   mockSdkConstructor: vi.fn(),
   mockSdkStartThread: vi.fn(),
   mockSdkRunStreamed: vi.fn(),
+  mockHandleDurableGoalCompletion: vi.fn(),
+  mockReconcileDurableGoalContinuation: vi.fn(),
 }));
 
 vi.mock('child_process', async (importOriginal) => {
@@ -280,7 +284,12 @@ function testableService(
     workspaceExecutionTrust,
     undefined,
     { getCurrent: vi.fn().mockResolvedValue(null) },
-    admission
+    admission,
+    undefined,
+    {
+      handleRunCompletion: mockHandleDurableGoalCompletion,
+      reconcilePlannedForTask: mockReconcileDurableGoalContinuation,
+    }
   ) as unknown as TestableClawdbotAgentService;
   service.logsDir = tmpDir;
   return service;
@@ -624,6 +633,8 @@ describe('ClawdbotAgentService Codex providers', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockHandleDurableGoalCompletion.mockResolvedValue({ action: 'not-found' });
+    mockReconcileDurableGoalContinuation.mockResolvedValue({ action: 'not-found' });
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-provider-'));
     task = {
       id: 'task_codex_fixture',
@@ -3054,6 +3065,17 @@ describe('ClawdbotAgentService Codex providers', () => {
     });
     expect(task.attempt?.completionResult?.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(task.attempt?.completionResult?.idempotencyKey).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(mockHandleDurableGoalCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: task.id,
+        attemptId: active.attemptId,
+        completion: expect.objectContaining({
+          status: 'success',
+          summary: 'natural completion won',
+        }),
+      }),
+      expect.any(Function)
+    );
     expect(
       mockUpdateTask.mock.calls.filter(
         ([, update]) =>
@@ -3663,6 +3685,30 @@ describe('ClawdbotAgentService Codex providers', () => {
       runLaunchManifestDigest: active.runLaunchManifest.digest,
       reason: fixture.credentialReason,
     });
+  });
+
+  it('does not schedule generic recovery when a durable goal owns continuation', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    mockHandleDurableGoalCompletion.mockResolvedValue({ action: 'dispatched' });
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+
+    await service.completeAgent(
+      task.id,
+      {
+        status: 'partial',
+        summary: 'The durable goal supervisor will continue this objective.',
+      },
+      {
+        attemptId: active.attemptId,
+        terminalSource: 'process',
+        providerRuntimeManifestDigest: active.providerRuntimeManifest.digest,
+      }
+    );
+
+    expect(mockHandleDurableGoalCompletion).toHaveBeenCalledTimes(1);
+    expect(task.attempt?.runRetry).toBeUndefined();
   });
 
   it('does not enforce a budget evaluation that outlives its active run', async () => {

--- a/server/src/__tests__/durable-goal-repository.test.ts
+++ b/server/src/__tests__/durable-goal-repository.test.ts
@@ -66,14 +66,52 @@ async function exerciseRepository(
       },
     ],
   });
-  const paused = await service.transition(created.id, {
+  const withOutcome = await service.recordRunOutcome(created.id, {
     expectedRevision: created.revision,
+    run: { taskId: 'task-865', attemptId: 'attempt-1' },
+    usageEvent: {
+      id: 'completion-1',
+      taskId: 'task-865',
+      attemptId: 'attempt-1',
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        costUsd: 0.01,
+        toolCalls: 2,
+        runtimeSeconds: 3,
+        idleRuntimeSeconds: 0,
+        retries: 0,
+        fanOut: 1,
+      },
+    },
+  });
+  const withPlan = await service.planContinuation(created.id, {
+    expectedRevision: withOutcome.revision,
+    sourceTaskId: 'task-865',
+    sourceAttemptId: 'attempt-1',
+    message: 'Continue after restart.',
+  });
+  const paused = await service.transition(created.id, {
+    expectedRevision: withPlan.revision,
     to: 'paused',
     actorId: 'operator-brad',
     reason: 'Exercise durable compare-and-set state.',
   });
 
-  expect(paused).toMatchObject({ state: 'paused', revision: 2 });
+  expect(paused).toMatchObject({
+    state: 'paused',
+    revision: 4,
+    usage: { totalTokens: 15, costUsd: 0.01 },
+    usageEvents: [{ id: 'completion-1' }],
+    continuationAttempts: [
+      {
+        sourceAttemptId: 'attempt-1',
+        state: 'planned',
+        admissionIdempotencyKey: `durable-goal:${created.id}:attempt-1`,
+      },
+    ],
+  });
   expect(
     await repository.list({
       workspaceId: 'workspace-a',
@@ -96,7 +134,7 @@ async function exerciseRepository(
       actorId: 'operator-brad',
       reason: 'Resume after restart.',
     })
-  ).toMatchObject({ state: 'active', revision: 3 });
+  ).toMatchObject({ state: 'active', revision: 5 });
 }
 
 async function temporaryRoot(): Promise<string> {

--- a/server/src/__tests__/durable-goal-supervisor-service.test.ts
+++ b/server/src/__tests__/durable-goal-supervisor-service.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  CompletionResult,
+  DurableGoalCompareAndSetInput,
+  DurableGoalCompareAndSetResult,
+  DurableGoalListQuery,
+  DurableGoalRecord,
+} from '@veritas-kanban/shared';
+import { ZERO_AGENT_BUDGET_USAGE } from '@veritas-kanban/shared';
+import { DurableGoalService } from '../services/durable-goal-service.js';
+import { DurableGoalSupervisorService } from '../services/durable-goal-supervisor-service.js';
+import type { DurableGoalRepository } from '../storage/interfaces.js';
+
+const NOW = new Date('2026-07-26T03:00:00.000Z');
+const GOAL_ID = 'goal_supervisor865';
+
+class InMemoryDurableGoalRepository implements DurableGoalRepository {
+  private readonly records = new Map<string, DurableGoalRecord>();
+
+  async create(record: DurableGoalRecord): Promise<DurableGoalRecord> {
+    this.records.set(record.id, structuredClone(record));
+    return structuredClone(record);
+  }
+
+  async get(id: string): Promise<DurableGoalRecord | null> {
+    const record = this.records.get(id);
+    return record ? structuredClone(record) : null;
+  }
+
+  async list(query: DurableGoalListQuery): Promise<DurableGoalRecord[]> {
+    return [...this.records.values()]
+      .filter((record) => record.workspaceId === query.workspaceId)
+      .filter((record) => !query.states || query.states.includes(record.state))
+      .filter(
+        (record) =>
+          !query.rootTaskId ||
+          (record.root.kind === 'task'
+            ? record.root.taskId === query.rootTaskId
+            : record.root.taskId === query.rootTaskId)
+      )
+      .map((record) => structuredClone(record));
+  }
+
+  async compareAndSet(
+    input: DurableGoalCompareAndSetInput
+  ): Promise<DurableGoalCompareAndSetResult> {
+    const current = this.records.get(input.id);
+    if (!current) return { updated: false, reason: 'not-found' };
+    if (current.revision !== input.expectedRevision) {
+      return { record: structuredClone(current), updated: false, reason: 'stale-revision' };
+    }
+    this.records.set(input.id, structuredClone(input.next));
+    return { record: structuredClone(input.next), updated: true };
+  }
+}
+
+function services() {
+  const goals = new DurableGoalService({
+    repository: new InMemoryDurableGoalRepository(),
+    now: () => NOW,
+  });
+  return { goals, supervisor: new DurableGoalSupervisorService(goals) };
+}
+
+async function createGoal(
+  goals: DurableGoalService,
+  options: {
+    continuation?: { mode: 'manual' | 'automatic'; maxTurns?: number };
+    budgets?: { totalTokens?: number };
+  } = {}
+) {
+  return goals.create({
+    id: GOAL_ID,
+    workspaceId: 'workspace-1',
+    objective: 'Ship the durable goal supervisor.',
+    constraints: ['Preserve admission controls.'],
+    acceptanceCriteria: ['Focused verification passes.'],
+    root: { kind: 'task', taskId: 'task-865' },
+    continuation: options.continuation ?? { mode: 'automatic', maxTurns: 4 },
+    budgets: options.budgets,
+    completionRequirements: [
+      {
+        id: 'focused-tests',
+        description: 'Focused verification passes.',
+        required: true,
+        verificationKind: 'test',
+      },
+    ],
+  });
+}
+
+function completion(overrides: Partial<CompletionResult> = {}): CompletionResult {
+  return {
+    schemaVersion: 'completion-result/v1',
+    digest: 'sha256:completion',
+    idempotencyKey: 'completion-attempt-1',
+    completedAt: NOW.toISOString(),
+    terminalSource: 'process',
+    taskEnvelopeSchemaVersion: 'task-envelope/v1',
+    taskEnvelopeDigest: 'sha256:envelope',
+    taskId: 'task-865',
+    attemptId: 'attempt-1',
+    providerRuntimeManifestDigest: 'sha256:runtime',
+    status: 'success',
+    summary: 'Implemented the next durable goal slice.',
+    error: null,
+    blockers: [],
+    evidence: [
+      {
+        id: 'focused-tests-evidence',
+        kind: 'verification',
+        source: 'harness',
+        summary: 'Focused tests passed.',
+        reference: null,
+        requirementIds: ['focused-tests'],
+        verified: true,
+      },
+    ],
+    changedFiles: [],
+    artifacts: [],
+    verification: [],
+    sideEffects: [],
+    continuation: {
+      provider: 'codex-cli',
+      kind: 'thread',
+      reference: 'thread-1',
+    },
+    ...overrides,
+  };
+}
+
+const usage = {
+  ...ZERO_AGENT_BUDGET_USAGE,
+  inputTokens: 10,
+  outputTokens: 5,
+  totalTokens: 15,
+  runtimeSeconds: 3,
+  toolCalls: 2,
+  fanOut: 1,
+};
+
+describe('DurableGoalSupervisorService', () => {
+  it('records a run once and completes only with verified required evidence', async () => {
+    const { goals, supervisor } = services();
+    await createGoal(goals);
+    const dispatch = vi.fn();
+
+    const result = await supervisor.handleRunCompletion(
+      {
+        workspaceId: 'workspace-1',
+        taskId: 'task-865',
+        attemptId: 'attempt-1',
+        completion: completion(),
+        usage,
+      },
+      dispatch
+    );
+
+    expect(result.action).toBe('complete');
+    expect(result.goal).toMatchObject({
+      state: 'complete',
+      usage: { totalTokens: 15, runtimeSeconds: 3, fanOut: 1 },
+      completionEvidence: [{ requirementId: 'focused-tests' }],
+      continuationChain: [{ attemptId: 'attempt-1' }],
+    });
+    expect(result.goal?.usageEvents).toHaveLength(1);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('persists a stable continuation plan before dispatch and deduplicates completion replay', async () => {
+    const { goals, supervisor } = services();
+    await createGoal(goals, { budgets: { totalTokens: 100 } });
+    const dispatch = vi.fn().mockResolvedValue({ attemptId: 'attempt-2', queueId: 'queue-2' });
+    const input = {
+      workspaceId: 'workspace-1',
+      taskId: 'task-865',
+      attemptId: 'attempt-1',
+      completion: completion({ evidence: [] }),
+      usage,
+    };
+
+    const first = await supervisor.handleRunCompletion(input, dispatch);
+    const replay = await supervisor.handleRunCompletion(input, dispatch);
+
+    expect(first.action).toBe('dispatched');
+    expect(first.continuation).toMatchObject({
+      state: 'dispatched',
+      sourceAttemptId: 'attempt-1',
+      resultAttemptId: 'attempt-2',
+      queueId: 'queue-2',
+      admissionIdempotencyKey: `durable-goal:${GOAL_ID}:attempt-1`,
+    });
+    expect(first.goal?.continuationChain.map((run) => run.attemptId)).toEqual([
+      'attempt-1',
+      'attempt-2',
+    ]);
+    expect(replay.action).toBe('already-handled');
+    expect(replay.goal?.usage.totalTokens).toBe(15);
+    expect(replay.goal?.usageEvents).toHaveLength(1);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ remainingBudget: { totalTokens: 85 } })
+    );
+  });
+
+  it('preserves an exact provider blocker without dispatching', async () => {
+    const { goals, supervisor } = services();
+    await createGoal(goals);
+    const dispatch = vi.fn();
+
+    const result = await supervisor.handleRunCompletion(
+      {
+        workspaceId: 'workspace-1',
+        taskId: 'task-865',
+        attemptId: 'attempt-1',
+        completion: completion({
+          status: 'blocked',
+          evidence: [],
+          blockers: [
+            {
+              code: 'EXTERNAL_APPROVAL_REQUIRED',
+              summary: 'Release approval is missing.',
+              detail: 'Wait for the release owner.',
+              retryable: true,
+            },
+          ],
+        }),
+      },
+      dispatch
+    );
+
+    expect(result.action).toBe('blocked');
+    expect(result.goal).toMatchObject({
+      state: 'blocked',
+      blockers: [
+        {
+          code: 'EXTERNAL_APPROVAL_REQUIRED',
+          summary: 'Release approval is missing.',
+          nextSafeAction: 'Wait for the release owner.',
+        },
+      ],
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('stops before dispatch when the aggregate budget is reached', async () => {
+    const { goals, supervisor } = services();
+    await createGoal(goals, { budgets: { totalTokens: 10 } });
+
+    const result = await supervisor.handleRunCompletion(
+      {
+        workspaceId: 'workspace-1',
+        taskId: 'task-865',
+        attemptId: 'attempt-1',
+        completion: completion({ evidence: [] }),
+        usage,
+      },
+      vi.fn()
+    );
+
+    expect(result.action).toBe('budget-limited');
+    expect(result.goal?.state).toBe('budget-limited');
+  });
+
+  it('stops before dispatch when the turn limit is reached', async () => {
+    const { goals, supervisor } = services();
+    await createGoal(goals, { continuation: { mode: 'automatic', maxTurns: 1 } });
+
+    const result = await supervisor.handleRunCompletion(
+      {
+        workspaceId: 'workspace-1',
+        taskId: 'task-865',
+        attemptId: 'attempt-1',
+        completion: completion({ evidence: [] }),
+      },
+      vi.fn()
+    );
+
+    expect(result.action).toBe('usage-limited');
+    expect(result.goal?.state).toBe('usage-limited');
+  });
+
+  it('reconciles a crash after dispatch without launching a duplicate continuation', async () => {
+    const { goals, supervisor } = services();
+    const goal = await createGoal(goals);
+    const withSource = await goals.recordRunOutcome(goal.id, {
+      expectedRevision: goal.revision,
+      run: { taskId: 'task-865', attemptId: 'attempt-1' },
+    });
+    await goals.planContinuation(goal.id, {
+      expectedRevision: withSource.revision,
+      sourceTaskId: 'task-865',
+      sourceAttemptId: 'attempt-1',
+      message: 'Continue safely.',
+    });
+    const dispatch = vi.fn();
+
+    const result = await supervisor.reconcilePlannedForTask(
+      {
+        workspaceId: 'workspace-1',
+        taskId: 'task-865',
+        currentAttemptId: 'attempt-2',
+        parentAttemptId: 'attempt-1',
+        currentAttemptRunning: true,
+      },
+      dispatch
+    );
+
+    expect(result.action).toBe('reconciled');
+    expect(result.continuation).toMatchObject({
+      state: 'dispatched',
+      resultAttemptId: 'attempt-2',
+    });
+    expect(result.goal?.continuationChain.map((run) => run.attemptId)).toEqual([
+      'attempt-1',
+      'attempt-2',
+    ]);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/schemas/durable-goal-schemas.ts
+++ b/server/src/schemas/durable-goal-schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   DURABLE_GOAL_CONTINUATION_MODES,
+  DURABLE_GOAL_CONTINUATION_STATES,
   DURABLE_GOAL_SCHEMA_VERSION,
   DURABLE_GOAL_STATES,
   type DurableGoalRecord,
@@ -35,6 +36,33 @@ const BudgetUsageSchema = z
     idleRuntimeSeconds: z.number().nonnegative(),
     retries: z.number().nonnegative(),
     fanOut: z.number().nonnegative(),
+  })
+  .strict();
+
+export const DurableGoalUsageEventSchema = z
+  .object({
+    id: IdentifierSchema,
+    taskId: IdentifierSchema,
+    attemptId: IdentifierSchema.optional(),
+    usage: BudgetUsageSchema,
+    recordedAt: IsoTimestampSchema,
+  })
+  .strict();
+
+export const DurableGoalContinuationAttemptSchema = z
+  .object({
+    id: IdentifierSchema,
+    sourceTaskId: IdentifierSchema,
+    sourceAttemptId: IdentifierSchema,
+    state: z.enum(DURABLE_GOAL_CONTINUATION_STATES),
+    admissionIdempotencyKey: IdentifierSchema,
+    message: z.string().trim().min(1).max(50_000),
+    resultAttemptId: IdentifierSchema.optional(),
+    queueId: IdentifierSchema.optional(),
+    errorCode: IdentifierSchema.optional(),
+    errorSummary: BoundedTextSchema.optional(),
+    createdAt: IsoTimestampSchema,
+    updatedAt: IsoTimestampSchema,
   })
   .strict();
 
@@ -99,8 +127,10 @@ export const DurableGoalRecordSchema: z.ZodType<DurableGoalRecord> = z
       .strict(),
     budgets: DurableGoalBudgetLimitsSchema.optional(),
     usage: BudgetUsageSchema,
+    usageEvents: z.array(DurableGoalUsageEventSchema).max(10_000).default([]),
     currentRun: DurableGoalRunLinkSchema.optional(),
     continuationChain: z.array(DurableGoalRunLinkSchema).max(10_000),
+    continuationAttempts: z.array(DurableGoalContinuationAttemptSchema).max(10_000).default([]),
     blockers: z
       .array(
         z
@@ -177,6 +207,39 @@ export const DurableGoalRecordSchema: z.ZodType<DurableGoalRecord> = z
       }
       evidenceIds.add(evidence.evidenceId);
       evidencedRequirements.add(evidence.requirementId);
+    }
+
+    const usageEventIds = new Set<string>();
+    for (const [index, event] of record.usageEvents.entries()) {
+      if (usageEventIds.has(event.id)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['usageEvents', index, 'id'],
+          message: 'Durable goal usage event IDs must be unique.',
+        });
+      }
+      usageEventIds.add(event.id);
+    }
+
+    const continuationIds = new Set<string>();
+    const continuationAdmissionKeys = new Set<string>();
+    for (const [index, continuation] of record.continuationAttempts.entries()) {
+      if (continuationIds.has(continuation.id)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['continuationAttempts', index, 'id'],
+          message: 'Durable goal continuation attempt IDs must be unique.',
+        });
+      }
+      if (continuationAdmissionKeys.has(continuation.admissionIdempotencyKey)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['continuationAttempts', index, 'admissionIdempotencyKey'],
+          message: 'Durable goal continuation admission keys must be unique.',
+        });
+      }
+      continuationIds.add(continuation.id);
+      continuationAdmissionKeys.add(continuation.admissionIdempotencyKey);
     }
 
     if (record.state === 'complete') {

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -34,6 +34,11 @@ import {
 } from './run-egress-gateway-service.js';
 import { getAgentBudgetService } from './agent-budget-service.js';
 import {
+  getDurableGoalSupervisorService,
+  type DurableGoalContinuationDispatchRequest,
+  type DurableGoalSupervisorService,
+} from './durable-goal-supervisor-service.js';
+import {
   AgentHealthService,
   type AgentHealthChecker,
   type AgentHealthStatus,
@@ -579,6 +584,10 @@ export class ClawdbotAgentService {
   >;
   private sandboxPolicies: Pick<SandboxPolicyService, 'dryRunWithTrace'>;
   private runEgressGateway: Pick<RunEgressGatewayService, 'start' | 'stopRun'>;
+  private durableGoalSupervisor: Pick<
+    DurableGoalSupervisorService,
+    'handleRunCompletion' | 'reconcilePlannedForTask'
+  >;
   private workspaceExecutionTrust: Pick<
     WorkspaceExecutionTrustService,
     'scan' | 'evaluateForLaunch' | 'assertFresh'
@@ -620,7 +629,11 @@ export class ClawdbotAgentService {
     runEgressGateway: Pick<
       RunEgressGatewayService,
       'start' | 'stopRun'
-    > = getRunEgressGatewayService()
+    > = getRunEgressGatewayService(),
+    durableGoalSupervisor: Pick<
+      DurableGoalSupervisorService,
+      'handleRunCompletion' | 'reconcilePlannedForTask'
+    > = getDurableGoalSupervisorService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -648,6 +661,7 @@ export class ClawdbotAgentService {
     this.filesystemSandbox = filesystemSandbox;
     this.sandboxPolicies = sandboxPolicies;
     this.runEgressGateway = runEgressGateway;
+    this.durableGoalSupervisor = durableGoalSupervisor;
     this.workspaceExecutionTrust = workspaceExecutionTrust;
     this.phaseAuthority = phaseAuthority;
     this.phaseTransitions = phaseTransitions;
@@ -1100,6 +1114,7 @@ export class ClawdbotAgentService {
         '[ClawdbotAgent] Durable run supervisor startup reconciliation complete'
       );
     }
+    await this.reconcileDurableGoalContinuations(tasks);
   }
 
   /**
@@ -4061,6 +4076,7 @@ export class ClawdbotAgentService {
     const { durationMs } = timing;
     const completionStepType = successful ? 'complete' : 'error';
     const requestFile = path.join(getRuntimeDir(), 'agent-requests', `${taskId}.json`);
+    let durableGoalSupervised = false;
     const postCommitEffects: Array<[string, () => void | Promise<void>]> = [
       [
         'release worktree ownership',
@@ -4152,6 +4168,27 @@ export class ClawdbotAgentService {
           }
         },
       ],
+      [
+        'supervise durable goal completion',
+        async () => {
+          // Fail closed: if ownership lookup errors or is ambiguous, do not let
+          // the legacy recovery loop race a possible durable goal continuation.
+          durableGoalSupervised = true;
+          const result = await this.durableGoalSupervisor.handleRunCompletion(
+            {
+              workspaceId: pending.taskEnvelope.workspace.workspaceId,
+              taskId,
+              attemptId,
+              parentAttemptId: pending.runLaunchParentAttemptId,
+              conversationId: pending.conversation.conversationId,
+              completion: completionResult,
+              usage: pending.executionTreeUsage,
+            },
+            (request) => this.dispatchDurableGoalContinuation(request)
+          );
+          durableGoalSupervised = result.action !== 'not-found';
+        },
+      ],
     ];
     for (const [effect, run] of postCommitEffects) {
       try {
@@ -4164,7 +4201,7 @@ export class ClawdbotAgentService {
       }
     }
 
-    if (!successful) {
+    if (!successful && !durableGoalSupervised) {
       await this.planTaskRecovery(
         taskId,
         preparedCompletion.completedAttempt,
@@ -4518,6 +4555,61 @@ export class ClawdbotAgentService {
         message,
       },
     });
+  }
+
+  private async dispatchDurableGoalContinuation(
+    request: DurableGoalContinuationDispatchRequest
+  ): Promise<{ attemptId: string; queueId?: string }> {
+    const result = await this.followUpConversation(
+      request.sourceTaskId,
+      request.sourceAttemptId,
+      request.message,
+      {
+        admissionIdempotencyKey: request.admissionIdempotencyKey,
+        budget: request.remainingBudget
+          ? {
+              enabled: true,
+              name: `Durable goal ${request.goal.id} remaining budget`,
+              scope: 'run',
+              limits: request.remainingBudget,
+              hardAction: 'pause',
+            }
+          : undefined,
+        rootTaskId:
+          request.goal.root.kind === 'task'
+            ? request.goal.root.taskId
+            : (request.goal.root.taskId ?? request.sourceTaskId),
+      }
+    );
+    return {
+      attemptId: result.attemptId,
+      ...('queueId' in result ? { queueId: result.queueId } : {}),
+    };
+  }
+
+  private async reconcileDurableGoalContinuations(tasks: Task[]): Promise<void> {
+    for (const task of tasks) {
+      const attempt = task.attempt;
+      const workspaceId = attempt?.taskEnvelope?.workspace.workspaceId;
+      if (!attempt || !workspaceId) continue;
+      try {
+        await this.durableGoalSupervisor.reconcilePlannedForTask(
+          {
+            workspaceId,
+            taskId: task.id,
+            currentAttemptId: attempt.id,
+            parentAttemptId: attempt.runLaunchParentAttemptId,
+            currentAttemptRunning: attempt.status === 'running',
+          },
+          (request) => this.dispatchDurableGoalContinuation(request)
+        );
+      } catch (error) {
+        log.warn(
+          { err: error, taskId: task.id, attemptId: attempt.id },
+          '[ClawdbotAgent] Failed to reconcile a durable goal continuation'
+        );
+      }
+    }
   }
 
   async forkConversation(

--- a/server/src/services/durable-goal-service.ts
+++ b/server/src/services/durable-goal-service.ts
@@ -1,15 +1,18 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import type {
   AgentBudgetLimits,
+  AgentBudgetUsage,
   DurableGoalBlocker,
   DurableGoalCompletionEvidence,
   DurableGoalCompletionRequirement,
+  DurableGoalContinuationAttempt,
   DurableGoalContinuationPolicy,
   DurableGoalListQuery,
   DurableGoalRecord,
   DurableGoalRoot,
   DurableGoalRunLink,
   DurableGoalState,
+  DurableGoalUsageEvent,
 } from '@veritas-kanban/shared';
 import { DURABLE_GOAL_SCHEMA_VERSION, ZERO_AGENT_BUDGET_USAGE } from '@veritas-kanban/shared';
 import { ConflictError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
@@ -112,6 +115,30 @@ export interface LinkDurableGoalRunInput {
   run: Omit<DurableGoalRunLink, 'linkedAt'> & { linkedAt?: string };
 }
 
+export interface RecordDurableGoalRunOutcomeInput {
+  expectedRevision: number;
+  run: Omit<DurableGoalRunLink, 'linkedAt'> & { linkedAt?: string };
+  usageEvent?: Omit<DurableGoalUsageEvent, 'recordedAt'> & { recordedAt?: string };
+  completionEvidence?: DurableGoalCompletionEvidence[];
+}
+
+export interface PlanDurableGoalContinuationInput {
+  expectedRevision: number;
+  sourceTaskId: string;
+  sourceAttemptId: string;
+  message: string;
+}
+
+export interface ResolveDurableGoalContinuationInput {
+  expectedRevision: number;
+  continuationId: string;
+  state: Extract<DurableGoalContinuationAttempt['state'], 'dispatched' | 'failed'>;
+  resultAttemptId?: string;
+  queueId?: string;
+  errorCode?: string;
+  errorSummary?: string;
+}
+
 export interface DurableGoalServiceOptions {
   repository?: DurableGoalRepository;
   now?: () => Date;
@@ -153,7 +180,9 @@ export class DurableGoalService {
       continuation: input.continuation,
       budgets: input.budgets,
       usage: { ...ZERO_AGENT_BUDGET_USAGE },
+      usageEvents: [],
       continuationChain: [],
+      continuationAttempts: [],
       blockers: [],
       completionRequirements: input.completionRequirements ?? [],
       completionEvidence: [],
@@ -260,6 +289,143 @@ export class DurableGoalService {
     return this.compareAndSet(current, next);
   }
 
+  async recordRunOutcome(
+    id: string,
+    input: RecordDurableGoalRunOutcomeInput
+  ): Promise<DurableGoalRecord> {
+    const current = await this.get(id);
+    this.requireRevision(current, input.expectedRevision);
+    if (TERMINAL_STATES.has(current.state)) {
+      throw new ValidationError('Terminal goals cannot accept another run outcome.', {
+        goalId: id,
+        state: current.state,
+      });
+    }
+
+    const timestamp = this.now().toISOString();
+    const run = { ...input.run, linkedAt: input.run.linkedAt ?? timestamp };
+    const hasRun = current.continuationChain.some(
+      (candidate) =>
+        candidate.taskId === run.taskId &&
+        candidate.attemptId === run.attemptId &&
+        candidate.workflowRunId === run.workflowRunId
+    );
+    const usageEvent = input.usageEvent
+      ? {
+          ...input.usageEvent,
+          recordedAt: input.usageEvent.recordedAt ?? timestamp,
+        }
+      : undefined;
+    const hasUsageEvent = usageEvent
+      ? current.usageEvents.some((candidate) => candidate.id === usageEvent.id)
+      : false;
+    const evidenceIds = new Set(current.completionEvidence.map((evidence) => evidence.evidenceId));
+    const newEvidence = (input.completionEvidence ?? []).filter(
+      (evidence) => !evidenceIds.has(evidence.evidenceId)
+    );
+    if (hasRun && (!usageEvent || hasUsageEvent) && newEvidence.length === 0) return current;
+
+    const next = DurableGoalRecordSchema.parse({
+      ...current,
+      revision: current.revision + 1,
+      usage:
+        usageEvent && !hasUsageEvent
+          ? addGoalUsage(current.usage, usageEvent.usage)
+          : current.usage,
+      usageEvents:
+        usageEvent && !hasUsageEvent ? [...current.usageEvents, usageEvent] : current.usageEvents,
+      currentRun: hasRun ? current.currentRun : run,
+      continuationChain: hasRun ? current.continuationChain : [...current.continuationChain, run],
+      completionEvidence: [...current.completionEvidence, ...newEvidence],
+      updatedAt: timestamp,
+    });
+    return this.compareAndSet(current, next);
+  }
+
+  async planContinuation(
+    id: string,
+    input: PlanDurableGoalContinuationInput
+  ): Promise<DurableGoalRecord> {
+    const current = await this.get(id);
+    this.requireRevision(current, input.expectedRevision);
+    if (current.state !== 'active') {
+      throw new ValidationError('Only active durable goals can plan a continuation.', {
+        goalId: id,
+        state: current.state,
+      });
+    }
+    const existing = current.continuationAttempts.find(
+      (attempt) => attempt.sourceAttemptId === input.sourceAttemptId
+    );
+    if (existing) return current;
+
+    const timestamp = this.now().toISOString();
+    const suffix = stableContinuationSuffix(id, input.sourceAttemptId);
+    const continuation: DurableGoalContinuationAttempt = {
+      id: `continuation_${suffix}`,
+      sourceTaskId: input.sourceTaskId,
+      sourceAttemptId: input.sourceAttemptId,
+      state: 'planned',
+      admissionIdempotencyKey: `durable-goal:${id}:${input.sourceAttemptId}`,
+      message: input.message,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    const next = DurableGoalRecordSchema.parse({
+      ...current,
+      revision: current.revision + 1,
+      continuationAttempts: [...current.continuationAttempts, continuation],
+      updatedAt: timestamp,
+    });
+    return this.compareAndSet(current, next);
+  }
+
+  async resolveContinuation(
+    id: string,
+    input: ResolveDurableGoalContinuationInput
+  ): Promise<DurableGoalRecord> {
+    const current = await this.get(id);
+    this.requireRevision(current, input.expectedRevision);
+    const index = current.continuationAttempts.findIndex(
+      (attempt) => attempt.id === input.continuationId
+    );
+    if (index < 0) throw new NotFoundError('Durable goal continuation attempt not found.');
+    const existing = current.continuationAttempts[index];
+    if (existing.state === input.state) return current;
+    if (existing.state !== 'planned') {
+      throw new ValidationError('Resolved durable goal continuations are immutable.', {
+        goalId: id,
+        continuationId: input.continuationId,
+        state: existing.state,
+      });
+    }
+    if (input.state === 'dispatched' && !input.resultAttemptId) {
+      throw new ValidationError('Dispatched durable goal continuations require a result attempt.');
+    }
+    if (input.state === 'failed' && !input.errorSummary) {
+      throw new ValidationError('Failed durable goal continuations require an error summary.');
+    }
+
+    const timestamp = this.now().toISOString();
+    const continuationAttempts = [...current.continuationAttempts];
+    continuationAttempts[index] = {
+      ...existing,
+      state: input.state,
+      resultAttemptId: input.resultAttemptId,
+      queueId: input.queueId,
+      errorCode: input.errorCode,
+      errorSummary: input.errorSummary,
+      updatedAt: timestamp,
+    };
+    const next = DurableGoalRecordSchema.parse({
+      ...current,
+      revision: current.revision + 1,
+      continuationAttempts,
+      updatedAt: timestamp,
+    });
+    return this.compareAndSet(current, next);
+  }
+
   private requireRevision(record: DurableGoalRecord, expectedRevision: number): void {
     if (record.revision !== expectedRevision) {
       throw new ConflictError('Durable goal compare-and-set revision is stale.', {
@@ -288,6 +454,29 @@ export class DurableGoalService {
       reason: result.reason,
     });
   }
+}
+
+function stableContinuationSuffix(goalId: string, sourceAttemptId: string): string {
+  return createHash('sha256')
+    .update(goalId)
+    .update('\0')
+    .update(sourceAttemptId)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+function addGoalUsage(left: AgentBudgetUsage, right: AgentBudgetUsage): AgentBudgetUsage {
+  return {
+    inputTokens: left.inputTokens + right.inputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    totalTokens: left.totalTokens + right.totalTokens,
+    costUsd: left.costUsd + right.costUsd,
+    toolCalls: left.toolCalls + right.toolCalls,
+    runtimeSeconds: left.runtimeSeconds + right.runtimeSeconds,
+    idleRuntimeSeconds: left.idleRuntimeSeconds + right.idleRuntimeSeconds,
+    retries: left.retries + right.retries,
+    fanOut: left.fanOut + right.fanOut,
+  };
 }
 
 let durableGoalService: DurableGoalService | undefined;

--- a/server/src/services/durable-goal-supervisor-service.ts
+++ b/server/src/services/durable-goal-supervisor-service.ts
@@ -1,0 +1,477 @@
+import { createHash } from 'node:crypto';
+import type {
+  AgentBudgetMetric,
+  AgentBudgetLimits,
+  AgentBudgetUsage,
+  CompletionResult,
+  DurableGoalBlocker,
+  DurableGoalCompletionEvidence,
+  DurableGoalContinuationAttempt,
+  DurableGoalRecord,
+} from '@veritas-kanban/shared';
+import { ZERO_AGENT_BUDGET_USAGE } from '@veritas-kanban/shared';
+import { DurableGoalService, getDurableGoalService } from './durable-goal-service.js';
+
+const NON_TERMINAL_STATES = [
+  'active',
+  'paused',
+  'blocked',
+  'awaiting-approval',
+  'usage-limited',
+  'budget-limited',
+] as const;
+
+const BUDGET_METRICS: AgentBudgetMetric[] = [
+  'inputTokens',
+  'outputTokens',
+  'totalTokens',
+  'costUsd',
+  'toolCalls',
+  'runtimeSeconds',
+  'idleRuntimeSeconds',
+  'retries',
+  'fanOut',
+];
+
+export interface DurableGoalContinuationDispatchRequest {
+  goal: DurableGoalRecord;
+  sourceTaskId: string;
+  sourceAttemptId: string;
+  message: string;
+  admissionIdempotencyKey: string;
+  remainingBudget?: AgentBudgetLimits;
+}
+
+export interface DurableGoalContinuationDispatchResult {
+  attemptId: string;
+  queueId?: string;
+}
+
+export type DurableGoalContinuationDispatcher = (
+  request: DurableGoalContinuationDispatchRequest
+) => Promise<DurableGoalContinuationDispatchResult>;
+
+export interface DurableGoalCompletionInput {
+  workspaceId: string;
+  taskId: string;
+  attemptId: string;
+  parentAttemptId?: string;
+  conversationId?: string;
+  completion: CompletionResult;
+  usage?: AgentBudgetUsage;
+}
+
+export interface DurableGoalReconcileTaskInput {
+  workspaceId: string;
+  taskId: string;
+  currentAttemptId?: string;
+  parentAttemptId?: string;
+  currentAttemptRunning?: boolean;
+}
+
+export interface DurableGoalSupervisionResult {
+  action:
+    | 'not-found'
+    | 'ambiguous'
+    | 'already-handled'
+    | 'complete'
+    | 'blocked'
+    | 'paused'
+    | 'usage-limited'
+    | 'budget-limited'
+    | 'dispatched'
+    | 'reconciled';
+  goal?: DurableGoalRecord;
+  continuation?: DurableGoalContinuationAttempt;
+}
+
+export class DurableGoalSupervisorService {
+  constructor(private readonly goals: DurableGoalService = getDurableGoalService()) {}
+
+  async handleRunCompletion(
+    input: DurableGoalCompletionInput,
+    dispatch: DurableGoalContinuationDispatcher
+  ): Promise<DurableGoalSupervisionResult> {
+    const owner = await this.findOwningGoal(input.workspaceId, input.taskId, input.attemptId);
+    if (owner.kind !== 'goal') return { action: owner.kind };
+
+    const evidence = completionEvidence(owner.goal, input.completion);
+    let goal = await this.goals.recordRunOutcome(owner.goal.id, {
+      expectedRevision: owner.goal.revision,
+      run: {
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        parentAttemptId: input.parentAttemptId,
+        conversationId: input.conversationId,
+      },
+      usageEvent: {
+        id: `completion:${input.completion.idempotencyKey}`,
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        usage: input.usage ?? { ...ZERO_AGENT_BUDGET_USAGE },
+        recordedAt: input.completion.completedAt,
+      },
+      completionEvidence: evidence,
+    });
+
+    if (goal.state !== 'active') {
+      return { action: 'already-handled', goal };
+    }
+
+    if (input.completion.status === 'blocked') {
+      goal = await this.blockGoal(goal, blockerFromCompletion(input.completion));
+      return { action: 'blocked', goal };
+    }
+    if (input.completion.status === 'failed' || input.completion.status === 'interrupted') {
+      goal = await this.blockGoal(goal, failedRunBlocker(input.completion));
+      return { action: 'blocked', goal };
+    }
+
+    if (input.completion.status === 'success' && requiredEvidenceComplete(goal)) {
+      goal = await this.goals.transition(goal.id, {
+        expectedRevision: goal.revision,
+        to: 'complete',
+        actorId: 'durable-goal-supervisor',
+        reason: 'All required durable goal completion evidence is verified.',
+      });
+      return { action: 'complete', goal };
+    }
+
+    if (goal.continuation.mode === 'manual') {
+      goal = await this.goals.transition(goal.id, {
+        expectedRevision: goal.revision,
+        to: 'paused',
+        actorId: 'durable-goal-supervisor',
+        reason: 'The durable goal requires an operator-triggered continuation.',
+      });
+      return { action: 'paused', goal };
+    }
+
+    if (
+      goal.continuation.maxTurns !== undefined &&
+      goal.continuationChain.length >= goal.continuation.maxTurns
+    ) {
+      goal = await this.goals.transition(goal.id, {
+        expectedRevision: goal.revision,
+        to: 'usage-limited',
+        actorId: 'durable-goal-supervisor',
+        reason: `The durable goal reached its ${goal.continuation.maxTurns}-turn limit.`,
+      });
+      return { action: 'usage-limited', goal };
+    }
+
+    if (budgetLimitReached(goal)) {
+      goal = await this.goals.transition(goal.id, {
+        expectedRevision: goal.revision,
+        to: 'budget-limited',
+        actorId: 'durable-goal-supervisor',
+        reason: 'The durable goal reached a configured aggregate budget limit.',
+      });
+      return { action: 'budget-limited', goal };
+    }
+
+    if (!input.completion.continuation) {
+      goal = await this.blockGoal(goal, {
+        id: stableId('blocker', goal.id, input.attemptId, 'continuation-handle'),
+        code: 'CONTINUATION_HANDLE_MISSING',
+        summary: 'The provider did not return a verified continuation handle.',
+        attempts: 1,
+        nextSafeAction:
+          'Start an operator-approved rollover or use a provider with resume support.',
+        recordedAt: input.completion.completedAt,
+      });
+      return { action: 'blocked', goal };
+    }
+
+    const existing = goal.continuationAttempts.find(
+      (attempt) => attempt.sourceAttemptId === input.attemptId
+    );
+    if (existing?.state === 'dispatched' || existing?.state === 'failed') {
+      return { action: 'already-handled', goal, continuation: existing };
+    }
+    if (!existing) {
+      goal = await this.goals.planContinuation(goal.id, {
+        expectedRevision: goal.revision,
+        sourceTaskId: input.taskId,
+        sourceAttemptId: input.attemptId,
+        message: continuationMessage(goal, input.completion),
+      });
+    }
+    return this.dispatchPlanned(goal, input.attemptId, dispatch);
+  }
+
+  async reconcilePlannedForTask(
+    input: DurableGoalReconcileTaskInput,
+    dispatch: DurableGoalContinuationDispatcher
+  ): Promise<DurableGoalSupervisionResult> {
+    const owner = await this.findOwningGoal(
+      input.workspaceId,
+      input.taskId,
+      input.parentAttemptId ?? input.currentAttemptId
+    );
+    if (owner.kind !== 'goal') return { action: owner.kind };
+    let goal = owner.goal;
+    const planned = [...goal.continuationAttempts]
+      .reverse()
+      .find((attempt) => attempt.state === 'planned');
+    if (!planned) return { action: 'already-handled', goal };
+
+    if (
+      input.currentAttemptId &&
+      input.currentAttemptId !== planned.sourceAttemptId &&
+      input.parentAttemptId === planned.sourceAttemptId
+    ) {
+      goal = await this.goals.resolveContinuation(goal.id, {
+        expectedRevision: goal.revision,
+        continuationId: planned.id,
+        state: 'dispatched',
+        resultAttemptId: input.currentAttemptId,
+      });
+      goal = await this.goals.linkRun(goal.id, {
+        expectedRevision: goal.revision,
+        run: {
+          taskId: planned.sourceTaskId,
+          attemptId: input.currentAttemptId,
+          parentAttemptId: planned.sourceAttemptId,
+        },
+      });
+      return {
+        action: 'reconciled',
+        goal,
+        continuation: goal.continuationAttempts.find((attempt) => attempt.id === planned.id),
+      };
+    }
+    if (input.currentAttemptRunning) {
+      return { action: 'already-handled', goal, continuation: planned };
+    }
+    return this.dispatchPlanned(goal, planned.sourceAttemptId, dispatch);
+  }
+
+  private async dispatchPlanned(
+    goal: DurableGoalRecord,
+    sourceAttemptId: string,
+    dispatch: DurableGoalContinuationDispatcher
+  ): Promise<DurableGoalSupervisionResult> {
+    const planned = goal.continuationAttempts.find(
+      (attempt) => attempt.sourceAttemptId === sourceAttemptId && attempt.state === 'planned'
+    );
+    if (!planned) return { action: 'already-handled', goal };
+
+    let result: DurableGoalContinuationDispatchResult;
+    try {
+      result = await dispatch({
+        goal,
+        sourceTaskId: planned.sourceTaskId,
+        sourceAttemptId: planned.sourceAttemptId,
+        message: planned.message,
+        admissionIdempotencyKey: planned.admissionIdempotencyKey,
+        remainingBudget: remainingBudget(goal),
+      });
+    } catch (error) {
+      const errorCode = dispatchErrorCode(error);
+      goal = await this.goals.resolveContinuation(goal.id, {
+        expectedRevision: goal.revision,
+        continuationId: planned.id,
+        state: 'failed',
+        errorCode,
+        errorSummary: `Continuation dispatch failed with ${errorName(error)}.`,
+      });
+      goal = await this.blockGoal(goal, {
+        id: stableId('blocker', goal.id, planned.id, 'dispatch'),
+        code: errorCode,
+        summary: 'The planned durable goal continuation could not be admitted.',
+        attempts: 1,
+        nextSafeAction:
+          'Inspect admission and provider readiness, then resume the goal explicitly.',
+        recordedAt: new Date().toISOString(),
+      });
+      return {
+        action: 'blocked',
+        goal,
+        continuation: goal.continuationAttempts.find((attempt) => attempt.id === planned.id),
+      };
+    }
+
+    goal = await this.goals.resolveContinuation(goal.id, {
+      expectedRevision: goal.revision,
+      continuationId: planned.id,
+      state: 'dispatched',
+      resultAttemptId: result.attemptId,
+      queueId: result.queueId,
+    });
+    goal = await this.goals.linkRun(goal.id, {
+      expectedRevision: goal.revision,
+      run: {
+        taskId: planned.sourceTaskId,
+        attemptId: result.attemptId,
+        parentAttemptId: planned.sourceAttemptId,
+      },
+    });
+    return {
+      action: 'dispatched',
+      goal,
+      continuation: goal.continuationAttempts.find((attempt) => attempt.id === planned.id),
+    };
+  }
+
+  private async findOwningGoal(
+    workspaceId: string,
+    taskId: string,
+    attemptId?: string
+  ): Promise<{ kind: 'goal'; goal: DurableGoalRecord } | { kind: 'not-found' | 'ambiguous' }> {
+    const candidates = await this.goals.list({
+      workspaceId,
+      rootTaskId: taskId,
+      states: [...NON_TERMINAL_STATES],
+      limit: 100,
+    });
+    if (candidates.length === 0) return { kind: 'not-found' };
+    if (attemptId) {
+      const exact = candidates.filter(
+        (goal) =>
+          goal.currentRun?.attemptId === attemptId ||
+          goal.continuationChain.some((run) => run.attemptId === attemptId) ||
+          goal.continuationAttempts.some(
+            (attempt) =>
+              attempt.sourceAttemptId === attemptId || attempt.resultAttemptId === attemptId
+          )
+      );
+      if (exact.length === 1) return { kind: 'goal', goal: exact[0] };
+      if (exact.length > 1) return { kind: 'ambiguous' };
+    }
+    return candidates.length === 1 ? { kind: 'goal', goal: candidates[0] } : { kind: 'ambiguous' };
+  }
+
+  private blockGoal(
+    goal: DurableGoalRecord,
+    blocker: DurableGoalBlocker
+  ): Promise<DurableGoalRecord> {
+    return this.goals.transition(goal.id, {
+      expectedRevision: goal.revision,
+      to: 'blocked',
+      actorId: 'durable-goal-supervisor',
+      reason: blocker.summary,
+      blocker,
+    });
+  }
+}
+
+function completionEvidence(
+  goal: DurableGoalRecord,
+  completion: CompletionResult
+): DurableGoalCompletionEvidence[] {
+  const requirementIds = new Set(goal.completionRequirements.map((requirement) => requirement.id));
+  return completion.evidence.flatMap((evidence) => {
+    if (!evidence.verified) return [];
+    return evidence.requirementIds
+      .filter((requirementId) => requirementIds.has(requirementId))
+      .map((requirementId) => ({
+        requirementId,
+        evidenceId: stableId('evidence', completion.attemptId, evidence.id, requirementId),
+        summary: evidence.summary,
+        verifier: `completion:${evidence.source}`,
+        verifiedAt: completion.completedAt,
+      }));
+  });
+}
+
+function requiredEvidenceComplete(goal: DurableGoalRecord): boolean {
+  const evidenced = new Set(goal.completionEvidence.map((evidence) => evidence.requirementId));
+  return goal.completionRequirements.every(
+    (requirement) => !requirement.required || evidenced.has(requirement.id)
+  );
+}
+
+function budgetLimitReached(goal: DurableGoalRecord): boolean {
+  if (!goal.budgets) return false;
+  return BUDGET_METRICS.some((metric) => {
+    const limit = goal.budgets?.[metric];
+    return limit !== undefined && goal.usage[metric] >= limit;
+  });
+}
+
+function remainingBudget(goal: DurableGoalRecord): AgentBudgetLimits | undefined {
+  if (!goal.budgets) return undefined;
+  const remaining: AgentBudgetLimits = {};
+  for (const metric of BUDGET_METRICS) {
+    const limit = goal.budgets[metric];
+    if (limit !== undefined) remaining[metric] = Math.max(0, limit - goal.usage[metric]);
+  }
+  return Object.keys(remaining).length > 0 ? remaining : undefined;
+}
+
+function blockerFromCompletion(completion: CompletionResult): DurableGoalBlocker {
+  const blocker = completion.blockers[0];
+  return {
+    id: stableId('blocker', completion.attemptId, blocker?.code ?? 'blocked'),
+    code: blocker?.code ?? 'PROVIDER_BLOCKED',
+    summary: blocker?.summary ?? 'The provider reported a blocked run.',
+    attempts: 1,
+    nextSafeAction: blocker?.detail || 'Inspect the run completion and resume when safe.',
+    externalStateChange: blocker?.retryable
+      ? 'The reported blocking condition must change before retry.'
+      : undefined,
+    recordedAt: completion.completedAt,
+  };
+}
+
+function failedRunBlocker(completion: CompletionResult): DurableGoalBlocker {
+  return {
+    id: stableId('blocker', completion.attemptId, completion.status),
+    code: `RUN_${completion.status.toUpperCase()}`,
+    summary: `The durable goal run ended with status ${completion.status}.`,
+    attempts: 1,
+    nextSafeAction: 'Inspect the verified completion record and resume or cancel the goal.',
+    recordedAt: completion.completedAt,
+  };
+}
+
+function continuationMessage(goal: DurableGoalRecord, completion: CompletionResult): string {
+  const evidenced = new Set(goal.completionEvidence.map((evidence) => evidence.requirementId));
+  const remaining = goal.completionRequirements
+    .filter((requirement) => requirement.required && !evidenced.has(requirement.id))
+    .map((requirement) => `- ${requirement.id}: ${requirement.description}`);
+  return [
+    `Continue durable goal ${goal.id}.`,
+    '',
+    `Objective: ${goal.objective}`,
+    '',
+    `Last run: ${completion.summary}`,
+    '',
+    'Remaining required evidence:',
+    ...(remaining.length > 0
+      ? remaining
+      : ['- Re-evaluate the acceptance criteria before completion.']),
+    '',
+    'Keep the existing constraints and authority boundaries. Do not mark the goal complete without verified evidence.',
+  ].join('\n');
+}
+
+function dispatchErrorCode(error: unknown): string {
+  const details =
+    error && typeof error === 'object' && 'details' in error
+      ? (error as { details?: unknown }).details
+      : undefined;
+  if (details && typeof details === 'object' && 'code' in details) {
+    const code = (details as { code?: unknown }).code;
+    if (typeof code === 'string' && code.trim()) return code.trim().slice(0, 240);
+  }
+  return 'CONTINUATION_DISPATCH_FAILED';
+}
+
+function errorName(error: unknown): string {
+  if (error instanceof Error && error.name.trim()) return error.name.trim().slice(0, 120);
+  return 'unknown error';
+}
+
+function stableId(prefix: string, ...parts: string[]): string {
+  const digest = createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 32);
+  return `${prefix}_${digest}`;
+}
+
+let durableGoalSupervisorService: DurableGoalSupervisorService | undefined;
+
+export function getDurableGoalSupervisorService(): DurableGoalSupervisorService {
+  durableGoalSupervisorService ??= new DurableGoalSupervisorService();
+  return durableGoalSupervisorService;
+}

--- a/shared/src/types/durable-goal.types.ts
+++ b/shared/src/types/durable-goal.types.ts
@@ -77,6 +77,32 @@ export interface DurableGoalRunLink {
   linkedAt: string;
 }
 
+export interface DurableGoalUsageEvent {
+  id: string;
+  taskId: string;
+  attemptId?: string;
+  usage: AgentBudgetUsage;
+  recordedAt: string;
+}
+
+export const DURABLE_GOAL_CONTINUATION_STATES = ['planned', 'dispatched', 'failed'] as const;
+export type DurableGoalContinuationState = (typeof DURABLE_GOAL_CONTINUATION_STATES)[number];
+
+export interface DurableGoalContinuationAttempt {
+  id: string;
+  sourceTaskId: string;
+  sourceAttemptId: string;
+  state: DurableGoalContinuationState;
+  admissionIdempotencyKey: string;
+  message: string;
+  resultAttemptId?: string;
+  queueId?: string;
+  errorCode?: string;
+  errorSummary?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface DurableGoalTransition {
   revision: number;
   from: DurableGoalState;
@@ -99,8 +125,10 @@ export interface DurableGoalRecord {
   continuation: DurableGoalContinuationPolicy;
   budgets?: AgentBudgetLimits;
   usage: AgentBudgetUsage;
+  usageEvents: DurableGoalUsageEvent[];
   currentRun?: DurableGoalRunLink;
   continuationChain: DurableGoalRunLink[];
+  continuationAttempts: DurableGoalContinuationAttempt[];
   blockers: DurableGoalBlocker[];
   completionRequirements: DurableGoalCompletionRequirement[];
   completionEvidence: DurableGoalCompletionEvidence[];


### PR DESCRIPTION
## Summary

- attach provider completions, verified evidence, run links, and deduplicated usage events to the owning durable goal
- persist automatic continuation plans before dispatch with stable admission idempotency keys
- dispatch through the existing provider follow-up and admission path with the goal's remaining budget
- reconcile planned continuations after restart without duplicating an already-created child attempt
- make durable goals the single recovery owner for matched runs
- document automatic continuation, failure states, and operator inspection

## Verification

- 16 focused durable goal service, repository, and supervisor tests
- 2 focused Clawdbot completion integration tests
- shared TypeScript typecheck
- server TypeScript typecheck
- targeted ESLint
- Prettier check
- `git diff --check`

## Notes

- File and SQLite restart parity both cover planned continuation and usage state.
- Provider blockers, missing continuation handles, budget limits, turn limits, ambiguous ownership, and failed admission all fail closed.
- One existing unused-type lint warning remains in `clawdbot-agent-service.ts`; this change adds no lint errors.

Part of #865
