### PR TITLE
feat: process durable reflection extraction jobs

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -3737,12 +3737,17 @@ POST /api/reflections
   "source": {
     "kind": "user-correction",
     "taskId": "task_20260626_reflect",
-    "messageId": "msg_123"
+    "messageId": "msg_123",
+    "eventIds": ["run_event_456"]
   },
   "summary": "The agent guessed a config field instead of reading the schema.",
   "previousApproach": "Used a remembered field name.",
   "correction": "Read the live schema and nearby route tests first.",
   "nextAttempt": "Inspect the current schema before changing config behavior.",
+  "proposedScope": "workspace",
+  "rationale": "The correction applies to schema-backed configuration work.",
+  "applicability": "Use for future configuration changes in this workspace.",
+  "contradictionIds": ["reflection_older_guess"],
   "evidence": [
     {
       "kind": "note",
@@ -3754,7 +3759,11 @@ POST /api/reflections
 }
 ```
 
-**Response** `201`: Created pending candidate. Tokens, credential-looking values, and `/Users/...` private paths are redacted before storage.
+**Response** `201`: Created pending candidate. `idempotencyKey` can be supplied by
+automated extractors to make candidate creation retry-safe. Tokens,
+credential-looking values, and `/Users/...` private paths are redacted before
+storage. Extracted candidates remain pending and cannot affect task lessons or
+agent context until accepted.
 
 ### Accept Candidate
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -604,6 +604,9 @@ Reviewed promotion queue for agent corrections, repeated mistakes, and durable l
 - **Redaction at ingestion** — Tokens, credentials, and local private paths are redacted before candidates are stored
 - **Durable extraction jobs** — `reflection-extraction-job/v1` persists only source task, attempt, completion, digest, and event identities; raw conversations and unrestricted transcripts are not copied into the queue
 - **Lease-safe worker foundation** — File and SQLite repositories atomically enforce global and per-workspace concurrency, stable idempotent enqueue, lease ownership and renewal, deterministic retry backoff, restart recovery, and bounded dead-lettering
+- **Non-blocking completion intake** — Eligible terminal completions schedule extraction after the authoritative task update; interrupted or empty completions are skipped
+- **Bounded extraction worker** — The background worker reloads the identified durable completion, verifies its identity and digest, and exposes only bounded summaries, blockers, verified evidence, and verification results to a typed extractor
+- **Safe pending output** — Extracted candidates include run/event attribution, proposed scope, confidence, rationale, applicability, and contradiction links; deterministic candidate idempotency prevents duplicates after retries
 - **Settings UI** — Review, accept, reject, delete, and merge candidates from Settings → Reflections
 - **Audit trail** — Create, accept, reject, merge, and delete actions write metadata-only audit events
 

--- a/server/src/__tests__/reflection-extraction-worker-service.test.ts
+++ b/server/src/__tests__/reflection-extraction-worker-service.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  CompletionResult,
+  ReflectionCandidate,
+  ReflectionExtractionJob,
+} from '@veritas-kanban/shared';
+import {
+  DeterministicReflectionCandidateExtractor,
+  ReflectionExtractionWorkerService,
+  scheduleReflectionExtractionJob,
+  type ReflectionExtractionSourceMaterial,
+} from '../services/reflection-extraction-worker-service.js';
+
+function job(): ReflectionExtractionJob {
+  return {
+    schemaVersion: 'reflection-extraction-job/v1',
+    id: 'reflection_job_1',
+    workspaceId: 'workspace_1',
+    idempotencyKey: 'completion:completion_1',
+    source: {
+      taskId: 'task_1',
+      attemptId: 'attempt_1',
+      completionId: 'completion_1',
+      completionDigest: `sha256:${'a'.repeat(64)}`,
+      runEventId: 'event_1',
+    },
+    state: 'leased',
+    revision: 2,
+    attemptCount: 1,
+    maxAttempts: 5,
+    availableAt: '2026-07-25T12:00:00.000Z',
+    lease: {
+      ownerId: 'worker_1',
+      acquiredAt: '2026-07-25T12:00:00.000Z',
+      expiresAt: '2026-07-25T12:02:00.000Z',
+    },
+    candidateIds: [],
+    failures: [],
+    createdAt: '2026-07-25T12:00:00.000Z',
+    updatedAt: '2026-07-25T12:00:00.000Z',
+  };
+}
+
+function source(
+  overrides: Partial<ReflectionExtractionSourceMaterial> = {}
+): ReflectionExtractionSourceMaterial {
+  return {
+    workspaceId: 'workspace_1',
+    taskId: 'task_1',
+    taskTitle: 'Fix durable completion',
+    attemptId: 'attempt_1',
+    completionId: 'completion_1',
+    completionDigest: `sha256:${'a'.repeat(64)}`,
+    runEventId: 'event_1',
+    status: 'blocked',
+    summary: 'The run could not prove the required release.',
+    blockers: [
+      {
+        code: 'RELEASE_NOT_VERIFIED',
+        summary: 'Release is not verified',
+        detail: 'Confirm the published version before retrying.',
+        retryable: true,
+      },
+    ],
+    evidence: [{ id: 'evidence_1', summary: 'Build passed.', verified: true }],
+    verification: [{ gateId: 'release', status: 'failed', summary: 'No release evidence.' }],
+    ...overrides,
+  };
+}
+
+function completion(overrides: Partial<CompletionResult> = {}): CompletionResult {
+  return {
+    schemaVersion: 'completion-result/v1',
+    digest: `sha256:${'a'.repeat(64)}`,
+    idempotencyKey: `sha256:${'b'.repeat(64)}`,
+    completedAt: '2026-07-25T12:00:00.000Z',
+    terminalSource: 'process',
+    taskEnvelopeSchemaVersion: 'task-envelope/v1',
+    taskEnvelopeDigest: `sha256:${'c'.repeat(64)}`,
+    taskId: 'task_1',
+    attemptId: 'attempt_1',
+    providerRuntimeManifestDigest: `sha256:${'d'.repeat(64)}`,
+    status: 'blocked',
+    summary: 'Blocked on release evidence.',
+    error: null,
+    blockers: [],
+    evidence: [],
+    changedFiles: [],
+    artifacts: [],
+    verification: [],
+    sideEffects: [],
+    continuation: null,
+    ...overrides,
+  };
+}
+
+describe('ReflectionExtractionWorkerService', () => {
+  it('queues eligible completion identities on a later microtask', async () => {
+    const enqueue = vi.fn().mockResolvedValue({ created: true, job: job() });
+    const result = scheduleReflectionExtractionJob({
+      jobs: { enqueue },
+      workspaceId: 'workspace_1',
+      completion: completion(),
+      runEventId: 'event_1',
+    });
+
+    expect(result).toBe(true);
+    expect(enqueue).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(enqueue).toHaveBeenCalledWith({
+      workspaceId: 'workspace_1',
+      idempotencyKey: `completion:sha256:${'b'.repeat(64)}`,
+      source: {
+        taskId: 'task_1',
+        attemptId: 'attempt_1',
+        completionId: `sha256:${'b'.repeat(64)}`,
+        completionDigest: `sha256:${'a'.repeat(64)}`,
+        runEventId: 'event_1',
+      },
+    });
+  });
+
+  it('does not queue interrupted completions', async () => {
+    const enqueue = vi.fn();
+    expect(
+      scheduleReflectionExtractionJob({
+        jobs: { enqueue },
+        workspaceId: 'workspace_1',
+        completion: completion({ status: 'interrupted' }),
+      })
+    ).toBe(false);
+    await Promise.resolve();
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('extracts bounded pending candidates and completes the leased job', async () => {
+    const claimed = job();
+    const complete = vi.fn().mockResolvedValue({ ...claimed, state: 'completed' });
+    const fail = vi.fn();
+    const create = vi.fn().mockResolvedValue({ id: 'reflection_1' } as ReflectionCandidate);
+    const extractor = new DeterministicReflectionCandidateExtractor();
+    const jobs = {
+      claim: vi.fn().mockResolvedValue({ claimed: true, job: claimed }),
+      complete,
+      fail,
+    };
+    const worker = new ReflectionExtractionWorkerService({
+      jobs,
+      reflections: { create },
+      sourceLoader: { load: vi.fn().mockResolvedValue(source()) },
+      extractor,
+      ownerId: 'worker_1',
+    });
+
+    await expect(worker.runOnce()).resolves.toBe('processed');
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: 'reflection_job_1:candidate:0',
+        promotionTarget: 'task-lesson',
+        proposedScope: 'task',
+        source: expect.objectContaining({
+          taskId: 'task_1',
+          runId: 'attempt_1',
+          eventIds: ['event_1'],
+        }),
+      })
+    );
+    expect(complete).toHaveBeenCalledWith('reflection_job_1', {
+      expectedRevision: 2,
+      ownerId: 'worker_1',
+      candidateIds: ['reflection_1'],
+    });
+    expect(fail).not.toHaveBeenCalled();
+  });
+
+  it('records a bounded retry failure without completing the job', async () => {
+    const claimed = job();
+    const fail = vi.fn().mockResolvedValue({ ...claimed, state: 'queued' });
+    const worker = new ReflectionExtractionWorkerService({
+      jobs: {
+        claim: vi.fn().mockResolvedValue({ claimed: true, job: claimed }),
+        complete: vi.fn(),
+        fail,
+      },
+      sourceLoader: {
+        load: vi.fn().mockRejectedValue(
+          Object.assign(
+            new Error(
+              'Authoritative completion disappeared with token=secret123 at /Users/brad/private.'
+            ),
+            {
+              code: 'SOURCE_COMPLETION_NOT_FOUND',
+            }
+          )
+        ),
+      },
+      reflections: { create: vi.fn() },
+      ownerId: 'worker_1',
+    });
+
+    await expect(worker.runOnce()).resolves.toBe('processed');
+    expect(fail).toHaveBeenCalledWith('reflection_job_1', {
+      expectedRevision: 2,
+      ownerId: 'worker_1',
+      code: 'SOURCE_COMPLETION_NOT_FOUND',
+      summary: 'Authoritative completion disappeared with token=[REDACTED] at [REDACTED_PATH]',
+    });
+  });
+
+  it('does not invent a lesson for a successful completion', async () => {
+    const extractor = new DeterministicReflectionCandidateExtractor();
+    await expect(extractor.extract(source({ status: 'success', blockers: [] }))).resolves.toEqual(
+      []
+    );
+  });
+});

--- a/server/src/__tests__/reflection-service.test.ts
+++ b/server/src/__tests__/reflection-service.test.ts
@@ -76,6 +76,46 @@ describe('ReflectionService', () => {
     expect(updateTask).not.toHaveBeenCalled();
   });
 
+  it('redacts extracted scope metadata before durable persistence', async () => {
+    const { service } = createHarness();
+
+    const candidate = await service.create(
+      createInput({
+        source: {
+          kind: 'error',
+          taskId: 'task_20260626_reflect',
+          runId: 'attempt_1',
+          eventIds: ['event_1'],
+        },
+        proposedScope: 'workspace',
+        rationale: 'Observed token=secret123 in /Users/bradgroux/Projects/private.',
+        applicability: 'Use when api_key=topsecret is present.',
+        contradictionIds: ['reflection_previous'],
+      })
+    );
+
+    expect(candidate).toMatchObject({
+      proposedScope: 'workspace',
+      source: { runId: 'attempt_1', eventIds: ['event_1'] },
+      contradictionIds: ['reflection_previous'],
+    });
+    expect(candidate.rationale).toContain('token=[REDACTED]');
+    expect(candidate.rationale).toContain('[REDACTED_PATH]');
+    expect(candidate.applicability).toContain('api_key=[REDACTED]');
+    expect(candidate.redaction.redacted).toBe(true);
+  });
+
+  it('returns the original candidate when an extraction retry reuses its idempotency key', async () => {
+    const { service, audit } = createHarness();
+    const input = createInput({ idempotencyKey: 'reflection_job_1:candidate:0' });
+
+    const first = await service.create(input);
+    const retried = await service.create(input);
+
+    expect(retried.id).toBe(first.id);
+    expect(audit).toHaveBeenCalledTimes(1);
+  });
+
   it('accepts a reviewed task-linked candidate into task lessons', async () => {
     const task = createTask({ lessonsLearned: 'Existing lesson', lessonTags: ['existing'] });
     const { service, updateTask } = createHarness(task);

--- a/server/src/routes/reflections.ts
+++ b/server/src/routes/reflections.ts
@@ -31,6 +31,7 @@ const sourceSchema = z
     kind: sourceKindSchema,
     taskId: z.string().min(1).optional(),
     runId: z.string().min(1).optional(),
+    eventIds: z.array(z.string().min(1).max(160)).min(1).max(20).optional(),
     messageId: z.string().min(1).optional(),
     errorId: z.string().min(1).optional(),
     observationId: z.string().min(1).optional(),
@@ -49,6 +50,7 @@ const evidenceSchema = z.object({
 });
 
 const createReflectionSchema = z.object({
+  idempotencyKey: z.string().min(1).max(240).optional(),
   category: categorySchema,
   promotionTarget: promotionTargetSchema.optional(),
   confidence: z.number().min(0).max(1).optional(),
@@ -57,6 +59,10 @@ const createReflectionSchema = z.object({
   previousApproach: z.string().min(1).max(4000),
   correction: z.string().min(1).max(4000),
   nextAttempt: z.string().min(1).max(4000),
+  proposedScope: z.enum(['task', 'workspace', 'team', 'global']).optional(),
+  rationale: z.string().min(1).max(4000).optional(),
+  applicability: z.string().min(1).max(4000).optional(),
+  contradictionIds: z.array(z.string().min(1).max(160)).max(20).optional(),
   evidence: z.array(evidenceSchema).max(10).optional(),
   tags: z.array(z.string().min(1).max(80)).max(20).optional(),
   duplicateKey: z.string().min(1).max(240).optional(),

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -83,6 +83,7 @@ import { getCommunicationAdapterService } from './services/communication-adapter
 import { getRunEventJournalService } from './services/run-event-journal-service.js';
 import { getToolControlPlaneService } from './services/tool-control-plane-service.js';
 import { runToolBridgeRoutes } from './routes/run-tool-bridge.js';
+import { getReflectionExtractionWorkerService } from './services/reflection-extraction-worker-service.js';
 
 const log = createLogger('server');
 
@@ -591,6 +592,8 @@ async function initializeServices(): Promise<void> {
   }
   await getCommunicationAdapterService().start();
   log.info('Communication adapter workers initialized');
+  getReflectionExtractionWorkerService().start();
+  log.info('Reflection extraction worker initialized');
 
   // 4. Reconcile any agent attempts that were left in `running` state from
   //    a previous server crash/restart (issue #781).
@@ -1234,6 +1237,8 @@ async function gracefulShutdown(signal: string) {
 
     stopScheduledDeliverablesRunner();
     log.info('Scheduled deliverables runner stopped');
+    getReflectionExtractionWorkerService().stop();
+    log.info('Reflection extraction worker stopped');
 
     await getCommunicationAdapterService().shutdown();
     log.info('Communication adapter workers stopped');

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -39,6 +39,11 @@ import {
   type DurableGoalSupervisorService,
 } from './durable-goal-supervisor-service.js';
 import {
+  getReflectionExtractionJobService,
+  type ReflectionExtractionJobService,
+} from './reflection-extraction-job-service.js';
+import { scheduleReflectionExtractionJob } from './reflection-extraction-worker-service.js';
+import {
   AgentHealthService,
   type AgentHealthChecker,
   type AgentHealthStatus,
@@ -589,6 +594,7 @@ export class ClawdbotAgentService {
     'handleRunCompletion' | 'reconcilePlannedForTask'
   > &
     Partial<Pick<DurableGoalSupervisorService, 'approveRollover'>>;
+  private reflectionExtractionJobs: Pick<ReflectionExtractionJobService, 'enqueue'>;
   private workspaceExecutionTrust: Pick<
     WorkspaceExecutionTrustService,
     'scan' | 'evaluateForLaunch' | 'assertFresh'
@@ -637,7 +643,11 @@ export class ClawdbotAgentService {
     > &
       Partial<
         Pick<DurableGoalSupervisorService, 'approveRollover'>
-      > = getDurableGoalSupervisorService()
+      > = getDurableGoalSupervisorService(),
+    reflectionExtractionJobs: Pick<
+      ReflectionExtractionJobService,
+      'enqueue'
+    > = getReflectionExtractionJobService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -666,6 +676,7 @@ export class ClawdbotAgentService {
     this.sandboxPolicies = sandboxPolicies;
     this.runEgressGateway = runEgressGateway;
     this.durableGoalSupervisor = durableGoalSupervisor;
+    this.reflectionExtractionJobs = reflectionExtractionJobs;
     this.workspaceExecutionTrust = workspaceExecutionTrust;
     this.phaseAuthority = phaseAuthority;
     this.phaseTransitions = phaseTransitions;
@@ -3594,6 +3605,7 @@ export class ClawdbotAgentService {
       }
     }
     if (lastError) throw lastError;
+    this.scheduleReflectionExtraction(attempt.taskEnvelope.workspace.workspaceId, completionResult);
     await this.admission.releaseByAttempt(
       attempt.taskEnvelope.workspace.workspaceId,
       task.id,
@@ -3688,7 +3700,7 @@ export class ClawdbotAgentService {
         dedupeKey: `run.recovery:${completionResult.idempotencyKey}`,
       }
     );
-    await this.appendRunEvent(
+    const terminalEvent = await this.appendRunEvent(
       task.id,
       attempt.id,
       completionResult.status === 'success'
@@ -3780,6 +3792,11 @@ export class ClawdbotAgentService {
       }
     }
     if (lastError) throw lastError;
+    this.scheduleReflectionExtraction(
+      attempt.taskEnvelope.workspace.workspaceId,
+      completionResult,
+      terminalEvent.eventId
+    );
 
     await this.admission.releaseByAttempt(
       attempt.taskEnvelope.workspace.workspaceId,
@@ -4031,7 +4048,7 @@ export class ClawdbotAgentService {
         : completionResult.status === 'interrupted'
           ? 'run.interrupted'
           : 'run.failed';
-    await this.appendRunEvent(
+    const terminalEvent = await this.appendRunEvent(
       taskId,
       attemptId,
       terminalKind,
@@ -4072,6 +4089,11 @@ export class ClawdbotAgentService {
       pending.admissionReservationId,
       admissionReleaseReason(completionResult.status),
       `completion:${completionResult.idempotencyKey}`
+    );
+    this.scheduleReflectionExtraction(
+      pending.taskEnvelope.workspace.workspaceId,
+      completionResult,
+      terminalEvent.eventId
     );
     if (!persistedHere) return;
 
@@ -4219,6 +4241,29 @@ export class ClawdbotAgentService {
     }
 
     log.info(`[ClawdbotAgent] Task ${taskId} completed with status: ${status}`);
+  }
+
+  private scheduleReflectionExtraction(
+    workspaceId: string,
+    completion: CompletionResult,
+    runEventId?: string
+  ): void {
+    scheduleReflectionExtractionJob({
+      jobs: this.reflectionExtractionJobs,
+      workspaceId,
+      completion,
+      runEventId,
+      onError: (error) => {
+        log.error(
+          {
+            err: error,
+            taskId: completion.taskId,
+            attemptId: completion.attemptId,
+          },
+          '[ClawdbotAgent] Reflection extraction enqueue failed'
+        );
+      },
+    });
   }
 
   private async revokeRunCredentialLeases(

--- a/server/src/services/reflection-extraction-worker-service.ts
+++ b/server/src/services/reflection-extraction-worker-service.ts
@@ -1,0 +1,342 @@
+import { nanoid } from 'nanoid';
+import type {
+  CompletionResult,
+  CreateReflectionCandidateInput,
+  ReflectionCandidate,
+  ReflectionExtractionJob,
+  Task,
+  TaskCompletionStatus,
+} from '@veritas-kanban/shared';
+import { createLogger } from '../lib/logger.js';
+import {
+  getReflectionExtractionJobService,
+  type ReflectionExtractionJobService,
+} from './reflection-extraction-job-service.js';
+import { getReflectionService } from './reflection-service.js';
+import { getTaskService } from './task-service.js';
+
+const log = createLogger('reflection-extraction-worker');
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const MAX_SOURCE_TEXT = 4_000;
+const MAX_SOURCE_ITEMS = 12;
+
+export interface ReflectionExtractionSourceMaterial {
+  workspaceId: string;
+  taskId: string;
+  taskTitle: string;
+  attemptId: string;
+  completionId: string;
+  completionDigest: string;
+  runEventId?: string;
+  status: TaskCompletionStatus;
+  summary: string;
+  error?: string;
+  blockers: Array<{ code: string; summary: string; detail: string; retryable: boolean }>;
+  evidence: Array<{ id: string; summary: string; verified: boolean }>;
+  verification: Array<{ gateId: string; status: string; summary: string }>;
+}
+
+export interface ReflectionExtractionSourceLoader {
+  load(job: ReflectionExtractionJob): Promise<ReflectionExtractionSourceMaterial>;
+}
+
+export interface ReflectionCandidateExtractor {
+  extract(source: ReflectionExtractionSourceMaterial): Promise<CreateReflectionCandidateInput[]>;
+}
+
+interface ReflectionJobClient {
+  claim(ownerId: string, workspaceId?: string): ReturnType<ReflectionExtractionJobService['claim']>;
+  complete(
+    id: string,
+    input: Parameters<ReflectionExtractionJobService['complete']>[1]
+  ): ReturnType<ReflectionExtractionJobService['complete']>;
+  fail(
+    id: string,
+    input: Parameters<ReflectionExtractionJobService['fail']>[1]
+  ): ReturnType<ReflectionExtractionJobService['fail']>;
+}
+
+export interface ReflectionExtractionEnqueuer {
+  enqueue(
+    input: Parameters<ReflectionExtractionJobService['enqueue']>[0]
+  ): ReturnType<ReflectionExtractionJobService['enqueue']>;
+}
+
+export interface ScheduleReflectionExtractionJobInput {
+  jobs: ReflectionExtractionEnqueuer;
+  workspaceId: string;
+  completion: CompletionResult;
+  runEventId?: string;
+  onError?: (error: unknown) => void;
+}
+
+export function scheduleReflectionExtractionJob(
+  input: ScheduleReflectionExtractionJobInput
+): boolean {
+  if (input.completion.status === 'interrupted' || !input.completion.summary.trim()) return false;
+  queueMicrotask(() => {
+    void input.jobs
+      .enqueue({
+        workspaceId: input.workspaceId,
+        idempotencyKey: `completion:${input.completion.idempotencyKey}`,
+        source: {
+          taskId: input.completion.taskId,
+          attemptId: input.completion.attemptId,
+          completionId: input.completion.idempotencyKey,
+          completionDigest: input.completion.digest,
+          runEventId: input.runEventId,
+        },
+      })
+      .catch((error) => input.onError?.(error));
+  });
+  return true;
+}
+
+interface ReflectionCandidateWriter {
+  create(input: CreateReflectionCandidateInput): Promise<ReflectionCandidate>;
+}
+
+export interface ReflectionExtractionWorkerOptions {
+  jobs?: ReflectionJobClient;
+  reflections?: ReflectionCandidateWriter;
+  sourceLoader?: ReflectionExtractionSourceLoader;
+  extractor?: ReflectionCandidateExtractor;
+  ownerId?: string;
+  pollIntervalMs?: number;
+}
+
+export class TaskCompletionReflectionSourceLoader implements ReflectionExtractionSourceLoader {
+  async load(job: ReflectionExtractionJob): Promise<ReflectionExtractionSourceMaterial> {
+    const task = await getTaskService().getTask(job.source.taskId);
+    if (!task) throw extractionError('SOURCE_TASK_NOT_FOUND', 'Source task no longer exists.');
+    const attempt = findAttempt(task, job.source.attemptId);
+    const completion = attempt?.completionResult;
+    if (!completion) {
+      throw extractionError(
+        'SOURCE_COMPLETION_NOT_FOUND',
+        'Source attempt has no durable completion result.'
+      );
+    }
+    if (
+      completion.idempotencyKey !== job.source.completionId ||
+      completion.digest !== job.source.completionDigest
+    ) {
+      throw extractionError(
+        'SOURCE_COMPLETION_MISMATCH',
+        'Durable completion identity does not match the extraction job.'
+      );
+    }
+    return minimizeCompletion(job, task, completion);
+  }
+}
+
+export class DeterministicReflectionCandidateExtractor implements ReflectionCandidateExtractor {
+  async extract(
+    source: ReflectionExtractionSourceMaterial
+  ): Promise<CreateReflectionCandidateInput[]> {
+    if (!['blocked', 'failed', 'partial'].includes(source.status)) return [];
+    const blocker = source.blockers[0];
+    const correction = blocker
+      ? `Resolve ${blocker.summary}. ${blocker.detail}`
+      : source.error
+        ? `Address the terminal failure: ${source.error}`
+        : 'Review the incomplete run and resolve the missing requirement before retrying.';
+    const nextAttempt = blocker?.retryable
+      ? `Retry only after confirming the ${blocker.code} blocker is resolved.`
+      : 'Revise the approach before starting another attempt.';
+    return [
+      {
+        category: 'session',
+        promotionTarget: 'task-lesson',
+        confidence: blocker ? 0.72 : 0.62,
+        source: {
+          kind: blocker ? 'error' : 'task-run',
+          taskId: source.taskId,
+          runId: source.attemptId,
+          eventIds: source.runEventId ? [source.runEventId] : undefined,
+          errorId: blocker?.code,
+        },
+        summary: source.summary,
+        previousApproach: `The run ended with status ${source.status}.`,
+        correction,
+        nextAttempt,
+        proposedScope: 'task',
+        rationale: 'Derived from the authoritative, durable completion result.',
+        applicability: `Future attempts for task ${source.taskId} with the same blocker or failure mode.`,
+        evidence: [
+          ...source.blockers.slice(0, 3).map((item) => ({
+            kind: 'error' as const,
+            title: item.summary,
+            content: item.detail,
+          })),
+          ...source.evidence
+            .filter((item) => item.verified)
+            .slice(0, 3)
+            .map((item) => ({
+              kind: 'task-run' as const,
+              title: item.id,
+              content: item.summary,
+            })),
+        ],
+        tags: ['extracted', `completion:${source.status}`],
+        createdBy: 'reflection-extraction-worker',
+      },
+    ];
+  }
+}
+
+export class ReflectionExtractionWorkerService {
+  private readonly jobs: ReflectionJobClient;
+  private readonly reflections: ReflectionCandidateWriter;
+  private readonly sourceLoader: ReflectionExtractionSourceLoader;
+  private readonly extractor: ReflectionCandidateExtractor;
+  private readonly ownerId: string;
+  private readonly pollIntervalMs: number;
+  private timer?: ReturnType<typeof setInterval>;
+  private tickActive = false;
+
+  constructor(options: ReflectionExtractionWorkerOptions = {}) {
+    this.jobs = options.jobs ?? getReflectionExtractionJobService();
+    this.reflections = options.reflections ?? getReflectionService();
+    this.sourceLoader = options.sourceLoader ?? new TaskCompletionReflectionSourceLoader();
+    this.extractor = options.extractor ?? new DeterministicReflectionCandidateExtractor();
+    this.ownerId = options.ownerId ?? `reflection-worker-${process.pid}-${nanoid(8)}`;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    void this.tick();
+    this.timer = setInterval(() => void this.tick(), this.pollIntervalMs);
+    this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  async runOnce(workspaceId?: string): Promise<'processed' | 'empty' | 'busy'> {
+    const claim = await this.jobs.claim(this.ownerId, workspaceId);
+    if (!claim.claimed) return claim.reason === 'empty' ? 'empty' : 'busy';
+    await this.process(claim.job);
+    return 'processed';
+  }
+
+  private async tick(): Promise<void> {
+    if (this.tickActive) return;
+    this.tickActive = true;
+    try {
+      for (let index = 0; index < 4; index++) {
+        const result = await this.runOnce();
+        if (result !== 'processed') break;
+      }
+    } catch (error) {
+      log.error({ err: error }, 'Reflection extraction worker tick failed');
+    } finally {
+      this.tickActive = false;
+    }
+  }
+
+  private async process(job: ReflectionExtractionJob): Promise<void> {
+    try {
+      const source = await this.sourceLoader.load(job);
+      const drafts = (await this.extractor.extract(source)).slice(0, 8);
+      const candidateIds: string[] = [];
+      for (const [index, draft] of drafts.entries()) {
+        const candidate = await this.reflections.create({
+          ...draft,
+          idempotencyKey: `${job.id}:candidate:${index}`,
+        });
+        candidateIds.push(candidate.id);
+      }
+      await this.jobs.complete(job.id, {
+        expectedRevision: job.revision,
+        ownerId: this.ownerId,
+        candidateIds,
+      });
+    } catch (error) {
+      const code = extractionErrorCode(error);
+      const summary = safeErrorSummary(error);
+      await this.jobs.fail(job.id, {
+        expectedRevision: job.revision,
+        ownerId: this.ownerId,
+        code,
+        summary,
+      });
+      log.warn({ jobId: job.id, code, summary }, 'Reflection extraction job failed');
+    }
+  }
+}
+
+function findAttempt(task: Task, attemptId: string) {
+  if (task.attempt?.id === attemptId) return task.attempt;
+  return task.attempts?.find((attempt) => attempt.id === attemptId);
+}
+
+function minimizeCompletion(
+  job: ReflectionExtractionJob,
+  task: Task,
+  completion: CompletionResult
+): ReflectionExtractionSourceMaterial {
+  const text = (value: string | null | undefined) => value?.slice(0, MAX_SOURCE_TEXT) ?? '';
+  return {
+    workspaceId: job.workspaceId,
+    taskId: job.source.taskId,
+    taskTitle: text(task.title),
+    attemptId: job.source.attemptId,
+    completionId: job.source.completionId,
+    completionDigest: job.source.completionDigest,
+    runEventId: job.source.runEventId,
+    status: completion.status,
+    summary: text(completion.summary),
+    error: completion.error ? text(completion.error) : undefined,
+    blockers: completion.blockers.slice(0, MAX_SOURCE_ITEMS).map((item) => ({
+      code: text(item.code),
+      summary: text(item.summary),
+      detail: text(item.detail),
+      retryable: item.retryable,
+    })),
+    evidence: completion.evidence.slice(0, MAX_SOURCE_ITEMS).map((item) => ({
+      id: text(item.id),
+      summary: text(item.summary),
+      verified: item.verified,
+    })),
+    verification: completion.verification.slice(0, MAX_SOURCE_ITEMS).map((item) => ({
+      gateId: text(item.gateId),
+      status: item.status,
+      summary: text(item.summary),
+    })),
+  };
+}
+
+function extractionError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+function extractionErrorCode(error: unknown): string {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error
+      ? String((error as { code: unknown }).code)
+      : 'EXTRACTION_FAILED';
+  return code.replace(/[^A-Z0-9_-]/gi, '_').slice(0, 80) || 'EXTRACTION_FAILED';
+}
+
+function safeErrorSummary(error: unknown): string {
+  const message = error instanceof Error ? error.message : 'Reflection extraction failed.';
+  return message
+    .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1[REDACTED]')
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[REDACTED_SECRET]')
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{8,}\b/g, '[REDACTED_SECRET]')
+    .replace(/\b(api[_-]?key|token|secret|password)\s*[:=]\s*['"]?[^'"\s]+/gi, '$1=[REDACTED]')
+    .replace(/\/Users\/[^/\s]+\/[^\s`"'<>)]*/g, '[REDACTED_PATH]')
+    .replace(/\s+/g, ' ')
+    .slice(0, 500);
+}
+
+let reflectionExtractionWorker: ReflectionExtractionWorkerService | undefined;
+
+export function getReflectionExtractionWorkerService(): ReflectionExtractionWorkerService {
+  reflectionExtractionWorker ??= new ReflectionExtractionWorkerService();
+  return reflectionExtractionWorker;
+}

