### PR TITLE
feat: add reviewed memory consolidation proposals

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -3717,14 +3717,17 @@ Reviewed queue for turning corrections, repeated mistakes, and failure lessons i
 
 Mounted at `/api/reflections`. Requires `workflow:read` for reads and `workflow:write` for writes.
 
-| Method   | Path                          | Description                                                             |
-| -------- | ----------------------------- | ----------------------------------------------------------------------- |
-| `GET`    | `/api/reflections`            | List candidates with filters for status, category, source kind, task ID |
-| `POST`   | `/api/reflections`            | Create a reflection candidate from a linked source                      |
-| `POST`   | `/api/reflections/:id/accept` | Accept a pending candidate and apply its reviewed promotion             |
-| `POST`   | `/api/reflections/:id/reject` | Reject a pending candidate without affecting future context             |
-| `POST`   | `/api/reflections/:id/merge`  | Soft-merge a duplicate into its representative candidate                |
-| `DELETE` | `/api/reflections/:id`        | Soft-delete a candidate while preserving audit history                  |
+| Method   | Path                                           | Description                                                             |
+| -------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
+| `GET`    | `/api/reflections`                             | List candidates with filters for status, category, source kind, task ID |
+| `POST`   | `/api/reflections`                             | Create a reflection candidate from a linked source                      |
+| `GET`    | `/api/reflections/consolidation/proposals`     | List durable proposals, optionally for one memory domain                |
+| `POST`   | `/api/reflections/consolidation/proposals`     | Create an idempotent proposal from explicit candidate IDs               |
+| `GET`    | `/api/reflections/consolidation/proposals/:id` | Inspect one proposal and its reviewer-facing diff                       |
+| `POST`   | `/api/reflections/:id/accept`                  | Accept a pending candidate and apply its reviewed promotion             |
+| `POST`   | `/api/reflections/:id/reject`                  | Reject a pending candidate without affecting future context             |
+| `POST`   | `/api/reflections/:id/merge`                   | Soft-merge a duplicate into its representative candidate                |
+| `DELETE` | `/api/reflections/:id`                         | Soft-delete a candidate while preserving audit history                  |
 
 Candidates support `session`, `agent`, `team`, `policy`, and `template` categories. Sources can link to `task-run`, `chat-message`, `error`, `user-correction`, `review-feedback`, or `task-observation`.
 
@@ -3771,6 +3774,36 @@ automated extractors to make candidate creation retry-safe. Tokens,
 credential-looking values, and `/Users/...` private paths are redacted before
 storage. Extracted candidates remain pending and cannot affect task lessons or
 agent context until accepted.
+
+### Create a Consolidation Proposal
+
+```http
+POST /api/reflections/consolidation/proposals
+```
+
+```json
+{
+  "domain": {
+    "kind": "workspace-memory",
+    "id": "primary",
+    "workspaceId": "workspace_1"
+  },
+  "candidateIds": ["reflection_1", "reflection_2"],
+  "policy": {
+    "staleAfterDays": 180,
+    "unusedAfterDays": 90,
+    "minimumConfidence": 0.5,
+    "maxCandidates": 500
+  }
+}
+```
+
+The server locks proposal computation per memory domain, rejects unknown or
+over-limit candidate sets, and persists an idempotent
+`reflection-consolidation-proposal/v1` record. The proposal includes the
+effective policy, source digest, stable duplicate clusters, and inspectable
+merge, contradiction, decay, and wider-promotion review operations. Creating a
+proposal never deletes, accepts, or promotes a candidate.
 
 ### Accept Candidate
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -609,6 +609,7 @@ Reviewed promotion queue for agent corrections, repeated mistakes, and durable l
 - **Safe pending output** — Extracted candidates include run/event attribution, proposed scope, confidence, rationale, applicability, and contradiction links; deterministic candidate idempotency prevents duplicates after retries
 - **Ranked reviewed retrieval** — Accepted task lessons are selected by task relevance, confidence, freshness, and observed use; only the top eight enter a run
 - **Run attribution** — Persisted task envelopes carry the reflection, source run, and source event IDs that influenced the run; preview envelopes do not increment use
+- **Inspectable consolidation proposals** — Explicit candidate sets are serialized per memory domain into durable, idempotent merge, contradiction, decay, and wider-promotion review diffs; no candidate is silently deleted or promoted
 - **Settings UI** — Review, accept, reject, delete, and merge candidates from Settings → Reflections
 - **Audit trail** — Create, accept, reject, merge, and delete actions write metadata-only audit events
 

