### PR TITLE
feat: attribute reviewed memory in task envelopes

### DIFF
--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -634,6 +634,11 @@ CLI, Codex SDK, Codex app-server, Claude Code, and Hermes renderers all include
 the envelope digest, runtime identity, objective and bounded context, a bounded
 workspace-baseline summary, explicit commit policy, allowed side effects,
 expected outputs, verification gates, and completion evidence contract.
+When reviewed reflection lessons are relevant, every renderer also receives
+the same bounded **Accepted Memory** section. Each entry includes its stable
+reflection ID and source task, run, and event attribution. Harnesses should
+treat these as human-reviewed supporting guidance and preserve the identifiers
+when reporting whether a lesson helped or regressed the run.
 Profile instructions and saved task checkpoints are rendered as separate,
 attributed sections and are capped at 20,000 characters each. The persisted
 task envelope retains the complete baseline fingerprints used for later

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -2733,6 +2733,13 @@ three times when HEAD, status, or fingerprints move, and fails closed if the
 worktree never stabilizes. Existing attempt records without an envelope remain
 readable.
 
+New envelopes may also include `subject.memory`, a maximum of eight ranked,
+human-accepted reflection lessons. Each item carries `reflectionId`, source
+task/run/event IDs, confidence, relevance, observed retrieval count, and the
+retrieval timestamp. The persisted envelope is the authoritative record of
+which reviewed memory influenced an attempt. Preview attempts select the same
+bounded context without incrementing observed use.
+
 Task create/update payloads may set reusable defaults under
 `executionPolicy`:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -607,6 +607,8 @@ Reviewed promotion queue for agent corrections, repeated mistakes, and durable l
 - **Non-blocking completion intake** — Eligible terminal completions schedule extraction after the authoritative task update; interrupted or empty completions are skipped
 - **Bounded extraction worker** — The background worker reloads the identified durable completion, verifies its identity and digest, and exposes only bounded summaries, blockers, verified evidence, and verification results to a typed extractor
 - **Safe pending output** — Extracted candidates include run/event attribution, proposed scope, confidence, rationale, applicability, and contradiction links; deterministic candidate idempotency prevents duplicates after retries
