### PR TITLE
feat: add typed reviewed reflection promotions

### DIFF
--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -634,6 +634,11 @@ CLI, Codex SDK, Codex app-server, Claude Code, and Hermes renderers all include
 the envelope digest, runtime identity, objective and bounded context, a bounded
 workspace-baseline summary, explicit commit policy, allowed side effects,
 expected outputs, verification gates, and completion evidence contract.
+When reviewed reflection lessons are relevant, every renderer also receives
+the same bounded **Accepted Memory** section. Each entry includes its stable
+reflection ID and source task, run, and event attribution. Harnesses should
+treat these as human-reviewed supporting guidance and preserve the identifiers
+when reporting whether a lesson helped or regressed the run.
 Profile instructions and saved task checkpoints are rendered as separate,
 attributed sections and are capped at 20,000 characters each. The persisted
 task envelope retains the complete baseline fingerprints used for later

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -3821,7 +3821,39 @@ POST /api/reflections/:id/accept
 }
 ```
 
-For `task-lesson`, the candidate must have a linked `source.taskId`; acceptance appends a reviewed reflection lesson to that task and adds `reflection` lesson tags. Other promotion targets are recorded as manual-review targets and do not mutate policy, profile, template, or memory stores automatically.
+For `task-lesson`, the candidate must have a linked `source.taskId`;
+acceptance appends a reviewed reflection lesson to that task and adds
+`reflection` lesson tags.
+
+Wider targets fail closed unless the request supplies a matching typed
+`promotion` object. The authenticated actor is the reviewer when `reviewedBy`
+is omitted. For example, a profile capability promotion is:
+
+```json
+{
+  "promotionTarget": "profile",
+  "promotion": {
+    "target": "profile",
+    "profileId": "backend-reviewer",
+    "capabilitiesToAdd": ["schema-review"]
+  },
+  "reviewerNote": "Approved for this profile."
+}
+```
+
+Typed inputs are available for:
+
+- `memory`: `workspaceId`
+- `team`: `rosterId`, `memberId`, and `capabilitiesToAdd`
+- `profile`: `profileId` and `capabilitiesToAdd`
+- `template`: `templateId`; the redacted candidate guidance is appended with a stable reflection marker
+- `decision`: `agentId`, `taskId`, `confidenceLevel`, `riskScore`, and optional `parentDecisionId`
+- `policy`: a complete validated `AgentPolicy`
+
+Each adapter writes through the existing target service, records the applied
+target on the reflection audit event, and is retry-safe for its target. A
+missing adapter, mismatched target, unknown target record, or incomplete typed
+payload rejects the acceptance without marking the candidate accepted.
 
 ### Reject or Merge
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -3717,14 +3717,17 @@ Reviewed queue for turning corrections, repeated mistakes, and failure lessons i
 
 Mounted at `/api/reflections`. Requires `workflow:read` for reads and `workflow:write` for writes.
 
-| Method   | Path                          | Description                                                             |
-| -------- | ----------------------------- | ----------------------------------------------------------------------- |
-| `GET`    | `/api/reflections`            | List candidates with filters for status, category, source kind, task ID |
-| `POST`   | `/api/reflections`            | Create a reflection candidate from a linked source                      |
-| `POST`   | `/api/reflections/:id/accept` | Accept a pending candidate and apply its reviewed promotion             |
-| `POST`   | `/api/reflections/:id/reject` | Reject a pending candidate without affecting future context             |
-| `POST`   | `/api/reflections/:id/merge`  | Soft-merge a duplicate into its representative candidate                |
-| `DELETE` | `/api/reflections/:id`        | Soft-delete a candidate while preserving audit history                  |
+| Method   | Path                                           | Description                                                             |
+| -------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
+| `GET`    | `/api/reflections`                             | List candidates with filters for status, category, source kind, task ID |
+| `POST`   | `/api/reflections`                             | Create a reflection candidate from a linked source                      |
+| `GET`    | `/api/reflections/consolidation/proposals`     | List durable proposals, optionally for one memory domain                |
+| `POST`   | `/api/reflections/consolidation/proposals`     | Create an idempotent proposal from explicit candidate IDs               |
+| `GET`    | `/api/reflections/consolidation/proposals/:id` | Inspect one proposal and its reviewer-facing diff                       |
+| `POST`   | `/api/reflections/:id/accept`                  | Accept a pending candidate and apply its reviewed promotion             |
+| `POST`   | `/api/reflections/:id/reject`                  | Reject a pending candidate without affecting future context             |
+| `POST`   | `/api/reflections/:id/merge`                   | Soft-merge a duplicate into its representative candidate                |
+| `DELETE` | `/api/reflections/:id`                         | Soft-delete a candidate while preserving audit history                  |
 
 Candidates support `session`, `agent`, `team`, `policy`, and `template` categories. Sources can link to `task-run`, `chat-message`, `error`, `user-correction`, `review-feedback`, or `task-observation`.
 
@@ -3771,6 +3774,36 @@ automated extractors to make candidate creation retry-safe. Tokens,
 credential-looking values, and `/Users/...` private paths are redacted before
 storage. Extracted candidates remain pending and cannot affect task lessons or
 agent context until accepted.
+
+### Create a Consolidation Proposal
+
+```http
+POST /api/reflections/consolidation/proposals
+```
+
+```json
+{
+  "domain": {
+    "kind": "workspace-memory",
+    "id": "primary",
+    "workspaceId": "workspace_1"
+  },
+  "candidateIds": ["reflection_1", "reflection_2"],
+  "policy": {
+    "staleAfterDays": 180,
+    "unusedAfterDays": 90,
+    "minimumConfidence": 0.5,
+    "maxCandidates": 500
+  }
+}
+```
+
+The server locks proposal computation per memory domain, rejects unknown or
+over-limit candidate sets, and persists an idempotent
+`reflection-consolidation-proposal/v1` record. The proposal includes the
+effective policy, source digest, stable duplicate clusters, and inspectable
+merge, contradiction, decay, and wider-promotion review operations. Creating a
+proposal never deletes, accepts, or promotes a candidate.
 
 ### Accept Candidate
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -2733,6 +2733,13 @@ three times when HEAD, status, or fingerprints move, and fails closed if the
 worktree never stabilizes. Existing attempt records without an envelope remain
 readable.
 
+New envelopes may also include `subject.memory`, a maximum of eight ranked,
+human-accepted reflection lessons. Each item carries `reflectionId`, source
+task/run/event IDs, confidence, relevance, observed retrieval count, and the
+retrieval timestamp. The persisted envelope is the authoritative record of
+which reviewed memory influenced an attempt. Preview attempts select the same
+bounded context without incrementing observed use.
+
 Task create/update payloads may set reusable defaults under
 `executionPolicy`:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -610,6 +610,7 @@ Reviewed promotion queue for agent corrections, repeated mistakes, and durable l
 - **Ranked reviewed retrieval** — Accepted task lessons are selected by task relevance, confidence, freshness, and observed use; only the top eight enter a run
 - **Run attribution** — Persisted task envelopes carry the reflection, source run, and source event IDs that influenced the run; preview envelopes do not increment use
 - **Inspectable consolidation proposals** — Explicit candidate sets are serialized per memory domain into durable, idempotent merge, contradiction, decay, and wider-promotion review diffs; no candidate is silently deleted or promoted
+- **Typed durable promotions** — Memory, team roster, agent profile, task template, decision, and policy changes require an authenticated reviewer plus target-specific validated input; unowned targets fail closed
 - **Settings UI** — Review, accept, reject, delete, and merge candidates from Settings → Reflections
 - **Audit trail** — Create, accept, reject, merge, and delete actions write metadata-only audit events
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -609,6 +609,7 @@ Reviewed promotion queue for agent corrections, repeated mistakes, and durable l
 - **Safe pending output** — Extracted candidates include run/event attribution, proposed scope, confidence, rationale, applicability, and contradiction links; deterministic candidate idempotency prevents duplicates after retries
 - **Ranked reviewed retrieval** — Accepted task lessons are selected by task relevance, confidence, freshness, and observed use; only the top eight enter a run
 - **Run attribution** — Persisted task envelopes carry the reflection, source run, and source event IDs that influenced the run; preview envelopes do not increment use
+- **Inspectable consolidation proposals** — Explicit candidate sets are serialized per memory domain into durable, idempotent merge, contradiction, decay, and wider-promotion review diffs; no candidate is silently deleted or promoted
 - **Settings UI** — Review, accept, reject, delete, and merge candidates from Settings → Reflections
 - **Audit trail** — Create, accept, reject, merge, and delete actions write metadata-only audit events
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -607,6 +607,8 @@ Reviewed promotion queue for agent corrections, repeated mistakes, and durable l
 - **Non-blocking completion intake** — Eligible terminal completions schedule extraction after the authoritative task update; interrupted or empty completions are skipped
 - **Bounded extraction worker** — The background worker reloads the identified durable completion, verifies its identity and digest, and exposes only bounded summaries, blockers, verified evidence, and verification results to a typed extractor
 - **Safe pending output** — Extracted candidates include run/event attribution, proposed scope, confidence, rationale, applicability, and contradiction links; deterministic candidate idempotency prevents duplicates after retries
+- **Ranked reviewed retrieval** — Accepted task lessons are selected by task relevance, confidence, freshness, and observed use; only the top eight enter a run
+- **Run attribution** — Persisted task envelopes carry the reflection, source run, and source event IDs that influenced the run; preview envelopes do not increment use
 - **Settings UI** — Review, accept, reject, delete, and merge candidates from Settings → Reflections
 - **Audit trail** — Create, accept, reject, merge, and delete actions write metadata-only audit events
 

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -133,6 +133,12 @@ vi.mock('../services/task-service.js', () => ({
       patchTaskAttempt: mockPatchTaskAttempt,
     };
   },
+  getTaskService: () => ({
+    getTask: mockGetTask,
+    listTasks: mockListTasks,
+    updateTask: mockUpdateTask,
+    patchTaskAttempt: mockPatchTaskAttempt,
+  }),
 }));
 
 vi.mock('../services/telemetry-service.js', () => ({

--- a/server/src/__tests__/provider-task-envelope-renderer.test.ts
+++ b/server/src/__tests__/provider-task-envelope-renderer.test.ts
@@ -4,6 +4,7 @@ import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-mani
 import {
   TaskEnvelopeService,
   type CompletionEvidenceSource,
+  type TaskMemoryRetriever,
 } from '../services/task-envelope-service.js';
 import {
   renderAcpStdioTaskEnvelope,
@@ -73,9 +74,10 @@ function task(provider: string): Task {
 async function envelope(
   provider: string,
   commitPolicy: TaskCommitPolicy,
-  profileInstructions = 'Follow the release checklist.'
+  profileInstructions = 'Follow the release checklist.',
+  memoryRetriever?: TaskMemoryRetriever
 ) {
-  return new TaskEnvelopeService(evidenceSource).build({
+  return new TaskEnvelopeService(evidenceSource, memoryRetriever).build({
     task: task(provider),
     attemptId: 'attempt_transport',
     createdAt,
@@ -88,6 +90,35 @@ async function envelope(
 }
 
 describe('provider task-envelope renderers', () => {
+  it('renders accepted memory with durable reflection and source attribution', async () => {
+    const taskEnvelope = await envelope('codex-cli', 'allowed', 'Follow the release checklist.', {
+      retrieveForTask: async () => [
+        {
+          reflectionId: 'reflection_route_schema',
+          sourceTaskId: 'task_source',
+          sourceRunId: 'attempt_source',
+          sourceEventIds: ['event_source'],
+          category: 'team',
+          summary: 'Read the current route schema before editing.',
+          guidance: 'Inspect the schema and nearby tests first.',
+          confidence: 0.91,
+          relevanceScore: 0.84,
+          retrievalCount: 3,
+          retrievedAt: createdAt,
+        },
+      ],
+    });
+
+    const transport = renderCodexCliTaskEnvelope({ taskEnvelope });
+
+    expect(transport.content).toContain('## Accepted Memory');
+    expect(transport.content).toContain('### reflection_route_schema');
+    expect(transport.content).toContain(
+      'Source: task=task_source run=attempt_source events=event_source'
+    );
+    expect(transport.content).toContain('Guidance: Inspect the schema and nearby tests first.');
+  });
+
   it('renders an OpenClaw callback transport from a required-commit envelope', async () => {
     const taskEnvelope = await envelope('openclaw', 'required');
 

--- a/server/src/__tests__/reflection-consolidation-service.test.ts
+++ b/server/src/__tests__/reflection-consolidation-service.test.ts
@@ -1,0 +1,182 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ReflectionCandidate,
+  ReflectionConsolidationProposal,
+  ReflectionMemoryDomain,
+} from '@veritas-kanban/shared';
+import { ReflectionConsolidationService } from '../services/reflection-consolidation-service.js';
+import { FileReflectionConsolidationProposalRepository } from '../storage/reflection-consolidation-proposal-repository.js';
+
+const roots: string[] = [];
+const domain: ReflectionMemoryDomain = {
+  kind: 'workspace-memory',
+  id: 'primary',
+  workspaceId: 'workspace_1',
+};
+
+function candidate(id: string, overrides: Partial<ReflectionCandidate> = {}): ReflectionCandidate {
+  return {
+    id,
+    status: 'pending',
+    category: 'team',
+    promotionTarget: 'memory',
+    confidence: 0.8,
+    source: { kind: 'task-run', taskId: 'task_1', runId: 'attempt_1' },
+    summary: `Summary ${id}`,
+    previousApproach: 'Old approach',
+    correction: 'Reviewed correction',
+    nextAttempt: 'Use the reviewed correction.',
+    proposedScope: 'workspace',
+    evidence: [],
+    tags: ['workflow'],
+    duplicateKey: `duplicate-${id}`,
+    duplicateCount: 1,
+    appliedTargets: [],
+    redaction: { redacted: false, notes: [] },
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function memoryRepository() {
+  const proposals = new Map<string, ReflectionConsolidationProposal>();
+  return {
+    get: vi.fn(async (id: string) => proposals.get(id)),
+    list: vi.fn(async () => [...proposals.values()]),
+    put: vi.fn(async (proposal: ReflectionConsolidationProposal) => {
+      const existing = proposals.get(proposal.id);
+      if (existing) return existing;
+      proposals.set(proposal.id, proposal);
+      return proposal;
+    }),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe('ReflectionConsolidationService', () => {
+  it('produces stable merge, contradiction, decay, and typed-promotion review diffs', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-reflection-consolidation-'));
+    roots.push(root);
+    const candidates = [
+      candidate('candidate_a', {
+        duplicateKey: 'same-lesson',
+        contradictionIds: ['candidate_c'],
+      }),
+      candidate('candidate_b', { duplicateKey: 'same-lesson', confidence: 0.7 }),
+      candidate('candidate_c', {
+        status: 'accepted',
+        promotionTarget: 'task-lesson',
+        reviewedAt: '2025-01-01T00:00:00.000Z',
+        appliedTargets: [
+          {
+            kind: 'task-lesson',
+            id: 'task_1',
+            appliedAt: '2025-01-01T00:00:00.000Z',
+            appliedBy: 'brad',
+          },
+        ],
+      }),
+      candidate('candidate_policy', { promotionTarget: 'policy', confidence: 0.95 }),
+    ];
+    const repository = memoryRepository();
+    const service = new ReflectionConsolidationService({
+      reflections: { list: vi.fn(async () => ({ candidates })) },
+      proposals: repository,
+      lockDir: root,
+    });
+
+    const first = await service.propose({
+      domain,
+      candidateIds: ['candidate_policy', 'candidate_c', 'candidate_b', 'candidate_a'],
+      createdAt: '2026-07-25T00:00:00.000Z',
+      policy: { unusedAfterDays: 30 },
+    });
+    const retried = await service.propose({
+      domain,
+      candidateIds: ['candidate_a', 'candidate_b', 'candidate_c', 'candidate_policy'],
+      createdAt: '2026-07-26T00:00:00.000Z',
+      policy: { unusedAfterDays: 30 },
+    });
+
+    expect(retried.id).toBe(first.id);
+    expect(retried.sourceDigest).toBe(first.sourceDigest);
+    expect(first.policy.unusedAfterDays).toBe(30);
+    expect(first.clusters.find((cluster) => cluster.clusterKey === 'same-lesson')).toMatchObject({
+      representativeId: 'candidate_a',
+      candidateIds: ['candidate_a', 'candidate_b'],
+    });
+    expect(first.diff.map((entry) => entry.operation)).toEqual(
+      expect.arrayContaining([
+        'merge-review',
+        'contradiction-review',
+        'decay-review',
+        'promotion-review',
+      ])
+    );
+    expect(repository.put).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects candidate sets above the configured bound instead of truncating silently', async () => {
+    const service = new ReflectionConsolidationService({
+      reflections: { list: vi.fn() },
+      proposals: memoryRepository(),
+    });
+
+    await expect(
+      service.propose({
+        domain,
+        candidateIds: ['candidate_a', 'candidate_b'],
+        policy: { maxCandidates: 1 },
+      })
+    ).rejects.toThrow('exceeds the configured maximum of 1');
+  });
+
+  it('serializes proposal computation for the same memory domain', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-reflection-lock-'));
+    roots.push(root);
+    let active = 0;
+    let maxActive = 0;
+    const reflections = {
+      list: vi.fn(async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        active--;
+        return { candidates: [candidate('candidate_a')] };
+      }),
+    };
+    const service = new ReflectionConsolidationService({
+      reflections,
+      proposals: memoryRepository(),
+      lockDir: root,
+    });
+
+    await Promise.all([
+      service.propose({ domain, candidateIds: ['candidate_a'] }),
+      service.propose({ domain, candidateIds: ['candidate_a'] }),
+    ]);
+
+    expect(maxActive).toBe(1);
+  });
+
+  it('persists proposals across file repository restarts', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-reflection-proposals-'));
+    roots.push(root);
+    const service = new ReflectionConsolidationService({
+      reflections: { list: vi.fn(async () => ({ candidates: [candidate('candidate_a')] })) },
+      proposals: new FileReflectionConsolidationProposalRepository(root),
+      lockDir: path.join(root, 'locks'),
+    });
+    const proposal = await service.propose({ domain, candidateIds: ['candidate_a'] });
+
+    const reopened = new FileReflectionConsolidationProposalRepository(root);
+    await expect(reopened.get(proposal.id)).resolves.toEqual(proposal);
+  });
+});

--- a/server/src/__tests__/reflection-promotion-adapters.test.ts
+++ b/server/src/__tests__/reflection-promotion-adapters.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  AgentPolicy,
+  AgentProfilePackage,
+  DecisionRecord,
+  ReflectionCandidate,
+  ReflectionTypedPromotionInput,
+  TaskTemplate,
+  TeamRosterManifest,
+} from '@veritas-kanban/shared';
+import {
+  createBuiltInReflectionPromotionAdapters,
+  ReflectionPromotionAdapterRegistry,
+  type ReflectionPromotionAdapterDependencies,
+} from '../services/reflection-promotion-adapters.js';
+
+function candidate(overrides: Partial<ReflectionCandidate> = {}): ReflectionCandidate {
+  return {
+    id: 'reflection_1',
+    status: 'pending',
+    category: 'team',
+    promotionTarget: 'memory',
+    confidence: 0.8,
+    source: { kind: 'task-run', taskId: 'task_1', runId: 'attempt_1' },
+    summary: 'Use the current schema.',
+    previousApproach: 'Guessed the old schema.',
+    correction: 'Inspect the current schema.',
+    nextAttempt: 'Read the current schema before editing.',
+    rationale: 'The correction is reusable.',
+    evidence: [],
+    tags: ['schema'],
+    duplicateKey: 'schema',
+    duplicateCount: 1,
+    appliedTargets: [],
+    redaction: { redacted: false, notes: [] },
+    createdAt: '2026-07-25T00:00:00.000Z',
+    updatedAt: '2026-07-25T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function harness() {
+  let roster: TeamRosterManifest = {
+    id: 'roster_1',
+    schemaVersion: 'team-roster/v1',
+    workspaceId: 'workspace_1',
+    name: 'Primary',
+    enabled: true,
+    members: [
+      {
+        id: 'member_1',
+        displayName: 'Builder',
+        role: 'Implementation',
+        agent: 'codex',
+        status: 'enabled',
+        capabilities: ['typescript'],
+      },
+    ],
+    routingRules: [],
+  };
+  let profile: AgentProfilePackage = {
+    id: 'profile_1',
+    schemaVersion: 'agent-profile-package/v1',
+    version: '1.0.0',
+    displayName: 'Builder',
+    role: 'Implementation',
+    enabled: true,
+    capabilities: ['typescript'],
+    defaultTaskTypes: ['feature'],
+    runtime: { agent: 'codex' },
+  };
+  let template: TaskTemplate = {
+    id: 'template_1',
+    name: 'Feature',
+    version: 1,
+    taskDefaults: { descriptionTemplate: 'Existing guidance.' },
+    created: '2026-07-25T00:00:00.000Z',
+    updated: '2026-07-25T00:00:00.000Z',
+  };
+  const decisions: DecisionRecord[] = [];
+  const policies = new Map<string, AgentPolicy>();
+  const updateProfile = vi.fn(async (_id: string, patch: { capabilities?: string[] }) => {
+    profile = { ...profile, capabilities: patch.capabilities ?? profile.capabilities };
+    return profile;
+  });
+  const updateTemplate = vi.fn(
+    async (_id: string, patch: { taskDefaults?: TaskTemplate['taskDefaults'] }) => {
+      template = {
+        ...template,
+        taskDefaults: { ...template.taskDefaults, ...patch.taskDefaults },
+      };
+      return template;
+    }
+  );
+  const dependencies: ReflectionPromotionAdapterDependencies = {
+    teamRoster: () => ({
+      async mutateRoster<T>(mutator) {
+        const mutation = mutator(roster, []);
+        roster = mutation.roster;
+        return mutation.result as T;
+      },
+    }),
+    profiles: () => ({
+      getProfile: vi.fn(async () => profile),
+      updateProfile,
+    }),
+    templates: () => ({
+      getTemplate: vi.fn(async () => template),
+      updateTemplate,
+    }),
+    decisions: () => ({
+      list: vi.fn(async () => decisions),
+      create: vi.fn(async (input) => {
+        const decision: DecisionRecord = {
+          id: `decision_${decisions.length + 1}`,
+          inputContext: input.inputContext,
+          outputAction: input.outputAction,
+          assumptions: (input.assumptions ?? []).map((assumption) => ({
+            text: typeof assumption === 'string' ? assumption : assumption.text,
+            status: 'pending',
+          })),
+          confidenceLevel: input.confidenceLevel,
+          riskScore: input.riskScore,
+          parentDecisionId: input.parentDecisionId,
+          agentId: input.agentId,
+          taskId: input.taskId,
+          timestamp: input.timestamp ?? '2026-07-25T00:00:00.000Z',
+        };
+        decisions.push(decision);
+        return decision;
+      }),
+    }),
+    policies: () => ({
+      getPolicy: vi.fn(async (id) => policies.get(id) ?? null),
+      createPolicy: vi.fn(async (policyInput) => {
+        policies.set(policyInput.id, policyInput);
+        return policyInput;
+      }),
+      updatePolicy: vi.fn(async (_id, policyInput) => {
+        policies.set(policyInput.id, policyInput);
+        return policyInput;
+      }),
+    }),
+  };
+  return {
+    registry: new ReflectionPromotionAdapterRegistry(
+      createBuiltInReflectionPromotionAdapters(dependencies)
+    ),
+    getRoster: () => roster,
+    getProfile: () => profile,
+    getTemplate: () => template,
+    getDecisions: () => decisions,
+    getPolicies: () => policies,
+    updateProfile,
+    updateTemplate,
+  };
+}
+
+async function apply(
+  registry: ReflectionPromotionAdapterRegistry,
+  promotion: ReflectionTypedPromotionInput,
+  overrides: Partial<ReflectionCandidate> = {}
+) {
+  return registry.apply({
+    candidate: candidate({ promotionTarget: promotion.target, ...overrides }),
+    promotion,
+    reviewedBy: 'brad',
+    timestamp: '2026-07-25T12:00:00.000Z',
+  });
+}
+
+describe('typed reflection promotion adapters', () => {
+  it('scopes accepted memory to an explicit workspace', async () => {
+    const { registry } = harness();
+
+    await expect(
+      apply(registry, { target: 'memory', workspaceId: 'workspace_1' })
+    ).resolves.toMatchObject({
+      kind: 'memory',
+      id: 'workspace_1',
+      appliedBy: 'brad',
+    });
+  });
+
+  it('adds reviewed team capabilities without replacing the roster', async () => {
+    const { registry, getRoster } = harness();
+
+    const result = await apply(registry, {
+      target: 'team',
+      rosterId: 'roster_1',
+      memberId: 'member_1',
+      capabilitiesToAdd: ['rust', 'typescript'],
+    });
+
+    expect(result).toMatchObject({ kind: 'team', id: 'roster_1:member_1' });
+    expect(getRoster().members[0].capabilities).toEqual(['typescript', 'rust']);
+  });
+
+  it('adds reviewed capabilities through the profile service', async () => {
+    const { registry, getProfile, updateProfile } = harness();
+
+    await apply(registry, {
+      target: 'profile',
+      profileId: 'profile_1',
+      capabilitiesToAdd: ['review', 'typescript'],
+    });
+
+    expect(getProfile().capabilities).toEqual(['typescript', 'review']);
+    expect(updateProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it('appends redacted reviewed guidance to a task template idempotently', async () => {
+    const { registry, getTemplate, updateTemplate } = harness();
+    const promotion: ReflectionTypedPromotionInput = {
+      target: 'template',
+      templateId: 'template_1',
+    };
+
+    await apply(registry, promotion);
+    await apply(registry, promotion);
+
+    expect(getTemplate().taskDefaults.descriptionTemplate).toContain('[Reflection reflection_1]');
+    expect(getTemplate().taskDefaults.descriptionTemplate).toContain(
+      'Read the current schema before editing.'
+    );
+    expect(updateTemplate).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates one source-linked decision across retries', async () => {
+    const { registry, getDecisions } = harness();
+    const promotion: ReflectionTypedPromotionInput = {
+      target: 'decision',
+      agentId: 'codex',
+      taskId: 'task_1',
+      confidenceLevel: 0.8,
+      riskScore: 20,
+    };
+
+    await apply(registry, promotion);
+    await apply(registry, promotion);
+
+    expect(getDecisions()).toHaveLength(1);
+    expect(getDecisions()[0]).toMatchObject({
+      inputContext: expect.stringContaining('[Reflection reflection_1]'),
+      outputAction: 'Read the current schema before editing.',
+    });
+  });
+
+  it('creates or updates a complete policy through the policy service', async () => {
+    const { registry, getPolicies } = harness();
+    const policy: AgentPolicy = {
+      id: 'review-schema',
+      name: 'Review schema',
+      type: 'require-approval',
+      enabled: true,
+      scope: { actionTypes: ['schema-change'] },
+      responseAction: 'require-approval',
+      config: { reason: 'Require review for schema changes.', approvers: ['brad'] },
+    };
+
+    await apply(registry, { target: 'policy', policy });
+    await apply(registry, {
+      target: 'policy',
+      policy: { ...policy, description: 'Updated by a reviewed reflection.' },
+    });
+
+    expect(getPolicies().get(policy.id)?.description).toBe('Updated by a reviewed reflection.');
+  });
+
+  it('fails closed when no adapter owns the requested target', async () => {
+    const registry = new ReflectionPromotionAdapterRegistry([]);
+
+    await expect(apply(registry, { target: 'memory', workspaceId: 'workspace_1' })).rejects.toThrow(
+      'No typed reflection promotion adapter is registered'
+    );
+  });
+});

--- a/server/src/__tests__/reflection-service.test.ts
+++ b/server/src/__tests__/reflection-service.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { CreateReflectionCandidateInput, Task } from '@veritas-kanban/shared';
-import { ReflectionService, type ReflectionTaskService } from '../services/reflection-service.js';
+import {
+  ReflectionService,
+  type ReflectionServiceOptions,
+  type ReflectionTaskService,
+} from '../services/reflection-service.js';
 
 function createInput(
   overrides: Partial<CreateReflectionCandidateInput> = {}
@@ -36,7 +40,10 @@ function createTask(overrides: Partial<Task> = {}): Task {
   } as Task;
 }
 
-function createHarness(task: Task = createTask()) {
+function createHarness(
+  task: Task = createTask(),
+  promotionAdapters?: ReflectionServiceOptions['promotionAdapters']
+) {
   const audit = vi.fn().mockResolvedValue(undefined);
   const updateTask = vi.fn().mockResolvedValue(task);
   const taskService: ReflectionTaskService = {
@@ -51,6 +58,7 @@ function createHarness(task: Task = createTask()) {
       persist: false,
       audit,
       taskService,
+      promotionAdapters,
     }),
   };
 }
@@ -134,6 +142,56 @@ describe('ReflectionService', () => {
       expect.objectContaining({
         lessonsLearned: expect.stringContaining('Reflection Lesson'),
         lessonTags: expect.arrayContaining(['reflection', 'reflection:team']),
+      })
+    );
+  });
+
+  it('fails closed when a wider promotion has no explicit typed target input', async () => {
+    const { service } = createHarness();
+    const candidate = await service.create(
+      createInput({
+        promotionTarget: 'profile',
+      })
+    );
+
+    await expect(
+      service.accept(candidate.id, {
+        reviewedBy: 'brad',
+        promotionTarget: 'profile',
+      })
+    ).rejects.toThrow('requires explicit typed target input');
+  });
+
+  it('records the target returned by the matching typed promotion adapter', async () => {
+    const promotionAdapters = {
+      apply: vi.fn(async () => ({
+        kind: 'profile' as const,
+        id: 'profile_1',
+        title: 'Backend reviewer',
+        appliedAt: '2026-07-25T12:00:00.000Z',
+        appliedBy: 'brad',
+      })),
+    };
+    const { service } = createHarness(createTask(), promotionAdapters);
+    const candidate = await service.create(createInput({ promotionTarget: 'profile' }));
+
+    const accepted = await service.accept(candidate.id, {
+      reviewedBy: 'brad',
+      promotion: {
+        target: 'profile',
+        profileId: 'profile_1',
+        capabilitiesToAdd: ['schema-review'],
+      },
+    });
+
+    expect(accepted).toMatchObject({
+      status: 'accepted',
+      appliedTargets: [{ kind: 'profile', id: 'profile_1', appliedBy: 'brad' }],
+    });
+    expect(promotionAdapters.apply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reviewedBy: 'brad',
+        promotion: expect.objectContaining({ target: 'profile', profileId: 'profile_1' }),
       })
     );
   });

--- a/server/src/__tests__/reflection-service.test.ts
+++ b/server/src/__tests__/reflection-service.test.ts
@@ -138,6 +138,101 @@ describe('ReflectionService', () => {
     );
   });
 
+  it('ranks accepted lessons and records immutable run attribution', async () => {
+    const task = createTask({
+      title: 'Repair the current route schema',
+      description: 'Inspect route contracts before editing.',
+    });
+    const { service, audit } = createHarness(task);
+    const exact = await service.create(
+      createInput({
+        confidence: 0.9,
+        source: {
+          kind: 'user-correction',
+          taskId: task.id,
+          runId: 'attempt_source',
+          eventIds: ['event_source'],
+        },
+      })
+    );
+    await service.accept(exact.id, { reviewedBy: 'brad' });
+    const lowerRelevance = await service.create(
+      createInput({
+        confidence: 0.55,
+        summary: 'Tune image rendering for a later pass.',
+        correction: 'Inspect the image pipeline.',
+        nextAttempt: 'Run image snapshots.',
+        source: { kind: 'task-run', taskId: task.id, runId: 'attempt_image' },
+      })
+    );
+    await service.accept(lowerRelevance.id, { reviewedBy: 'brad' });
+    const unrelated = await service.create(
+      createInput({
+        summary: 'Tune unrelated image rendering.',
+        correction: 'Inspect the image pipeline.',
+        nextAttempt: 'Run image snapshots.',
+        source: { kind: 'task-run', taskId: 'task_other', runId: 'attempt_other' },
+      })
+    );
+    await service.accept(unrelated.id, { reviewedBy: 'brad' });
+
+    const selected = await service.retrieveForTask({
+      task,
+      workspaceId: 'veritas-kanban',
+      attemptId: 'attempt_next',
+      retrievedAt: '2026-07-25T20:00:00.000Z',
+      recordAttribution: true,
+    });
+
+    expect(selected[0]).toMatchObject({
+      reflectionId: exact.id,
+      sourceTaskId: task.id,
+      sourceRunId: 'attempt_source',
+      sourceEventIds: ['event_source'],
+      retrievalCount: 1,
+    });
+    expect(selected.map((item) => item.reflectionId)).toEqual([exact.id, lowerRelevance.id]);
+    expect(selected.some((item) => item.reflectionId === unrelated.id)).toBe(false);
+    const listed = await service.list({ status: 'accepted' });
+    expect(listed.candidates.find((candidate) => candidate.id === exact.id)).toMatchObject({
+      retrievalCount: 1,
+      lastRetrievedAt: '2026-07-25T20:00:00.000Z',
+      retrievals: [
+        {
+          taskId: task.id,
+          attemptId: 'attempt_next',
+          workspaceId: 'veritas-kanban',
+        },
+      ],
+    });
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'reflection.retrieved',
+        resource: exact.id,
+        details: expect.objectContaining({ attemptId: 'attempt_next' }),
+      })
+    );
+  });
+
+  it('previews accepted memory without incrementing observed use', async () => {
+    const task = createTask();
+    const { service } = createHarness(task);
+    const candidate = await service.create(createInput());
+    await service.accept(candidate.id, { reviewedBy: 'brad' });
+
+    const preview = await service.retrieveForTask({
+      task,
+      workspaceId: 'veritas-kanban',
+      attemptId: 'preview_1',
+      retrievedAt: '2026-07-25T20:00:00.000Z',
+      recordAttribution: false,
+    });
+
+    expect(preview[0].retrievalCount).toBe(0);
+    const listed = await service.list({ status: 'accepted' });
+    expect(listed.candidates[0].retrievalCount).toBeUndefined();
+  });
+
   it('keeps rejected candidates auditable without applying lessons', async () => {
     const { service, updateTask } = createHarness();
     const candidate = await service.create(createInput());

--- a/server/src/__tests__/routes/reflections.test.ts
+++ b/server/src/__tests__/routes/reflections.test.ts
@@ -191,6 +191,30 @@ describe('reflection routes', () => {
     });
   });
 
+  it('validates typed wider-promotion input before acceptance', async () => {
+    const res = await request(createApp())
+      .post('/api/reflections/reflection_1/accept')
+      .send({
+        promotionTarget: 'profile',
+        promotion: {
+          target: 'profile',
+          profileId: 'profile_1',
+          capabilitiesToAdd: ['schema-review'],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockReflectionService.accept).toHaveBeenCalledWith('reflection_1', {
+      reviewedBy: 'brad',
+      promotionTarget: 'profile',
+      promotion: {
+        target: 'profile',
+        profileId: 'profile_1',
+        capabilitiesToAdd: ['schema-review'],
+      },
+    });
+  });
+
   it('rejects candidates without a source identifier', async () => {
     const res = await request(createApp())
       .post('/api/reflections')

--- a/server/src/__tests__/routes/reflections.test.ts
+++ b/server/src/__tests__/routes/reflections.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import express, { type NextFunction, type Request, type Response } from 'express';
 import request from 'supertest';
 
-const { mockReflectionService } = vi.hoisted(() => ({
+const { mockReflectionService, mockConsolidationService } = vi.hoisted(() => ({
   mockReflectionService: {
     list: vi.fn(),
     create: vi.fn(),
@@ -11,10 +11,19 @@ const { mockReflectionService } = vi.hoisted(() => ({
     delete: vi.fn(),
     mergeDuplicate: vi.fn(),
   },
+  mockConsolidationService: {
+    propose: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+  },
 }));
 
 vi.mock('../../services/reflection-service.js', () => ({
   getReflectionService: () => mockReflectionService,
+}));
+
+vi.mock('../../services/reflection-consolidation-service.js', () => ({
+  getReflectionConsolidationService: () => mockConsolidationService,
 }));
 
 import { reflectionRoutes } from '../../routes/reflections.js';
@@ -49,6 +58,26 @@ const candidate = {
   updatedAt: '2026-06-26T12:00:00.000Z',
 };
 
+const proposal = {
+  schemaVersion: 'reflection-consolidation-proposal/v1',
+  id: 'reflection_proposal_1',
+  domain: { kind: 'workspace-memory', id: 'primary', workspaceId: 'workspace_1' },
+  state: 'proposed',
+  revision: 1,
+  sourceDigest: `sha256:${'a'.repeat(64)}`,
+  policy: {
+    staleAfterDays: 180,
+    unusedAfterDays: 90,
+    minimumConfidence: 0.5,
+    maxCandidates: 500,
+  },
+  clusters: [],
+  diff: [],
+  candidateIds: ['reflection_1'],
+  createdAt: '2026-07-25T12:00:00.000Z',
+  updatedAt: '2026-07-25T12:00:00.000Z',
+};
+
 function createApp() {
   const app = express();
   app.use(express.json());
@@ -80,6 +109,32 @@ describe('reflection routes', () => {
       status: 'deleted',
       mergedInto: 'reflection_0',
     });
+    mockConsolidationService.propose.mockResolvedValue(proposal);
+    mockConsolidationService.get.mockResolvedValue(proposal);
+    mockConsolidationService.list.mockResolvedValue([proposal]);
+  });
+
+  it('creates and inspects bounded consolidation proposals', async () => {
+    const app = createApp();
+    const created = await request(app)
+      .post('/api/reflections/consolidation/proposals')
+      .send({
+        domain: { kind: 'workspace-memory', id: 'primary', workspaceId: 'workspace_1' },
+        candidateIds: ['reflection_1'],
+      });
+    const listed = await request(app).get(
+      '/api/reflections/consolidation/proposals?kind=workspace-memory&id=primary&workspaceId=workspace_1'
+    );
+    const fetched = await request(app).get(
+      '/api/reflections/consolidation/proposals/reflection_proposal_1'
+    );
+
+    expect(created.status).toBe(201);
+    expect(listed.body.proposals).toHaveLength(1);
+    expect(fetched.body.id).toBe('reflection_proposal_1');
+    expect(mockConsolidationService.propose).toHaveBeenCalledWith(
+      expect.objectContaining({ candidateIds: ['reflection_1'] })
+    );
   });
 
   it('lists reflection candidates with validated filters', async () => {

--- a/server/src/__tests__/services/clawdbot-reconcile.test.ts
+++ b/server/src/__tests__/services/clawdbot-reconcile.test.ts
@@ -43,6 +43,11 @@ vi.mock('../../services/task-service.js', () => ({
     getTask = mockGetTask;
     updateTask = mockUpdateTask;
   },
+  getTaskService: () => ({
+    listTasks: mockListTasks,
+    getTask: mockGetTask,
+    updateTask: mockUpdateTask,
+  }),
 }));
 
 vi.mock('../../services/config-service.js', () => {

--- a/server/src/__tests__/task-envelope-service.test.ts
+++ b/server/src/__tests__/task-envelope-service.test.ts
@@ -215,6 +215,67 @@ describe('TaskEnvelopeService', () => {
     expect(TaskEnvelopeSchema.safeParse(tampered).success).toBe(false);
   });
 
+  it('binds ranked accepted memory and retrieval attribution into the envelope', async () => {
+    const retrieveForTask = vi.fn().mockResolvedValue([
+      {
+        reflectionId: 'reflection_route_schema',
+        sourceTaskId: 'task_source',
+        sourceRunId: 'attempt_source',
+        sourceEventIds: ['event_source'],
+        category: 'team',
+        summary: 'Read the current route schema before editing.',
+        guidance: 'Inspect the schema and nearby tests first.',
+        confidence: 0.91,
+        relevanceScore: 0.84,
+        retrievalCount: 3,
+        retrievedAt: createdAt,
+      },
+    ]);
+    const result = await new TaskEnvelopeService(evidenceSource, { retrieveForTask }).build({
+      task: task(),
+      attemptId: 'attempt_memory',
+      createdAt,
+      worktreePath: '/tmp/veritas-kanban-task',
+      providerRuntimeManifest: providerRuntimeManifestFixture(),
+      commitPolicy: 'allowed',
+    });
+
+    expect(retrieveForTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({ id: 'task_20260716_contract' }),
+        workspaceId: 'veritas-kanban',
+        attemptId: 'attempt_memory',
+        recordAttribution: true,
+        limit: 8,
+      })
+    );
+    expect(result.subject.memory).toEqual([
+      expect.objectContaining({
+        reflectionId: 'reflection_route_schema',
+        sourceEventIds: ['event_source'],
+        relevanceScore: 0.84,
+      }),
+    ]);
+    expect(TaskEnvelopeSchema.safeParse(result).success).toBe(true);
+    expect(verifyTaskEnvelopeDigest(result)).toBe(true);
+  });
+
+  it('does not record observed use while building a preview envelope', async () => {
+    const retrieveForTask = vi.fn().mockResolvedValue([]);
+    await new TaskEnvelopeService(evidenceSource, { retrieveForTask }).build({
+      task: task(),
+      attemptId: 'preview_memory',
+      createdAt,
+      worktreePath: '/tmp/veritas-kanban-task',
+      providerRuntimeManifest: providerRuntimeManifestFixture(),
+      commitPolicy: 'allowed',
+    });
+
+    expect(retrieveForTask).toHaveBeenCalledWith(
+      expect.objectContaining({ recordAttribution: false })
+    );
+  });
+
   it('resolves run, task, legacy, and compatible default commit policy precedence', () => {
     expect(TaskExecutionPolicySchema.safeParse({ commitPolicy: 'sometimes' }).success).toBe(false);
     expect(

--- a/server/src/routes/reflections.ts
+++ b/server/src/routes/reflections.ts
@@ -5,6 +5,7 @@ import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { getReflectionConsolidationService } from '../services/reflection-consolidation-service.js';
 import { getReflectionService } from '../services/reflection-service.js';
+import { policySchema } from '../schemas/policy-schemas.js';
 
 const router: RouterType = Router();
 
@@ -21,6 +22,7 @@ const sourceKindSchema = z.enum([
 const promotionTargetSchema = z.enum([
   'task-lesson',
   'memory',
+  'team',
   'decision',
   'profile',
   'template',
@@ -39,6 +41,41 @@ const memoryDomainSchema = z.object({
   id: z.string().trim().min(1).max(160),
   workspaceId: z.string().trim().min(1).max(160),
 });
+const targetIdSchema = z.string().trim().min(1).max(160);
+const capabilitySchema = z.string().trim().min(1).max(160);
+const typedPromotionSchema = z.discriminatedUnion('target', [
+  z.object({
+    target: z.literal('memory'),
+    workspaceId: targetIdSchema,
+  }),
+  z.object({
+    target: z.literal('team'),
+    rosterId: targetIdSchema,
+    memberId: targetIdSchema,
+    capabilitiesToAdd: z.array(capabilitySchema).min(1).max(80),
+  }),
+  z.object({
+    target: z.literal('profile'),
+    profileId: targetIdSchema,
+    capabilitiesToAdd: z.array(capabilitySchema).min(1).max(80),
+  }),
+  z.object({
+    target: z.literal('template'),
+    templateId: targetIdSchema,
+  }),
+  z.object({
+    target: z.literal('decision'),
+    agentId: targetIdSchema,
+    taskId: targetIdSchema,
+    confidenceLevel: z.number().min(0).max(1),
+    riskScore: z.number().min(0).max(100),
+    parentDecisionId: targetIdSchema.optional(),
+  }),
+  z.object({
+    target: z.literal('policy'),
+    policy: policySchema,
+  }),
+]);
 
 const sourceSchema = z
   .object({
@@ -91,11 +128,26 @@ const listQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(500).optional(),
 });
 
-const acceptReflectionSchema = z.object({
-  reviewedBy: z.string().min(1).max(120).optional(),
-  promotionTarget: promotionTargetSchema.optional(),
-  reviewerNote: z.string().max(2000).optional(),
-});
+const acceptReflectionSchema = z
+  .object({
+    reviewedBy: z.string().min(1).max(120).optional(),
+    promotionTarget: promotionTargetSchema.optional(),
+    promotion: typedPromotionSchema.optional(),
+    reviewerNote: z.string().max(2000).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.promotion &&
+      value.promotionTarget &&
+      value.promotion.target !== value.promotionTarget
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['promotion'],
+        message: 'promotion.target must match promotionTarget',
+      });
+    }
+  });
 
 const rejectReflectionSchema = z.object({
   reviewedBy: z.string().min(1).max(120).optional(),

--- a/server/src/routes/reflections.ts
+++ b/server/src/routes/reflections.ts
@@ -2,7 +2,8 @@ import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { asyncHandler } from '../middleware/async-handler.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
-import { ValidationError } from '../middleware/error-handler.js';
+import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { getReflectionConsolidationService } from '../services/reflection-consolidation-service.js';
 import { getReflectionService } from '../services/reflection-service.js';
 
 const router: RouterType = Router();
@@ -25,6 +26,19 @@ const promotionTargetSchema = z.enum([
   'template',
   'policy',
 ]);
+const memoryDomainKindSchema = z.enum([
+  'workspace-memory',
+  'team',
+  'profile',
+  'template',
+  'decision',
+  'policy',
+]);
+const memoryDomainSchema = z.object({
+  kind: memoryDomainKindSchema,
+  id: z.string().trim().min(1).max(160),
+  workspaceId: z.string().trim().min(1).max(160),
+});
 
 const sourceSchema = z
   .object({
@@ -96,6 +110,30 @@ const deleteReflectionSchema = z.object({
 const mergeReflectionSchema = z.object({
   mergedBy: z.string().min(1).max(120).optional(),
 });
+const createConsolidationProposalSchema = z.object({
+  domain: memoryDomainSchema,
+  candidateIds: z.array(z.string().trim().min(1).max(160)).min(1).max(2000),
+  policy: z
+    .object({
+      staleAfterDays: z.number().int().min(1).max(3650).optional(),
+      unusedAfterDays: z.number().int().min(1).max(3650).optional(),
+      minimumConfidence: z.number().min(0).max(1).optional(),
+      maxCandidates: z.number().int().min(1).max(2000).optional(),
+    })
+    .optional(),
+});
+const listConsolidationProposalSchema = z
+  .object({
+    kind: memoryDomainKindSchema.optional(),
+    id: z.string().trim().min(1).max(160).optional(),
+    workspaceId: z.string().trim().min(1).max(160).optional(),
+  })
+  .refine(
+    (value) =>
+      (!value.kind && !value.id && !value.workspaceId) ||
+      (!!value.kind && !!value.id && !!value.workspaceId),
+    { message: 'kind, id, and workspaceId must be supplied together' }
+  );
 
 function parseOrThrow<T>(schema: z.ZodType<T>, value: unknown): T {
   try {
@@ -125,6 +163,36 @@ router.get(
   asyncHandler(async (req, res) => {
     const query = parseOrThrow(listQuerySchema, req.query);
     res.json(await getReflectionService().list(query));
+  })
+);
+
+router.get(
+  '/consolidation/proposals',
+  asyncHandler(async (req, res) => {
+    const query = parseOrThrow(listConsolidationProposalSchema, req.query);
+    const domain =
+      query.kind && query.id && query.workspaceId
+        ? { kind: query.kind, id: query.id, workspaceId: query.workspaceId }
+        : undefined;
+    res.json({ proposals: await getReflectionConsolidationService().list(domain) });
+  })
+);
+
+router.get(
+  '/consolidation/proposals/:proposalId',
+  asyncHandler(async (req, res) => {
+    const proposal = await getReflectionConsolidationService().get(String(req.params.proposalId));
+    if (!proposal) throw new NotFoundError('Reflection consolidation proposal not found');
+    res.json(proposal);
+  })
+);
+
+router.post(
+  '/consolidation/proposals',
+  asyncHandler(async (req, res) => {
+    const body = parseOrThrow(createConsolidationProposalSchema, req.body);
+    const proposal = await getReflectionConsolidationService().propose(body);
+    res.status(201).json(proposal);
   })
 );
 

--- a/server/src/schemas/task-envelope-schemas.ts
+++ b/server/src/schemas/task-envelope-schemas.ts
@@ -68,6 +68,26 @@ export const TaskEnvelopeSchema = z
         background: z.array(z.string().trim().min(1).max(4000)).max(64),
         constraints: z.array(z.string().trim().min(1).max(4000)).max(128),
         acceptanceCriteria: z.array(z.string().trim().min(1).max(4000)).max(256),
+        memory: z
+          .array(
+            z
+              .object({
+                reflectionId: idSchema,
+                sourceTaskId: idSchema.optional(),
+                sourceRunId: idSchema.optional(),
+                sourceEventIds: z.array(idSchema).max(20),
+                category: idSchema,
+                summary: textSchema,
+                guidance: textSchema,
+                confidence: z.number().min(0).max(1),
+                relevanceScore: z.number().min(0).max(1),
+                retrievalCount: z.number().int().min(0),
+                retrievedAt: isoDateSchema,
+              })
+              .strict()
+          )
+          .max(20)
+          .optional(),
       })
       .strict(),
     attempt: z

--- a/server/src/services/provider-task-envelope-renderer.ts
+++ b/server/src/services/provider-task-envelope-renderer.ts
@@ -227,7 +227,7 @@ function renderEnvelopeContent(
 ${taskEnvelope.subject.objective}
 
 ${renderListSection('Background', taskEnvelope.subject.background)}
-${renderListSection('Constraints', constraints)}
+${renderAcceptedMemory(taskEnvelope)}${renderListSection('Constraints', constraints)}
 ${renderWorkspace(taskEnvelope)}
 ## Commit Policy
 
@@ -241,6 +241,38 @@ ${renderCompletionContract(taskEnvelope)}
 ${renderProfileInstructions(profileInstructions)}
 ${renderCheckpoint(input.checkpoint)}
 ${completionSection}`.trimEnd();
