### PR TITLE
feat: define governed run output spill contract

### DIFF
--- a/server/src/__tests__/run-output-spill-service.test.ts
+++ b/server/src/__tests__/run-output-spill-service.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RUN_OUTPUT_ARTIFACT_SCHEMA_VERSION,
+  RUN_OUTPUT_PREVIEW_SCHEMA_VERSION,
+} from '@veritas-kanban/shared';
+import {
+  DEFAULT_RUN_OUTPUT_SPILL_POLICY,
+  RunOutputSpillService,
+  type PrepareRunOutputInput,
+} from '../services/run-output-spill-service.js';
+
+function input(overrides: Partial<PrepareRunOutputInput> = {}): PrepareRunOutputInput {
+  return {
+    scope: {
+      workspaceId: 'workspace_1',
+      taskId: 'task_1',
+      runId: 'run_1',
+      attemptId: 'attempt_1',
+      turnId: 'turn_1',
+    },
+    source: {
+      kind: 'tool-result',
+      name: 'example',
+      eventId: 'event_1',
+      toolCallId: 'tool_1',
+    },
+    content: 'safe output',
+    mediaType: 'text/plain',
+    now: new Date('2026-07-25T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function service(inlineBytes = 16): RunOutputSpillService {
+  return new RunOutputSpillService({
+    ...DEFAULT_RUN_OUTPUT_SPILL_POLICY,
+    inlineBytes: Math.max(256, inlineBytes),
+  });
+}
+
+function textWithBytes(bytes: number): string {
+  return `${'. '.repeat(Math.floor(bytes / 2))}${bytes % 2 === 1 ? '.' : ''}`;
+}
+
+describe('RunOutputSpillService', () => {
+  it('keeps output immediately below and at the inline limit inline', () => {
+    const spill = service(256);
+
+    for (const bytes of [255, 256]) {
+      const result = spill.prepare(input({ content: textWithBytes(bytes) }));
+      expect(result.preview).toMatchObject({
+        schemaVersion: RUN_OUTPUT_PREVIEW_SCHEMA_VERSION,
+        inline: true,
+        originalBytes: bytes,
+        previewBytes: bytes,
+        truncated: false,
+      });
+      expect(result.artifact).toBeUndefined();
+    }
+  });
+
+  it('returns a bounded preview and opaque artifact reference above the limit', () => {
+    const result = service(256).prepare(input({ content: textWithBytes(257) }));
+
+    expect(result.preview).toMatchObject({
+      inline: false,
+      previewBytes: 256,
+      truncated: true,
+      truncationReason: 'inline-limit',
+    });
+    expect(result.preview.artifact?.artifactId).toMatch(/^spill_[A-Za-z0-9_-]{24}$/);
+    expect(result.preview.artifact?.operations).toEqual([
+      'metadata',
+      'byte-range',
+      'line-range',
+      'download',
+    ]);
+    expect(result.artifact?.metadata.schemaVersion).toBe(RUN_OUTPUT_ARTIFACT_SCHEMA_VERSION);
+    expect(result.artifact?.content).toHaveLength(257);
+  });
+
+  it('clips multi-byte UTF-8 without emitting a broken code point', () => {
+    const prefix = textWithBytes(255);
+    const result = service(256).prepare(input({ content: `${prefix}💥` }));
+
+    expect(result.preview.content).toBe(prefix);
+    expect(result.preview.previewBytes).toBe(255);
+    expect(result.preview.content).not.toContain('�');
+  });
+
+  it('redacts secret-shaped text before hashing and persistence', () => {
+    const raw = `token=super-secret-value${' output'.repeat(60)}`;
+    const result = service(256).prepare(input({ content: raw }));
+    const stored = Buffer.from(result.artifact?.content ?? []).toString('utf-8');
+
+    expect(stored).not.toContain('super-secret-value');
+    expect(stored).toContain('token=[REDACTED]');
+    expect(result.artifact?.metadata.redaction).toMatchObject({
+      state: 'redacted',
+      fields: ['$'],
+    });
+  });
+
+  it('redacts sensitive JSON fields and exposes bounded structured queries', () => {
+    const result = service(256).prepare(
+      input({
+        mediaType: 'application/json',
+        content: JSON.stringify({
+          api_key: 'short-secret',
+          rows: Array.from({ length: 100 }, (_, index) => ({ index, value: 'row' })),
+        }),
+      })
+    );
+    const stored = Buffer.from(result.artifact?.content ?? []).toString('utf-8');
+
+    expect(stored).not.toContain('short-secret');
+    expect(JSON.parse(stored).api_key).toBe('[REDACTED]');
+    expect(result.preview.artifact?.operations).toContain('json-path');
+    expect(result.preview.queryHints).toMatchObject({
+      maxResultBytes: DEFAULT_RUN_OUTPUT_SPILL_POLICY.maxQueryBytes,
+      maxJsonDepth: DEFAULT_RUN_OUTPUT_SPILL_POLICY.maxJsonDepth,
+    });
+  });
+
+  it('quarantines invalid UTF-8 declared as text without persisting bytes', () => {
+    const result = service().prepare(
+      input({
+        content: Uint8Array.from([0xc3, 0x28]),
+        mediaType: 'text/plain',
+      })
+    );
+
+    expect(result.preview).toMatchObject({
+      contentClass: 'invalid-utf8',
+      truncationReason: 'content-policy',
+      artifact: { state: 'quarantined', operations: ['metadata'] },
+    });
+    expect(result.artifact?.content).toBeNull();
+    expect(result.artifact?.metadata).toMatchObject({
+      encoding: 'binary',
+      storedBytes: 0,
+      redaction: { state: 'quarantined' },
+    });
+  });
+
+  it.each([
+    ['application/octet-stream', Uint8Array.from([0, 255, 1]), 'binary'],
+    ['application/gzip', Uint8Array.from([31, 139, 8]), 'compressed'],
+  ])('quarantines disallowed %s payloads', (mediaType, content, contentClass) => {
+    const result = service().prepare(input({ mediaType, content }));
+
+    expect(result.preview).toMatchObject({
+      inline: false,
+      contentClass,
+      truncationReason: 'content-policy',
+      artifact: { state: 'quarantined', operations: ['metadata'] },
+    });
+    expect(result.artifact?.content).toBeNull();
+  });
+
+  it('uses an explicit caller limit as causal truncation evidence', () => {
+    const result = service(256).prepare(
+      input({ content: textWithBytes(300), truncationReason: 'websocket-limit' })
+    );
+
+    expect(result.preview.truncationReason).toBe('websocket-limit');
+    expect(result.artifact?.metadata.truncationReason).toBe('websocket-limit');
+  });
+
+  it('retains the causal scope without exposing a host path', () => {
+    const result = service(256).prepare(input({ content: textWithBytes(300) }));
+    const serialized = JSON.stringify(result);
+
+    expect(result.artifact?.metadata.scope).toEqual(input().scope);
+    expect(result.artifact?.metadata.source).toEqual(input().source);
+    expect(result.artifact?.metadata.retention).toEqual({
+      createdAt: '2026-07-25T12:00:00.000Z',
+      expiresAt: '2026-08-01T12:00:00.000Z',
+      activeLeaseUntil: '2026-07-26T12:00:00.000Z',
+    });
+    expect(serialized).not.toContain('/Users/');
+    expect(serialized).not.toContain('file://');
+  });
+});

--- a/server/src/schemas/run-output-artifact-schemas.ts
+++ b/server/src/schemas/run-output-artifact-schemas.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+import {
+  RUN_OUTPUT_ARTIFACT_SCHEMA_VERSION,
+  RUN_OUTPUT_ARTIFACT_STATES,
+  RUN_OUTPUT_CONTENT_CLASSES,
+  RUN_OUTPUT_PREVIEW_SCHEMA_VERSION,
+  RUN_OUTPUT_QUERY_OPERATIONS,
+  RUN_OUTPUT_SOURCE_KINDS,
+  RUN_OUTPUT_TRUNCATION_REASONS,
+  type RunOutputArtifactMetadata,
+  type RunOutputPreview,
+  type RunOutputSpillPolicy,
+} from '@veritas-kanban/shared';
+
+const IdentifierSchema = z.string().trim().min(1).max(240);
+const TimestampSchema = z.string().datetime();
+const ByteCountSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+
+export const RunOutputSpillPolicySchema: z.ZodType<RunOutputSpillPolicy> = z
+  .object({
+    schemaVersion: z.literal('run-output-spill-policy/v1'),
+    inlineBytes: z.number().int().min(256).max(4 * 1024 * 1024),
+    maxQueryBytes: z.number().int().min(256).max(4 * 1024 * 1024),
+    maxJsonDepth: z.number().int().min(1).max(64),
+    retentionSeconds: z.number().int().min(60).max(90 * 24 * 60 * 60),
+    activeLeaseSeconds: z.number().int().min(0).max(7 * 24 * 60 * 60),
+    allowBinaryPersistence: z.boolean(),
+    allowCompressedPersistence: z.boolean(),
+  })
+  .strict();
+
+export const RunOutputArtifactMetadataSchema: z.ZodType<RunOutputArtifactMetadata> = z
+  .object({
+    schemaVersion: z.literal(RUN_OUTPUT_ARTIFACT_SCHEMA_VERSION),
+    id: z.string().regex(/^spill_[A-Za-z0-9_-]{20,40}$/),
+    scope: z
+      .object({
+        workspaceId: IdentifierSchema,
+        taskId: IdentifierSchema,
+        runId: IdentifierSchema,
+        attemptId: IdentifierSchema,
+        turnId: IdentifierSchema.optional(),
+      })
+      .strict(),
+    source: z
+      .object({
+        kind: z.enum(RUN_OUTPUT_SOURCE_KINDS),
+        name: z.string().trim().min(1).max(240).optional(),
+        eventId: IdentifierSchema.optional(),
+        toolCallId: IdentifierSchema.optional(),
+        commandId: IdentifierSchema.optional(),
+      })
+      .strict(),
+    mediaType: z.string().trim().min(1).max(240),
+    encoding: z.enum(['utf-8', 'binary']),
+    contentClass: z.enum(RUN_OUTPUT_CONTENT_CLASSES),
+    originalBytes: ByteCountSchema,
+    storedBytes: ByteCountSchema,
+    previewBytes: ByteCountSchema,
+    truncationReason: z.enum(RUN_OUTPUT_TRUNCATION_REASONS),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    redaction: z
+      .object({
+        state: z.enum(['none', 'redacted', 'quarantined', 'dropped']),
+        fields: z.array(z.string().min(1).max(512)).max(256),
+        validatedAt: TimestampSchema,
+      })
+      .strict(),
+    retention: z
+      .object({
+        createdAt: TimestampSchema,
+        expiresAt: TimestampSchema,
+        activeLeaseUntil: TimestampSchema.optional(),
+      })
+      .strict(),
+    state: z.enum(RUN_OUTPUT_ARTIFACT_STATES),
+  })
+  .strict();
+
+export const RunOutputPreviewSchema: z.ZodType<RunOutputPreview> = z
+  .object({
+    schemaVersion: z.literal(RUN_OUTPUT_PREVIEW_SCHEMA_VERSION),
+    inline: z.boolean(),
+    content: z.string(),
+    mediaType: z.string().trim().min(1).max(240),
+    contentClass: z.enum(RUN_OUTPUT_CONTENT_CLASSES),
+    originalBytes: ByteCountSchema,
+    previewBytes: ByteCountSchema,
+    truncated: z.boolean(),
+    truncationReason: z.enum(RUN_OUTPUT_TRUNCATION_REASONS).optional(),
+    artifact: z
+      .object({
+        artifactId: z.string().regex(/^spill_[A-Za-z0-9_-]{20,40}$/),
+        state: z.enum(RUN_OUTPUT_ARTIFACT_STATES),
+        operations: z.array(z.enum(RUN_OUTPUT_QUERY_OPERATIONS)).min(1).max(5),
+      })
+      .strict()
+      .optional(),
+    queryHints: z
+      .object({
+        maxResultBytes: ByteCountSchema,
+        maxJsonDepth: z.number().int().min(1).max(64),
+        operations: z.array(z.enum(RUN_OUTPUT_QUERY_OPERATIONS)).min(1).max(5),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();

--- a/server/src/services/run-output-spill-service.ts
+++ b/server/src/services/run-output-spill-service.ts
@@ -1,0 +1,302 @@
+import { createHash } from 'node:crypto';
+import { TextDecoder } from 'node:util';
+import { nanoid } from 'nanoid';
+import {
+  RUN_OUTPUT_ARTIFACT_SCHEMA_VERSION,
+  RUN_OUTPUT_PREVIEW_SCHEMA_VERSION,
+  type RunOutputArtifactMetadata,
+  type RunOutputArtifactScope,
+  type RunOutputArtifactSource,
+  type RunOutputContentClass,
+  type RunOutputPreview,
+  type RunOutputQueryOperation,
+  type RunOutputSpillPolicy,
+  type RunOutputTruncationReason,
+} from '@veritas-kanban/shared';
+import { redactString } from '../lib/redact.js';
+import {
+  RunOutputArtifactMetadataSchema,
+  RunOutputPreviewSchema,
+  RunOutputSpillPolicySchema,
+} from '../schemas/run-output-artifact-schemas.js';
+
+const UTF8_DECODER = new TextDecoder('utf-8', { fatal: true });
+const COMPRESSED_MEDIA_TYPE =
+  /(?:gzip|zip|x-7z-compressed|x-rar-compressed|x-tar|zstd|compressed)/i;
+const JSON_MEDIA_TYPE = /(?:^application\/json$|\+json$)/i;
+const TEXT_MEDIA_TYPE = /^(?:text\/|application\/(?:xml|javascript|x-ndjson))/i;
+const SECRET_ASSIGNMENT =
+  /\b(api[_-]?key|access[_-]?token|refresh[_-]?token|token|authorization|password|secret)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,"'}]+)/gi;
+
+export const DEFAULT_RUN_OUTPUT_SPILL_POLICY: RunOutputSpillPolicy = {
+  schemaVersion: 'run-output-spill-policy/v1',
+  inlineBytes: 8 * 1024,
+  maxQueryBytes: 32 * 1024,
+  maxJsonDepth: 12,
+  retentionSeconds: 7 * 24 * 60 * 60,
+  activeLeaseSeconds: 24 * 60 * 60,
+  allowBinaryPersistence: false,
+  allowCompressedPersistence: false,
+};
+
+export interface PrepareRunOutputInput {
+  scope: RunOutputArtifactScope;
+  source: RunOutputArtifactSource;
+  content: string | Uint8Array;
+  mediaType?: string;
+  truncationReason?: RunOutputTruncationReason;
+  now?: Date;
+}
+
+export interface PreparedRunOutput {
+  preview: RunOutputPreview;
+  artifact?: {
+    metadata: RunOutputArtifactMetadata;
+    content: Uint8Array | null;
+  };
+}
+
+interface ClassifiedContent {
+  contentClass: RunOutputContentClass;
+  encoding: 'utf-8' | 'binary';
+  text?: string;
+}
+
+interface RedactedContent {
+  content: Uint8Array;
+  text: string;
+  state: 'none' | 'redacted';
+  fields: string[];
+}
+
+function addSeconds(timestamp: Date, seconds: number): string {
+  return new Date(timestamp.getTime() + seconds * 1000).toISOString();
+}
+
+function sha256(content: Uint8Array): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function clipUtf8(text: string, maxBytes: number): string {
+  const bytes = Buffer.from(text, 'utf-8');
+  if (bytes.byteLength <= maxBytes) return text;
+  let end = maxBytes;
+  while (end > 0 && (bytes[end] & 0xc0) === 0x80) end -= 1;
+  return bytes.subarray(0, end).toString('utf-8');
+}
+
+function redactAssignments(value: string): string {
+  return value.replace(SECRET_ASSIGNMENT, (_match, key: string) => `${key}=[REDACTED]`);
+}
+
+function redactText(value: string): RedactedContent {
+  const assignmentRedacted = redactAssignments(value);
+  const redacted = redactString(assignmentRedacted);
+  return {
+    content: Buffer.from(redacted, 'utf-8'),
+    text: redacted,
+    state: redacted === value ? 'none' : 'redacted',
+    fields: redacted === value ? [] : ['$'],
+  };
+}
+
+function redactJson(value: string): RedactedContent {
+  const fields: string[] = [];
+  const sensitiveKey =
+    /^(?:authorization|api[_-]?key|apikey|token|access[_-]?token|refresh[_-]?token|secret|password|credentials?|private[_-]?key|cookie)$/i;
+  const parsed = JSON.parse(value) as unknown;
+  const seen = new WeakSet<object>();
+
+  const visit = (candidate: unknown, path: string, depth: number): unknown => {
+    if (depth > 64) {
+      fields.push(path);
+      return '[depth limit]';
+    }
+    if (typeof candidate === 'string') {
+      const redacted = redactAssignments(redactString(candidate));
+      if (redacted !== candidate) fields.push(path);
+      return redacted;
+    }
+    if (!candidate || typeof candidate !== 'object') return candidate;
+    if (seen.has(candidate)) {
+      fields.push(path);
+      return '[circular]';
+    }
+    seen.add(candidate);
+    if (Array.isArray(candidate)) {
+      const result = candidate.map((entry, index) => visit(entry, `${path}[${index}]`, depth + 1));
+      seen.delete(candidate);
+      return result;
+    }
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(candidate as Record<string, unknown>)) {
+      const childPath = `${path}.${key}`;
+      if (sensitiveKey.test(key)) {
+        result[key] = '[REDACTED]';
+        fields.push(childPath);
+      } else {
+        result[key] = visit(entry, childPath, depth + 1);
+      }
+    }
+    seen.delete(candidate);
+    return result;
+  };
+
+  const text = JSON.stringify(visit(parsed, '$', 0));
+  return {
+    content: Buffer.from(text, 'utf-8'),
+    text,
+    state: fields.length > 0 ? 'redacted' : 'none',
+    fields: [...new Set(fields)].slice(0, 256),
+  };
+}
+
+function classifyContent(content: Uint8Array, mediaType: string): ClassifiedContent {
+  if (COMPRESSED_MEDIA_TYPE.test(mediaType)) {
+    return { contentClass: 'compressed', encoding: 'binary' };
+  }
+  let text: string;
+  try {
+    text = UTF8_DECODER.decode(content);
+  } catch {
+    return {
+      contentClass:
+        TEXT_MEDIA_TYPE.test(mediaType) || JSON_MEDIA_TYPE.test(mediaType) ? 'invalid-utf8' : 'binary',
+      encoding: 'binary',
+    };
+  }
+  if (JSON_MEDIA_TYPE.test(mediaType)) {
+    try {
+      JSON.parse(text);
+      return { contentClass: 'json', encoding: 'utf-8', text };
+    } catch {
+      return { contentClass: 'text', encoding: 'utf-8', text };
+    }
+  }
+  return {
+    contentClass: TEXT_MEDIA_TYPE.test(mediaType) ? 'text' : 'text',
+    encoding: 'utf-8',
+    text,
+  };
+}
+
+function operationsFor(contentClass: RunOutputContentClass): RunOutputQueryOperation[] {
+  const operations: RunOutputQueryOperation[] = ['metadata', 'byte-range'];
+  if (contentClass === 'text') operations.push('line-range');
+  if (contentClass === 'json') operations.push('line-range', 'json-path');
+  operations.push('download');
+  return operations;
+}
+
+function defaultMediaType(content: string | Uint8Array): string {
+  return typeof content === 'string' ? 'text/plain' : 'application/octet-stream';
+}
+
+export class RunOutputSpillService {
+  private readonly policy: RunOutputSpillPolicy;
+
+  constructor(policy: RunOutputSpillPolicy = DEFAULT_RUN_OUTPUT_SPILL_POLICY) {
+    this.policy = RunOutputSpillPolicySchema.parse(policy);
+  }
+
+  prepare(input: PrepareRunOutputInput): PreparedRunOutput {
+    const now = input.now ?? new Date();
+    const mediaType = (input.mediaType ?? defaultMediaType(input.content)).trim().toLowerCase();
+    const original = typeof input.content === 'string' ? Buffer.from(input.content) : input.content;
+    const classified = classifyContent(original, mediaType);
+    const unsafeByPolicy =
+      classified.contentClass === 'invalid-utf8' ||
+      (classified.contentClass === 'binary' && !this.policy.allowBinaryPersistence) ||
+      (classified.contentClass === 'compressed' && !this.policy.allowCompressedPersistence);
+    const redacted =
+      classified.text === undefined
+        ? undefined
+        : classified.contentClass === 'json'
+          ? redactJson(classified.text)
+          : redactText(classified.text);
+    const stored = redacted?.content ?? original;
+    const requiresArtifact =
+      unsafeByPolicy || stored.byteLength > this.policy.inlineBytes || classified.encoding === 'binary';
+    const previewText =
+      redacted?.text === undefined
+        ? `[${classified.contentClass} output withheld by content policy]`
+        : clipUtf8(redacted.text, this.policy.inlineBytes);
+    const previewBytes = Buffer.byteLength(previewText, 'utf-8');
+
+    if (!requiresArtifact) {
+      return {
+        preview: RunOutputPreviewSchema.parse({
+          schemaVersion: RUN_OUTPUT_PREVIEW_SCHEMA_VERSION,
+          inline: true,
+          content: previewText,
+          mediaType,
+          contentClass: classified.contentClass,
+          originalBytes: original.byteLength,
+          previewBytes,
+          truncated: false,
+        }),
+      };
+    }
+
+    const reason = unsafeByPolicy
+      ? 'content-policy'
+      : (input.truncationReason ?? 'inline-limit');
+    const state = unsafeByPolicy ? 'quarantined' : 'available';
+    const operations = unsafeByPolicy ? ['metadata'] : operationsFor(classified.contentClass);
+    const artifactId = `spill_${nanoid(24)}`;
+    const createdAt = now.toISOString();
+    const metadata = RunOutputArtifactMetadataSchema.parse({
+      schemaVersion: RUN_OUTPUT_ARTIFACT_SCHEMA_VERSION,
+      id: artifactId,
+      scope: input.scope,
+      source: input.source,
+      mediaType,
+      encoding: classified.encoding,
+      contentClass: classified.contentClass,
+      originalBytes: original.byteLength,
+      storedBytes: unsafeByPolicy ? 0 : stored.byteLength,
+      previewBytes,
+      truncationReason: reason,
+      sha256: sha256(unsafeByPolicy ? original : stored),
+      redaction: {
+        state: unsafeByPolicy ? 'quarantined' : (redacted?.state ?? 'none'),
+        fields: redacted?.fields ?? [],
+        validatedAt: createdAt,
+      },
+      retention: {
+        createdAt,
+        expiresAt: addSeconds(now, this.policy.retentionSeconds),
+        activeLeaseUntil:
+          this.policy.activeLeaseSeconds > 0
+            ? addSeconds(now, this.policy.activeLeaseSeconds)
+            : undefined,
+      },
+      state,
+    });
+    const preview = RunOutputPreviewSchema.parse({
+      schemaVersion: RUN_OUTPUT_PREVIEW_SCHEMA_VERSION,
+      inline: false,
+      content: previewText,
+      mediaType,
+      contentClass: classified.contentClass,
+      originalBytes: original.byteLength,
+      previewBytes,
+      truncated: true,
+      truncationReason: reason,
+      artifact: { artifactId, state, operations },
+      queryHints: {
+        maxResultBytes: this.policy.maxQueryBytes,
+        maxJsonDepth: this.policy.maxJsonDepth,
+        operations,
+      },
+    });
+
+    return {
+      preview,
+      artifact: {
+        metadata,
+        content: unsafeByPolicy ? null : stored,
+      },
+    };
+  }
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -61,6 +61,7 @@ export * from './task-envelope.types.js';
 export * from './run-launch-manifest.types.js';
 export * from './run-event.types.js';
 export * from './progress-watchdog.types.js';
+export * from './run-output-artifact.types.js';
 export * from './run-recovery.types.js';
 export * from './runtime-hook.types.js';
 export * from './auth.types.js';

--- a/shared/src/types/run-output-artifact.types.ts
+++ b/shared/src/types/run-output-artifact.types.ts
@@ -1,0 +1,132 @@
+export const RUN_OUTPUT_ARTIFACT_SCHEMA_VERSION = 'run-output-artifact/v1' as const;
+export const RUN_OUTPUT_PREVIEW_SCHEMA_VERSION = 'run-output-preview/v1' as const;
+
+export const RUN_OUTPUT_SOURCE_KINDS = [
+  'tool-result',
+  'command-output',
+  'mcp-result',
+  'provider-payload',
+  'run-event',
+] as const;
+
+export const RUN_OUTPUT_CONTENT_CLASSES = [
+  'text',
+  'json',
+  'binary',
+  'compressed',
+  'invalid-utf8',
+] as const;
+
+export const RUN_OUTPUT_TRUNCATION_REASONS = [
+  'inline-limit',
+  'model-limit',
+  'event-limit',
+  'websocket-limit',
+  'log-limit',
+  'content-policy',
+] as const;
+
+export const RUN_OUTPUT_ARTIFACT_STATES = [
+  'available',
+  'quarantined',
+  'expired',
+  'deleted',
+] as const;
+
+export const RUN_OUTPUT_QUERY_OPERATIONS = [
+  'metadata',
+  'byte-range',
+  'line-range',
+  'json-path',
+  'download',
+] as const;
+
+export type RunOutputSourceKind = (typeof RUN_OUTPUT_SOURCE_KINDS)[number];
+export type RunOutputContentClass = (typeof RUN_OUTPUT_CONTENT_CLASSES)[number];
+export type RunOutputTruncationReason = (typeof RUN_OUTPUT_TRUNCATION_REASONS)[number];
+export type RunOutputArtifactState = (typeof RUN_OUTPUT_ARTIFACT_STATES)[number];
+export type RunOutputQueryOperation = (typeof RUN_OUTPUT_QUERY_OPERATIONS)[number];
+export type RunOutputRedactionState = 'none' | 'redacted' | 'quarantined' | 'dropped';
+
+export interface RunOutputArtifactSource {
+  kind: RunOutputSourceKind;
+  name?: string;
+  eventId?: string;
+  toolCallId?: string;
+  commandId?: string;
+}
+
+export interface RunOutputArtifactScope {
+  workspaceId: string;
+  taskId: string;
+  runId: string;
+  attemptId: string;
+  turnId?: string;
+}
+
+export interface RunOutputArtifactRedaction {
+  state: RunOutputRedactionState;
+  fields: string[];
+  validatedAt: string;
+}
+
+export interface RunOutputArtifactRetention {
+  createdAt: string;
+  expiresAt: string;
+  activeLeaseUntil?: string;
+}
+
+export interface RunOutputArtifactReference {
+  artifactId: string;
+  state: RunOutputArtifactState;
+  operations: RunOutputQueryOperation[];
+}
+
+export interface RunOutputArtifactMetadata {
+  schemaVersion: typeof RUN_OUTPUT_ARTIFACT_SCHEMA_VERSION;
+  id: string;
+  scope: RunOutputArtifactScope;
+  source: RunOutputArtifactSource;
+  mediaType: string;
+  encoding: 'utf-8' | 'binary';
+  contentClass: RunOutputContentClass;
+  originalBytes: number;
+  storedBytes: number;
+  previewBytes: number;
+  truncationReason: RunOutputTruncationReason;
+  sha256: string;
+  redaction: RunOutputArtifactRedaction;
+  retention: RunOutputArtifactRetention;
+  state: RunOutputArtifactState;
+}
+
+export interface RunOutputQueryHints {
+  maxResultBytes: number;
+  maxJsonDepth: number;
+  operations: RunOutputQueryOperation[];
+}
+
+export interface RunOutputPreview {
+  schemaVersion: typeof RUN_OUTPUT_PREVIEW_SCHEMA_VERSION;
+  inline: boolean;
+  content: string;
+  mediaType: string;
+  contentClass: RunOutputContentClass;
+  originalBytes: number;
+  previewBytes: number;
+  truncated: boolean;
+  truncationReason?: RunOutputTruncationReason;
+  artifact?: RunOutputArtifactReference;
+  queryHints?: RunOutputQueryHints;
+}
+
+export interface RunOutputSpillPolicy {
+  schemaVersion: 'run-output-spill-policy/v1';
+  inlineBytes: number;
+  maxQueryBytes: number;
+  maxJsonDepth: number;
+  retentionSeconds: number;
+  activeLeaseSeconds: number;
+  allowBinaryPersistence: boolean;
+  allowCompressedPersistence: boolean;
+}


### PR DESCRIPTION
Part of #876. Defines the versioned provider-neutral spill contract, complete pre-persistence redaction, bounded previews, opaque references, retention, and explicit text, JSON, binary, compressed, and invalid UTF-8 policy.