### PR TITLE
feat: add durable goal conversation rollovers

### DIFF
--- a/cli/src/__tests__/goals.test.ts
+++ b/cli/src/__tests__/goals.test.ts
@@ -172,4 +172,43 @@ describe('vk goals commands', () => {
     });
     output.mockRestore();
   });
+
+  it('approves and dispatches a bounded conversation rollover', async () => {
+    api.mockResolvedValue({
+      action: 'dispatched',
+      goal: { id: GOAL_ID, revision: 8 },
+      continuation: {
+        id: 'continuation-rollover',
+        kind: 'rollover',
+        state: 'dispatched',
+        resultAttemptId: 'attempt-8',
+      },
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerGoalCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'goals',
+      'rollover',
+      GOAL_ID,
+      '--revision',
+      '7',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith(`/api/goals/${GOAL_ID}/rollover`, {
+      method: 'POST',
+      body: JSON.stringify({
+        expectedRevision: 7,
+      }),
+    });
+    expect(JSON.parse(String(output.mock.calls[0][0]))).toMatchObject({
+      action: 'dispatched',
+      continuation: { kind: 'rollover', resultAttemptId: 'attempt-8' },
+    });
+    output.mockRestore();
+  });
 });

--- a/cli/src/commands/goals.ts
+++ b/cli/src/commands/goals.ts
@@ -16,6 +16,18 @@ interface GoalListResponse {
   goals: DurableGoalRecord[];
 }
 
+interface GoalRolloverResponse {
+  action: string;
+  goal?: DurableGoalRecord;
+  continuation?: {
+    id: string;
+    kind: string;
+    state: string;
+    resultAttemptId?: string;
+    queueId?: string;
+  };
+}
+
 type GoalBlockerInput = Omit<DurableGoalBlocker, 'id' | 'recordedAt'> & { id?: string };
 
 const VERIFICATION_KINDS = new Set(['test', 'build', 'artifact', 'operator', 'external', 'other']);
@@ -201,6 +213,32 @@ export function registerGoalCommands(program: Command): void {
         });
         if (options.json) return printJson(goal);
         console.log(chalk.green(`✓ Linked run to goal ${goal.id} at revision ${goal.revision}`));
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  goals
+    .command('rollover <id>')
+    .description('Approve and dispatch one bounded fresh-conversation rollover')
+    .requiredOption('--revision <number>', 'Expected goal revision')
+    .option('--json', 'Output as JSON')
+    .action(async (id, options) => {
+      try {
+        const result = await api<GoalRolloverResponse>(
+          `/api/goals/${encodeURIComponent(id)}/rollover`,
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              expectedRevision: parsePositiveInteger(options.revision),
+            }),
+          }
+        );
+        if (options.json) return printJson(result);
+        const attempt = result.continuation?.resultAttemptId;
+        console.log(
+          chalk.green(`✓ Goal ${id} rollover ${result.action}${attempt ? ` as ${attempt}` : ''}`)
+        );
       } catch (error) {
         printError(error);
       }

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -4390,13 +4390,14 @@ Durable goals persist an evidence-gated objective independently of any one
 provider run. Reads require `agent:read`; creation and mutation require
 `admin:manage`. Every endpoint is scoped to the authenticated workspace.
 
-| Method | Path                            | Description                                    |
-| ------ | ------------------------------- | ---------------------------------------------- |
-| `GET`  | `/api/goals`                    | List bounded goals with state and root filters |
-| `POST` | `/api/goals`                    | Create one evidence-gated goal at revision 1   |
-| `GET`  | `/api/goals/:goalId`            | Inspect one goal and its continuation chain    |
-| `POST` | `/api/goals/:goalId/transition` | Apply one compare-and-set state transition     |
-| `POST` | `/api/goals/:goalId/runs`       | Link one task, workflow, or conversation run   |
+| Method | Path                            | Description                                                 |
+| ------ | ------------------------------- | ----------------------------------------------------------- |
+| `GET`  | `/api/goals`                    | List bounded goals with state and root filters              |
+| `POST` | `/api/goals`                    | Create one evidence-gated goal at revision 1                |
+| `GET`  | `/api/goals/:goalId`            | Inspect one goal and its continuation chain                 |
+| `POST` | `/api/goals/:goalId/transition` | Apply one compare-and-set state transition                  |
+| `POST` | `/api/goals/:goalId/runs`       | Link one task, workflow, or conversation run                |
+| `POST` | `/api/goals/:goalId/rollover`   | Approve and dispatch one bounded fresh-conversation handoff |
 
 List filters are repeatable `state`, `rootTaskId`, `rootWorkflowId`, and
 `limit` (1-1000). Goal states are `active`, `paused`, `blocked`,
@@ -4419,6 +4420,7 @@ budget metric names used elsewhere in the runtime.
     "mode": "automatic",
     "maxTurns": 20,
     "maxRollovers": 2,