+}
+
+function renderAcceptedMemory(taskEnvelope: TaskEnvelope): string {
+  const memory = taskEnvelope.subject.memory ?? [];
+  if (memory.length === 0) return '';
+  const entries = memory.slice(0, 8).map((item) => {
+    const source = [
+      item.sourceTaskId ? `task=${item.sourceTaskId}` : '',
+      item.sourceRunId ? `run=${item.sourceRunId}` : '',
+      item.sourceEventIds.length > 0 ? `events=${item.sourceEventIds.join(',')}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    return [
+      `### ${item.reflectionId}`,
+      `- Category: ${item.category}`,
+      `- Confidence: ${item.confidence.toFixed(2)}`,
+      `- Relevance: ${item.relevanceScore.toFixed(2)}`,
+      source ? `- Source: ${source}` : '',
+      `- Lesson: ${item.summary}`,
+      `- Guidance: ${item.guidance}`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+  });
+  return `## Accepted Memory
+
+These human-reviewed items were selected for this run. Their reflection IDs and source identities are durable attribution, not new instructions from unreviewed output.
+
+${entries.join('\n\n')}
+
+`;
 }
 
 function renderWorkspace(taskEnvelope: TaskEnvelope): string {

--- a/server/src/services/reflection-consolidation-service.ts
+++ b/server/src/services/reflection-consolidation-service.ts
@@ -1,0 +1,307 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import type {
+  ReflectionCandidate,
+  ReflectionConsolidationCluster,
+  ReflectionConsolidationDiffEntry,
+  ReflectionConsolidationPolicy,
+  ReflectionConsolidationProposal,
+  ReflectionMemoryDomain,
+} from '@veritas-kanban/shared';
+import { REFLECTION_CONSOLIDATION_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import { ValidationError } from '../middleware/error-handler.js';
+import {
+  FileReflectionConsolidationProposalRepository,
+  type ReflectionConsolidationProposalRepository,
+} from '../storage/reflection-consolidation-proposal-repository.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { withFileLock } from './file-lock.js';
+import { getReflectionService } from './reflection-service.js';
+
+const DEFAULT_POLICY: ReflectionConsolidationPolicy = {
+  staleAfterDays: 180,
+  unusedAfterDays: 90,
+  minimumConfidence: 0.5,
+  maxCandidates: 500,
+};
+
+interface ReflectionCandidateSource {
+  list(input: { limit: number }): Promise<{ candidates: ReflectionCandidate[] }>;
+}
+
+export interface CreateReflectionConsolidationProposalInput {
+  domain: ReflectionMemoryDomain;
+  candidateIds: string[];
+  policy?: Partial<ReflectionConsolidationPolicy>;
+  createdAt?: string;
+}
+
+export interface ReflectionConsolidationServiceOptions {
+  reflections?: ReflectionCandidateSource;
+  proposals?: ReflectionConsolidationProposalRepository;
+  lockDir?: string;
+  now?: () => Date;
+}
+
+export class ReflectionConsolidationService {
+  private readonly reflections: ReflectionCandidateSource;
+  private readonly proposals: ReflectionConsolidationProposalRepository;
+  private readonly lockDir: string;
+  private readonly now: () => Date;
+
+  constructor(options: ReflectionConsolidationServiceOptions = {}) {
+    this.reflections = options.reflections ?? getReflectionService();
+    this.proposals = options.proposals ?? new FileReflectionConsolidationProposalRepository();
+    this.lockDir =
+      options.lockDir ?? path.join(getRuntimeDir(), 'reflections', 'consolidation-locks');
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async propose(
+    input: CreateReflectionConsolidationProposalInput
+  ): Promise<ReflectionConsolidationProposal> {
+    const policy = normalizePolicy(input.policy);
+    const candidateIds = [
+      ...new Set(input.candidateIds.map((id) => id.trim()).filter(Boolean)),
+    ].sort();
+    if (candidateIds.length === 0) {
+      throw new ValidationError('At least one reflection candidate is required.');
+    }
+    if (candidateIds.length > policy.maxCandidates) {
+      throw new ValidationError(
+        `Consolidation candidate count exceeds the configured maximum of ${policy.maxCandidates}.`
+      );
+    }
+    const lockPath = path.join(this.lockDir, `${domainKey(input.domain)}.json`);
+    return withFileLock(lockPath, async () => {
+      const listed = await this.reflections.list({ limit: 2000 });
+      const byId = new Map(listed.candidates.map((candidate) => [candidate.id, candidate]));
+      const missingIds = candidateIds.filter((id) => !byId.has(id));
+      if (missingIds.length > 0) {
+        throw new ValidationError('Consolidation references unknown reflection candidates.', {
+          missingIds,
+        });
+      }
+      const candidates = candidateIds.map((id) => byId.get(id) as ReflectionCandidate);
+      const createdAt = input.createdAt ?? this.now().toISOString();
+      const sourceDigest = digest(candidates.map(candidateSnapshot));
+      const clusters = stableClusters(candidates);
+      const diff = stableDiff(candidates, policy, createdAt);
+      const id = `reflection_proposal_${digest({
+        domain: input.domain,
+        sourceDigest,
+        policy,
+        clusters,
+        diff,
+      }).slice('sha256:'.length, 'sha256:'.length + 32)}`;
+      const previous = (await this.proposals.list(input.domain)).find(
+        (proposal) => proposal.state === 'proposed' && proposal.id !== id
+      );
+      const proposal: ReflectionConsolidationProposal = {
+        schemaVersion: REFLECTION_CONSOLIDATION_SCHEMA_VERSION,
+        id,
+        domain: input.domain,
+        state: 'proposed',
+        revision: 1,
+        sourceDigest,
+        policy,
+        clusters,
+        diff,
+        candidateIds,
+        createdAt,
+        updatedAt: createdAt,
+        supersedesProposalId: previous?.id,
+      };
+      return this.proposals.put(proposal);
+    });
+  }
+
+  get(id: string): Promise<ReflectionConsolidationProposal | undefined> {
+    return this.proposals.get(id);
+  }
+
+  list(domain?: ReflectionMemoryDomain): Promise<ReflectionConsolidationProposal[]> {
+    return this.proposals.list(domain);
+  }
+}
+
+let reflectionConsolidationService: ReflectionConsolidationService | undefined;
+
+export function getReflectionConsolidationService(): ReflectionConsolidationService {
+  reflectionConsolidationService ??= new ReflectionConsolidationService();
+  return reflectionConsolidationService;
+}
+
+function normalizePolicy(
+  input: Partial<ReflectionConsolidationPolicy> | undefined
+): ReflectionConsolidationPolicy {
+  const policy = { ...DEFAULT_POLICY, ...input };
+  if (
+    !Number.isInteger(policy.staleAfterDays) ||
+    policy.staleAfterDays < 1 ||
+    !Number.isInteger(policy.unusedAfterDays) ||
+    policy.unusedAfterDays < 1 ||
+    !Number.isFinite(policy.minimumConfidence) ||
+    policy.minimumConfidence < 0 ||
+    policy.minimumConfidence > 1 ||
+    !Number.isInteger(policy.maxCandidates) ||
+    policy.maxCandidates < 1 ||
+    policy.maxCandidates > 2000
+  ) {
+    throw new ValidationError('Reflection consolidation policy is invalid.');
+  }
+  return policy;
+}
+
+function stableClusters(candidates: ReflectionCandidate[]): ReflectionConsolidationCluster[] {
+  const groups = new Map<string, ReflectionCandidate[]>();
+  for (const candidate of candidates) {
+    const group = groups.get(candidate.duplicateKey) ?? [];
+    group.push(candidate);
+    groups.set(candidate.duplicateKey, group);
+  }
+  return [...groups.entries()]
+    .map(([clusterKey, members]) => {
+      const ordered = [...members].sort(
+        (left, right) =>
+          right.confidence - left.confidence ||
+          Date.parse(left.createdAt) - Date.parse(right.createdAt) ||
+          left.id.localeCompare(right.id)
+      );
+      return {
+        clusterKey,
+        representativeId: ordered[0].id,
+        candidateIds: ordered.map((candidate) => candidate.id).sort(),
+        contradictionIds: [
+          ...new Set(ordered.flatMap((candidate) => candidate.contradictionIds ?? [])),
+        ].sort(),
+      };
+    })
+    .sort(
+      (left, right) =>
+        left.clusterKey.localeCompare(right.clusterKey) ||
+        left.representativeId.localeCompare(right.representativeId)
+    );
+}
+
+function stableDiff(
+  candidates: ReflectionCandidate[],
+  policy: ReflectionConsolidationPolicy,
+  createdAt: string
+): ReflectionConsolidationDiffEntry[] {
+  const entries: ReflectionConsolidationDiffEntry[] = [];
+  for (const cluster of stableClusters(candidates)) {
+    if (cluster.candidateIds.length > 1) {
+      entries.push({
+        operation: 'merge-review',
+        path: `/clusters/${encodeURIComponent(cluster.clusterKey)}`,
+        candidateIds: cluster.candidateIds,
+        before: { candidateIds: cluster.candidateIds },
+        after: { representativeId: cluster.representativeId },
+        reason: 'Candidates share a stable duplicate key and require reviewer-confirmed merge.',
+      });
+    }
+  }
+  const selected = new Set(candidates.map((candidate) => candidate.id));
+  const contradictionPairs = new Set<string>();
+  for (const candidate of candidates) {
+    for (const contradictionId of candidate.contradictionIds ?? []) {
+      if (!selected.has(contradictionId)) continue;
+      const pair = [candidate.id, contradictionId].sort();
+      const key = pair.join('\0');
+      if (contradictionPairs.has(key)) continue;
+      contradictionPairs.add(key);
+      entries.push({
+        operation: 'contradiction-review',
+        path: `/contradictions/${pair.map(encodeURIComponent).join('/')}`,
+        candidateIds: pair,
+        before: null,
+        after: { resolution: 'review-required' },
+        reason: 'Linked candidates contradict one another and cannot be promoted together.',
+      });
+    }
+  }
+  for (const candidate of candidates) {
+    if (shouldProposeDecay(candidate, policy, createdAt)) {
+      entries.push({
+        operation: 'decay-review',
+        path: `/candidates/${encodeURIComponent(candidate.id)}/retention`,
+        candidateIds: [candidate.id],
+        before: {
+          status: candidate.status,
+          retrievalCount: candidate.retrievalCount ?? 0,
+          lastRetrievedAt: candidate.lastRetrievedAt ?? null,
+        },
+        after: { status: 'decay-proposed' },
+        reason: 'Accepted lesson is stale or unused; no deletion occurs without review.',
+      });
+    }
+    if (
+      candidate.status === 'pending' &&
+      candidate.confidence >= policy.minimumConfidence &&
+      candidate.promotionTarget !== 'task-lesson'
+    ) {
+      entries.push({
+        operation: 'promotion-review',
+        path: `/targets/${candidate.promotionTarget}/${encodeURIComponent(candidate.id)}`,
+        candidateIds: [candidate.id],
+        before: null,
+        after: {
+          target: candidate.promotionTarget,
+          proposedScope: candidate.proposedScope ?? 'workspace',
+        },
+        reason: 'Wider-scope promotion requires an explicit reviewer and typed target adapter.',
+      });
+    }
+  }
+  return entries.sort(
+    (left, right) =>
+      left.path.localeCompare(right.path) ||
+      left.operation.localeCompare(right.operation) ||
+      left.candidateIds.join('\0').localeCompare(right.candidateIds.join('\0'))
+  );
+}
+
+function shouldProposeDecay(
+  candidate: ReflectionCandidate,
+  policy: ReflectionConsolidationPolicy,
+  createdAt: string
+): boolean {
+  if (candidate.status !== 'accepted') return false;
+  const reference = candidate.lastRetrievedAt ?? candidate.reviewedAt ?? candidate.updatedAt;
+  const ageDays = (Date.parse(createdAt) - Date.parse(reference)) / 86_400_000;
+  if (!Number.isFinite(ageDays)) return false;
+  return candidate.retrievalCount
+    ? ageDays >= policy.staleAfterDays
+    : ageDays >= policy.unusedAfterDays;
+}
+
+function candidateSnapshot(candidate: ReflectionCandidate) {
+  return {
+    id: candidate.id,
+    status: candidate.status,
+    category: candidate.category,
+    promotionTarget: candidate.promotionTarget,
+    confidence: candidate.confidence,
+    duplicateKey: candidate.duplicateKey,
+    contradictionIds: [...(candidate.contradictionIds ?? [])].sort(),
+    retrievalCount: candidate.retrievalCount ?? 0,
+    lastRetrievedAt: candidate.lastRetrievedAt ?? null,
+    reviewedAt: candidate.reviewedAt ?? null,
+    updatedAt: candidate.updatedAt,
+  };
+}
+
+function digest(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}
+
+function domainKey(domain: ReflectionMemoryDomain): string {
+  return createHash('sha256')
+    .update(domain.workspaceId)
+    .update('\0')
+    .update(domain.kind)
+    .update('\0')
+    .update(domain.id)
+    .digest('hex');
+}

--- a/server/src/services/reflection-promotion-adapters.ts
+++ b/server/src/services/reflection-promotion-adapters.ts
@@ -1,0 +1,252 @@
+import type {
+  ReflectionAppliedTarget,
+  ReflectionCandidate,
+  ReflectionTypedPromotionInput,
+  TeamRosterManifest,
+  TeamRosterMember,
+} from '@veritas-kanban/shared';
+import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
+import {
+  getAgentProfilePackageService,
+  type AgentProfilePackageService,
+} from './agent-profile-package-service.js';
+import { getDecisionService, type DecisionService } from './decision-service.js';
+import { getPolicyService, type PolicyService } from './policy-service.js';
+import { getTeamRosterService, type TeamRosterService } from './team-roster-service.js';
+import { TemplateService } from './template-service.js';
+
+export interface ReflectionPromotionApplyContext {
+  candidate: ReflectionCandidate;
+  promotion: ReflectionTypedPromotionInput;
+  reviewedBy: string;
+  timestamp: string;
+}
+
+export interface ReflectionPromotionAdapter {
+  target: ReflectionTypedPromotionInput['target'];
+  apply(context: ReflectionPromotionApplyContext): Promise<ReflectionAppliedTarget>;
+}
+
+export interface ReflectionPromotionAdapterDependencies {
+  teamRoster: () => Pick<TeamRosterService, 'mutateRoster'>;
+  profiles: () => Pick<AgentProfilePackageService, 'getProfile' | 'updateProfile'>;
+  templates: () => Pick<TemplateService, 'getTemplate' | 'updateTemplate'>;
+  decisions: () => Pick<DecisionService, 'create' | 'list'>;
+  policies: () => Pick<PolicyService, 'getPolicy' | 'createPolicy' | 'updatePolicy'>;
+}
+
+export class ReflectionPromotionAdapterRegistry {
+  private readonly adapters: Map<
+    ReflectionTypedPromotionInput['target'],
+    ReflectionPromotionAdapter
+  >;
+
+  constructor(adapters: ReflectionPromotionAdapter[] = createBuiltInReflectionPromotionAdapters()) {
+    this.adapters = new Map();
+    for (const adapter of adapters) {
+      if (this.adapters.has(adapter.target)) {
+        throw new ConflictError(
+          `Multiple typed reflection promotion adapters are registered for ${adapter.target}.`
+        );
+      }
+      this.adapters.set(adapter.target, adapter);
+    }
+  }
+
+  async apply(context: ReflectionPromotionApplyContext): Promise<ReflectionAppliedTarget> {
+    const adapter = this.adapters.get(context.promotion.target);
+    if (!adapter) {
+      throw new ConflictError(
+        `No typed reflection promotion adapter is registered for ${context.promotion.target}.`
+      );
+    }
+    return adapter.apply(context);
+  }
+}
+
+export function createBuiltInReflectionPromotionAdapters(
+  dependencies: ReflectionPromotionAdapterDependencies = defaultDependencies()
+): ReflectionPromotionAdapter[] {
+  return [
+    {
+      target: 'memory',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'memory');
+        return appliedTarget('memory', promotion.workspaceId, 'Reviewed workspace memory', context);
+      },
+    },
+    {
+      target: 'team',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'team');
+        const member = await dependencies.teamRoster().mutateRoster((roster) => {
+          if (!roster || roster.id !== promotion.rosterId) {
+            throw new NotFoundError(`Team roster not found: ${promotion.rosterId}`);
+          }
+          const existing = roster.members.find((item) => item.id === promotion.memberId);
+          if (!existing) {
+            throw new NotFoundError(`Team roster member not found: ${promotion.memberId}`);
+          }
+          const updated: TeamRosterMember = {
+            ...existing,
+            capabilities: stableUnion(existing.capabilities, promotion.capabilitiesToAdd),
+          };
+          const next: TeamRosterManifest = {
+            ...roster,
+            members: roster.members.map((item) => (item.id === updated.id ? updated : item)),
+          };
+          return { roster: next, result: updated };
+        });
+        return appliedTarget(
+          'team',
+          `${promotion.rosterId}:${member.id}`,
+          member.displayName,
+          context
+        );
+      },
+    },
+    {
+      target: 'profile',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'profile');
+        const service = dependencies.profiles();
+        const existing = await service.getProfile(promotion.profileId);
+        if (!existing) {
+          throw new NotFoundError(`Agent profile package not found: ${promotion.profileId}`);
+        }
+        const updated = await service.updateProfile(promotion.profileId, {
+          capabilities: stableUnion(existing.capabilities, promotion.capabilitiesToAdd),
+        });
+        return appliedTarget('profile', updated.id, updated.displayName, context);
+      },
+    },
+    {
+      target: 'template',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'template');
+        const service = dependencies.templates();
+        const existing = await service.getTemplate(promotion.templateId);
+        if (!existing) {
+          throw new NotFoundError(`Task template not found: ${promotion.templateId}`);
+        }
+        const marker = `[Reflection ${context.candidate.id}]`;
+        const current = existing.taskDefaults.descriptionTemplate?.trim();
+        const guidance = `${marker}\n${context.candidate.nextAttempt}`;
+        const updated = current?.includes(marker)
+          ? existing
+          : await service.updateTemplate(existing.id, {
+              taskDefaults: {
+                descriptionTemplate: current ? `${current}\n\n${guidance}` : guidance,
+              },
+            });
+        if (!updated) {
+          throw new NotFoundError(`Task template not found: ${promotion.templateId}`);
+        }
+        return appliedTarget('template', updated.id, updated.name, context);
+      },
+    },
+    {
+      target: 'decision',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'decision');
+        const service = dependencies.decisions();
+        const marker = `[Reflection ${context.candidate.id}]`;
+        const existing = (
+          await service.list({
+            agent: promotion.agentId,
+          })
+        ).find(
+          (decision) =>
+            decision.taskId === promotion.taskId && decision.inputContext.startsWith(marker)
+        );
+        const decision =
+          existing ??
+          (await service.create({
+            inputContext: `${marker}\n${context.candidate.rationale ?? context.candidate.summary}`,
+            outputAction: context.candidate.nextAttempt,
+            assumptions: context.candidate.previousApproach
+              ? [context.candidate.previousApproach]
+              : undefined,
+            confidenceLevel: promotion.confidenceLevel,
+            riskScore: promotion.riskScore,
+            parentDecisionId: promotion.parentDecisionId,
+            agentId: promotion.agentId,
+            taskId: promotion.taskId,
+            timestamp: context.timestamp,
+          }));
+        return appliedTarget('decision', decision.id, decision.outputAction, context);
+      },
+    },
+    {
+      target: 'policy',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'policy');
+        const service = dependencies.policies();
+        const existing = await service.getPolicy(promotion.policy.id);
+        const policy = existing
+          ? await service.updatePolicy(existing.id, promotion.policy)
+          : await service.createPolicy(promotion.policy);
+        return appliedTarget('policy', policy.id, policy.name, context);
+      },
+    },
+  ];
+}
+
+function promotionFor<TTarget extends ReflectionTypedPromotionInput['target']>(
+  promotion: ReflectionTypedPromotionInput,
+  target: TTarget
+): Extract<ReflectionTypedPromotionInput, { target: TTarget }> {
+  if (promotion.target !== target) {
+    throw new ConflictError(`Expected ${target} promotion input, received ${promotion.target}.`);
+  }
+  return promotion as Extract<ReflectionTypedPromotionInput, { target: TTarget }>;
+}
+
+function stableUnion(existing: string[], additions: string[]): string[] {
+  const values: string[] = [];
+  const seen = new Set<string>();
+  for (const value of [...existing, ...additions]) {
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    values.push(normalized);
+  }
+  return values.slice(0, 80);
+}
+
+function appliedTarget(
+  kind: ReflectionAppliedTarget['kind'],
+  id: string,
+  title: string,
+  context: Pick<ReflectionPromotionApplyContext, 'reviewedBy' | 'timestamp'>
+): ReflectionAppliedTarget {
+  return {
+    kind,
+    id,
+    title,
+    appliedAt: context.timestamp,
+    appliedBy: context.reviewedBy,
+  };
+}
+
+let templateService: TemplateService | undefined;
+
+function defaultDependencies(): ReflectionPromotionAdapterDependencies {
+  return {
+    teamRoster: () => getTeamRosterService(),
+    profiles: () => getAgentProfilePackageService(),
+    templates: () => {
+      templateService ??= new TemplateService();
+      return templateService;
+    },
+    decisions: () => getDecisionService(),
+    policies: () => getPolicyService(),
+  };
+}
+
+let reflectionPromotionAdapterRegistry: ReflectionPromotionAdapterRegistry | undefined;
+
+export function getReflectionPromotionAdapterRegistry(): ReflectionPromotionAdapterRegistry {
+  reflectionPromotionAdapterRegistry ??= new ReflectionPromotionAdapterRegistry();
+  return reflectionPromotionAdapterRegistry;
+}