--- a/server/src/services/reflection-service.ts
+++ b/server/src/services/reflection-service.ts
@@ -30,6 +30,8 @@ const MAX_CANDIDATES = 2000;
 const MAX_TEXT_LENGTH = 4000;
 const MAX_EVIDENCE_ITEMS = 10;
 const MAX_TAGS = 20;
+const MAX_CONTRADICTION_IDS = 20;
+const MAX_SOURCE_EVENT_IDS = 20;
 
 interface ReflectionState {
   version: 1;
@@ -158,24 +160,45 @@ export class ReflectionService {
     await this.ensureLoaded();
 
     const sanitized = this.sanitizeInput(input);
+    const idempotencyKey = input.idempotencyKey
+      ? this.sanitizeText(input.idempotencyKey).value.slice(0, 240)
+      : undefined;
+    if (idempotencyKey) {
+      const existing = this.state.candidates.find(
+        (candidate) => candidate.idempotencyKey === idempotencyKey
+      );
+      if (existing) return existing;
+    }
     const duplicateKey = deriveDuplicateKey({ ...input, ...sanitized.values });
     const duplicateOf = this.findDuplicateRepresentative(duplicateKey);
     const timestamp = nowIso();
 
     const candidate: ReflectionCandidate = {
       id: `reflection_${Date.now()}_${nanoid(6)}`,
+      idempotencyKey,
       status: 'pending',
       category: input.category,
       promotionTarget: defaultPromotionTarget(input),
       confidence: clampConfidence(input.confidence),
       source: {
         ...input.source,
+        eventIds: input.source.eventIds
+          ?.slice(0, MAX_SOURCE_EVENT_IDS)
+          .map((id) => this.sanitizeText(id).value)
+          .filter(Boolean),
         url: input.source.url ? this.sanitizeText(input.source.url).value : undefined,
       },
       summary: sanitized.values.summary,
       previousApproach: sanitized.values.previousApproach,
       correction: sanitized.values.correction,
       nextAttempt: sanitized.values.nextAttempt,
+      proposedScope: input.proposedScope,
+      rationale: sanitized.values.rationale,
+      applicability: sanitized.values.applicability,
+      contradictionIds: input.contradictionIds
+        ?.slice(0, MAX_CONTRADICTION_IDS)
+        .map((id) => this.sanitizeText(id).value)
+        .filter(Boolean),
       evidence: sanitized.evidence,
       tags: this.sanitizeTags(input.tags ?? []),
       duplicateKey,
@@ -418,7 +441,7 @@ export class ReflectionService {
   private sanitizeInput(input: CreateReflectionCandidateInput): {
     values: Pick<
       CreateReflectionCandidateInput,
-      'summary' | 'previousApproach' | 'correction' | 'nextAttempt'
+      'summary' | 'previousApproach' | 'correction' | 'nextAttempt' | 'rationale' | 'applicability'
     >;
     evidence: ReflectionEvidence[];
     redaction: ReflectionRedactionSummary;
@@ -445,6 +468,8 @@ export class ReflectionService {
         previousApproach: sanitizeField(input.previousApproach),
         correction: sanitizeField(input.correction),
         nextAttempt: sanitizeField(input.nextAttempt),
+        rationale: input.rationale ? sanitizeField(input.rationale) : undefined,
+        applicability: input.applicability ? sanitizeField(input.applicability) : undefined,
       },
       evidence,
       redaction: {
@@ -550,6 +575,7 @@ export class ReflectionService {
       resource: candidate.id,
       details: {
         status: candidate.status,
+        idempotencyKey: candidate.idempotencyKey,
         category: candidate.category,
         promotionTarget: candidate.promotionTarget,
         source: candidate.source,

--- a/shared/src/types/reflection.types.ts
+++ b/shared/src/types/reflection.types.ts
@@ -8,17 +8,14 @@ export type ReflectionSourceKind =
   | 'review-feedback'
   | 'task-observation';
 export type ReflectionPromotionTarget =
-  | 'task-lesson'
-  | 'memory'
-  | 'decision'
-  | 'profile'
-  | 'template'
-  | 'policy';
+  'task-lesson' | 'memory' | 'decision' | 'profile' | 'template' | 'policy';
+export type ReflectionProposedScope = 'task' | 'workspace' | 'team' | 'global';
 
 export interface ReflectionSourceLink {
   kind: ReflectionSourceKind;
   taskId?: string;
   runId?: string;
+  eventIds?: string[];
   messageId?: string;
   errorId?: string;
   observationId?: string;
@@ -48,6 +45,7 @@ export interface ReflectionRedactionSummary {
 
 export interface ReflectionCandidate {
   id: string;
+  idempotencyKey?: string;
   status: ReflectionCandidateStatus;
   category: ReflectionCandidateCategory;
   promotionTarget: ReflectionPromotionTarget;
@@ -57,6 +55,10 @@ export interface ReflectionCandidate {
   previousApproach: string;
   correction: string;
   nextAttempt: string;
+  proposedScope?: ReflectionProposedScope;
+  rationale?: string;
+  applicability?: string;
+  contradictionIds?: string[];
   evidence: ReflectionEvidence[];
   tags: string[];
   duplicateKey: string;
@@ -91,6 +93,7 @@ export interface ReflectionListResponse {
 }
 
 export interface CreateReflectionCandidateInput {
+  idempotencyKey?: string;
   category: ReflectionCandidateCategory;
   promotionTarget?: ReflectionPromotionTarget;
   confidence?: number;
@@ -99,6 +102,10 @@ export interface CreateReflectionCandidateInput {
   previousApproach: string;
   correction: string;
   nextAttempt: string;
+  proposedScope?: ReflectionProposedScope;
+  rationale?: string;
+  applicability?: string;
+  contradictionIds?: string[];
   evidence?: ReflectionEvidence[];
   tags?: string[];
   duplicateKey?: string;


### PR DESCRIPTION
## Summary

- enqueue durable reflection extraction jobs after authoritative agent completion without delaying the completion path
- run a bounded background worker that verifies completion identity, exposes minimized source material to a typed extractor, and persists pending candidates through the existing redaction gate
- make candidate creation retry-safe and add run/event attribution, proposed scope, rationale, applicability, and contradiction metadata
- document the extraction path and expanded reflection API

## Verification

- `node_modules/.bin/tsc -p shared/tsconfig.json`
- `node_modules/.bin/tsc -p server/tsconfig.json --noEmit`
- `17` focused server tests passed across extraction jobs, extraction worker, and reflection persistence
- targeted ESLint passed with one pre-existing unused-type warning in `clawdbot-agent-service.ts`
- `git diff --check`

Part of #866.