--- a/server/src/__tests__/reflection-consolidation-service.test.ts
+++ b/server/src/__tests__/reflection-consolidation-service.test.ts
@@ -1,0 +1,182 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ReflectionCandidate,
+  ReflectionConsolidationProposal,
+  ReflectionMemoryDomain,
+} from '@veritas-kanban/shared';
+import { ReflectionConsolidationService } from '../services/reflection-consolidation-service.js';
+import { FileReflectionConsolidationProposalRepository } from '../storage/reflection-consolidation-proposal-repository.js';
+
+const roots: string[] = [];
+const domain: ReflectionMemoryDomain = {
+  kind: 'workspace-memory',
+  id: 'primary',
+  workspaceId: 'workspace_1',
+};
+
+function candidate(id: string, overrides: Partial<ReflectionCandidate> = {}): ReflectionCandidate {
+  return {
+    id,
+    status: 'pending',
+    category: 'team',
+    promotionTarget: 'memory',
+    confidence: 0.8,
+    source: { kind: 'task-run', taskId: 'task_1', runId: 'attempt_1' },
+    summary: `Summary ${id}`,
+    previousApproach: 'Old approach',
+    correction: 'Reviewed correction',
+    nextAttempt: 'Use the reviewed correction.',
+    proposedScope: 'workspace',
+    evidence: [],
+    tags: ['workflow'],
+    duplicateKey: `duplicate-${id}`,
+    duplicateCount: 1,
+    appliedTargets: [],
+    redaction: { redacted: false, notes: [] },
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function memoryRepository() {
+  const proposals = new Map<string, ReflectionConsolidationProposal>();
+  return {
+    get: vi.fn(async (id: string) => proposals.get(id)),
+    list: vi.fn(async () => [...proposals.values()]),
+    put: vi.fn(async (proposal: ReflectionConsolidationProposal) => {
+      const existing = proposals.get(proposal.id);
+      if (existing) return existing;
+      proposals.set(proposal.id, proposal);
+      return proposal;
+    }),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe('ReflectionConsolidationService', () => {
+  it('produces stable merge, contradiction, decay, and typed-promotion review diffs', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-reflection-consolidation-'));
+    roots.push(root);
+    const candidates = [
+      candidate('candidate_a', {
+        duplicateKey: 'same-lesson',
+        contradictionIds: ['candidate_c'],
+      }),
+      candidate('candidate_b', { duplicateKey: 'same-lesson', confidence: 0.7 }),
+      candidate('candidate_c', {
+        status: 'accepted',
+        promotionTarget: 'task-lesson',
+        reviewedAt: '2025-01-01T00:00:00.000Z',
+        appliedTargets: [
+          {
+            kind: 'task-lesson',
+            id: 'task_1',
+            appliedAt: '2025-01-01T00:00:00.000Z',
+            appliedBy: 'brad',
+          },
+        ],
+      }),
+      candidate('candidate_policy', { promotionTarget: 'policy', confidence: 0.95 }),
+    ];
+    const repository = memoryRepository();
+    const service = new ReflectionConsolidationService({
+      reflections: { list: vi.fn(async () => ({ candidates })) },
+      proposals: repository,
+      lockDir: root,
+    });
+
+    const first = await service.propose({
+      domain,
+      candidateIds: ['candidate_policy', 'candidate_c', 'candidate_b', 'candidate_a'],
+      createdAt: '2026-07-25T00:00:00.000Z',
+      policy: { unusedAfterDays: 30 },
+    });
+    const retried = await service.propose({
+      domain,
+      candidateIds: ['candidate_a', 'candidate_b', 'candidate_c', 'candidate_policy'],
+      createdAt: '2026-07-26T00:00:00.000Z',
+      policy: { unusedAfterDays: 30 },
+    });
+
+    expect(retried.id).toBe(first.id);
+    expect(retried.sourceDigest).toBe(first.sourceDigest);
+    expect(first.policy.unusedAfterDays).toBe(30);
+    expect(first.clusters.find((cluster) => cluster.clusterKey === 'same-lesson')).toMatchObject({
+      representativeId: 'candidate_a',
+      candidateIds: ['candidate_a', 'candidate_b'],
+    });
+    expect(first.diff.map((entry) => entry.operation)).toEqual(
+      expect.arrayContaining([
+        'merge-review',
+        'contradiction-review',
+        'decay-review',
+        'promotion-review',
+      ])
+    );
+    expect(repository.put).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects candidate sets above the configured bound instead of truncating silently', async () => {
+    const service = new ReflectionConsolidationService({
+      reflections: { list: vi.fn() },
+      proposals: memoryRepository(),
+    });
+
+    await expect(
+      service.propose({
+        domain,
+        candidateIds: ['candidate_a', 'candidate_b'],
+        policy: { maxCandidates: 1 },
+      })
+    ).rejects.toThrow('exceeds the configured maximum of 1');
+  });
+
+  it('serializes proposal computation for the same memory domain', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-reflection-lock-'));
+    roots.push(root);
+    let active = 0;
+    let maxActive = 0;
+    const reflections = {
+      list: vi.fn(async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        active--;
+        return { candidates: [candidate('candidate_a')] };
+      }),
+    };
+    const service = new ReflectionConsolidationService({
+      reflections,
+      proposals: memoryRepository(),
+      lockDir: root,
+    });
+
+    await Promise.all([
+      service.propose({ domain, candidateIds: ['candidate_a'] }),
+      service.propose({ domain, candidateIds: ['candidate_a'] }),
+    ]);
+
+    expect(maxActive).toBe(1);
+  });
+
+  it('persists proposals across file repository restarts', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-reflection-proposals-'));
+    roots.push(root);
+    const service = new ReflectionConsolidationService({
+      reflections: { list: vi.fn(async () => ({ candidates: [candidate('candidate_a')] })) },
+      proposals: new FileReflectionConsolidationProposalRepository(root),
+      lockDir: path.join(root, 'locks'),
+    });
+    const proposal = await service.propose({ domain, candidateIds: ['candidate_a'] });
+
+    const reopened = new FileReflectionConsolidationProposalRepository(root);
+    await expect(reopened.get(proposal.id)).resolves.toEqual(proposal);
+  });
+});