+    "compactAfterTokens": 120000,
     "requireApprovalForRollover": true
   },
   "completionRequirements": [
@@ -4460,6 +4462,23 @@ launching another provider. Otherwise the same admission idempotency key is
 reused. Failed admission blocks the goal with an actionable reason. Provider
 blockers, missing continuation handles, turn limits, budget limits, and manual
 continuation mode all fail closed instead of creating a hidden retry loop.
+
+When `compactAfterTokens` is reached, or a provider has no verified resume
+handle, the supervisor may plan `kind: "rollover"` only while
+`maxRollovers` has capacity. A rollover starts a fresh provider conversation
+with a bounded handoff containing the objective, constraints, acceptance
+criteria, evidence identifiers, unresolved requirements, recent state
+decisions, prior attempt identities, and cumulative usage. It retains the
+normal parent-attempt, admission, sandbox, phase, launch-manifest, and
+remaining-budget controls without copying transient provider authority.
+
+If `requireApprovalForRollover` is true, the supervisor first transitions the
+goal to `awaiting-approval`. `POST /api/goals/:goalId/rollover` accepts
+`expectedRevision`; the authenticated actor becomes the approver and the
+goal's exact current run becomes the source. The endpoint rejects stale
+revisions, missing current-run evidence, non-active states, and exhausted
+rollover limits. Its planned handoff and admission idempotency key are durable,
+so startup reconciliation cannot duplicate a fresh conversation.
 
 ---
 

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -676,6 +676,8 @@ vk goals create \
   --root-task task_0123456789abcdef \
   --mode automatic \
   --max-turns 20 \
+  --max-rollovers 2 \
+  --compact-after-tokens 120000 \
   --require-rollover-approval \
   --json
 
@@ -700,6 +702,10 @@ vk goals link-run goal_0123456789abcdef \
   --task task_0123456789abcdef \
   --attempt attempt_0123456789abcdef \
   --conversation conversation_0123456789abcdef \
+  --json
+
+vk goals rollover goal_0123456789abcdef \
+  --revision 6 \
   --json
 ```
 
@@ -727,10 +733,18 @@ idempotency key is reused; an already-created child attempt is linked without a
 duplicate launch.
 
 Manual goals pause after an incomplete run. Automatic goals block when the
-provider has no verified continuation handle or admission fails, and enter
-`usage-limited` or `budget-limited` at their configured boundary. Resume those
-states explicitly after addressing the reported condition; do not build a
-second client-side continuation loop.
+provider has no verified continuation handle and no rollover allowance, or
+when admission fails. They enter `usage-limited` or `budget-limited` at their
+configured boundary. A configured `--compact-after-tokens` threshold starts a
+fresh conversation only while `--max-rollovers` still has capacity. Each
+rollover persists `kind: "rollover"` before dispatch and carries a bounded
+goal contract with objective, constraints, acceptance criteria, verified
+evidence links, remaining requirements, recent state decisions, and aggregate
+usage. If `--require-rollover-approval` is set, the goal enters
+`awaiting-approval`; run `goals rollover` with the current revision to approve
+and dispatch that exact handoff. Resume other limited states explicitly after
+addressing the reported condition; do not build a second client-side
+continuation loop.
 
 ---
 

--- a/server/src/__tests__/durable-goal-supervisor-service.test.ts
+++ b/server/src/__tests__/durable-goal-supervisor-service.test.ts
@@ -3,6 +3,7 @@ import type {
   CompletionResult,
   DurableGoalCompareAndSetInput,
   DurableGoalCompareAndSetResult,
+  DurableGoalContinuationPolicy,
   DurableGoalListQuery,
   DurableGoalRecord,
 } from '@veritas-kanban/shared';
@@ -65,7 +66,7 @@ function services() {
 async function createGoal(
   goals: DurableGoalService,
   options: {
-    continuation?: { mode: 'manual' | 'automatic'; maxTurns?: number };
+    continuation?: DurableGoalContinuationPolicy;
     budgets?: { totalTokens?: number };
   } = {}
 ) {
@@ -184,6 +185,7 @@ describe('DurableGoalSupervisorService', () => {
 
     expect(first.action).toBe('dispatched');
     expect(first.continuation).toMatchObject({
+      kind: 'resume',
       state: 'dispatched',
       sourceAttemptId: 'attempt-1',
       resultAttemptId: 'attempt-2',
@@ -201,6 +203,147 @@ describe('DurableGoalSupervisorService', () => {
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ remainingBudget: { totalTokens: 85 } })
     );
+  });
+
+  it('rolls over to a fresh bounded conversation at the configured token threshold', async () => {
+    const { goals, supervisor } = services();
+    await createGoal(goals, {
+      continuation: {
+        mode: 'automatic',
+        maxTurns: 4,
+        maxRollovers: 2,
+        compactAfterTokens: 10,
+      },
+    });
+    const dispatch = vi.fn().mockResolvedValue({ attemptId: 'attempt-2' });
+
+    const result = await supervisor.handleRunCompletion(
+      {
+        workspaceId: 'workspace-1',
+        taskId: 'task-865',
+        attemptId: 'attempt-1',
+        completion: completion({ evidence: [] }),
+        usage,
+      },
+      dispatch
+    );
+
+    expect(result.action).toBe('dispatched');
+    expect(result.continuation).toMatchObject({
+      kind: 'rollover',
+      state: 'dispatched',
+      sourceAttemptId: 'attempt-1',
+      resultAttemptId: 'attempt-2',
+      admissionIdempotencyKey: `durable-goal:${GOAL_ID}:attempt-1:rollover`,
+    });
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'rollover',
+        message: expect.stringContaining('Start a fresh conversation'),
+      })
+    );
+    expect(dispatch.mock.calls[0][0].message).toContain('Preserve admission controls.');
+    expect(dispatch.mock.calls[0][0].message).toContain('focused-tests');
+    expect(Buffer.byteLength(dispatch.mock.calls[0][0].message, 'utf8')).toBeLessThanOrEqual(
+      18_000
+    );
+  });
+
+  it('waits for explicit rollover approval and then dispatches the persisted handoff', async () => {
+    const { goals, supervisor } = services();
+    await createGoal(goals, {
+      continuation: {
+        mode: 'automatic',
+        maxTurns: 4,
+        maxRollovers: 1,
+        compactAfterTokens: 10,
+        requireApprovalForRollover: true,
+      },
+    });
+    const dispatch = vi.fn().mockResolvedValue({ attemptId: 'attempt-2' });
+    const pending = await supervisor.handleRunCompletion(
+      {
+        workspaceId: 'workspace-1',
+        taskId: 'task-865',
+        attemptId: 'attempt-1',
+        completion: completion({ evidence: [] }),
+        usage,
+      },
+      dispatch
+    );
+
+    expect(pending.action).toBe('awaiting-approval');
+    expect(pending.goal?.state).toBe('awaiting-approval');
+    expect(dispatch).not.toHaveBeenCalled();
+
+    const approved = await supervisor.approveRollover(
+      {
+        goalId: GOAL_ID,
+        expectedRevision: pending.goal?.revision as number,
+        actorId: 'operator-brad',
+      },
+      dispatch
+    );
+
+    expect(approved.action).toBe('dispatched');
+    expect(approved.goal?.state).toBe('active');
+    expect(approved.continuation).toMatchObject({
+      kind: 'rollover',
+      resultAttemptId: 'attempt-2',
+    });
+    expect(approved.goal?.transitions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'awaiting-approval',
+          to: 'active',
+          actorId: 'operator-brad',
+        }),
+      ])
+    );
+  });
+
+  it('stops at the configured rollover limit instead of extending context indefinitely', async () => {
+    const { goals, supervisor } = services();
+    await createGoal(goals, {
+      continuation: {
+        mode: 'automatic',
+        maxTurns: 6,
+        maxRollovers: 1,
+        compactAfterTokens: 10,
+      },
+    });
+    const dispatch = vi.fn().mockResolvedValue({ attemptId: 'attempt-2' });
+    const first = await supervisor.handleRunCompletion(
+      {
+        workspaceId: 'workspace-1',
+        taskId: 'task-865',
+        attemptId: 'attempt-1',
+        completion: completion({ evidence: [] }),
+        usage,
+      },
+      dispatch
+    );
+    expect(first.action).toBe('dispatched');
+
+    const second = await supervisor.handleRunCompletion(
+      {
+        workspaceId: 'workspace-1',
+        taskId: 'task-865',
+        attemptId: 'attempt-2',
+        parentAttemptId: 'attempt-1',
+        completion: completion({
+          attemptId: 'attempt-2',
+          idempotencyKey: 'completion-attempt-2',
+          evidence: [],
+        }),
+        usage,
+      },
+      dispatch
+    );
+
+    expect(second.action).toBe('usage-limited');
+    expect(second.goal?.state).toBe('usage-limited');
+    expect(dispatch).toHaveBeenCalledTimes(1);
   });
 
   it('preserves an exact provider blocker without dispatching', async () => {

--- a/server/src/__tests__/routes/goals.test.ts
+++ b/server/src/__tests__/routes/goals.test.ts
@@ -12,8 +12,16 @@ const goals = vi.hoisted(() => ({
   linkRun: vi.fn(),
 }));
 
+const agents = vi.hoisted(() => ({
+  rolloverDurableGoal: vi.fn(),
+}));
+
 vi.mock('../../services/durable-goal-service.js', () => ({
   getDurableGoalService: () => goals,
+}));
+
+vi.mock('../../services/clawdbot-agent-service.js', () => ({
+  clawdbotAgentService: agents,
 }));
 
 import { goalRoutes } from '../../routes/goals.js';
@@ -166,5 +174,25 @@ describe('durable goal routes', () => {
     });
     expect(spoofed.status).toBe(400);
     expect(goals.transition).not.toHaveBeenCalled();
+  });
+
+  it('approves a bounded rollover with server-derived workspace and actor identity', async () => {
+    goals.get.mockResolvedValue({ id: GOAL_ID, workspaceId: 'workspace-a' });
+    agents.rolloverDurableGoal.mockResolvedValue({
+      action: 'dispatched',
+      goal: { id: GOAL_ID, revision: 7 },
+      continuation: { kind: 'rollover', resultAttemptId: 'attempt-7' },
+    });
+
+    const response = await request(createApp()).post(`/api/goals/${GOAL_ID}/rollover`).send({
+      expectedRevision: 6,
+    });
+
+    expect(response.status).toBe(201);
+    expect(agents.rolloverDurableGoal).toHaveBeenCalledWith(GOAL_ID, 6, 'user-brad');
+    expect(response.body).toMatchObject({
+      action: 'dispatched',
+      continuation: { kind: 'rollover', resultAttemptId: 'attempt-7' },
+    });
   });
 });

--- a/server/src/routes/goals.ts
+++ b/server/src/routes/goals.ts
@@ -9,6 +9,7 @@ import {
 import { asyncHandler } from '../middleware/async-handler.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { clawdbotAgentService } from '../services/clawdbot-agent-service.js';
 import { getDurableGoalService } from '../services/durable-goal-service.js';
 
 const router: RouterType = Router();
@@ -133,6 +134,12 @@ const runLinkSchema = z
     workflowRunId: IdentifierSchema.optional(),
     conversationId: IdentifierSchema.optional(),
     parentAttemptId: IdentifierSchema.optional(),
+  })
+  .strict();
+
+const rolloverSchema = z
+  .object({
+    expectedRevision: z.number().int().positive(),
   })
   .strict();
 
@@ -262,6 +269,21 @@ router.post(
         },
       })
     );
+  })
+);
+
+router.post(
+  '/:goalId/rollover',
+  asyncHandler(async (req, res) => {
+    const { goalId } = parseOrThrow(paramsSchema, req.params);
+    const input = parseOrThrow(rolloverSchema, req.body);
+    const actor = actorFromRequest(req);
+    await requireWorkspaceGoal(goalId, actor.workspaceId);
+    res
+      .status(201)
+      .json(
+        await clawdbotAgentService.rolloverDurableGoal(goalId, input.expectedRevision, actor.id)
+      );
   })
 );
 

--- a/server/src/schemas/durable-goal-schemas.ts
+++ b/server/src/schemas/durable-goal-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+  DURABLE_GOAL_CONTINUATION_KINDS,
   DURABLE_GOAL_CONTINUATION_MODES,
   DURABLE_GOAL_CONTINUATION_STATES,
   DURABLE_GOAL_SCHEMA_VERSION,
@@ -54,6 +55,7 @@ export const DurableGoalContinuationAttemptSchema = z
     id: IdentifierSchema,
     sourceTaskId: IdentifierSchema,
     sourceAttemptId: IdentifierSchema,
+    kind: z.enum(DURABLE_GOAL_CONTINUATION_KINDS).default('resume'),
     state: z.enum(DURABLE_GOAL_CONTINUATION_STATES),
     admissionIdempotencyKey: IdentifierSchema,
     message: z.string().trim().min(1).max(50_000),

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -587,7 +587,8 @@ export class ClawdbotAgentService {
   private durableGoalSupervisor: Pick<
     DurableGoalSupervisorService,
     'handleRunCompletion' | 'reconcilePlannedForTask'
-  >;
+  > &
+    Partial<Pick<DurableGoalSupervisorService, 'approveRollover'>>;
   private workspaceExecutionTrust: Pick<
     WorkspaceExecutionTrustService,
     'scan' | 'evaluateForLaunch' | 'assertFresh'
@@ -633,7 +634,10 @@ export class ClawdbotAgentService {
     durableGoalSupervisor: Pick<
       DurableGoalSupervisorService,
       'handleRunCompletion' | 'reconcilePlannedForTask'
-    > = getDurableGoalSupervisorService()
+    > &
+      Partial<
+        Pick<DurableGoalSupervisorService, 'approveRollover'>
+      > = getDurableGoalSupervisorService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -4557,34 +4561,76 @@ export class ClawdbotAgentService {
     });
   }
 
+  async rolloverDurableGoal(goalId: string, expectedRevision: number, actorId: string) {
+    const approveRollover = this.durableGoalSupervisor.approveRollover;
+    if (!approveRollover) {
+      throw new ConflictError('Durable goal rollover supervision is unavailable.');
+    }
+    return approveRollover.call(
+      this.durableGoalSupervisor,
+      {
+        goalId,
+        expectedRevision,
+        actorId,
+      },
+      (request) => this.dispatchDurableGoalContinuation(request)
+    );
+  }
+
   private async dispatchDurableGoalContinuation(
     request: DurableGoalContinuationDispatchRequest
   ): Promise<{ attemptId: string; queueId?: string }> {
-    const result = await this.followUpConversation(
-      request.sourceTaskId,
-      request.sourceAttemptId,
-      request.message,
-      {
-        admissionIdempotencyKey: request.admissionIdempotencyKey,
-        budget: request.remainingBudget
-          ? {
-              enabled: true,
-              name: `Durable goal ${request.goal.id} remaining budget`,
-              scope: 'run',
-              limits: request.remainingBudget,
-              hardAction: 'pause',
-            }
-          : undefined,
-        rootTaskId:
-          request.goal.root.kind === 'task'
-            ? request.goal.root.taskId
-            : (request.goal.root.taskId ?? request.sourceTaskId),
-      }
-    );
+    const options: Omit<AgentStartOptions, 'conversation' | 'parentAttemptId'> = {
+      admissionIdempotencyKey: request.admissionIdempotencyKey,
+      budget: request.remainingBudget
+        ? {
+            enabled: true,
+            name: `Durable goal ${request.goal.id} remaining budget`,
+            scope: 'run',
+            limits: request.remainingBudget,
+            hardAction: 'pause',
+          }
+        : undefined,
+      rootTaskId:
+        request.goal.root.kind === 'task'
+          ? request.goal.root.taskId
+          : (request.goal.root.taskId ?? request.sourceTaskId),
+    };
+    const result =
+      request.kind === 'rollover'
+        ? await this.startDurableGoalRollover(request, options)
+        : await this.followUpConversation(
+            request.sourceTaskId,
+            request.sourceAttemptId,
+            request.message,
+            options
+          );
     return {
       attemptId: result.attemptId,
       ...('queueId' in result ? { queueId: result.queueId } : {}),
     };
+  }
+
+  private async startDurableGoalRollover(
+    request: DurableGoalContinuationDispatchRequest,
+    options: Omit<AgentStartOptions, 'conversation' | 'parentAttemptId'>
+  ): Promise<AgentLaunchStatus> {
+    const source = await this.findAttempt(request.sourceAttemptId);
+    if (!source || !['complete', 'failed'].includes(source.status)) {
+      throw new ConflictError('Durable goal rollover requires a terminal source attempt.', {
+        sourceAttemptId: request.sourceAttemptId,
+        sourceStatus: source?.status,
+      });
+    }
+    return this.startAgent(request.sourceTaskId, source.agent, {
+      ...options,
+      parentAttemptId: source.id,
+      conversation: {
+        mode: 'fresh',
+        intent: 'fresh',
+        message: request.message,
+      },
+    });
   }
 
   private async reconcileDurableGoalContinuations(tasks: Task[]): Promise<void> {

--- a/server/src/services/durable-goal-service.ts
+++ b/server/src/services/durable-goal-service.ts
@@ -126,6 +126,7 @@ export interface PlanDurableGoalContinuationInput {
   expectedRevision: number;
   sourceTaskId: string;
   sourceAttemptId: string;
+  kind?: DurableGoalContinuationAttempt['kind'];
   message: string;
 }
 
@@ -360,13 +361,22 @@ export class DurableGoalService {
     if (existing) return current;
 
     const timestamp = this.now().toISOString();
-    const suffix = stableContinuationSuffix(id, input.sourceAttemptId);
+    const kind = input.kind ?? 'resume';
+    const suffix = stableContinuationSuffix(
+      id,
+      input.sourceAttemptId,
+      kind === 'resume' ? undefined : kind
+    );
     const continuation: DurableGoalContinuationAttempt = {
       id: `continuation_${suffix}`,
       sourceTaskId: input.sourceTaskId,
       sourceAttemptId: input.sourceAttemptId,
+      kind,
       state: 'planned',
-      admissionIdempotencyKey: `durable-goal:${id}:${input.sourceAttemptId}`,
+      admissionIdempotencyKey:
+        kind === 'resume'
+          ? `durable-goal:${id}:${input.sourceAttemptId}`
+          : `durable-goal:${id}:${input.sourceAttemptId}:${kind}`,
       message: input.message,
       createdAt: timestamp,
       updatedAt: timestamp,
@@ -456,13 +466,14 @@ export class DurableGoalService {
   }
 }
 
-function stableContinuationSuffix(goalId: string, sourceAttemptId: string): string {
-  return createHash('sha256')
-    .update(goalId)
-    .update('\0')
-    .update(sourceAttemptId)
-    .digest('hex')
-    .slice(0, 32);
+function stableContinuationSuffix(
+  goalId: string,
+  sourceAttemptId: string,
+  kind?: DurableGoalContinuationAttempt['kind']
+): string {
+  const hash = createHash('sha256').update(goalId).update('\0').update(sourceAttemptId);
+  if (kind) hash.update('\0').update(kind);
+  return hash.digest('hex').slice(0, 32);
 }
 
 function addGoalUsage(left: AgentBudgetUsage, right: AgentBudgetUsage): AgentBudgetUsage {

--- a/server/src/services/durable-goal-supervisor-service.ts
+++ b/server/src/services/durable-goal-supervisor-service.ts
@@ -10,6 +10,7 @@ import type {
   DurableGoalRecord,
 } from '@veritas-kanban/shared';
 import { ZERO_AGENT_BUDGET_USAGE } from '@veritas-kanban/shared';
+import { ConflictError, ValidationError } from '../middleware/error-handler.js';
 import { DurableGoalService, getDurableGoalService } from './durable-goal-service.js';
 
 const NON_TERMINAL_STATES = [
@@ -37,6 +38,7 @@ export interface DurableGoalContinuationDispatchRequest {
   goal: DurableGoalRecord;
   sourceTaskId: string;
   sourceAttemptId: string;
+  kind: DurableGoalContinuationAttempt['kind'];
   message: string;
   admissionIdempotencyKey: string;
   remainingBudget?: AgentBudgetLimits;
@@ -69,6 +71,12 @@ export interface DurableGoalReconcileTaskInput {
   currentAttemptRunning?: boolean;
 }
 
+export interface DurableGoalRolloverApprovalInput {
+  goalId: string;
+  expectedRevision: number;
+  actorId: string;
+}
+
 export interface DurableGoalSupervisionResult {
   action:
     | 'not-found'
@@ -77,6 +85,7 @@ export interface DurableGoalSupervisionResult {
     | 'complete'
     | 'blocked'
     | 'paused'
+    | 'awaiting-approval'
     | 'usage-limited'
     | 'budget-limited'
     | 'dispatched'
@@ -170,16 +179,43 @@ export class DurableGoalSupervisorService {
       return { action: 'budget-limited', goal };
     }
 
-    if (!input.completion.continuation) {
-      goal = await this.blockGoal(goal, {
-        id: stableId('blocker', goal.id, input.attemptId, 'continuation-handle'),
-        code: 'CONTINUATION_HANDLE_MISSING',
-        summary: 'The provider did not return a verified continuation handle.',
-        attempts: 1,
-        nextSafeAction:
-          'Start an operator-approved rollover or use a provider with resume support.',
-        recordedAt: input.completion.completedAt,
+    const rolloverReason = requiredRolloverReason(goal, input.completion);
+    if (rolloverReason) {
+      const rolloverLimit = goal.continuation.maxRollovers ?? 0;
+      if (rolloverCount(goal) >= rolloverLimit) {
+        if (!input.completion.continuation && !goal.continuation.compactAfterTokens) {
+          goal = await this.blockMissingContinuation(goal, input);
+          return { action: 'blocked', goal };
+        }
+        goal = await this.goals.transition(goal.id, {
+          expectedRevision: goal.revision,
+          to: 'usage-limited',
+          actorId: 'durable-goal-supervisor',
+          reason: `A conversation rollover is required, but the ${rolloverLimit}-rollover limit is exhausted.`,
+        });
+        return { action: 'usage-limited', goal };
+      }
+      if (goal.continuation.requireApprovalForRollover) {
+        goal = await this.goals.transition(goal.id, {
+          expectedRevision: goal.revision,
+          to: 'awaiting-approval',
+          actorId: 'durable-goal-supervisor',
+          reason: `Conversation rollover approval is required: ${rolloverReason}`,
+        });
+        return { action: 'awaiting-approval', goal };
+      }
+      goal = await this.goals.planContinuation(goal.id, {
+        expectedRevision: goal.revision,
+        sourceTaskId: input.taskId,
+        sourceAttemptId: input.attemptId,
+        kind: 'rollover',
+        message: rolloverMessage(goal, input.completion, rolloverReason),
       });
+      return this.dispatchPlanned(goal, input.attemptId, dispatch);
+    }
+
+    if (!input.completion.continuation) {
+      goal = await this.blockMissingContinuation(goal, input);
       return { action: 'blocked', goal };
     }
 
@@ -198,6 +234,73 @@ export class DurableGoalSupervisorService {
       });
     }
     return this.dispatchPlanned(goal, input.attemptId, dispatch);
+  }
+
+  async approveRollover(
+    input: DurableGoalRolloverApprovalInput,
+    dispatch: DurableGoalContinuationDispatcher
+  ): Promise<DurableGoalSupervisionResult> {
+    let goal = await this.goals.get(input.goalId);
+    if (goal.revision !== input.expectedRevision) {
+      throw new ConflictError('Durable goal compare-and-set revision is stale.', {
+        goalId: goal.id,
+        expectedRevision: input.expectedRevision,
+        currentRevision: goal.revision,
+      });
+    }
+    if (!['active', 'awaiting-approval'].includes(goal.state)) {
+      throw new ValidationError('Only active or awaiting-approval goals can roll over.', {
+        goalId: goal.id,
+        state: goal.state,
+      });
+    }
+    const rolloverLimit = goal.continuation.maxRollovers ?? 0;
+    if (rolloverLimit === 0 || rolloverCount(goal) >= rolloverLimit) {
+      throw new ValidationError('The durable goal has no remaining conversation rollovers.', {
+        goalId: goal.id,
+        maxRollovers: rolloverLimit,
+        rollovers: rolloverCount(goal),
+      });
+    }
+    const sourceAttemptId = goal.currentRun?.attemptId;
+    const sourceRun = sourceAttemptId
+      ? [...goal.continuationChain].reverse().find((run) => run.attemptId === sourceAttemptId)
+      : undefined;
+    if (!sourceAttemptId || !sourceRun) {
+      throw new ValidationError('Conversation rollover requires a linked source attempt.', {
+        goalId: goal.id,
+      });
+    }
+    if (goal.state === 'awaiting-approval') {
+      goal = await this.goals.transition(goal.id, {
+        expectedRevision: goal.revision,
+        to: 'active',
+        actorId: input.actorId,
+        reason: 'Approved the pending bounded conversation rollover.',
+      });
+    }
+    const existing = goal.continuationAttempts.find(
+      (attempt) => attempt.sourceAttemptId === sourceAttemptId
+    );
+    if (existing) {
+      return {
+        action: 'already-handled',
+        goal,
+        continuation: existing,
+      };
+    }
+    goal = await this.goals.planContinuation(goal.id, {
+      expectedRevision: goal.revision,
+      sourceTaskId: sourceRun.taskId,
+      sourceAttemptId,
+      kind: 'rollover',
+      message: rolloverMessage(
+        goal,
+        undefined,
+        `Operator ${input.actorId} approved a fresh conversation handoff.`
+      ),
+    });
+    return this.dispatchPlanned(goal, sourceAttemptId, dispatch);
   }
 
   async reconcilePlannedForTask(
@@ -263,6 +366,7 @@ export class DurableGoalSupervisorService {
         goal,
         sourceTaskId: planned.sourceTaskId,
         sourceAttemptId: planned.sourceAttemptId,
+        kind: planned.kind,
         message: planned.message,
         admissionIdempotencyKey: planned.admissionIdempotencyKey,
         remainingBudget: remainingBudget(goal),
@@ -354,6 +458,20 @@ export class DurableGoalSupervisorService {
       blocker,
     });
   }
+
+  private blockMissingContinuation(
+    goal: DurableGoalRecord,
+    input: DurableGoalCompletionInput
+  ): Promise<DurableGoalRecord> {
+    return this.blockGoal(goal, {
+      id: stableId('blocker', goal.id, input.attemptId, 'continuation-handle'),
+      code: 'CONTINUATION_HANDLE_MISSING',
+      summary: 'The provider did not return a verified continuation handle.',
+      attempts: 1,
+      nextSafeAction: 'Configure a bounded rollover or use a provider with resume support.',
+      recordedAt: input.completion.completedAt,
+    });
+  }
 }
 
 function completionEvidence(
@@ -426,6 +544,56 @@ function failedRunBlocker(completion: CompletionResult): DurableGoalBlocker {
   };
 }
 
+function requiredRolloverReason(
+  goal: DurableGoalRecord,
+  completion: CompletionResult
+): string | undefined {
+  const threshold = goal.continuation.compactAfterTokens;
+  const tokens = tokensSinceLastRollover(goal);
+  if (threshold !== undefined && tokens >= threshold) {
+    return `The active conversation accumulated ${tokens} tokens, meeting the ${threshold}-token rollover threshold.`;
+  }
+  if (!completion.continuation && (goal.continuation.maxRollovers ?? 0) > 0) {
+    return 'The provider returned no verified resume handle, so continuation requires a fresh conversation.';
+  }
+  return undefined;
+}
+
+function rolloverCount(goal: DurableGoalRecord): number {
+  return goal.continuationAttempts.filter(
+    (attempt) => attempt.kind === 'rollover' && attempt.state === 'dispatched'
+  ).length;
+}
+
+function tokensSinceLastRollover(goal: DurableGoalRecord): number {
+  const latest = [...goal.continuationAttempts]
+    .reverse()
+    .find(
+      (attempt) =>
+        attempt.kind === 'rollover' && attempt.state === 'dispatched' && attempt.resultAttemptId
+    );
+  if (!latest?.resultAttemptId) {
+    return goal.usageEvents.reduce((total, event) => total + event.usage.totalTokens, 0);
+  }
+  const rolloverIndex = goal.continuationChain.findIndex(
+    (run) => run.attemptId === latest.resultAttemptId
+  );
+  if (rolloverIndex < 0) return 0;
+  const rolloverAttempts = new Set(
+    goal.continuationChain
+      .slice(rolloverIndex)
+      .map((run) => run.attemptId)
+      .filter((attemptId): attemptId is string => Boolean(attemptId))
+  );
+  return goal.usageEvents.reduce(
+    (total, event) =>
+      event.attemptId && rolloverAttempts.has(event.attemptId)
+        ? total + event.usage.totalTokens
+        : total,
+    0
+  );
+}
+
 function continuationMessage(goal: DurableGoalRecord, completion: CompletionResult): string {
   const evidenced = new Set(goal.completionEvidence.map((evidence) => evidence.requirementId));
   const remaining = goal.completionRequirements
@@ -445,6 +613,86 @@ function continuationMessage(goal: DurableGoalRecord, completion: CompletionResu
     '',
     'Keep the existing constraints and authority boundaries. Do not mark the goal complete without verified evidence.',
   ].join('\n');
+}
+
+function rolloverMessage(
+  goal: DurableGoalRecord,
+  completion: CompletionResult | undefined,
+  reason: string
+): string {
+  const evidenced = new Set(goal.completionEvidence.map((evidence) => evidence.requirementId));
+  const list = (values: string[], empty: string) =>
+    values.length > 0 ? values.map((value) => `- ${truncateUtf8(value, 700)}`) : [`- ${empty}`];
+  const message = [
+    `Start a fresh conversation for durable goal ${goal.id} at revision ${goal.revision}.`,
+    '',
+    `Rollover reason: ${reason}`,
+    '',
+    'Objective:',
+    truncateUtf8(goal.objective, 4_000),
+    '',
+    'Constraints:',
+    ...list(goal.constraints.slice(0, 20), 'No additional constraints recorded.'),
+    '',
+    'Acceptance criteria:',
+    ...list(goal.acceptanceCriteria.slice(0, 20), 'No acceptance criteria recorded.'),
+    '',
+    'Verified evidence links:',
+    ...list(
+      goal.completionEvidence
+        .slice(-30)
+        .map(
+          (evidence) => `${evidence.requirementId} -> ${evidence.evidenceId}: ${evidence.summary}`
+        ),
+      'No completion evidence has been verified.'
+    ),
+    '',
+    'Remaining required evidence:',
+    ...list(
+      goal.completionRequirements
+        .filter((requirement) => requirement.required && !evidenced.has(requirement.id))
+        .map((requirement) => `${requirement.id}: ${requirement.description}`),
+      'Re-evaluate all acceptance criteria before completion.'
+    ),
+    '',
+    'Recent durable decisions:',
+    ...list(
+      goal.transitions
+        .slice(-20)
+        .map(
+          (transition) =>
+            `revision ${transition.revision} ${transition.from} -> ${transition.to} by ${transition.actorId}: ${transition.reason}`
+        ),
+      'No state decisions recorded.'
+    ),
+    '',
+    `Cumulative usage: ${JSON.stringify(goal.usage)}`,
+    `Prior run attempts: ${goal.continuationChain
+      .slice(-30)
+      .map((run) => run.attemptId ?? run.taskId)
+      .join(', ')}`,
+    ...(completion ? ['', `Last run summary: ${completion.summary}`] : []),
+    '',
+    'Continue from this durable contract. Preserve the existing authority boundaries, inspect linked evidence when needed, and do not repeat verified side effects or mark the goal complete without its required evidence.',
+  ].join('\n');
+  return truncateUtf8(message, 18_000);
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value;
+  const suffix = '\n[truncated; inspect the durable goal record for full context]';
+  const contentLimit = Math.max(0, maxBytes - Buffer.byteLength(suffix, 'utf8'));
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const midpoint = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(value.slice(0, midpoint), 'utf8') <= contentLimit) {
+      low = midpoint;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+  return `${value.slice(0, low).trimEnd()}${suffix}`;
 }
 
 function dispatchErrorCode(error: unknown): string {

--- a/shared/src/types/durable-goal.types.ts
+++ b/shared/src/types/durable-goal.types.ts
@@ -88,10 +88,14 @@ export interface DurableGoalUsageEvent {
 export const DURABLE_GOAL_CONTINUATION_STATES = ['planned', 'dispatched', 'failed'] as const;
 export type DurableGoalContinuationState = (typeof DURABLE_GOAL_CONTINUATION_STATES)[number];
 
+export const DURABLE_GOAL_CONTINUATION_KINDS = ['resume', 'rollover'] as const;
+export type DurableGoalContinuationKind = (typeof DURABLE_GOAL_CONTINUATION_KINDS)[number];
+
 export interface DurableGoalContinuationAttempt {
   id: string;
   sourceTaskId: string;
   sourceAttemptId: string;
+  kind: DurableGoalContinuationKind;
   state: DurableGoalContinuationState;
   admissionIdempotencyKey: string;
   message: string;


### PR DESCRIPTION
## Summary

- add bounded fresh-conversation rollovers to the durable goal supervisor
- persist rollover intent before dispatch with a distinct stable admission key
- carry objective, constraints, acceptance criteria, evidence links, decisions, run identities, and cumulative usage into the fresh conversation
- require exact current-run provenance, configured rollover capacity, and optional operator approval
- expose rollover approval through the workspace-scoped API and `vk goals rollover`
- document threshold, approval, restart, and limit behavior

## Verification

- 19 focused durable goal service, repository, supervisor, and restart tests
- 5 focused CLI goal tests
- shared, server, and CLI TypeScript checks
- targeted ESLint with no new errors
- route test is included and will run in CI; local Supertest binding is unavailable in the managed sandbox

Closes #865