+- **Ranked reviewed retrieval** — Accepted task lessons are selected by task relevance, confidence, freshness, and observed use; only the top eight enter a run
+- **Run attribution** — Persisted task envelopes carry the reflection, source run, and source event IDs that influenced the run; preview envelopes do not increment use
 - **Settings UI** — Review, accept, reject, delete, and merge candidates from Settings → Reflections
 - **Audit trail** — Create, accept, reject, merge, and delete actions write metadata-only audit events
 

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -133,6 +133,12 @@ vi.mock('../services/task-service.js', () => ({
       patchTaskAttempt: mockPatchTaskAttempt,
     };
   },
+  getTaskService: () => ({
+    getTask: mockGetTask,
+    listTasks: mockListTasks,
+    updateTask: mockUpdateTask,
+    patchTaskAttempt: mockPatchTaskAttempt,
+  }),
 }));
 
 vi.mock('../services/telemetry-service.js', () => ({

--- a/server/src/__tests__/provider-task-envelope-renderer.test.ts
+++ b/server/src/__tests__/provider-task-envelope-renderer.test.ts
@@ -4,6 +4,7 @@ import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-mani
 import {
   TaskEnvelopeService,
   type CompletionEvidenceSource,
+  type TaskMemoryRetriever,
 } from '../services/task-envelope-service.js';
 import {
   renderAcpStdioTaskEnvelope,
@@ -73,9 +74,10 @@ function task(provider: string): Task {
 async function envelope(
   provider: string,
   commitPolicy: TaskCommitPolicy,
-  profileInstructions = 'Follow the release checklist.'
+  profileInstructions = 'Follow the release checklist.',
+  memoryRetriever?: TaskMemoryRetriever
 ) {
-  return new TaskEnvelopeService(evidenceSource).build({
+  return new TaskEnvelopeService(evidenceSource, memoryRetriever).build({
     task: task(provider),
     attemptId: 'attempt_transport',
     createdAt,
@@ -88,6 +90,35 @@ async function envelope(
 }
 
 describe('provider task-envelope renderers', () => {
+  it('renders accepted memory with durable reflection and source attribution', async () => {
+    const taskEnvelope = await envelope('codex-cli', 'allowed', 'Follow the release checklist.', {
+      retrieveForTask: async () => [
+        {
+          reflectionId: 'reflection_route_schema',
+          sourceTaskId: 'task_source',
+          sourceRunId: 'attempt_source',
+          sourceEventIds: ['event_source'],
+          category: 'team',
+          summary: 'Read the current route schema before editing.',
+          guidance: 'Inspect the schema and nearby tests first.',
+          confidence: 0.91,
+          relevanceScore: 0.84,
+          retrievalCount: 3,
+          retrievedAt: createdAt,
+        },
+      ],
+    });
+
+    const transport = renderCodexCliTaskEnvelope({ taskEnvelope });
+
+    expect(transport.content).toContain('## Accepted Memory');
+    expect(transport.content).toContain('### reflection_route_schema');
+    expect(transport.content).toContain(
+      'Source: task=task_source run=attempt_source events=event_source'
+    );
+    expect(transport.content).toContain('Guidance: Inspect the schema and nearby tests first.');
+  });
+
   it('renders an OpenClaw callback transport from a required-commit envelope', async () => {
     const taskEnvelope = await envelope('openclaw', 'required');
 

--- a/server/src/__tests__/reflection-service.test.ts
+++ b/server/src/__tests__/reflection-service.test.ts
@@ -138,6 +138,101 @@ describe('ReflectionService', () => {
     );
   });
 
+  it('ranks accepted lessons and records immutable run attribution', async () => {
+    const task = createTask({
+      title: 'Repair the current route schema',
+      description: 'Inspect route contracts before editing.',
+    });
+    const { service, audit } = createHarness(task);
+    const exact = await service.create(
+      createInput({
+        confidence: 0.9,
+        source: {
+          kind: 'user-correction',
+          taskId: task.id,
+          runId: 'attempt_source',
+          eventIds: ['event_source'],
+        },
+      })
+    );
+    await service.accept(exact.id, { reviewedBy: 'brad' });
+    const lowerRelevance = await service.create(
+      createInput({
+        confidence: 0.55,
+        summary: 'Tune image rendering for a later pass.',
+        correction: 'Inspect the image pipeline.',
+        nextAttempt: 'Run image snapshots.',
+        source: { kind: 'task-run', taskId: task.id, runId: 'attempt_image' },
+      })
+    );
+    await service.accept(lowerRelevance.id, { reviewedBy: 'brad' });
+    const unrelated = await service.create(
+      createInput({
+        summary: 'Tune unrelated image rendering.',
+        correction: 'Inspect the image pipeline.',
+        nextAttempt: 'Run image snapshots.',
+        source: { kind: 'task-run', taskId: 'task_other', runId: 'attempt_other' },
+      })
+    );
+    await service.accept(unrelated.id, { reviewedBy: 'brad' });
+
+    const selected = await service.retrieveForTask({
+      task,
+      workspaceId: 'veritas-kanban',
+      attemptId: 'attempt_next',
+      retrievedAt: '2026-07-25T20:00:00.000Z',
+      recordAttribution: true,
+    });
+
+    expect(selected[0]).toMatchObject({
+      reflectionId: exact.id,
+      sourceTaskId: task.id,
+      sourceRunId: 'attempt_source',
+      sourceEventIds: ['event_source'],
+      retrievalCount: 1,
+    });
+    expect(selected.map((item) => item.reflectionId)).toEqual([exact.id, lowerRelevance.id]);
+    expect(selected.some((item) => item.reflectionId === unrelated.id)).toBe(false);
+    const listed = await service.list({ status: 'accepted' });
+    expect(listed.candidates.find((candidate) => candidate.id === exact.id)).toMatchObject({
+      retrievalCount: 1,
+      lastRetrievedAt: '2026-07-25T20:00:00.000Z',
+      retrievals: [
+        {
+          taskId: task.id,
+          attemptId: 'attempt_next',
+          workspaceId: 'veritas-kanban',
+        },
+      ],
+    });
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'reflection.retrieved',
+        resource: exact.id,
+        details: expect.objectContaining({ attemptId: 'attempt_next' }),
+      })
+    );
+  });
+
+  it('previews accepted memory without incrementing observed use', async () => {
+    const task = createTask();
+    const { service } = createHarness(task);
+    const candidate = await service.create(createInput());
+    await service.accept(candidate.id, { reviewedBy: 'brad' });
+
+    const preview = await service.retrieveForTask({
+      task,
+      workspaceId: 'veritas-kanban',
+      attemptId: 'preview_1',
+      retrievedAt: '2026-07-25T20:00:00.000Z',
+      recordAttribution: false,
+    });
+
+    expect(preview[0].retrievalCount).toBe(0);
+    const listed = await service.list({ status: 'accepted' });
+    expect(listed.candidates[0].retrievalCount).toBeUndefined();
+  });
+
   it('keeps rejected candidates auditable without applying lessons', async () => {
     const { service, updateTask } = createHarness();
     const candidate = await service.create(createInput());

--- a/server/src/__tests__/services/clawdbot-reconcile.test.ts
+++ b/server/src/__tests__/services/clawdbot-reconcile.test.ts
@@ -43,6 +43,11 @@ vi.mock('../../services/task-service.js', () => ({
     getTask = mockGetTask;
     updateTask = mockUpdateTask;
   },
+  getTaskService: () => ({
+    listTasks: mockListTasks,
+    getTask: mockGetTask,
+    updateTask: mockUpdateTask,
+  }),
 }));
 
 vi.mock('../../services/config-service.js', () => {

--- a/server/src/__tests__/task-envelope-service.test.ts
+++ b/server/src/__tests__/task-envelope-service.test.ts
@@ -215,6 +215,67 @@ describe('TaskEnvelopeService', () => {
     expect(TaskEnvelopeSchema.safeParse(tampered).success).toBe(false);
   });
 
+  it('binds ranked accepted memory and retrieval attribution into the envelope', async () => {
+    const retrieveForTask = vi.fn().mockResolvedValue([
+      {
+        reflectionId: 'reflection_route_schema',
+        sourceTaskId: 'task_source',
+        sourceRunId: 'attempt_source',
+        sourceEventIds: ['event_source'],
+        category: 'team',
+        summary: 'Read the current route schema before editing.',
+        guidance: 'Inspect the schema and nearby tests first.',
+        confidence: 0.91,
+        relevanceScore: 0.84,
+        retrievalCount: 3,
+        retrievedAt: createdAt,
+      },
+    ]);
+    const result = await new TaskEnvelopeService(evidenceSource, { retrieveForTask }).build({
+      task: task(),
+      attemptId: 'attempt_memory',
+      createdAt,
+      worktreePath: '/tmp/veritas-kanban-task',
+      providerRuntimeManifest: providerRuntimeManifestFixture(),
+      commitPolicy: 'allowed',
+    });
+
+    expect(retrieveForTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({ id: 'task_20260716_contract' }),
+        workspaceId: 'veritas-kanban',
+        attemptId: 'attempt_memory',
+        recordAttribution: true,
+        limit: 8,
+      })
+    );
+    expect(result.subject.memory).toEqual([
+      expect.objectContaining({
+        reflectionId: 'reflection_route_schema',
+        sourceEventIds: ['event_source'],
+        relevanceScore: 0.84,
+      }),
+    ]);
+    expect(TaskEnvelopeSchema.safeParse(result).success).toBe(true);
+    expect(verifyTaskEnvelopeDigest(result)).toBe(true);
+  });
+
+  it('does not record observed use while building a preview envelope', async () => {
+    const retrieveForTask = vi.fn().mockResolvedValue([]);
+    await new TaskEnvelopeService(evidenceSource, { retrieveForTask }).build({
+      task: task(),
+      attemptId: 'preview_memory',
+      createdAt,
+      worktreePath: '/tmp/veritas-kanban-task',
+      providerRuntimeManifest: providerRuntimeManifestFixture(),
+      commitPolicy: 'allowed',
+    });
+
+    expect(retrieveForTask).toHaveBeenCalledWith(
+      expect.objectContaining({ recordAttribution: false })
+    );
+  });
+
   it('resolves run, task, legacy, and compatible default commit policy precedence', () => {
     expect(TaskExecutionPolicySchema.safeParse({ commitPolicy: 'sometimes' }).success).toBe(false);
     expect(

--- a/server/src/schemas/task-envelope-schemas.ts
+++ b/server/src/schemas/task-envelope-schemas.ts
@@ -68,6 +68,26 @@ export const TaskEnvelopeSchema = z
         background: z.array(z.string().trim().min(1).max(4000)).max(64),
         constraints: z.array(z.string().trim().min(1).max(4000)).max(128),
         acceptanceCriteria: z.array(z.string().trim().min(1).max(4000)).max(256),
+        memory: z
+          .array(
+            z
+              .object({
+                reflectionId: idSchema,
+                sourceTaskId: idSchema.optional(),
+                sourceRunId: idSchema.optional(),
+                sourceEventIds: z.array(idSchema).max(20),
+                category: idSchema,
+                summary: textSchema,
+                guidance: textSchema,
+                confidence: z.number().min(0).max(1),
+                relevanceScore: z.number().min(0).max(1),
+                retrievalCount: z.number().int().min(0),
+                retrievedAt: isoDateSchema,
+              })
+              .strict()
+          )
+          .max(20)
+          .optional(),
       })
       .strict(),
     attempt: z

--- a/server/src/services/provider-task-envelope-renderer.ts
+++ b/server/src/services/provider-task-envelope-renderer.ts
@@ -227,7 +227,7 @@ function renderEnvelopeContent(
 ${taskEnvelope.subject.objective}
 
 ${renderListSection('Background', taskEnvelope.subject.background)}
-${renderListSection('Constraints', constraints)}
+${renderAcceptedMemory(taskEnvelope)}${renderListSection('Constraints', constraints)}
 ${renderWorkspace(taskEnvelope)}
 ## Commit Policy
 
@@ -241,6 +241,38 @@ ${renderCompletionContract(taskEnvelope)}
 ${renderProfileInstructions(profileInstructions)}
 ${renderCheckpoint(input.checkpoint)}
 ${completionSection}`.trimEnd();
+}
+
+function renderAcceptedMemory(taskEnvelope: TaskEnvelope): string {
+  const memory = taskEnvelope.subject.memory ?? [];
+  if (memory.length === 0) return '';
+  const entries = memory.slice(0, 8).map((item) => {
+    const source = [
+      item.sourceTaskId ? `task=${item.sourceTaskId}` : '',
+      item.sourceRunId ? `run=${item.sourceRunId}` : '',
+      item.sourceEventIds.length > 0 ? `events=${item.sourceEventIds.join(',')}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    return [
+      `### ${item.reflectionId}`,
+      `- Category: ${item.category}`,
+      `- Confidence: ${item.confidence.toFixed(2)}`,
+      `- Relevance: ${item.relevanceScore.toFixed(2)}`,
+      source ? `- Source: ${source}` : '',
+      `- Lesson: ${item.summary}`,
+      `- Guidance: ${item.guidance}`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+  });
+  return `## Accepted Memory
+
+These human-reviewed items were selected for this run. Their reflection IDs and source identities are durable attribution, not new instructions from unreviewed output.
+
+${entries.join('\n\n')}
+
+`;
 }
 
 function renderWorkspace(taskEnvelope: TaskEnvelope): string {

--- a/server/src/services/reflection-service.ts
+++ b/server/src/services/reflection-service.ts
@@ -18,6 +18,7 @@ import type {
   ReflectionSourceKind,
   RejectReflectionCandidateInput,
   Task,
+  TaskEnvelopeMemoryReference,
 } from '@veritas-kanban/shared';
 import { auditLog, type AuditEvent } from './audit-service.js';
 import { withFileLock } from './file-lock.js';
@@ -25,13 +26,17 @@ import { getTaskService } from './task-service.js';
 import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
 import { ensureWithinBase, stripHtml, validatePathSegment } from '../utils/sanitize.js';
 import { getRuntimeDir } from '../utils/paths.js';
+import { createLogger } from '../lib/logger.js';
 
+const log = createLogger('reflection');
 const MAX_CANDIDATES = 2000;
 const MAX_TEXT_LENGTH = 4000;
 const MAX_EVIDENCE_ITEMS = 10;
 const MAX_TAGS = 20;
 const MAX_CONTRADICTION_IDS = 20;
 const MAX_SOURCE_EVENT_IDS = 20;
+const MAX_RETRIEVALS_PER_CANDIDATE = 100;
+const DEFAULT_RETRIEVAL_LIMIT = 8;
 
 interface ReflectionState {
   version: 1;
@@ -45,6 +50,15 @@ export interface ReflectionListFilters {
   sourceKind?: ReflectionSourceKind;
   taskId?: string;
   limit?: number;
+}
+
+export interface ReflectionRetrievalInput {
+  task: Pick<Task, 'id' | 'title' | 'description' | 'project' | 'lessonTags'>;
+  workspaceId: string;
+  attemptId: string;
+  retrievedAt: string;
+  limit?: number;
+  recordAttribution?: boolean;
 }
 
 export interface ReflectionTaskService {
@@ -154,6 +168,105 @@ export class ReflectionService {
       duplicateGroups: this.duplicateGroups(filtered),
       total: filtered.length,
     };
+  }
+
+  async retrieveForTask(input: ReflectionRetrievalInput): Promise<TaskEnvelopeMemoryReference[]> {
+    await this.ensureLoaded();
+    const limit = Math.max(1, Math.min(Math.floor(input.limit ?? DEFAULT_RETRIEVAL_LIMIT), 20));
+    const queryTokens = tokenizeReflectionText(
+      [
+        input.task.title,
+        input.task.description,
+        input.task.project,
+        ...(input.task.lessonTags ?? []),
+      ]
+        .filter(Boolean)
+        .join(' ')
+    );
+    const ranked = this.state.candidates
+      .filter(
+        (candidate) =>
+          candidate.status === 'accepted' &&
+          candidate.source.taskId === input.task.id &&
+          (candidate.appliedTargets ?? []).some((target) => target.kind === 'task-lesson')
+      )
+      .map((candidate) => ({
+        candidate,
+        score: reflectionRelevanceScore(candidate, input.task.id, queryTokens, input.retrievedAt),
+      }))
+      .sort(
+        (left, right) =>
+          right.score - left.score ||
+          right.candidate.confidence - left.candidate.confidence ||
+          Date.parse(right.candidate.updatedAt) - Date.parse(left.candidate.updatedAt) ||
+          left.candidate.id.localeCompare(right.candidate.id)
+      )
+      .slice(0, limit);
+
+    const references = ranked.map(({ candidate, score }) => ({
+      reflectionId: candidate.id.slice(0, 160),
+      sourceTaskId: candidate.source.taskId?.slice(0, 160),
+      sourceRunId: candidate.source.runId?.slice(0, 160),
+      sourceEventIds:
+        candidate.source.eventIds
+          ?.slice(0, MAX_SOURCE_EVENT_IDS)
+          .map((eventId) => eventId.trim().slice(0, 160))
+          .filter(Boolean) ?? [],
+      category: candidate.category,
+      summary:
+        candidate.summary ||
+        candidate.correction ||
+        candidate.nextAttempt ||
+        'Reviewed reflection lesson.',
+      guidance:
+        candidate.nextAttempt ||
+        candidate.correction ||
+        candidate.summary ||
+        'Apply the reviewed lesson when relevant.',
+      confidence: candidate.confidence,
+      relevanceScore: score,
+      retrievalCount: (candidate.retrievalCount ?? 0) + (input.recordAttribution ? 1 : 0),
+      retrievedAt: input.retrievedAt,
+    }));
+
+    if (input.recordAttribution && ranked.length > 0) {
+      for (const { candidate, score } of ranked) {
+        candidate.retrievalCount = (candidate.retrievalCount ?? 0) + 1;
+        candidate.lastRetrievedAt = input.retrievedAt;
+        candidate.retrievals = [
+          ...(candidate.retrievals ?? []),
+          {
+            taskId: input.task.id,
+            attemptId: input.attemptId,
+            workspaceId: input.workspaceId,
+            relevanceScore: score,
+            retrievedAt: input.retrievedAt,
+          },
+        ].slice(-MAX_RETRIEVALS_PER_CANDIDATE);
+      }
+      await this.saveState();
+      for (const { candidate, score } of ranked) {
+        await this.audit({
+          action: 'reflection.retrieved',
+          actor: 'system',
+          resource: candidate.id,
+          details: {
+            taskId: input.task.id,
+            attemptId: input.attemptId,
+            workspaceId: input.workspaceId,
+            relevanceScore: score,
+            retrievalCount: candidate.retrievalCount,
+          },
+        }).catch((error) => {
+          log.warn(
+            { err: error, reflectionId: candidate.id, attemptId: input.attemptId },
+            'Failed to append reflection retrieval audit event'
+          );
+        });
+      }
+    }
+
+    return references;
   }
 
   async create(input: CreateReflectionCandidateInput): Promise<ReflectionCandidate> {
@@ -588,6 +701,55 @@ export class ReflectionService {
       },
     });
   }
+}
+
+function tokenizeReflectionText(value: string): Set<string> {
+  return new Set(
+    value
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .map((token) => token.trim())
+      .filter((token) => token.length >= 3)
+      .slice(0, 256)
+  );
+}
+
+function reflectionRelevanceScore(
+  candidate: ReflectionCandidate,
+  taskId: string,
+  queryTokens: Set<string>,
+  retrievedAt: string
+): number {
+  const candidateTokens = tokenizeReflectionText(
+    [
+      candidate.summary,
+      candidate.correction,
+      candidate.nextAttempt,
+      candidate.applicability,
+      ...(candidate.tags ?? []),
+    ]
+      .filter(Boolean)
+      .join(' ')
+  );
+  const overlap = [...candidateTokens].filter((token) => queryTokens.has(token)).length;
+  const overlapRatio =
+    candidateTokens.size === 0 || queryTokens.size === 0
+      ? 0
+      : overlap / Math.min(candidateTokens.size, queryTokens.size);
+  const exactTaskBoost = candidate.source.taskId === taskId ? 0.5 : 0;
+  const relevance = Math.min(0.3, overlapRatio * 0.3);
+  const confidence = candidate.confidence * 0.12;
+  const observedUse = Math.min(0.06, Math.log1p(candidate.retrievalCount ?? 0) * 0.02);
+  const retrievedTime = Date.parse(retrievedAt);
+  const candidateTime = Date.parse(candidate.reviewedAt ?? candidate.updatedAt);
+  const ageDays =
+    Number.isFinite(retrievedTime) && Number.isFinite(candidateTime)
+      ? Math.max(0, (retrievedTime - candidateTime) / 86_400_000)
+      : 365;
+  const freshness = Math.max(0, 0.02 - Math.min(ageDays, 365) * (0.02 / 365));
+  return Number(
+    Math.min(1, exactTaskBoost + relevance + confidence + observedUse + freshness).toFixed(6)
+  );
 }
 
 let reflectionService: ReflectionService | null = null;

--- a/server/src/services/task-envelope-service.ts
+++ b/server/src/services/task-envelope-service.ts
@@ -19,6 +19,7 @@ import {
   type TaskExpectedOutput,
   type TaskLaunchBaseline,
   type TaskLaunchBaselineFile,
+  type TaskEnvelopeMemoryReference,
 } from '@veritas-kanban/shared';
 import { parseTaskEnvelope } from '../schemas/task-envelope-schemas.js';
 import {
@@ -26,7 +27,10 @@ import {
   type TaskEnvelopePayload,
 } from '../utils/task-envelope-digest.js';
 import { sha256WorktreeEntry } from '../utils/worktree-fingerprint.js';
+import { createLogger } from '../lib/logger.js';
+import { getReflectionService, type ReflectionRetrievalInput } from './reflection-service.js';
 
+const log = createLogger('task-envelope');
 const MAX_BASELINE_FILES = 1000;
 const BASELINE_GIT_TIMEOUT_MS = 10_000;
 const MAX_BASELINE_CAPTURE_ATTEMPTS = 3;
@@ -250,9 +254,14 @@ export interface BuildTaskEnvelopeInput {
   executionPolicy?: TaskExecutionPolicy;
 }
 
+export interface TaskMemoryRetriever {
+  retrieveForTask(input: ReflectionRetrievalInput): Promise<TaskEnvelopeMemoryReference[]>;
+}
+
 export class TaskEnvelopeService {
   constructor(
-    private readonly evidenceSource: CompletionEvidenceSource = new GitCompletionEvidenceSource()
+    private readonly evidenceSource: CompletionEvidenceSource = new GitCompletionEvidenceSource(),
+    private readonly memoryRetriever: TaskMemoryRetriever = getReflectionService()
   ) {}
 
   async build(input: BuildTaskEnvelopeInput): Promise<TaskEnvelope> {
@@ -260,6 +269,25 @@ export class TaskEnvelopeService {
       input.worktreePath,
       input.createdAt
     );
+    const workspaceId = normalizeWorkspaceId(
+      input.task.project?.trim() || input.task.git?.repo || input.task.id
+    );
+    let memory: TaskEnvelopeMemoryReference[] = [];
+    try {
+      memory = await this.memoryRetriever.retrieveForTask({
+        task: input.task,
+        workspaceId,
+        attemptId: input.attemptId,
+        retrievedAt: input.createdAt,
+        recordAttribution: !input.attemptId.startsWith('preview_'),
+        limit: 8,
+      });
+    } catch (error) {
+      log.warn(
+        { err: error, taskId: input.task.id, attemptId: input.attemptId },
+        'Accepted reflection retrieval failed; continuing without memory context'
+      );
+    }
     const payload: TaskEnvelopePayload = {
       schemaVersion: TASK_ENVELOPE_SCHEMA_VERSION,
       subject: {
@@ -281,15 +309,14 @@ export class TaskEnvelopeService {
         acceptanceCriteria: compactTaskEnvelopeStrings(
           (input.task.subtasks ?? []).flatMap((subtask) => subtask.acceptanceCriteria ?? [])
         ).slice(0, 256),
+        ...(memory.length > 0 ? { memory } : {}),
       },
       attempt: {
         id: input.attemptId,
         createdAt: input.createdAt,
       },
       workspace: {
-        workspaceId: normalizeWorkspaceId(
-          input.task.project?.trim() || input.task.git?.repo || input.task.id
-        ),
+        workspaceId,
         worktreeId: input.task.id,
         ...(input.task.git?.worktreeManifestId
           ? { worktreeManifestId: input.task.git.worktreeManifestId }

--- a/shared/src/types/reflection.types.ts
+++ b/shared/src/types/reflection.types.ts
@@ -43,6 +43,14 @@ export interface ReflectionRedactionSummary {
   notes: string[];
 }
 
+export interface ReflectionRetrievalAttribution {
+  taskId: string;
+  attemptId: string;
+  workspaceId: string;
+  relevanceScore: number;
+  retrievedAt: string;
+}
+
 export interface ReflectionCandidate {
   id: string;
   idempotencyKey?: string;
@@ -77,6 +85,9 @@ export interface ReflectionCandidate {
   deletedBy?: string;
   deleteReason?: string;
   mergedInto?: string;
+  retrievalCount?: number;
+  lastRetrievedAt?: string;
+  retrievals?: ReflectionRetrievalAttribution[];
 }
 
 export interface ReflectionDuplicateGroup {

--- a/shared/src/types/task-envelope.types.ts
+++ b/shared/src/types/task-envelope.types.ts
@@ -105,6 +105,21 @@ export interface TaskEnvelopeSubject {
   background: string[];
   constraints: string[];
   acceptanceCriteria: string[];
+  memory?: TaskEnvelopeMemoryReference[];
+}
+
+export interface TaskEnvelopeMemoryReference {
+  reflectionId: string;
+  sourceTaskId?: string;
+  sourceRunId?: string;
+  sourceEventIds: string[];
+  category: string;
+  summary: string;
+  guidance: string;
+  confidence: number;
+  relevanceScore: number;
+  retrievalCount: number;
+  retrievedAt: string;
 }
 
 export interface TaskEnvelopeAttempt {


### PR DESCRIPTION
## Summary

- rank human-accepted task lessons by relevance, confidence, freshness, and observed use
- bind at most eight reviewed lessons plus reflection, source run, and source event attribution into immutable task envelopes
- render the same Accepted Memory section for every executable harness while keeping preview retrievals non-mutating
- record bounded retrieval attribution on accepted candidates for later usefulness and regression analysis
- document the provider-neutral memory contract

## Verification

- `node_modules/.bin/tsc -p shared/tsconfig.json`
- `node_modules/.bin/tsc -p server/tsconfig.json --noEmit`
- `32` focused server tests passed for reflection ranking, task-envelope validation, and all provider renderers
- targeted ESLint passed
- `git diff --check`

Part of #866.