--- a/server/src/__tests__/routes/reflections.test.ts
+++ b/server/src/__tests__/routes/reflections.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import express, { type NextFunction, type Request, type Response } from 'express';
 import request from 'supertest';
 
-const { mockReflectionService } = vi.hoisted(() => ({
+const { mockReflectionService, mockConsolidationService } = vi.hoisted(() => ({
   mockReflectionService: {
     list: vi.fn(),
     create: vi.fn(),
@@ -11,10 +11,19 @@ const { mockReflectionService } = vi.hoisted(() => ({
     delete: vi.fn(),
     mergeDuplicate: vi.fn(),
   },
+  mockConsolidationService: {
+    propose: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+  },
 }));
 
 vi.mock('../../services/reflection-service.js', () => ({
   getReflectionService: () => mockReflectionService,
+}));
+
+vi.mock('../../services/reflection-consolidation-service.js', () => ({
+  getReflectionConsolidationService: () => mockConsolidationService,
 }));
 
 import { reflectionRoutes } from '../../routes/reflections.js';
@@ -49,6 +58,26 @@ const candidate = {
   updatedAt: '2026-06-26T12:00:00.000Z',
 };
 
+const proposal = {
+  schemaVersion: 'reflection-consolidation-proposal/v1',
+  id: 'reflection_proposal_1',
+  domain: { kind: 'workspace-memory', id: 'primary', workspaceId: 'workspace_1' },
+  state: 'proposed',
+  revision: 1,
+  sourceDigest: `sha256:${'a'.repeat(64)}`,
+  policy: {
+    staleAfterDays: 180,
+    unusedAfterDays: 90,
+    minimumConfidence: 0.5,
+    maxCandidates: 500,
+  },
+  clusters: [],
+  diff: [],
+  candidateIds: ['reflection_1'],
+  createdAt: '2026-07-25T12:00:00.000Z',
+  updatedAt: '2026-07-25T12:00:00.000Z',
+};
+
 function createApp() {
   const app = express();
   app.use(express.json());
@@ -80,6 +109,32 @@ describe('reflection routes', () => {
       status: 'deleted',
       mergedInto: 'reflection_0',
     });
+    mockConsolidationService.propose.mockResolvedValue(proposal);
+    mockConsolidationService.get.mockResolvedValue(proposal);
+    mockConsolidationService.list.mockResolvedValue([proposal]);
+  });
+
+  it('creates and inspects bounded consolidation proposals', async () => {
+    const app = createApp();
+    const created = await request(app)
+      .post('/api/reflections/consolidation/proposals')
+      .send({
+        domain: { kind: 'workspace-memory', id: 'primary', workspaceId: 'workspace_1' },
+        candidateIds: ['reflection_1'],
+      });
+    const listed = await request(app).get(
+      '/api/reflections/consolidation/proposals?kind=workspace-memory&id=primary&workspaceId=workspace_1'
+    );
+    const fetched = await request(app).get(
+      '/api/reflections/consolidation/proposals/reflection_proposal_1'
+    );
+
+    expect(created.status).toBe(201);
+    expect(listed.body.proposals).toHaveLength(1);
+    expect(fetched.body.id).toBe('reflection_proposal_1');
+    expect(mockConsolidationService.propose).toHaveBeenCalledWith(
+      expect.objectContaining({ candidateIds: ['reflection_1'] })
+    );
   });
 
   it('lists reflection candidates with validated filters', async () => {

--- a/server/src/routes/reflections.ts
+++ b/server/src/routes/reflections.ts
@@ -2,7 +2,8 @@ import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { asyncHandler } from '../middleware/async-handler.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
-import { ValidationError } from '../middleware/error-handler.js';
+import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { getReflectionConsolidationService } from '../services/reflection-consolidation-service.js';
 import { getReflectionService } from '../services/reflection-service.js';
 
 const router: RouterType = Router();
@@ -25,6 +26,19 @@ const promotionTargetSchema = z.enum([
   'template',
   'policy',
 ]);
+const memoryDomainKindSchema = z.enum([
+  'workspace-memory',
+  'team',
+  'profile',
+  'template',
+  'decision',
+  'policy',
+]);
+const memoryDomainSchema = z.object({
+  kind: memoryDomainKindSchema,
+  id: z.string().trim().min(1).max(160),
+  workspaceId: z.string().trim().min(1).max(160),
+});
 
 const sourceSchema = z
   .object({
@@ -96,6 +110,30 @@ const deleteReflectionSchema = z.object({
 const mergeReflectionSchema = z.object({
   mergedBy: z.string().min(1).max(120).optional(),
 });
+const createConsolidationProposalSchema = z.object({
+  domain: memoryDomainSchema,
+  candidateIds: z.array(z.string().trim().min(1).max(160)).min(1).max(2000),
+  policy: z
+    .object({
+      staleAfterDays: z.number().int().min(1).max(3650).optional(),
+      unusedAfterDays: z.number().int().min(1).max(3650).optional(),
+      minimumConfidence: z.number().min(0).max(1).optional(),
+      maxCandidates: z.number().int().min(1).max(2000).optional(),
+    })
+    .optional(),
+});
+const listConsolidationProposalSchema = z
+  .object({
+    kind: memoryDomainKindSchema.optional(),
+    id: z.string().trim().min(1).max(160).optional(),
+    workspaceId: z.string().trim().min(1).max(160).optional(),
+  })
+  .refine(
+    (value) =>
+      (!value.kind && !value.id && !value.workspaceId) ||
+      (!!value.kind && !!value.id && !!value.workspaceId),
+    { message: 'kind, id, and workspaceId must be supplied together' }
+  );
 
 function parseOrThrow<T>(schema: z.ZodType<T>, value: unknown): T {
   try {
@@ -125,6 +163,36 @@ router.get(
   asyncHandler(async (req, res) => {
     const query = parseOrThrow(listQuerySchema, req.query);
     res.json(await getReflectionService().list(query));
+  })
+);
+
+router.get(
+  '/consolidation/proposals',
+  asyncHandler(async (req, res) => {
+    const query = parseOrThrow(listConsolidationProposalSchema, req.query);
+    const domain =
+      query.kind && query.id && query.workspaceId
+        ? { kind: query.kind, id: query.id, workspaceId: query.workspaceId }
+        : undefined;
+    res.json({ proposals: await getReflectionConsolidationService().list(domain) });
+  })
+);
+
+router.get(
+  '/consolidation/proposals/:proposalId',
+  asyncHandler(async (req, res) => {
+    const proposal = await getReflectionConsolidationService().get(String(req.params.proposalId));
+    if (!proposal) throw new NotFoundError('Reflection consolidation proposal not found');
+    res.json(proposal);
+  })
+);
+
+router.post(
+  '/consolidation/proposals',
+  asyncHandler(async (req, res) => {
+    const body = parseOrThrow(createConsolidationProposalSchema, req.body);
+    const proposal = await getReflectionConsolidationService().propose(body);
+    res.status(201).json(proposal);
   })
 );
 

--- a/server/src/services/reflection-consolidation-service.ts
+++ b/server/src/services/reflection-consolidation-service.ts
@@ -1,0 +1,307 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import type {
+  ReflectionCandidate,
+  ReflectionConsolidationCluster,
+  ReflectionConsolidationDiffEntry,
+  ReflectionConsolidationPolicy,
+  ReflectionConsolidationProposal,
+  ReflectionMemoryDomain,
+} from '@veritas-kanban/shared';
+import { REFLECTION_CONSOLIDATION_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import { ValidationError } from '../middleware/error-handler.js';
+import {
+  FileReflectionConsolidationProposalRepository,
+  type ReflectionConsolidationProposalRepository,
+} from '../storage/reflection-consolidation-proposal-repository.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { withFileLock } from './file-lock.js';
+import { getReflectionService } from './reflection-service.js';
+
+const DEFAULT_POLICY: ReflectionConsolidationPolicy = {
+  staleAfterDays: 180,
+  unusedAfterDays: 90,
+  minimumConfidence: 0.5,
+  maxCandidates: 500,
+};
+
+interface ReflectionCandidateSource {
+  list(input: { limit: number }): Promise<{ candidates: ReflectionCandidate[] }>;
+}
+
+export interface CreateReflectionConsolidationProposalInput {
+  domain: ReflectionMemoryDomain;
+  candidateIds: string[];
+  policy?: Partial<ReflectionConsolidationPolicy>;
+  createdAt?: string;
+}
+
+export interface ReflectionConsolidationServiceOptions {
+  reflections?: ReflectionCandidateSource;
+  proposals?: ReflectionConsolidationProposalRepository;
+  lockDir?: string;
+  now?: () => Date;
+}
+
+export class ReflectionConsolidationService {
+  private readonly reflections: ReflectionCandidateSource;
+  private readonly proposals: ReflectionConsolidationProposalRepository;
+  private readonly lockDir: string;
+  private readonly now: () => Date;
+
+  constructor(options: ReflectionConsolidationServiceOptions = {}) {
+    this.reflections = options.reflections ?? getReflectionService();
+    this.proposals = options.proposals ?? new FileReflectionConsolidationProposalRepository();
+    this.lockDir =
+      options.lockDir ?? path.join(getRuntimeDir(), 'reflections', 'consolidation-locks');
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async propose(
+    input: CreateReflectionConsolidationProposalInput
+  ): Promise<ReflectionConsolidationProposal> {
+    const policy = normalizePolicy(input.policy);
+    const candidateIds = [
+      ...new Set(input.candidateIds.map((id) => id.trim()).filter(Boolean)),
+    ].sort();
+    if (candidateIds.length === 0) {
+      throw new ValidationError('At least one reflection candidate is required.');
+    }
+    if (candidateIds.length > policy.maxCandidates) {
+      throw new ValidationError(
+        `Consolidation candidate count exceeds the configured maximum of ${policy.maxCandidates}.`
+      );
+    }
+    const lockPath = path.join(this.lockDir, `${domainKey(input.domain)}.json`);
+    return withFileLock(lockPath, async () => {
+      const listed = await this.reflections.list({ limit: 2000 });
+      const byId = new Map(listed.candidates.map((candidate) => [candidate.id, candidate]));
+      const missingIds = candidateIds.filter((id) => !byId.has(id));
+      if (missingIds.length > 0) {
+        throw new ValidationError('Consolidation references unknown reflection candidates.', {
+          missingIds,
+        });
+      }
+      const candidates = candidateIds.map((id) => byId.get(id) as ReflectionCandidate);
+      const createdAt = input.createdAt ?? this.now().toISOString();
+      const sourceDigest = digest(candidates.map(candidateSnapshot));
+      const clusters = stableClusters(candidates);
+      const diff = stableDiff(candidates, policy, createdAt);
+      const id = `reflection_proposal_${digest({
+        domain: input.domain,
+        sourceDigest,
+        policy,
+        clusters,
+        diff,
+      }).slice('sha256:'.length, 'sha256:'.length + 32)}`;
+      const previous = (await this.proposals.list(input.domain)).find(
+        (proposal) => proposal.state === 'proposed' && proposal.id !== id
+      );
+      const proposal: ReflectionConsolidationProposal = {
+        schemaVersion: REFLECTION_CONSOLIDATION_SCHEMA_VERSION,
+        id,
+        domain: input.domain,
+        state: 'proposed',
+        revision: 1,
+        sourceDigest,
+        policy,
+        clusters,
+        diff,
+        candidateIds,
+        createdAt,
+        updatedAt: createdAt,
+        supersedesProposalId: previous?.id,
+      };
+      return this.proposals.put(proposal);
+    });
+  }
+
+  get(id: string): Promise<ReflectionConsolidationProposal | undefined> {
+    return this.proposals.get(id);
+  }
+
+  list(domain?: ReflectionMemoryDomain): Promise<ReflectionConsolidationProposal[]> {
+    return this.proposals.list(domain);
+  }
+}
+
+let reflectionConsolidationService: ReflectionConsolidationService | undefined;
+
+export function getReflectionConsolidationService(): ReflectionConsolidationService {
+  reflectionConsolidationService ??= new ReflectionConsolidationService();
+  return reflectionConsolidationService;
+}
+
+function normalizePolicy(
+  input: Partial<ReflectionConsolidationPolicy> | undefined
+): ReflectionConsolidationPolicy {
+  const policy = { ...DEFAULT_POLICY, ...input };
+  if (
+    !Number.isInteger(policy.staleAfterDays) ||
+    policy.staleAfterDays < 1 ||
+    !Number.isInteger(policy.unusedAfterDays) ||
+    policy.unusedAfterDays < 1 ||
+    !Number.isFinite(policy.minimumConfidence) ||
+    policy.minimumConfidence < 0 ||
+    policy.minimumConfidence > 1 ||
+    !Number.isInteger(policy.maxCandidates) ||
+    policy.maxCandidates < 1 ||
+    policy.maxCandidates > 2000
+  ) {
+    throw new ValidationError('Reflection consolidation policy is invalid.');
+  }
+  return policy;
+}
+
+function stableClusters(candidates: ReflectionCandidate[]): ReflectionConsolidationCluster[] {
+  const groups = new Map<string, ReflectionCandidate[]>();
+  for (const candidate of candidates) {
+    const group = groups.get(candidate.duplicateKey) ?? [];
+    group.push(candidate);
+    groups.set(candidate.duplicateKey, group);
+  }
+  return [...groups.entries()]
+    .map(([clusterKey, members]) => {
+      const ordered = [...members].sort(
+        (left, right) =>
+          right.confidence - left.confidence ||
+          Date.parse(left.createdAt) - Date.parse(right.createdAt) ||
+          left.id.localeCompare(right.id)
+      );
+      return {
+        clusterKey,
+        representativeId: ordered[0].id,
+        candidateIds: ordered.map((candidate) => candidate.id).sort(),
+        contradictionIds: [
+          ...new Set(ordered.flatMap((candidate) => candidate.contradictionIds ?? [])),
+        ].sort(),
+      };
+    })
+    .sort(
+      (left, right) =>
+        left.clusterKey.localeCompare(right.clusterKey) ||
+        left.representativeId.localeCompare(right.representativeId)
+    );
+}
+
+function stableDiff(
+  candidates: ReflectionCandidate[],
+  policy: ReflectionConsolidationPolicy,
+  createdAt: string
+): ReflectionConsolidationDiffEntry[] {
+  const entries: ReflectionConsolidationDiffEntry[] = [];
+  for (const cluster of stableClusters(candidates)) {
+    if (cluster.candidateIds.length > 1) {
+      entries.push({
+        operation: 'merge-review',
+        path: `/clusters/${encodeURIComponent(cluster.clusterKey)}`,
+        candidateIds: cluster.candidateIds,
+        before: { candidateIds: cluster.candidateIds },
+        after: { representativeId: cluster.representativeId },
+        reason: 'Candidates share a stable duplicate key and require reviewer-confirmed merge.',
+      });
+    }
+  }
+  const selected = new Set(candidates.map((candidate) => candidate.id));
+  const contradictionPairs = new Set<string>();
+  for (const candidate of candidates) {
+    for (const contradictionId of candidate.contradictionIds ?? []) {
+      if (!selected.has(contradictionId)) continue;
+      const pair = [candidate.id, contradictionId].sort();
+      const key = pair.join('\0');
+      if (contradictionPairs.has(key)) continue;
+      contradictionPairs.add(key);
+      entries.push({
+        operation: 'contradiction-review',
+        path: `/contradictions/${pair.map(encodeURIComponent).join('/')}`,
+        candidateIds: pair,
+        before: null,
+        after: { resolution: 'review-required' },
+        reason: 'Linked candidates contradict one another and cannot be promoted together.',
+      });
+    }
+  }
+  for (const candidate of candidates) {
+    if (shouldProposeDecay(candidate, policy, createdAt)) {
+      entries.push({
+        operation: 'decay-review',
+        path: `/candidates/${encodeURIComponent(candidate.id)}/retention`,
+        candidateIds: [candidate.id],
+        before: {
+          status: candidate.status,
+          retrievalCount: candidate.retrievalCount ?? 0,
+          lastRetrievedAt: candidate.lastRetrievedAt ?? null,
+        },
+        after: { status: 'decay-proposed' },
+        reason: 'Accepted lesson is stale or unused; no deletion occurs without review.',
+      });
+    }
+    if (
+      candidate.status === 'pending' &&
+      candidate.confidence >= policy.minimumConfidence &&
+      candidate.promotionTarget !== 'task-lesson'
+    ) {
+      entries.push({
+        operation: 'promotion-review',
+        path: `/targets/${candidate.promotionTarget}/${encodeURIComponent(candidate.id)}`,
+        candidateIds: [candidate.id],
+        before: null,
+        after: {
+          target: candidate.promotionTarget,
+          proposedScope: candidate.proposedScope ?? 'workspace',
+        },
+        reason: 'Wider-scope promotion requires an explicit reviewer and typed target adapter.',
+      });
+    }
+  }
+  return entries.sort(
+    (left, right) =>
+      left.path.localeCompare(right.path) ||
+      left.operation.localeCompare(right.operation) ||
+      left.candidateIds.join('\0').localeCompare(right.candidateIds.join('\0'))
+  );
+}
+
+function shouldProposeDecay(
+  candidate: ReflectionCandidate,
+  policy: ReflectionConsolidationPolicy,
+  createdAt: string
+): boolean {
+  if (candidate.status !== 'accepted') return false;
+  const reference = candidate.lastRetrievedAt ?? candidate.reviewedAt ?? candidate.updatedAt;
+  const ageDays = (Date.parse(createdAt) - Date.parse(reference)) / 86_400_000;
+  if (!Number.isFinite(ageDays)) return false;
+  return candidate.retrievalCount
+    ? ageDays >= policy.staleAfterDays
+    : ageDays >= policy.unusedAfterDays;
+}
+
+function candidateSnapshot(candidate: ReflectionCandidate) {
+  return {
+    id: candidate.id,
+    status: candidate.status,
+    category: candidate.category,
+    promotionTarget: candidate.promotionTarget,
+    confidence: candidate.confidence,
+    duplicateKey: candidate.duplicateKey,
+    contradictionIds: [...(candidate.contradictionIds ?? [])].sort(),
+    retrievalCount: candidate.retrievalCount ?? 0,
+    lastRetrievedAt: candidate.lastRetrievedAt ?? null,
+    reviewedAt: candidate.reviewedAt ?? null,
+    updatedAt: candidate.updatedAt,
+  };
+}
+
+function digest(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}
+
+function domainKey(domain: ReflectionMemoryDomain): string {
+  return createHash('sha256')
+    .update(domain.workspaceId)
+    .update('\0')
+    .update(domain.kind)
+    .update('\0')
+    .update(domain.id)
+    .digest('hex');
+}

--- a/server/src/storage/reflection-consolidation-proposal-repository.ts
+++ b/server/src/storage/reflection-consolidation-proposal-repository.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  ReflectionConsolidationProposal,
+  ReflectionMemoryDomain,
+} from '@veritas-kanban/shared';
+import { REFLECTION_CONSOLIDATION_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import { withFileLock } from '../services/file-lock.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+
+const MAX_PROPOSALS = 500;
+
+interface ProposalState {
+  version: 1;
+  proposals: ReflectionConsolidationProposal[];
+}
+
+export interface ReflectionConsolidationProposalRepository {
+  get(id: string): Promise<ReflectionConsolidationProposal | undefined>;
+  list(domain?: ReflectionMemoryDomain): Promise<ReflectionConsolidationProposal[]>;
+  put(proposal: ReflectionConsolidationProposal): Promise<ReflectionConsolidationProposal>;
+}
+
+export class FileReflectionConsolidationProposalRepository implements ReflectionConsolidationProposalRepository {
+  private readonly storageDir: string;
+  private readonly statePath: string;
+
+  constructor(storageDir = path.join(getRuntimeDir(), 'reflections')) {
+    this.storageDir = storageDir;
+    this.statePath = path.join(storageDir, 'consolidation-proposals.json');
+    ensureWithinBase(storageDir, this.statePath);
+  }
+
+  async get(id: string): Promise<ReflectionConsolidationProposal | undefined> {
+    return (await this.read()).proposals.find((proposal) => proposal.id === id);
+  }
+
+  async list(domain?: ReflectionMemoryDomain): Promise<ReflectionConsolidationProposal[]> {
+    const proposals = (await this.read()).proposals;
+    return proposals
+      .filter((proposal) => !domain || sameDomain(proposal.domain, domain))
+      .sort(
+        (left, right) =>
+          Date.parse(right.updatedAt) - Date.parse(left.updatedAt) ||
+          left.id.localeCompare(right.id)
+      );
+  }
+
+  async put(proposal: ReflectionConsolidationProposal): Promise<ReflectionConsolidationProposal> {
+    await fs.mkdir(this.storageDir, { recursive: true });
+    return withFileLock(this.statePath, async () => {
+      const state = await this.read();
+      const existing = state.proposals.find((item) => item.id === proposal.id);
+      if (existing) return existing;
+      state.proposals.push(proposal);
+      state.proposals = state.proposals
+        .sort(
+          (left, right) =>
+            Date.parse(left.createdAt) - Date.parse(right.createdAt) ||
+            left.id.localeCompare(right.id)
+        )
+        .slice(-MAX_PROPOSALS);
+      await fs.writeFile(this.statePath, JSON.stringify(state, null, 2), 'utf8');
+      return proposal;
+    });
+  }
+
+  private async read(): Promise<ProposalState> {
+    try {
+      const parsed = JSON.parse(
+        await fs.readFile(this.statePath, 'utf8')
+      ) as Partial<ProposalState>;
+      return {
+        version: 1,
+        proposals: Array.isArray(parsed.proposals) ? parsed.proposals.filter(isProposal) : [],
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { version: 1, proposals: [] };
+      }
+      throw error;
+    }
+  }
+}
+
+function isProposal(value: unknown): value is ReflectionConsolidationProposal {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as ReflectionConsolidationProposal).schemaVersion ===
+      REFLECTION_CONSOLIDATION_SCHEMA_VERSION &&
+    typeof (value as ReflectionConsolidationProposal).id === 'string' &&
+    Array.isArray((value as ReflectionConsolidationProposal).diff)
+  );
+}
+
+function sameDomain(left: ReflectionMemoryDomain, right: ReflectionMemoryDomain): boolean {
+  return left.kind === right.kind && left.id === right.id && left.workspaceId === right.workspaceId;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -11,6 +11,7 @@ export * from './communication-adapter.types.js';
 export * from './ceremony.types.js';
 export * from './reflection.types.js';
 export * from './reflection-extraction-job.types.js';
+export * from './reflection-consolidation.types.js';
 export * from './external-tracker.types.js';
 export * from './transition-hooks.types.js';
 export * from './delegation.types.js';

--- a/shared/src/types/reflection-consolidation.types.ts
+++ b/shared/src/types/reflection-consolidation.types.ts
@@ -1,0 +1,59 @@
+export const REFLECTION_CONSOLIDATION_SCHEMA_VERSION =
+  'reflection-consolidation-proposal/v1' as const;
+
+export type ReflectionMemoryDomainKind =
+  'workspace-memory' | 'team' | 'profile' | 'template' | 'decision' | 'policy';
+
+export interface ReflectionMemoryDomain {
+  kind: ReflectionMemoryDomainKind;
+  id: string;
+  workspaceId: string;
+}
+
+export type ReflectionConsolidationProposalState =
+  'proposed' | 'accepted' | 'rejected' | 'applied' | 'superseded';
+
+export interface ReflectionConsolidationCluster {
+  clusterKey: string;
+  representativeId: string;
+  candidateIds: string[];
+  contradictionIds: string[];
+}
+
+export type ReflectionConsolidationDiffOperation =
+  'merge-review' | 'contradiction-review' | 'decay-review' | 'promotion-review';
+
+export interface ReflectionConsolidationDiffEntry {
+  operation: ReflectionConsolidationDiffOperation;
+  path: string;
+  candidateIds: string[];
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  reason: string;
+}
+
+export interface ReflectionConsolidationProposal {
+  schemaVersion: typeof REFLECTION_CONSOLIDATION_SCHEMA_VERSION;
+  id: string;
+  domain: ReflectionMemoryDomain;
+  state: ReflectionConsolidationProposalState;
+  revision: number;
+  sourceDigest: string;
+  policy: ReflectionConsolidationPolicy;
+  clusters: ReflectionConsolidationCluster[];
+  diff: ReflectionConsolidationDiffEntry[];
+  candidateIds: string[];
+  createdAt: string;
+  updatedAt: string;
+  reviewedAt?: string;
+  reviewedBy?: string;
+  reviewerNote?: string;
+  supersedesProposalId?: string;
+}
+
+export interface ReflectionConsolidationPolicy {
+  staleAfterDays: number;
+  unusedAfterDays: number;
+  minimumConfidence: number;
+  maxCandidates: number;
+}


### PR DESCRIPTION
## Summary

- persist idempotent `reflection-consolidation-proposal/v1` records from explicit candidate IDs
- serialize proposal computation per memory domain and reject unknown or over-limit candidate sets
- expose stable merge, contradiction, decay, and wider-promotion review diffs through the reflections API
- document the proposal contract and its no-mutation boundary

## Verification

- `node_modules/.bin/tsc -p shared/tsconfig.json`
- `node_modules/.bin/tsc -p server/tsconfig.json --noEmit`
- `../node_modules/.bin/vitest --config vitest.config.ts run src/__tests__/reflection-consolidation-service.test.ts` (4 passed)
- targeted ESLint for all changed TypeScript files

## Notes

- proposals are inspectable only; they do not delete, accept, or promote candidates
- replaces #1088, which GitHub closed when its temporary base branch was deleted

Part of #866.