--- a/server/src/services/reflection-service.ts
+++ b/server/src/services/reflection-service.ts
@@ -14,6 +14,7 @@ import type {
   ReflectionListResponse,
   MergeReflectionCandidateInput,
   ReflectionPromotionTarget,
+  ReflectionTypedPromotionInput,
   ReflectionRedactionSummary,
   ReflectionSourceKind,
   RejectReflectionCandidateInput,
@@ -27,6 +28,10 @@ import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
 import { ensureWithinBase, stripHtml, validatePathSegment } from '../utils/sanitize.js';
 import { getRuntimeDir } from '../utils/paths.js';
 import { createLogger } from '../lib/logger.js';
+import {
+  getReflectionPromotionAdapterRegistry,
+  type ReflectionPromotionAdapterRegistry,
+} from './reflection-promotion-adapters.js';
 
 const log = createLogger('reflection');
 const MAX_CANDIDATES = 2000;
@@ -74,6 +79,7 @@ export interface ReflectionServiceOptions {
   persist?: boolean;
   audit?: (event: AuditEvent) => Promise<void>;
   taskService?: ReflectionTaskService;
+  promotionAdapters?: Pick<ReflectionPromotionAdapterRegistry, 'apply'>;
 }
 
 interface SanitizedText {
@@ -141,6 +147,7 @@ export class ReflectionService {
   private readonly persist: boolean;
   private readonly audit: (event: AuditEvent) => Promise<void>;
   private readonly taskService: ReflectionTaskService;
+  private readonly promotionAdapters: Pick<ReflectionPromotionAdapterRegistry, 'apply'>;
   private loaded = false;
   private state: ReflectionState = this.emptyState();
 
@@ -149,6 +156,7 @@ export class ReflectionService {
     this.persist = options.persist ?? process.env.VITEST !== 'true';
     this.audit = options.audit ?? auditLog;
     this.taskService = options.taskService ?? getTaskService();
+    this.promotionAdapters = options.promotionAdapters ?? getReflectionPromotionAdapterRegistry();
   }
 
   async list(filters: ReflectionListFilters = {}): Promise<ReflectionListResponse> {
@@ -340,7 +348,15 @@ export class ReflectionService {
     const candidate = this.findPendingCandidate(id);
     const timestamp = nowIso();
     const reviewedBy = this.sanitizeText(input.reviewedBy).value || 'operator';
-    const promotionTarget = input.promotionTarget ?? candidate.promotionTarget;
+    if (
+      input.promotion &&
+      input.promotionTarget &&
+      input.promotion.target !== input.promotionTarget
+    ) {
+      throw new ConflictError('Typed promotion input does not match the requested target.');
+    }
+    const promotionTarget =
+      input.promotion?.target ?? input.promotionTarget ?? candidate.promotionTarget;
     const reviewerNote = input.reviewerNote
       ? this.sanitizeText(input.reviewerNote).value
       : undefined;
@@ -352,6 +368,7 @@ export class ReflectionService {
     const appliedTargets = await this.applyPromotion(
       promotionCandidate,
       promotionTarget,
+      input.promotion,
       reviewedBy,
       timestamp
     );
@@ -447,19 +464,27 @@ export class ReflectionService {
   private async applyPromotion(
     candidate: ReflectionCandidate,
     target: ReflectionPromotionTarget,
+    promotion: ReflectionTypedPromotionInput | undefined,
     reviewedBy: string,
     timestamp: string
   ): Promise<ReflectionAppliedTarget[]> {
     if (target !== 'task-lesson') {
+      if (!promotion || promotion.target !== target) {
+        throw new ConflictError(
+          `${target} promotion requires explicit typed target input from the reviewer.`
+        );
+      }
       return [
-        {
-          kind: 'manual-review',
-          id: target,
-          title: `${target} promotion queued for manual application`,
-          appliedAt: timestamp,
-          appliedBy: reviewedBy,
-        },
+        await this.promotionAdapters.apply({
+          candidate,
+          promotion,
+          reviewedBy,
+          timestamp,
+        }),
       ];
+    }
+    if (promotion) {
+      throw new ConflictError('Task lesson promotion does not accept wider target input.');
     }
 
     const taskId = candidate.source.taskId;

--- a/server/src/services/reflection-service.ts
+++ b/server/src/services/reflection-service.ts
@@ -18,6 +18,7 @@ import type {
   ReflectionSourceKind,
   RejectReflectionCandidateInput,
   Task,
+  TaskEnvelopeMemoryReference,
 } from '@veritas-kanban/shared';
 import { auditLog, type AuditEvent } from './audit-service.js';
 import { withFileLock } from './file-lock.js';
@@ -25,13 +26,17 @@ import { getTaskService } from './task-service.js';
 import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
 import { ensureWithinBase, stripHtml, validatePathSegment } from '../utils/sanitize.js';
 import { getRuntimeDir } from '../utils/paths.js';
+import { createLogger } from '../lib/logger.js';
 
+const log = createLogger('reflection');
 const MAX_CANDIDATES = 2000;
 const MAX_TEXT_LENGTH = 4000;
 const MAX_EVIDENCE_ITEMS = 10;
 const MAX_TAGS = 20;
 const MAX_CONTRADICTION_IDS = 20;
 const MAX_SOURCE_EVENT_IDS = 20;
+const MAX_RETRIEVALS_PER_CANDIDATE = 100;
+const DEFAULT_RETRIEVAL_LIMIT = 8;
 
 interface ReflectionState {
   version: 1;
@@ -45,6 +50,15 @@ export interface ReflectionListFilters {
   sourceKind?: ReflectionSourceKind;
   taskId?: string;
   limit?: number;
+}
+
+export interface ReflectionRetrievalInput {
+  task: Pick<Task, 'id' | 'title' | 'description' | 'project' | 'lessonTags'>;
+  workspaceId: string;
+  attemptId: string;
+  retrievedAt: string;
+  limit?: number;
+  recordAttribution?: boolean;
 }
 
 export interface ReflectionTaskService {
@@ -154,6 +168,105 @@ export class ReflectionService {
       duplicateGroups: this.duplicateGroups(filtered),
       total: filtered.length,
     };
+  }
+
+  async retrieveForTask(input: ReflectionRetrievalInput): Promise<TaskEnvelopeMemoryReference[]> {
+    await this.ensureLoaded();
+    const limit = Math.max(1, Math.min(Math.floor(input.limit ?? DEFAULT_RETRIEVAL_LIMIT), 20));
+    const queryTokens = tokenizeReflectionText(
+      [
+        input.task.title,
+        input.task.description,
+        input.task.project,
+        ...(input.task.lessonTags ?? []),
+      ]
+        .filter(Boolean)
+        .join(' ')
+    );
+    const ranked = this.state.candidates
+      .filter(
+        (candidate) =>
+          candidate.status === 'accepted' &&
+          candidate.source.taskId === input.task.id &&
+          (candidate.appliedTargets ?? []).some((target) => target.kind === 'task-lesson')
+      )
+      .map((candidate) => ({
+        candidate,
+        score: reflectionRelevanceScore(candidate, input.task.id, queryTokens, input.retrievedAt),
+      }))
+      .sort(
+        (left, right) =>
+          right.score - left.score ||
+          right.candidate.confidence - left.candidate.confidence ||
+          Date.parse(right.candidate.updatedAt) - Date.parse(left.candidate.updatedAt) ||
+          left.candidate.id.localeCompare(right.candidate.id)
+      )
+      .slice(0, limit);
+
+    const references = ranked.map(({ candidate, score }) => ({
+      reflectionId: candidate.id.slice(0, 160),
+      sourceTaskId: candidate.source.taskId?.slice(0, 160),
+      sourceRunId: candidate.source.runId?.slice(0, 160),
+      sourceEventIds:
+        candidate.source.eventIds
+          ?.slice(0, MAX_SOURCE_EVENT_IDS)
+          .map((eventId) => eventId.trim().slice(0, 160))
+          .filter(Boolean) ?? [],
+      category: candidate.category,
+      summary:
+        candidate.summary ||
+        candidate.correction ||
+        candidate.nextAttempt ||
+        'Reviewed reflection lesson.',
+      guidance:
+        candidate.nextAttempt ||
+        candidate.correction ||
+        candidate.summary ||
+        'Apply the reviewed lesson when relevant.',
+      confidence: candidate.confidence,
+      relevanceScore: score,
+      retrievalCount: (candidate.retrievalCount ?? 0) + (input.recordAttribution ? 1 : 0),
+      retrievedAt: input.retrievedAt,
+    }));
+
+    if (input.recordAttribution && ranked.length > 0) {
+      for (const { candidate, score } of ranked) {
+        candidate.retrievalCount = (candidate.retrievalCount ?? 0) + 1;
+        candidate.lastRetrievedAt = input.retrievedAt;
+        candidate.retrievals = [
+          ...(candidate.retrievals ?? []),
+          {
+            taskId: input.task.id,
+            attemptId: input.attemptId,
+            workspaceId: input.workspaceId,
+            relevanceScore: score,
+            retrievedAt: input.retrievedAt,
+          },
+        ].slice(-MAX_RETRIEVALS_PER_CANDIDATE);
+      }
+      await this.saveState();
+      for (const { candidate, score } of ranked) {
+        await this.audit({
+          action: 'reflection.retrieved',
+          actor: 'system',
+          resource: candidate.id,
+          details: {
+            taskId: input.task.id,
+            attemptId: input.attemptId,
+            workspaceId: input.workspaceId,
+            relevanceScore: score,
+            retrievalCount: candidate.retrievalCount,
+          },
+        }).catch((error) => {
+          log.warn(
+            { err: error, reflectionId: candidate.id, attemptId: input.attemptId },
+            'Failed to append reflection retrieval audit event'
+          );
+        });
+      }
+    }
+
+    return references;
   }
 
   async create(input: CreateReflectionCandidateInput): Promise<ReflectionCandidate> {
@@ -588,6 +701,55 @@ export class ReflectionService {
       },
     });
   }
+}
+
+function tokenizeReflectionText(value: string): Set<string> {
+  return new Set(
+    value
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .map((token) => token.trim())
+      .filter((token) => token.length >= 3)
+      .slice(0, 256)
+  );
+}
+
+function reflectionRelevanceScore(
+  candidate: ReflectionCandidate,
+  taskId: string,
+  queryTokens: Set<string>,
+  retrievedAt: string
+): number {
+  const candidateTokens = tokenizeReflectionText(
+    [
+      candidate.summary,
+      candidate.correction,
+      candidate.nextAttempt,
+      candidate.applicability,
+      ...(candidate.tags ?? []),
+    ]
+      .filter(Boolean)
+      .join(' ')
+  );
+  const overlap = [...candidateTokens].filter((token) => queryTokens.has(token)).length;
+  const overlapRatio =
+    candidateTokens.size === 0 || queryTokens.size === 0
+      ? 0
+      : overlap / Math.min(candidateTokens.size, queryTokens.size);
+  const exactTaskBoost = candidate.source.taskId === taskId ? 0.5 : 0;
+  const relevance = Math.min(0.3, overlapRatio * 0.3);
+  const confidence = candidate.confidence * 0.12;
+  const observedUse = Math.min(0.06, Math.log1p(candidate.retrievalCount ?? 0) * 0.02);
+  const retrievedTime = Date.parse(retrievedAt);
+  const candidateTime = Date.parse(candidate.reviewedAt ?? candidate.updatedAt);
+  const ageDays =
+    Number.isFinite(retrievedTime) && Number.isFinite(candidateTime)
+      ? Math.max(0, (retrievedTime - candidateTime) / 86_400_000)
+      : 365;
+  const freshness = Math.max(0, 0.02 - Math.min(ageDays, 365) * (0.02 / 365));
+  return Number(
+    Math.min(1, exactTaskBoost + relevance + confidence + observedUse + freshness).toFixed(6)
+  );
 }
 
 let reflectionService: ReflectionService | null = null;

--- a/server/src/services/task-envelope-service.ts
+++ b/server/src/services/task-envelope-service.ts
@@ -19,6 +19,7 @@ import {
   type TaskExpectedOutput,
   type TaskLaunchBaseline,
   type TaskLaunchBaselineFile,
+  type TaskEnvelopeMemoryReference,
 } from '@veritas-kanban/shared';
 import { parseTaskEnvelope } from '../schemas/task-envelope-schemas.js';
 import {
@@ -26,7 +27,10 @@ import {
   type TaskEnvelopePayload,
 } from '../utils/task-envelope-digest.js';
 import { sha256WorktreeEntry } from '../utils/worktree-fingerprint.js';
+import { createLogger } from '../lib/logger.js';
+import { getReflectionService, type ReflectionRetrievalInput } from './reflection-service.js';
 
+const log = createLogger('task-envelope');
 const MAX_BASELINE_FILES = 1000;
 const BASELINE_GIT_TIMEOUT_MS = 10_000;
 const MAX_BASELINE_CAPTURE_ATTEMPTS = 3;
@@ -250,9 +254,14 @@ export interface BuildTaskEnvelopeInput {
   executionPolicy?: TaskExecutionPolicy;
 }
 
+export interface TaskMemoryRetriever {
+  retrieveForTask(input: ReflectionRetrievalInput): Promise<TaskEnvelopeMemoryReference[]>;
+}
+
 export class TaskEnvelopeService {
   constructor(
-    private readonly evidenceSource: CompletionEvidenceSource = new GitCompletionEvidenceSource()
+    private readonly evidenceSource: CompletionEvidenceSource = new GitCompletionEvidenceSource(),
+    private readonly memoryRetriever: TaskMemoryRetriever = getReflectionService()
   ) {}
 
   async build(input: BuildTaskEnvelopeInput): Promise<TaskEnvelope> {
@@ -260,6 +269,25 @@ export class TaskEnvelopeService {
       input.worktreePath,
       input.createdAt
     );
+    const workspaceId = normalizeWorkspaceId(
+      input.task.project?.trim() || input.task.git?.repo || input.task.id
+    );
+    let memory: TaskEnvelopeMemoryReference[] = [];
+    try {
+      memory = await this.memoryRetriever.retrieveForTask({
+        task: input.task,
+        workspaceId,
+        attemptId: input.attemptId,
+        retrievedAt: input.createdAt,
+        recordAttribution: !input.attemptId.startsWith('preview_'),
+        limit: 8,
+      });
+    } catch (error) {
+      log.warn(
+        { err: error, taskId: input.task.id, attemptId: input.attemptId },
+        'Accepted reflection retrieval failed; continuing without memory context'
+      );
+    }
     const payload: TaskEnvelopePayload = {
       schemaVersion: TASK_ENVELOPE_SCHEMA_VERSION,
       subject: {
@@ -281,15 +309,14 @@ export class TaskEnvelopeService {
         acceptanceCriteria: compactTaskEnvelopeStrings(
           (input.task.subtasks ?? []).flatMap((subtask) => subtask.acceptanceCriteria ?? [])
         ).slice(0, 256),
+        ...(memory.length > 0 ? { memory } : {}),
       },
       attempt: {
         id: input.attemptId,
         createdAt: input.createdAt,
       },
       workspace: {
-        workspaceId: normalizeWorkspaceId(
-          input.task.project?.trim() || input.task.git?.repo || input.task.id
-        ),
+        workspaceId,
         worktreeId: input.task.id,
         ...(input.task.git?.worktreeManifestId
           ? { worktreeManifestId: input.task.git.worktreeManifestId }

--- a/server/src/storage/reflection-consolidation-proposal-repository.ts
+++ b/server/src/storage/reflection-consolidation-proposal-repository.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  ReflectionConsolidationProposal,
+  ReflectionMemoryDomain,
+} from '@veritas-kanban/shared';
+import { REFLECTION_CONSOLIDATION_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import { withFileLock } from '../services/file-lock.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+
+const MAX_PROPOSALS = 500;
+
+interface ProposalState {
+  version: 1;
+  proposals: ReflectionConsolidationProposal[];
+}
+
+export interface ReflectionConsolidationProposalRepository {
+  get(id: string): Promise<ReflectionConsolidationProposal | undefined>;
+  list(domain?: ReflectionMemoryDomain): Promise<ReflectionConsolidationProposal[]>;
+  put(proposal: ReflectionConsolidationProposal): Promise<ReflectionConsolidationProposal>;
+}
+
+export class FileReflectionConsolidationProposalRepository implements ReflectionConsolidationProposalRepository {
+  private readonly storageDir: string;
+  private readonly statePath: string;
+
+  constructor(storageDir = path.join(getRuntimeDir(), 'reflections')) {
+    this.storageDir = storageDir;
+    this.statePath = path.join(storageDir, 'consolidation-proposals.json');
+    ensureWithinBase(storageDir, this.statePath);
+  }
+
+  async get(id: string): Promise<ReflectionConsolidationProposal | undefined> {
+    return (await this.read()).proposals.find((proposal) => proposal.id === id);
+  }
+
+  async list(domain?: ReflectionMemoryDomain): Promise<ReflectionConsolidationProposal[]> {
+    const proposals = (await this.read()).proposals;
+    return proposals
+      .filter((proposal) => !domain || sameDomain(proposal.domain, domain))
+      .sort(
+        (left, right) =>
+          Date.parse(right.updatedAt) - Date.parse(left.updatedAt) ||
+          left.id.localeCompare(right.id)
+      );
+  }
+
+  async put(proposal: ReflectionConsolidationProposal): Promise<ReflectionConsolidationProposal> {
+    await fs.mkdir(this.storageDir, { recursive: true });
+    return withFileLock(this.statePath, async () => {
+      const state = await this.read();
+      const existing = state.proposals.find((item) => item.id === proposal.id);
+      if (existing) return existing;
+      state.proposals.push(proposal);
+      state.proposals = state.proposals
+        .sort(
+          (left, right) =>
+            Date.parse(left.createdAt) - Date.parse(right.createdAt) ||
+            left.id.localeCompare(right.id)
+        )
+        .slice(-MAX_PROPOSALS);
+      await fs.writeFile(this.statePath, JSON.stringify(state, null, 2), 'utf8');
+      return proposal;
+    });
+  }
+
+  private async read(): Promise<ProposalState> {
+    try {
+      const parsed = JSON.parse(
+        await fs.readFile(this.statePath, 'utf8')
+      ) as Partial<ProposalState>;
+      return {
+        version: 1,
+        proposals: Array.isArray(parsed.proposals) ? parsed.proposals.filter(isProposal) : [],
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { version: 1, proposals: [] };
+      }
+      throw error;
+    }
+  }
+}
+
+function isProposal(value: unknown): value is ReflectionConsolidationProposal {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as ReflectionConsolidationProposal).schemaVersion ===
+      REFLECTION_CONSOLIDATION_SCHEMA_VERSION &&
+    typeof (value as ReflectionConsolidationProposal).id === 'string' &&
+    Array.isArray((value as ReflectionConsolidationProposal).diff)
+  );
+}
+
+function sameDomain(left: ReflectionMemoryDomain, right: ReflectionMemoryDomain): boolean {
+  return left.kind === right.kind && left.id === right.id && left.workspaceId === right.workspaceId;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -11,6 +11,7 @@ export * from './communication-adapter.types.js';
 export * from './ceremony.types.js';
 export * from './reflection.types.js';
 export * from './reflection-extraction-job.types.js';
+export * from './reflection-consolidation.types.js';
 export * from './external-tracker.types.js';
 export * from './transition-hooks.types.js';
 export * from './delegation.types.js';

--- a/shared/src/types/reflection-consolidation.types.ts
+++ b/shared/src/types/reflection-consolidation.types.ts
@@ -1,0 +1,59 @@
+export const REFLECTION_CONSOLIDATION_SCHEMA_VERSION =
+  'reflection-consolidation-proposal/v1' as const;
+
+export type ReflectionMemoryDomainKind =
+  'workspace-memory' | 'team' | 'profile' | 'template' | 'decision' | 'policy';
+
+export interface ReflectionMemoryDomain {
+  kind: ReflectionMemoryDomainKind;
+  id: string;
+  workspaceId: string;
+}
+
+export type ReflectionConsolidationProposalState =
+  'proposed' | 'accepted' | 'rejected' | 'applied' | 'superseded';
+
+export interface ReflectionConsolidationCluster {
+  clusterKey: string;
+  representativeId: string;
+  candidateIds: string[];
+  contradictionIds: string[];
+}
+
+export type ReflectionConsolidationDiffOperation =
+  'merge-review' | 'contradiction-review' | 'decay-review' | 'promotion-review';
+
+export interface ReflectionConsolidationDiffEntry {
+  operation: ReflectionConsolidationDiffOperation;
+  path: string;
+  candidateIds: string[];
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  reason: string;
+}
+
+export interface ReflectionConsolidationProposal {
+  schemaVersion: typeof REFLECTION_CONSOLIDATION_SCHEMA_VERSION;
+  id: string;
+  domain: ReflectionMemoryDomain;
+  state: ReflectionConsolidationProposalState;
+  revision: number;
+  sourceDigest: string;
+  policy: ReflectionConsolidationPolicy;
+  clusters: ReflectionConsolidationCluster[];
+  diff: ReflectionConsolidationDiffEntry[];
+  candidateIds: string[];
+  createdAt: string;
+  updatedAt: string;
+  reviewedAt?: string;
+  reviewedBy?: string;
+  reviewerNote?: string;
+  supersedesProposalId?: string;
+}
+
+export interface ReflectionConsolidationPolicy {
+  staleAfterDays: number;
+  unusedAfterDays: number;
+  minimumConfidence: number;
+  maxCandidates: number;
+}

--- a/shared/src/types/reflection.types.ts
+++ b/shared/src/types/reflection.types.ts
@@ -43,6 +43,14 @@ export interface ReflectionRedactionSummary {
   notes: string[];
 }
 
+export interface ReflectionRetrievalAttribution {
+  taskId: string;
+  attemptId: string;
+  workspaceId: string;
+  relevanceScore: number;
+  retrievedAt: string;
+}
+
 export interface ReflectionCandidate {
   id: string;
   idempotencyKey?: string;
@@ -77,6 +85,9 @@ export interface ReflectionCandidate {
   deletedBy?: string;
   deleteReason?: string;
   mergedInto?: string;
+  retrievalCount?: number;
+  lastRetrievedAt?: string;
+  retrievals?: ReflectionRetrievalAttribution[];
 }
 
 export interface ReflectionDuplicateGroup {

--- a/shared/src/types/reflection.types.ts
+++ b/shared/src/types/reflection.types.ts
@@ -1,3 +1,5 @@
+import type { AgentPolicy } from './policy.types.js';
+
 export type ReflectionCandidateCategory = 'session' | 'agent' | 'team' | 'policy' | 'template';
 export type ReflectionCandidateStatus = 'pending' | 'accepted' | 'rejected' | 'deleted';
 export type ReflectionSourceKind =
@@ -8,7 +10,7 @@ export type ReflectionSourceKind =
   | 'review-feedback'
   | 'task-observation';
 export type ReflectionPromotionTarget =
-  'task-lesson' | 'memory' | 'decision' | 'profile' | 'template' | 'policy';
+  'task-lesson' | 'memory' | 'team' | 'decision' | 'profile' | 'template' | 'policy';
 export type ReflectionProposedScope = 'task' | 'workspace' | 'team' | 'global';
 
 export interface ReflectionSourceLink {
@@ -50,6 +52,39 @@ export interface ReflectionRetrievalAttribution {
   relevanceScore: number;
   retrievedAt: string;
 }
+
+export type ReflectionTypedPromotionInput =
+  | {
+      target: 'memory';
+      workspaceId: string;
+    }
+  | {
+      target: 'team';
+      rosterId: string;
+      memberId: string;
+      capabilitiesToAdd: string[];
+    }
+  | {
+      target: 'profile';
+      profileId: string;
+      capabilitiesToAdd: string[];
+    }
+  | {
+      target: 'template';
+      templateId: string;
+    }
+  | {
+      target: 'decision';
+      agentId: string;
+      taskId: string;
+      confidenceLevel: number;
+      riskScore: number;
+      parentDecisionId?: string;
+    }
+  | {
+      target: 'policy';
+      policy: AgentPolicy;
+    };
 
 export interface ReflectionCandidate {
   id: string;
@@ -126,6 +161,7 @@ export interface CreateReflectionCandidateInput {
 export interface AcceptReflectionCandidateInput {
   reviewedBy: string;
   promotionTarget?: ReflectionPromotionTarget;
+  promotion?: ReflectionTypedPromotionInput;
   reviewerNote?: string;
 }
 

--- a/shared/src/types/task-envelope.types.ts
+++ b/shared/src/types/task-envelope.types.ts
@@ -105,6 +105,21 @@ export interface TaskEnvelopeSubject {
   background: string[];
   constraints: string[];
   acceptanceCriteria: string[];
+  memory?: TaskEnvelopeMemoryReference[];
+}
+
+export interface TaskEnvelopeMemoryReference {
+  reflectionId: string;
+  sourceTaskId?: string;
+  sourceRunId?: string;
+  sourceEventIds: string[];
+  category: string;
+  summary: string;
+  guidance: string;
+  confidence: number;
+  relevanceScore: number;
+  retrievalCount: number;
+  retrievedAt: string;
 }
 
 export interface TaskEnvelopeAttempt {

--- a/web/src/components/settings/tabs/ReflectionTab.tsx
+++ b/web/src/components/settings/tabs/ReflectionTab.tsx
@@ -204,6 +204,9 @@ function ReflectionCandidateItem({
   busy: boolean;
 }) {
   const canReview = canWrite && candidate.status === 'pending';
+  const requiresTypedPromotion =
+    candidate.status === 'pending' && candidate.promotionTarget !== 'task-lesson';
+  const canAcceptHere = canReview && !requiresTypedPromotion;
   const isMergeable = canReview && candidate.duplicateCount > 1 && !!candidate.duplicateOf;
 
   return (
@@ -236,11 +239,16 @@ function ReflectionCandidateItem({
               size="xs"
               variant="light"
               color="green"
-              disabled={!canReview || busy}
+              disabled={!canAcceptHere || busy}
+              title={
+                requiresTypedPromotion
+                  ? 'This target requires explicit typed review input through the API.'
+                  : undefined
+              }
               leftSection={<CheckCircle2 className="h-3.5 w-3.5" />}
               onClick={onAccept}
             >
-              Accept
+              {requiresTypedPromotion ? 'Typed review' : 'Accept'}
             </Button>
             <Button
               size="xs"
@@ -280,6 +288,11 @@ function ReflectionCandidateItem({
           <Meta label="Correction" value={candidate.correction} />
           <Meta label="Next" value={candidate.nextAttempt} />
           <Meta label="Target" value={promotionLabel(candidate.promotionTarget)} />
+          {requiresTypedPromotion && (
+            <Text size="xs" c="blue">
+              Wider promotion requires explicit typed target input and a reviewer.
+            </Text>
+          )}
         </Stack>
 
         {candidate.evidence.length > 0 && (


### PR DESCRIPTION
## Summary

- require explicit, validated target input before accepting wider-scope reflection promotions
- add retry-safe adapters for workspace memory, team rosters, agent profiles, task templates, decisions, and policies
- write through existing target services and record the applied target on the reflection audit trail
- fail closed on missing adapters, mismatched targets, unknown records, or incomplete input
- prevent the Settings queue from implying that wider targets can be accepted without typed review input

## Verification

- shared, server, and web TypeScript checks
- targeted ESLint for all changed TypeScript and TSX files
- reflection service and adapter tests: 17 passed
- Settings reflections UI tests: 2 passed

## Notes

- task-linked lessons keep their existing direct reviewed path
- stacked on #1088 and will be retargeted to `main` after its prerequisites merge

Completes the remaining typed-promotion acceptance criteria for #866.
