### PR TITLE
feat: add typed reviewed reflection promotions

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -3821,7 +3821,39 @@ POST /api/reflections/:id/accept
 }
 ```
 
-For `task-lesson`, the candidate must have a linked `source.taskId`; acceptance appends a reviewed reflection lesson to that task and adds `reflection` lesson tags. Other promotion targets are recorded as manual-review targets and do not mutate policy, profile, template, or memory stores automatically.
+For `task-lesson`, the candidate must have a linked `source.taskId`;
+acceptance appends a reviewed reflection lesson to that task and adds
+`reflection` lesson tags.
+
+Wider targets fail closed unless the request supplies a matching typed
+`promotion` object. The authenticated actor is the reviewer when `reviewedBy`
+is omitted. For example, a profile capability promotion is:
+
+```json
+{
+  "promotionTarget": "profile",
+  "promotion": {
+    "target": "profile",
+    "profileId": "backend-reviewer",
+    "capabilitiesToAdd": ["schema-review"]
+  },
+  "reviewerNote": "Approved for this profile."
+}
+```
+
+Typed inputs are available for:
+
+- `memory`: `workspaceId`
+- `team`: `rosterId`, `memberId`, and `capabilitiesToAdd`
+- `profile`: `profileId` and `capabilitiesToAdd`
+- `template`: `templateId`; the redacted candidate guidance is appended with a stable reflection marker
+- `decision`: `agentId`, `taskId`, `confidenceLevel`, `riskScore`, and optional `parentDecisionId`
+- `policy`: a complete validated `AgentPolicy`
+
+Each adapter writes through the existing target service, records the applied
+target on the reflection audit event, and is retry-safe for its target. A
+missing adapter, mismatched target, unknown target record, or incomplete typed
+payload rejects the acceptance without marking the candidate accepted.
 
 ### Reject or Merge
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -610,6 +610,7 @@ Reviewed promotion queue for agent corrections, repeated mistakes, and durable l
 - **Ranked reviewed retrieval** — Accepted task lessons are selected by task relevance, confidence, freshness, and observed use; only the top eight enter a run
 - **Run attribution** — Persisted task envelopes carry the reflection, source run, and source event IDs that influenced the run; preview envelopes do not increment use
 - **Inspectable consolidation proposals** — Explicit candidate sets are serialized per memory domain into durable, idempotent merge, contradiction, decay, and wider-promotion review diffs; no candidate is silently deleted or promoted
+- **Typed durable promotions** — Memory, team roster, agent profile, task template, decision, and policy changes require an authenticated reviewer plus target-specific validated input; unowned targets fail closed
 - **Settings UI** — Review, accept, reject, delete, and merge candidates from Settings → Reflections
 - **Audit trail** — Create, accept, reject, merge, and delete actions write metadata-only audit events
 

--- a/server/src/__tests__/reflection-promotion-adapters.test.ts
+++ b/server/src/__tests__/reflection-promotion-adapters.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  AgentPolicy,
+  AgentProfilePackage,
+  DecisionRecord,
+  ReflectionCandidate,
+  ReflectionTypedPromotionInput,
+  TaskTemplate,
+  TeamRosterManifest,
+} from '@veritas-kanban/shared';
+import {
+  createBuiltInReflectionPromotionAdapters,
+  ReflectionPromotionAdapterRegistry,
+  type ReflectionPromotionAdapterDependencies,
+} from '../services/reflection-promotion-adapters.js';
+
+function candidate(overrides: Partial<ReflectionCandidate> = {}): ReflectionCandidate {
+  return {
+    id: 'reflection_1',
+    status: 'pending',
+    category: 'team',
+    promotionTarget: 'memory',
+    confidence: 0.8,
+    source: { kind: 'task-run', taskId: 'task_1', runId: 'attempt_1' },
+    summary: 'Use the current schema.',
+    previousApproach: 'Guessed the old schema.',
+    correction: 'Inspect the current schema.',
+    nextAttempt: 'Read the current schema before editing.',
+    rationale: 'The correction is reusable.',
+    evidence: [],
+    tags: ['schema'],
+    duplicateKey: 'schema',
+    duplicateCount: 1,
+    appliedTargets: [],
+    redaction: { redacted: false, notes: [] },
+    createdAt: '2026-07-25T00:00:00.000Z',
+    updatedAt: '2026-07-25T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function harness() {
+  let roster: TeamRosterManifest = {
+    id: 'roster_1',
+    schemaVersion: 'team-roster/v1',
+    workspaceId: 'workspace_1',
+    name: 'Primary',
+    enabled: true,
+    members: [
+      {
+        id: 'member_1',
+        displayName: 'Builder',
+        role: 'Implementation',
+        agent: 'codex',
+        status: 'enabled',
+        capabilities: ['typescript'],
+      },
+    ],
+    routingRules: [],
+  };
+  let profile: AgentProfilePackage = {
+    id: 'profile_1',
+    schemaVersion: 'agent-profile-package/v1',
+    version: '1.0.0',
+    displayName: 'Builder',
+    role: 'Implementation',
+    enabled: true,
+    capabilities: ['typescript'],
+    defaultTaskTypes: ['feature'],
+    runtime: { agent: 'codex' },
+  };
+  let template: TaskTemplate = {
+    id: 'template_1',
+    name: 'Feature',
+    version: 1,
+    taskDefaults: { descriptionTemplate: 'Existing guidance.' },
+    created: '2026-07-25T00:00:00.000Z',
+    updated: '2026-07-25T00:00:00.000Z',
+  };
+  const decisions: DecisionRecord[] = [];
+  const policies = new Map<string, AgentPolicy>();
+  const updateProfile = vi.fn(async (_id: string, patch: { capabilities?: string[] }) => {
+    profile = { ...profile, capabilities: patch.capabilities ?? profile.capabilities };
+    return profile;
+  });
+  const updateTemplate = vi.fn(
+    async (_id: string, patch: { taskDefaults?: TaskTemplate['taskDefaults'] }) => {
+      template = {
+        ...template,
+        taskDefaults: { ...template.taskDefaults, ...patch.taskDefaults },
+      };
+      return template;
+    }
+  );
+  const dependencies: ReflectionPromotionAdapterDependencies = {
+    teamRoster: () => ({
+      async mutateRoster<T>(mutator) {
+        const mutation = mutator(roster, []);
+        roster = mutation.roster;
+        return mutation.result as T;
+      },
+    }),
+    profiles: () => ({
+      getProfile: vi.fn(async () => profile),
+      updateProfile,
+    }),
+    templates: () => ({
+      getTemplate: vi.fn(async () => template),
+      updateTemplate,
+    }),
+    decisions: () => ({
+      list: vi.fn(async () => decisions),
+      create: vi.fn(async (input) => {
+        const decision: DecisionRecord = {
+          id: `decision_${decisions.length + 1}`,
+          inputContext: input.inputContext,
+          outputAction: input.outputAction,
+          assumptions: (input.assumptions ?? []).map((assumption) => ({
+            text: typeof assumption === 'string' ? assumption : assumption.text,
+            status: 'pending',
+          })),
+          confidenceLevel: input.confidenceLevel,
+          riskScore: input.riskScore,
+          parentDecisionId: input.parentDecisionId,
+          agentId: input.agentId,
+          taskId: input.taskId,
+          timestamp: input.timestamp ?? '2026-07-25T00:00:00.000Z',
+        };
+        decisions.push(decision);
+        return decision;
+      }),
+    }),
+    policies: () => ({
+      getPolicy: vi.fn(async (id) => policies.get(id) ?? null),
+      createPolicy: vi.fn(async (policyInput) => {
+        policies.set(policyInput.id, policyInput);
+        return policyInput;
+      }),
+      updatePolicy: vi.fn(async (_id, policyInput) => {
+        policies.set(policyInput.id, policyInput);
+        return policyInput;
+      }),
+    }),
+  };
+  return {
+    registry: new ReflectionPromotionAdapterRegistry(
+      createBuiltInReflectionPromotionAdapters(dependencies)
+    ),
+    getRoster: () => roster,
+    getProfile: () => profile,
+    getTemplate: () => template,
+    getDecisions: () => decisions,
+    getPolicies: () => policies,
+    updateProfile,
+    updateTemplate,
+  };
+}
+
+async function apply(
+  registry: ReflectionPromotionAdapterRegistry,
+  promotion: ReflectionTypedPromotionInput,
+  overrides: Partial<ReflectionCandidate> = {}
+) {
+  return registry.apply({
+    candidate: candidate({ promotionTarget: promotion.target, ...overrides }),
+    promotion,
+    reviewedBy: 'brad',
+    timestamp: '2026-07-25T12:00:00.000Z',
+  });
+}
+
+describe('typed reflection promotion adapters', () => {
+  it('scopes accepted memory to an explicit workspace', async () => {
+    const { registry } = harness();
+
+    await expect(
+      apply(registry, { target: 'memory', workspaceId: 'workspace_1' })
+    ).resolves.toMatchObject({
+      kind: 'memory',
+      id: 'workspace_1',
+      appliedBy: 'brad',
+    });
+  });
+
+  it('adds reviewed team capabilities without replacing the roster', async () => {
+    const { registry, getRoster } = harness();
+
+    const result = await apply(registry, {
+      target: 'team',
+      rosterId: 'roster_1',
+      memberId: 'member_1',
+      capabilitiesToAdd: ['rust', 'typescript'],
+    });
+
+    expect(result).toMatchObject({ kind: 'team', id: 'roster_1:member_1' });
+    expect(getRoster().members[0].capabilities).toEqual(['typescript', 'rust']);
+  });
+
+  it('adds reviewed capabilities through the profile service', async () => {
+    const { registry, getProfile, updateProfile } = harness();
+
+    await apply(registry, {
+      target: 'profile',
+      profileId: 'profile_1',
+      capabilitiesToAdd: ['review', 'typescript'],
+    });
+
+    expect(getProfile().capabilities).toEqual(['typescript', 'review']);
+    expect(updateProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it('appends redacted reviewed guidance to a task template idempotently', async () => {
+    const { registry, getTemplate, updateTemplate } = harness();
+    const promotion: ReflectionTypedPromotionInput = {
+      target: 'template',
+      templateId: 'template_1',
+    };
+
+    await apply(registry, promotion);
+    await apply(registry, promotion);
+
+    expect(getTemplate().taskDefaults.descriptionTemplate).toContain('[Reflection reflection_1]');
+    expect(getTemplate().taskDefaults.descriptionTemplate).toContain(
+      'Read the current schema before editing.'
+    );
+    expect(updateTemplate).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates one source-linked decision across retries', async () => {
+    const { registry, getDecisions } = harness();
+    const promotion: ReflectionTypedPromotionInput = {
+      target: 'decision',
+      agentId: 'codex',
+      taskId: 'task_1',
+      confidenceLevel: 0.8,
+      riskScore: 20,
+    };
+
+    await apply(registry, promotion);
+    await apply(registry, promotion);
+
+    expect(getDecisions()).toHaveLength(1);
+    expect(getDecisions()[0]).toMatchObject({
+      inputContext: expect.stringContaining('[Reflection reflection_1]'),
+      outputAction: 'Read the current schema before editing.',
+    });
+  });
+
+  it('creates or updates a complete policy through the policy service', async () => {
+    const { registry, getPolicies } = harness();
+    const policy: AgentPolicy = {
+      id: 'review-schema',
+      name: 'Review schema',
+      type: 'require-approval',
+      enabled: true,
+      scope: { actionTypes: ['schema-change'] },
+      responseAction: 'require-approval',
+      config: { reason: 'Require review for schema changes.', approvers: ['brad'] },
+    };
+
+    await apply(registry, { target: 'policy', policy });
+    await apply(registry, {
+      target: 'policy',
+      policy: { ...policy, description: 'Updated by a reviewed reflection.' },
+    });
+
+    expect(getPolicies().get(policy.id)?.description).toBe('Updated by a reviewed reflection.');
+  });
+
+  it('fails closed when no adapter owns the requested target', async () => {
+    const registry = new ReflectionPromotionAdapterRegistry([]);
+
+    await expect(apply(registry, { target: 'memory', workspaceId: 'workspace_1' })).rejects.toThrow(
+      'No typed reflection promotion adapter is registered'
+    );
+  });
+});

--- a/server/src/__tests__/reflection-service.test.ts
+++ b/server/src/__tests__/reflection-service.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { CreateReflectionCandidateInput, Task } from '@veritas-kanban/shared';
-import { ReflectionService, type ReflectionTaskService } from '../services/reflection-service.js';
+import {
+  ReflectionService,
+  type ReflectionServiceOptions,
+  type ReflectionTaskService,
+} from '../services/reflection-service.js';
 
 function createInput(
   overrides: Partial<CreateReflectionCandidateInput> = {}
@@ -36,7 +40,10 @@ function createTask(overrides: Partial<Task> = {}): Task {
   } as Task;
 }
 
-function createHarness(task: Task = createTask()) {
+function createHarness(
+  task: Task = createTask(),
+  promotionAdapters?: ReflectionServiceOptions['promotionAdapters']
+) {
   const audit = vi.fn().mockResolvedValue(undefined);
   const updateTask = vi.fn().mockResolvedValue(task);
   const taskService: ReflectionTaskService = {
@@ -51,6 +58,7 @@ function createHarness(task: Task = createTask()) {
       persist: false,
       audit,
       taskService,
+      promotionAdapters,
     }),
   };
 }
@@ -134,6 +142,56 @@ describe('ReflectionService', () => {
       expect.objectContaining({
         lessonsLearned: expect.stringContaining('Reflection Lesson'),
         lessonTags: expect.arrayContaining(['reflection', 'reflection:team']),
+      })
+    );
+  });
+
+  it('fails closed when a wider promotion has no explicit typed target input', async () => {
+    const { service } = createHarness();
+    const candidate = await service.create(
+      createInput({
+        promotionTarget: 'profile',
+      })
+    );
+
+    await expect(
+      service.accept(candidate.id, {
+        reviewedBy: 'brad',
+        promotionTarget: 'profile',
+      })
+    ).rejects.toThrow('requires explicit typed target input');
+  });
+
+  it('records the target returned by the matching typed promotion adapter', async () => {
+    const promotionAdapters = {
+      apply: vi.fn(async () => ({
+        kind: 'profile' as const,
+        id: 'profile_1',
+        title: 'Backend reviewer',
+        appliedAt: '2026-07-25T12:00:00.000Z',
+        appliedBy: 'brad',
+      })),
+    };
+    const { service } = createHarness(createTask(), promotionAdapters);
+    const candidate = await service.create(createInput({ promotionTarget: 'profile' }));
+
+    const accepted = await service.accept(candidate.id, {
+      reviewedBy: 'brad',
+      promotion: {
+        target: 'profile',
+        profileId: 'profile_1',
+        capabilitiesToAdd: ['schema-review'],
+      },
+    });
+
+    expect(accepted).toMatchObject({
+      status: 'accepted',
+      appliedTargets: [{ kind: 'profile', id: 'profile_1', appliedBy: 'brad' }],
+    });
+    expect(promotionAdapters.apply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reviewedBy: 'brad',
+        promotion: expect.objectContaining({ target: 'profile', profileId: 'profile_1' }),
       })
     );
   });

--- a/server/src/__tests__/routes/reflections.test.ts
+++ b/server/src/__tests__/routes/reflections.test.ts
@@ -191,6 +191,30 @@ describe('reflection routes', () => {
     });
   });
 
+  it('validates typed wider-promotion input before acceptance', async () => {
+    const res = await request(createApp())
+      .post('/api/reflections/reflection_1/accept')
+      .send({
+        promotionTarget: 'profile',
+        promotion: {
+          target: 'profile',
+          profileId: 'profile_1',
+          capabilitiesToAdd: ['schema-review'],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockReflectionService.accept).toHaveBeenCalledWith('reflection_1', {
+      reviewedBy: 'brad',
+      promotionTarget: 'profile',
+      promotion: {
+        target: 'profile',
+        profileId: 'profile_1',
+        capabilitiesToAdd: ['schema-review'],
+      },
+    });
+  });
+
   it('rejects candidates without a source identifier', async () => {
     const res = await request(createApp())
       .post('/api/reflections')

--- a/server/src/routes/reflections.ts
+++ b/server/src/routes/reflections.ts
@@ -5,6 +5,7 @@ import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { getReflectionConsolidationService } from '../services/reflection-consolidation-service.js';
 import { getReflectionService } from '../services/reflection-service.js';
+import { policySchema } from '../schemas/policy-schemas.js';
 
 const router: RouterType = Router();
 
@@ -21,6 +22,7 @@ const sourceKindSchema = z.enum([
 const promotionTargetSchema = z.enum([
   'task-lesson',
   'memory',
+  'team',
   'decision',
   'profile',
   'template',
@@ -39,6 +41,41 @@ const memoryDomainSchema = z.object({
   id: z.string().trim().min(1).max(160),
   workspaceId: z.string().trim().min(1).max(160),
 });
+const targetIdSchema = z.string().trim().min(1).max(160);
+const capabilitySchema = z.string().trim().min(1).max(160);
+const typedPromotionSchema = z.discriminatedUnion('target', [
+  z.object({
+    target: z.literal('memory'),
+    workspaceId: targetIdSchema,
+  }),
+  z.object({
+    target: z.literal('team'),
+    rosterId: targetIdSchema,
+    memberId: targetIdSchema,
+    capabilitiesToAdd: z.array(capabilitySchema).min(1).max(80),
+  }),
+  z.object({
+    target: z.literal('profile'),
+    profileId: targetIdSchema,
+    capabilitiesToAdd: z.array(capabilitySchema).min(1).max(80),
+  }),
+  z.object({
+    target: z.literal('template'),
+    templateId: targetIdSchema,
+  }),
+  z.object({
+    target: z.literal('decision'),
+    agentId: targetIdSchema,
+    taskId: targetIdSchema,
+    confidenceLevel: z.number().min(0).max(1),
+    riskScore: z.number().min(0).max(100),
+    parentDecisionId: targetIdSchema.optional(),
+  }),
+  z.object({
+    target: z.literal('policy'),
+    policy: policySchema,
+  }),
+]);
 
 const sourceSchema = z
   .object({
@@ -91,11 +128,26 @@ const listQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(500).optional(),
 });
 
-const acceptReflectionSchema = z.object({
-  reviewedBy: z.string().min(1).max(120).optional(),
-  promotionTarget: promotionTargetSchema.optional(),
-  reviewerNote: z.string().max(2000).optional(),
-});
+const acceptReflectionSchema = z
+  .object({
+    reviewedBy: z.string().min(1).max(120).optional(),
+    promotionTarget: promotionTargetSchema.optional(),
+    promotion: typedPromotionSchema.optional(),
+    reviewerNote: z.string().max(2000).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.promotion &&
+      value.promotionTarget &&
+      value.promotion.target !== value.promotionTarget
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['promotion'],
+        message: 'promotion.target must match promotionTarget',
+      });
+    }
+  });
 
 const rejectReflectionSchema = z.object({
   reviewedBy: z.string().min(1).max(120).optional(),

--- a/server/src/services/reflection-promotion-adapters.ts
+++ b/server/src/services/reflection-promotion-adapters.ts
@@ -1,0 +1,252 @@
+import type {
+  ReflectionAppliedTarget,
+  ReflectionCandidate,
+  ReflectionTypedPromotionInput,
+  TeamRosterManifest,
+  TeamRosterMember,
+} from '@veritas-kanban/shared';
+import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
+import {
+  getAgentProfilePackageService,
+  type AgentProfilePackageService,
+} from './agent-profile-package-service.js';
+import { getDecisionService, type DecisionService } from './decision-service.js';
+import { getPolicyService, type PolicyService } from './policy-service.js';
+import { getTeamRosterService, type TeamRosterService } from './team-roster-service.js';
+import { TemplateService } from './template-service.js';
+
+export interface ReflectionPromotionApplyContext {
+  candidate: ReflectionCandidate;
+  promotion: ReflectionTypedPromotionInput;
+  reviewedBy: string;
+  timestamp: string;
+}
+
+export interface ReflectionPromotionAdapter {
+  target: ReflectionTypedPromotionInput['target'];
+  apply(context: ReflectionPromotionApplyContext): Promise<ReflectionAppliedTarget>;
+}
+
+export interface ReflectionPromotionAdapterDependencies {
+  teamRoster: () => Pick<TeamRosterService, 'mutateRoster'>;
+  profiles: () => Pick<AgentProfilePackageService, 'getProfile' | 'updateProfile'>;
+  templates: () => Pick<TemplateService, 'getTemplate' | 'updateTemplate'>;
+  decisions: () => Pick<DecisionService, 'create' | 'list'>;
+  policies: () => Pick<PolicyService, 'getPolicy' | 'createPolicy' | 'updatePolicy'>;
+}
+
+export class ReflectionPromotionAdapterRegistry {
+  private readonly adapters: Map<
+    ReflectionTypedPromotionInput['target'],
+    ReflectionPromotionAdapter
+  >;
+
+  constructor(adapters: ReflectionPromotionAdapter[] = createBuiltInReflectionPromotionAdapters()) {
+    this.adapters = new Map();
+    for (const adapter of adapters) {
+      if (this.adapters.has(adapter.target)) {
+        throw new ConflictError(
+          `Multiple typed reflection promotion adapters are registered for ${adapter.target}.`
+        );
+      }
+      this.adapters.set(adapter.target, adapter);
+    }
+  }
+
+  async apply(context: ReflectionPromotionApplyContext): Promise<ReflectionAppliedTarget> {
+    const adapter = this.adapters.get(context.promotion.target);
+    if (!adapter) {
+      throw new ConflictError(
+        `No typed reflection promotion adapter is registered for ${context.promotion.target}.`
+      );
+    }
+    return adapter.apply(context);
+  }
+}
+
+export function createBuiltInReflectionPromotionAdapters(
+  dependencies: ReflectionPromotionAdapterDependencies = defaultDependencies()
+): ReflectionPromotionAdapter[] {
+  return [
+    {
+      target: 'memory',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'memory');
+        return appliedTarget('memory', promotion.workspaceId, 'Reviewed workspace memory', context);
+      },
+    },
+    {
+      target: 'team',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'team');
+        const member = await dependencies.teamRoster().mutateRoster((roster) => {
+          if (!roster || roster.id !== promotion.rosterId) {
+            throw new NotFoundError(`Team roster not found: ${promotion.rosterId}`);
+          }
+          const existing = roster.members.find((item) => item.id === promotion.memberId);
+          if (!existing) {
+            throw new NotFoundError(`Team roster member not found: ${promotion.memberId}`);
+          }
+          const updated: TeamRosterMember = {
+            ...existing,
+            capabilities: stableUnion(existing.capabilities, promotion.capabilitiesToAdd),
+          };
+          const next: TeamRosterManifest = {
+            ...roster,
+            members: roster.members.map((item) => (item.id === updated.id ? updated : item)),
+          };
+          return { roster: next, result: updated };
+        });
+        return appliedTarget(
+          'team',
+          `${promotion.rosterId}:${member.id}`,
+          member.displayName,
+          context
+        );
+      },
+    },
+    {
+      target: 'profile',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'profile');
+        const service = dependencies.profiles();
+        const existing = await service.getProfile(promotion.profileId);
+        if (!existing) {
+          throw new NotFoundError(`Agent profile package not found: ${promotion.profileId}`);
+        }
+        const updated = await service.updateProfile(promotion.profileId, {
+          capabilities: stableUnion(existing.capabilities, promotion.capabilitiesToAdd),
+        });
+        return appliedTarget('profile', updated.id, updated.displayName, context);
+      },
+    },
+    {
+      target: 'template',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'template');
+        const service = dependencies.templates();
+        const existing = await service.getTemplate(promotion.templateId);
+        if (!existing) {
+          throw new NotFoundError(`Task template not found: ${promotion.templateId}`);
+        }
+        const marker = `[Reflection ${context.candidate.id}]`;
+        const current = existing.taskDefaults.descriptionTemplate?.trim();
+        const guidance = `${marker}\n${context.candidate.nextAttempt}`;
+        const updated = current?.includes(marker)
+          ? existing
+          : await service.updateTemplate(existing.id, {
+              taskDefaults: {
+                descriptionTemplate: current ? `${current}\n\n${guidance}` : guidance,
+              },
+            });
+        if (!updated) {
+          throw new NotFoundError(`Task template not found: ${promotion.templateId}`);
+        }
+        return appliedTarget('template', updated.id, updated.name, context);
+      },
+    },
+    {
+      target: 'decision',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'decision');
+        const service = dependencies.decisions();
+        const marker = `[Reflection ${context.candidate.id}]`;
+        const existing = (
+          await service.list({
+            agent: promotion.agentId,
+          })
+        ).find(
+          (decision) =>
+            decision.taskId === promotion.taskId && decision.inputContext.startsWith(marker)
+        );
+        const decision =
+          existing ??
+          (await service.create({
+            inputContext: `${marker}\n${context.candidate.rationale ?? context.candidate.summary}`,
+            outputAction: context.candidate.nextAttempt,
+            assumptions: context.candidate.previousApproach
+              ? [context.candidate.previousApproach]
+              : undefined,
+            confidenceLevel: promotion.confidenceLevel,
+            riskScore: promotion.riskScore,
+            parentDecisionId: promotion.parentDecisionId,
+            agentId: promotion.agentId,
+            taskId: promotion.taskId,
+            timestamp: context.timestamp,
+          }));
+        return appliedTarget('decision', decision.id, decision.outputAction, context);
+      },
+    },
+    {
+      target: 'policy',
+      async apply(context) {
+        const promotion = promotionFor(context.promotion, 'policy');
+        const service = dependencies.policies();
+        const existing = await service.getPolicy(promotion.policy.id);
+        const policy = existing
+          ? await service.updatePolicy(existing.id, promotion.policy)
+          : await service.createPolicy(promotion.policy);
+        return appliedTarget('policy', policy.id, policy.name, context);
+      },
+    },
+  ];
+}
+
+function promotionFor<TTarget extends ReflectionTypedPromotionInput['target']>(
+  promotion: ReflectionTypedPromotionInput,
+  target: TTarget
+): Extract<ReflectionTypedPromotionInput, { target: TTarget }> {
+  if (promotion.target !== target) {
+    throw new ConflictError(`Expected ${target} promotion input, received ${promotion.target}.`);
+  }
+  return promotion as Extract<ReflectionTypedPromotionInput, { target: TTarget }>;
+}
+
+function stableUnion(existing: string[], additions: string[]): string[] {
+  const values: string[] = [];
+  const seen = new Set<string>();
+  for (const value of [...existing, ...additions]) {
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    values.push(normalized);
+  }
+  return values.slice(0, 80);
+}
+
+function appliedTarget(
+  kind: ReflectionAppliedTarget['kind'],
+  id: string,
+  title: string,
+  context: Pick<ReflectionPromotionApplyContext, 'reviewedBy' | 'timestamp'>
+): ReflectionAppliedTarget {
+  return {
+    kind,
+    id,
+    title,
+    appliedAt: context.timestamp,
+    appliedBy: context.reviewedBy,
+  };
+}
+
+let templateService: TemplateService | undefined;
+
+function defaultDependencies(): ReflectionPromotionAdapterDependencies {
+  return {
+    teamRoster: () => getTeamRosterService(),
+    profiles: () => getAgentProfilePackageService(),
+    templates: () => {
+      templateService ??= new TemplateService();
+      return templateService;
+    },
+    decisions: () => getDecisionService(),
+    policies: () => getPolicyService(),
+  };
+}
+
+let reflectionPromotionAdapterRegistry: ReflectionPromotionAdapterRegistry | undefined;
+
+export function getReflectionPromotionAdapterRegistry(): ReflectionPromotionAdapterRegistry {
+  reflectionPromotionAdapterRegistry ??= new ReflectionPromotionAdapterRegistry();
+  return reflectionPromotionAdapterRegistry;
+}

--- a/server/src/services/reflection-service.ts
+++ b/server/src/services/reflection-service.ts
@@ -14,6 +14,7 @@ import type {
   ReflectionListResponse,
   MergeReflectionCandidateInput,
   ReflectionPromotionTarget,
+  ReflectionTypedPromotionInput,
   ReflectionRedactionSummary,
   ReflectionSourceKind,
   RejectReflectionCandidateInput,
@@ -27,6 +28,10 @@ import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
 import { ensureWithinBase, stripHtml, validatePathSegment } from '../utils/sanitize.js';
 import { getRuntimeDir } from '../utils/paths.js';
 import { createLogger } from '../lib/logger.js';
+import {
+  getReflectionPromotionAdapterRegistry,
+  type ReflectionPromotionAdapterRegistry,
+} from './reflection-promotion-adapters.js';
 
 const log = createLogger('reflection');
 const MAX_CANDIDATES = 2000;
@@ -74,6 +79,7 @@ export interface ReflectionServiceOptions {
   persist?: boolean;
   audit?: (event: AuditEvent) => Promise<void>;
   taskService?: ReflectionTaskService;
+  promotionAdapters?: Pick<ReflectionPromotionAdapterRegistry, 'apply'>;
 }
 
 interface SanitizedText {
@@ -141,6 +147,7 @@ export class ReflectionService {
   private readonly persist: boolean;
   private readonly audit: (event: AuditEvent) => Promise<void>;
   private readonly taskService: ReflectionTaskService;
+  private readonly promotionAdapters: Pick<ReflectionPromotionAdapterRegistry, 'apply'>;
   private loaded = false;
   private state: ReflectionState = this.emptyState();
 
@@ -149,6 +156,7 @@ export class ReflectionService {
     this.persist = options.persist ?? process.env.VITEST !== 'true';
     this.audit = options.audit ?? auditLog;
     this.taskService = options.taskService ?? getTaskService();
+    this.promotionAdapters = options.promotionAdapters ?? getReflectionPromotionAdapterRegistry();
   }
 
   async list(filters: ReflectionListFilters = {}): Promise<ReflectionListResponse> {
@@ -340,7 +348,15 @@ export class ReflectionService {
     const candidate = this.findPendingCandidate(id);
     const timestamp = nowIso();
     const reviewedBy = this.sanitizeText(input.reviewedBy).value || 'operator';
-    const promotionTarget = input.promotionTarget ?? candidate.promotionTarget;
+    if (
+      input.promotion &&
+      input.promotionTarget &&
+      input.promotion.target !== input.promotionTarget
+    ) {
+      throw new ConflictError('Typed promotion input does not match the requested target.');
+    }
+    const promotionTarget =
+      input.promotion?.target ?? input.promotionTarget ?? candidate.promotionTarget;
     const reviewerNote = input.reviewerNote
       ? this.sanitizeText(input.reviewerNote).value
       : undefined;
@@ -352,6 +368,7 @@ export class ReflectionService {
     const appliedTargets = await this.applyPromotion(
       promotionCandidate,
       promotionTarget,
+      input.promotion,
       reviewedBy,
       timestamp
     );
@@ -447,19 +464,27 @@ export class ReflectionService {
   private async applyPromotion(
     candidate: ReflectionCandidate,
     target: ReflectionPromotionTarget,
+    promotion: ReflectionTypedPromotionInput | undefined,
     reviewedBy: string,
     timestamp: string
   ): Promise<ReflectionAppliedTarget[]> {
     if (target !== 'task-lesson') {
+      if (!promotion || promotion.target !== target) {
+        throw new ConflictError(
+          `${target} promotion requires explicit typed target input from the reviewer.`
+        );
+      }
       return [
-        {
-          kind: 'manual-review',
-          id: target,
-          title: `${target} promotion queued for manual application`,
-          appliedAt: timestamp,
-          appliedBy: reviewedBy,
-        },
+        await this.promotionAdapters.apply({
+          candidate,
+          promotion,
+          reviewedBy,
+          timestamp,
+        }),
       ];
+    }
+    if (promotion) {
+      throw new ConflictError('Task lesson promotion does not accept wider target input.');
     }
 
     const taskId = candidate.source.taskId;

--- a/shared/src/types/reflection.types.ts
+++ b/shared/src/types/reflection.types.ts
@@ -1,3 +1,5 @@
+import type { AgentPolicy } from './policy.types.js';
+
 export type ReflectionCandidateCategory = 'session' | 'agent' | 'team' | 'policy' | 'template';
 export type ReflectionCandidateStatus = 'pending' | 'accepted' | 'rejected' | 'deleted';
 export type ReflectionSourceKind =
@@ -8,7 +10,7 @@ export type ReflectionSourceKind =
   | 'review-feedback'
   | 'task-observation';
 export type ReflectionPromotionTarget =
-  'task-lesson' | 'memory' | 'decision' | 'profile' | 'template' | 'policy';
+  'task-lesson' | 'memory' | 'team' | 'decision' | 'profile' | 'template' | 'policy';
 export type ReflectionProposedScope = 'task' | 'workspace' | 'team' | 'global';
 
 export interface ReflectionSourceLink {
@@ -50,6 +52,39 @@ export interface ReflectionRetrievalAttribution {
   relevanceScore: number;
   retrievedAt: string;
 }
+
+export type ReflectionTypedPromotionInput =
+  | {
+      target: 'memory';
+      workspaceId: string;
+    }
+  | {
+      target: 'team';
+      rosterId: string;
+      memberId: string;
+      capabilitiesToAdd: string[];
+    }
+  | {
+      target: 'profile';
+      profileId: string;
+      capabilitiesToAdd: string[];
+    }
+  | {
+      target: 'template';
+      templateId: string;
+    }
+  | {
+      target: 'decision';
+      agentId: string;
+      taskId: string;
+      confidenceLevel: number;
+      riskScore: number;
+      parentDecisionId?: string;
+    }
+  | {
+      target: 'policy';
+      policy: AgentPolicy;
+    };
 
 export interface ReflectionCandidate {
   id: string;
@@ -126,6 +161,7 @@ export interface CreateReflectionCandidateInput {
 export interface AcceptReflectionCandidateInput {
   reviewedBy: string;
   promotionTarget?: ReflectionPromotionTarget;
+  promotion?: ReflectionTypedPromotionInput;
   reviewerNote?: string;
 }
 

--- a/web/src/components/settings/tabs/ReflectionTab.tsx
+++ b/web/src/components/settings/tabs/ReflectionTab.tsx
@@ -204,6 +204,9 @@ function ReflectionCandidateItem({
   busy: boolean;
 }) {
   const canReview = canWrite && candidate.status === 'pending';
+  const requiresTypedPromotion =
+    candidate.status === 'pending' && candidate.promotionTarget !== 'task-lesson';
+  const canAcceptHere = canReview && !requiresTypedPromotion;
   const isMergeable = canReview && candidate.duplicateCount > 1 && !!candidate.duplicateOf;
 
   return (
@@ -236,11 +239,16 @@ function ReflectionCandidateItem({
               size="xs"
               variant="light"
               color="green"
-              disabled={!canReview || busy}
+              disabled={!canAcceptHere || busy}
+              title={
+                requiresTypedPromotion
+                  ? 'This target requires explicit typed review input through the API.'
+                  : undefined
+              }
               leftSection={<CheckCircle2 className="h-3.5 w-3.5" />}
               onClick={onAccept}
             >
-              Accept
+              {requiresTypedPromotion ? 'Typed review' : 'Accept'}
             </Button>
             <Button
               size="xs"
@@ -280,6 +288,11 @@ function ReflectionCandidateItem({
           <Meta label="Correction" value={candidate.correction} />
           <Meta label="Next" value={candidate.nextAttempt} />
           <Meta label="Target" value={promotionLabel(candidate.promotionTarget)} />
+          {requiresTypedPromotion && (
+            <Text size="xs" c="blue">
+              Wider promotion requires explicit typed target input and a reviewer.
+            </Text>
+          )}
         </Stack>
 
         {candidate.evidence.length > 0 && (


### PR DESCRIPTION
## Summary

- require explicit, validated target input before accepting wider-scope reflection promotions
- add retry-safe adapters for workspace memory, team rosters, agent profiles, task templates, decisions, and policies
- write through existing target services and record the applied target on the reflection audit trail
- fail closed on missing adapters, mismatched targets, unknown records, or incomplete input
- prevent the Settings queue from implying that wider targets can be accepted without typed review input

## Verification

- shared, server, and web TypeScript checks
- targeted ESLint for all changed TypeScript and TSX files
- reflection service and adapter tests: 17 passed
- Settings reflections UI tests: 2 passed

## Notes

- task-linked lessons keep their existing direct reviewed path
- replaces #1089, which GitHub closed when its temporary base branch was deleted

Completes the remaining typed-promotion acceptance criteria for #866.