### PR TITLE
feat: persist governed run output artifacts

### DIFF
--- a/server/src/__tests__/run-output-artifact-repository.test.ts
+++ b/server/src/__tests__/run-output-artifact-repository.test.ts
@@ -1,0 +1,223 @@
+import { mkdtemp, mkdir, readdir, rm, symlink } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type {
+  RunOutputArtifactLookup,
+  RunOutputArtifactMetadata,
+} from '@veritas-kanban/shared';
+import { RunOutputSpillService } from '../services/run-output-spill-service.js';
+import {
+  FileRunOutputArtifactRepository,
+  type FileRunOutputArtifactRepositoryHooks,
+} from '../storage/run-output-artifact-repository.js';
+import type { RunOutputArtifactRepository } from '../storage/interfaces.js';
+import { SqliteDatabase } from '../storage/sqlite/database.js';
+import { SqliteRunOutputArtifactRepository } from '../storage/sqlite/run-output-artifact-repository.js';
+
+const cleanupPaths: string[] = [];
+const databases: SqliteDatabase[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'veritas-run-output-'));
+  cleanupPaths.push(directory);
+  return directory;
+}
+
+function prepared(
+  content = `${'bounded output line\n'.repeat(30)}`,
+  now = new Date('2026-07-25T12:00:00.000Z')
+) {
+  const result = new RunOutputSpillService({
+    schemaVersion: 'run-output-spill-policy/v1',
+    inlineBytes: 256,
+    maxQueryBytes: 1_024,
+    maxJsonDepth: 8,
+    retentionSeconds: 60,
+    activeLeaseSeconds: 120,
+    allowBinaryPersistence: false,
+    allowCompressedPersistence: false,
+  }).prepare({
+    scope: {
+      workspaceId: 'workspace_1',
+      taskId: 'task_1',
+      runId: 'run_1',
+      attemptId: 'attempt_1',
+      turnId: 'turn_1',
+    },
+    source: {
+      kind: 'tool-result',
+      name: 'example',
+      eventId: 'event_1',
+      toolCallId: 'tool_1',
+    },
+    content,
+    mediaType: 'text/plain',
+    now,
+  });
+  if (!result.artifact) throw new Error('Test fixture must create an artifact.');
+  return result.artifact;
+}
+
+function lookup(metadata: RunOutputArtifactMetadata): RunOutputArtifactLookup {
+  return { ...metadata.scope, artifactId: metadata.id };
+}
+
+async function fileRepository(
+  hooks: FileRunOutputArtifactRepositoryHooks = {}
+): Promise<RunOutputArtifactRepository> {
+  return new FileRunOutputArtifactRepository(await temporaryDirectory(), hooks);
+}
+
+function sqliteRepository(): RunOutputArtifactRepository {
+  const database = new SqliteDatabase({ databasePath: ':memory:' });
+  database.open();
+  databases.push(database);
+  return new SqliteRunOutputArtifactRepository(database);
+}
+
+afterEach(async () => {
+  for (const database of databases.splice(0)) database.close();
+  await Promise.all(cleanupPaths.splice(0).map((entry) => rm(entry, { recursive: true })));
+});
+
+describe.each([
+  ['file', fileRepository],
+  ['sqlite', async () => sqliteRepository()],
+] as const)('RunOutputArtifactRepository (%s)', (_name, repositoryFactory) => {
+  it('persists one artifact idempotently and serves bounded ranges', async () => {
+    const repository = await repositoryFactory();
+    const artifact = prepared();
+
+    const first = await repository.create(artifact.metadata, artifact.content);
+    const duplicate = await repository.create(artifact.metadata, artifact.content);
+    const range = await repository.readRange({
+      ...lookup(artifact.metadata),
+      offset: 8,
+      length: 24,
+    });
+
+    expect(first.created).toBe(true);
+    expect(duplicate).toEqual({ metadata: artifact.metadata, created: false });
+    expect(range).toMatchObject({
+      metadata: artifact.metadata,
+      offset: 8,
+      length: 24,
+    });
+    expect(Buffer.from(range?.content ?? []).toString('utf-8')).toBe(
+      Buffer.from(artifact.content ?? []).subarray(8, 32).toString('utf-8')
+    );
+  });
+
+  it('requires the exact workspace and run scope for retrieval', async () => {
+    const repository = await repositoryFactory();
+    const artifact = prepared();
+    await repository.create(artifact.metadata, artifact.content);
+
+    expect(
+      await repository.get({
+        ...lookup(artifact.metadata),
+        workspaceId: 'workspace_2',
+      })
+    ).toBeNull();
+    expect(
+      await repository.get({
+        ...lookup(artifact.metadata),
+        runId: 'run_2',
+      })
+    ).toBeNull();
+    expect(
+      await repository.get({
+        ...lookup(artifact.metadata),
+        turnId: undefined,
+      })
+    ).toEqual(artifact.metadata);
+  });
+
+  it('rejects an artifact ID reused for different content', async () => {
+    const repository = await repositoryFactory();
+    const first = prepared();
+    const other = prepared(`${'different output line\n'.repeat(30)}`);
+    await repository.create(first.metadata, first.content);
+
+    await expect(
+      repository.create(
+        {
+          ...other.metadata,
+          id: first.metadata.id,
+        },
+        other.content
+      )
+    ).rejects.toThrow('conflicting identity');
+  });
+
+  it('keeps expired metadata as a tombstone and honors active-run leases', async () => {
+    const repository = await repositoryFactory();
+    const artifact = prepared();
+    await repository.create(artifact.metadata, artifact.content);
+
+    const leased = await repository.cleanup({
+      now: '2026-07-25T12:01:01.000Z',
+      workspaceId: 'workspace_1',
+    });
+    expect(leased).toEqual({
+      expiredArtifactIds: [],
+      reclaimedBytes: 0,
+      retainedByLease: 1,
+      hasMore: false,
+    });
+
+    const expired = await repository.cleanup({
+      now: '2026-07-25T12:02:01.000Z',
+      workspaceId: 'workspace_1',
+    });
+    expect(expired).toEqual({
+      expiredArtifactIds: [artifact.metadata.id],
+      reclaimedBytes: artifact.metadata.storedBytes,
+      retainedByLease: 0,
+      hasMore: false,
+    });
+    expect(await repository.get(lookup(artifact.metadata))).toMatchObject({ state: 'expired' });
+    expect(
+      await repository.readRange({ ...lookup(artifact.metadata), offset: 0, length: 32 })
+    ).toBeNull();
+  });
+});
+
+describe('FileRunOutputArtifactRepository safety', () => {
+  it('does not publish a partial artifact when interrupted before the atomic rename', async () => {
+    const baseDir = await temporaryDirectory();
+    const repository = new FileRunOutputArtifactRepository(baseDir, {
+      beforePublish: () => {
+        throw new Error('simulated crash');
+      },
+    });
+    const artifact = prepared();
+
+    await expect(repository.create(artifact.metadata, artifact.content)).rejects.toThrow(
+      'simulated crash'
+    );
+    expect(await repository.get(lookup(artifact.metadata))).toBeNull();
+    const attemptDirectory = path.join(
+      baseDir,
+      'workspace_1',
+      'task_1',
+      'run_1',
+      'attempt_1'
+    );
+    expect(await readdir(attemptDirectory)).toEqual([]);
+  });
+
+  it.runIf(process.platform !== 'win32')('refuses a symlinked scope directory', async () => {
+    const baseDir = await temporaryDirectory();
+    const outside = await temporaryDirectory();
+    await mkdir(baseDir, { recursive: true });
+    await symlink(outside, path.join(baseDir, 'workspace_1'));
+    const repository = new FileRunOutputArtifactRepository(baseDir);
+    const artifact = prepared();
+
+    await expect(repository.create(artifact.metadata, artifact.content)).rejects.toThrow(
+      'not a private regular directory'
+    );
+  });
+});

--- a/server/src/schemas/run-output-artifact-schemas.ts
+++ b/server/src/schemas/run-output-artifact-schemas.ts
@@ -5,6 +5,7 @@ import {
   RUN_OUTPUT_CONTENT_CLASSES,
   RUN_OUTPUT_PREVIEW_SCHEMA_VERSION,
   RUN_OUTPUT_QUERY_OPERATIONS,
+  RUN_OUTPUT_QUARANTINE_REASONS,
   RUN_OUTPUT_SOURCE_KINDS,
   RUN_OUTPUT_TRUNCATION_REASONS,
   type RunOutputArtifactMetadata,
@@ -74,6 +75,7 @@ export const RunOutputArtifactMetadataSchema: z.ZodType<RunOutputArtifactMetadat
       })
       .strict(),
     state: z.enum(RUN_OUTPUT_ARTIFACT_STATES),
+    quarantineReason: z.enum(RUN_OUTPUT_QUARANTINE_REASONS).optional(),
   })
   .strict();
 

--- a/server/src/services/run-output-spill-service.ts
+++ b/server/src/services/run-output-spill-service.ts
@@ -89,9 +89,12 @@ function redactAssignments(value: string): string {
   return value.replace(SECRET_ASSIGNMENT, (_match, key: string) => `${key}=[REDACTED]`);
 }
 
+export function redactRunOutputText(value: string): string {
+  return redactString(redactAssignments(value));
+}
+
 function redactText(value: string): RedactedContent {
-  const assignmentRedacted = redactAssignments(value);
-  const redacted = redactString(assignmentRedacted);
+  const redacted = redactRunOutputText(value);
   return {
     content: Buffer.from(redacted, 'utf-8'),
     text: redacted,
@@ -113,7 +116,7 @@ function redactJson(value: string): RedactedContent {
       return '[depth limit]';
     }
     if (typeof candidate === 'string') {
-      const redacted = redactAssignments(redactString(candidate));
+      const redacted = redactRunOutputText(candidate);
       if (redacted !== candidate) fields.push(path);
       return redacted;
     }
@@ -266,12 +269,12 @@ export class RunOutputSpillService {
       retention: {
         createdAt,
         expiresAt: addSeconds(now, this.policy.retentionSeconds),
-        activeLeaseUntil:
-          this.policy.activeLeaseSeconds > 0
-            ? addSeconds(now, this.policy.activeLeaseSeconds)
-            : undefined,
+        ...(this.policy.activeLeaseSeconds > 0
+          ? { activeLeaseUntil: addSeconds(now, this.policy.activeLeaseSeconds) }
+          : {}),
       },
       state,
+      ...(unsafeByPolicy ? { quarantineReason: 'content-policy' } : {}),
     });
     const preview = RunOutputPreviewSchema.parse({
       schemaVersion: RUN_OUTPUT_PREVIEW_SCHEMA_VERSION,

--- a/server/src/storage/file-storage.ts
+++ b/server/src/storage/file-storage.ts
@@ -47,6 +47,7 @@ import type {
   ReflectionExtractionJobRepository,
   AdmissionReservationRepository,
   ToolControlPlaneRepository,
+  RunOutputArtifactRepository,
 } from './interfaces.js';
 import { TaskService, type TaskServiceOptions } from '../services/task-service.js';
 import { ConfigService, type ConfigServiceOptions } from '../services/config-service.js';
@@ -78,6 +79,7 @@ import { FileDurableGoalRepository } from './durable-goal-repository.js';
 import { FileReflectionExtractionJobRepository } from './reflection-extraction-job-repository.js';
 import { FileAdmissionReservationRepository } from './admission-reservation-repository.js';
 import { FileToolControlPlaneRepository } from './tool-control-plane-repository.js';
+import { FileRunOutputArtifactRepository } from './run-output-artifact-repository.js';
 
 // ---------------------------------------------------------------------------
 // FileTaskRepository
@@ -502,6 +504,7 @@ export interface FileStorageOptions {
   reflectionExtractionJobsPath?: string;
   admissionReservationsPath?: string;
   toolControlPlanePath?: string;
+  runOutputArtifactsDir?: string;
 }
 
 export class FileStorageProvider implements StorageProvider {
@@ -521,6 +524,7 @@ export class FileStorageProvider implements StorageProvider {
   readonly reflectionExtractionJobs: ReflectionExtractionJobRepository;
   readonly admissionReservations: AdmissionReservationRepository;
   readonly toolControlPlane: ToolControlPlaneRepository;
+  readonly runOutputArtifacts: RunOutputArtifactRepository;
 
   private taskService: TaskService;
   private configService: ConfigService;
@@ -582,6 +586,7 @@ export class FileStorageProvider implements StorageProvider {
       options.admissionReservationsPath
     );
     this.toolControlPlane = new FileToolControlPlaneRepository(options.toolControlPlanePath);
+    this.runOutputArtifacts = new FileRunOutputArtifactRepository(options.runOutputArtifactsDir);
   }
 
   async initialize(): Promise<void> {

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -32,6 +32,7 @@ export type {
   ReflectionExtractionJobRepository,
   AdmissionReservationRepository,
   ToolControlPlaneRepository,
+  RunOutputArtifactRepository,
   SetupContextRepository,
   WorkspaceFileRepository,
   WorkspaceExecutionTrustRepository,
@@ -60,6 +61,10 @@ export {
   FileTelemetryRepository,
 } from './file-storage.js';
 export { FileRunEventRepository, getRunEventsDir } from './run-event-repository.js';
+export {
+  FileRunOutputArtifactRepository,
+  getRunOutputArtifactsDir,
+} from './run-output-artifact-repository.js';
 export { FileRunApprovalRepository, getRunApprovalsPath } from './run-approval-repository.js';
 export {
   FilePhaseTransitionRepository,
@@ -101,6 +106,7 @@ export { SqliteActivityRepository } from './sqlite/activity-repository.js';
 export { SqliteStatusHistoryRepository } from './sqlite/status-history-repository.js';
 export { SqliteTelemetryRepository } from './sqlite/telemetry-repository.js';
 export { SqliteRunEventRepository } from './sqlite/run-event-repository.js';
+export { SqliteRunOutputArtifactRepository } from './sqlite/run-output-artifact-repository.js';
 export { SqliteRunApprovalRepository } from './sqlite/run-approval-repository.js';
 export { SqlitePhaseTransitionRepository } from './sqlite/phase-transition-repository.js';
 export { SqliteDurableGoalRepository } from './sqlite/durable-goal-repository.js';

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -74,6 +74,15 @@ import type {
   ToolServerDiscovery,
   WorkspaceExecutionTrustDecision,
   WorkspaceExecutionTrustInventory,
+  RunOutputArtifactCleanupInput,
+  RunOutputArtifactCleanupResult,
+  RunOutputArtifactCreateResult,
+  RunOutputArtifactListQuery,
+  RunOutputArtifactLookup,
+  RunOutputArtifactMetadata,
+  RunOutputArtifactRange,
+  RunOutputArtifactRangeQuery,
+  RunOutputQuarantineReason,
 } from '@veritas-kanban/shared';
 import type { Activity, ActivityType } from '../services/activity-service.js';
 import type {
@@ -381,6 +390,37 @@ export interface RunEventRepository {
 }
 
 // ---------------------------------------------------------------------------
+// Governed Run Output Artifacts
+// ---------------------------------------------------------------------------
+
+export interface RunOutputArtifactRepository {
+  /** Atomically persist redacted content and its immutable causal metadata. */
+  create(
+    metadata: RunOutputArtifactMetadata,
+    content: Uint8Array | null
+  ): Promise<RunOutputArtifactCreateResult>;
+
+  /** Resolve metadata only when every workspace/run scope component matches. */
+  get(lookup: RunOutputArtifactLookup): Promise<RunOutputArtifactMetadata | null>;
+
+  /** Return a bounded content range without materializing the complete artifact. */
+  readRange(query: RunOutputArtifactRangeQuery): Promise<RunOutputArtifactRange | null>;
+
+  /** List bounded metadata records without returning artifact content. */
+  list(query: RunOutputArtifactListQuery): Promise<RunOutputArtifactMetadata[]>;
+
+  /** Expire eligible bodies while preserving metadata tombstones for event references. */
+  cleanup(input: RunOutputArtifactCleanupInput): Promise<RunOutputArtifactCleanupResult>;
+
+  /** Quarantine an unsafe body while retaining a scoped metadata tombstone. */
+  quarantine(
+    lookup: RunOutputArtifactLookup,
+    reason: RunOutputQuarantineReason,
+    now: string
+  ): Promise<RunOutputArtifactMetadata | null>;
+}
+
+// ---------------------------------------------------------------------------
 // Run Approval Repository
 // ---------------------------------------------------------------------------
 
@@ -543,6 +583,7 @@ export interface StorageProvider {
   readonly managedLists: ManagedListProvider;
   readonly telemetry: TelemetryRepository;
   readonly runEvents: RunEventRepository;
+  readonly runOutputArtifacts: RunOutputArtifactRepository;
   readonly runApprovals: RunApprovalRepository;
   readonly phaseTransitions: PhaseTransitionRepository;
   readonly runSupervisors: RunSupervisorRepository;

--- a/server/src/storage/run-output-artifact-repository.ts
+++ b/server/src/storage/run-output-artifact-repository.ts
@@ -1,0 +1,421 @@
+import { createHash } from 'node:crypto';
+import { constants } from 'node:fs';
+import { lstat, mkdir, open, readdir, rename, rm, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { nanoid } from 'nanoid';
+import type {
+  RunOutputArtifactCleanupInput,
+  RunOutputArtifactCleanupResult,
+  RunOutputArtifactCreateResult,
+  RunOutputArtifactListQuery,
+  RunOutputArtifactLookup,
+  RunOutputArtifactMetadata,
+  RunOutputArtifactRange,
+  RunOutputArtifactRangeQuery,
+  RunOutputQuarantineReason,
+} from '@veritas-kanban/shared';
+import { RunOutputArtifactMetadataSchema } from '../schemas/run-output-artifact-schemas.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import type { RunOutputArtifactRepository } from './interfaces.js';
+
+const MAX_METADATA_BYTES = 64 * 1024;
+const MAX_RANGE_BYTES = 4 * 1024 * 1024;
+const MAX_SCAN_RECORDS = 20_000;
+const MAX_LIST_LIMIT = 2_000;
+const MAX_CLEANUP_LIMIT = 2_000;
+
+export interface FileRunOutputArtifactRepositoryHooks {
+  beforePublish?: (metadata: RunOutputArtifactMetadata) => void | Promise<void>;
+}
+
+export function getRunOutputArtifactsDir(): string {
+  return path.join(getRuntimeDir(), 'run-output-artifacts');
+}
+
+function contentHash(content: Uint8Array): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function sameIdentity(
+  left: RunOutputArtifactMetadata,
+  right: RunOutputArtifactMetadata
+): boolean {
+  return (
+    left.id === right.id &&
+    left.sha256 === right.sha256 &&
+    left.scope.workspaceId === right.scope.workspaceId &&
+    left.scope.taskId === right.scope.taskId &&
+    left.scope.runId === right.scope.runId &&
+    left.scope.attemptId === right.scope.attemptId
+  );
+}
+
+function exactScope(metadata: RunOutputArtifactMetadata, lookup: RunOutputArtifactLookup): boolean {
+  return (
+    metadata.id === lookup.artifactId &&
+    metadata.scope.workspaceId === lookup.workspaceId &&
+    metadata.scope.taskId === lookup.taskId &&
+    metadata.scope.runId === lookup.runId &&
+    metadata.scope.attemptId === lookup.attemptId &&
+    (lookup.turnId === undefined || metadata.scope.turnId === lookup.turnId)
+  );
+}
+
+export class FileRunOutputArtifactRepository implements RunOutputArtifactRepository {
+  constructor(
+    private readonly baseDir = getRunOutputArtifactsDir(),
+    private readonly hooks: FileRunOutputArtifactRepositoryHooks = {}
+  ) {
+    ensureWithinBase(path.dirname(baseDir), baseDir);
+  }
+
+  async create(
+    candidate: RunOutputArtifactMetadata,
+    content: Uint8Array | null
+  ): Promise<RunOutputArtifactCreateResult> {
+    const metadata = RunOutputArtifactMetadataSchema.parse(candidate);
+    this.validateContent(metadata, content);
+    const parent = await this.prepareScope(metadata.scope);
+    const artifactDir = this.artifactPath(metadata.scope, metadata.id);
+    const existing = await this.get(this.lookupFor(metadata));
+    if (existing) {
+      if (!sameIdentity(existing, metadata)) {
+        throw new Error(`Run output artifact ${metadata.id} has conflicting identity.`);
+      }
+      return { metadata: existing, created: false };
+    }
+
+    const temporaryDir = path.join(parent, `.tmp-${metadata.id}-${nanoid(8)}`);
+    ensureWithinBase(parent, temporaryDir);
+    await mkdir(temporaryDir, { mode: 0o700 });
+    try {
+      await this.writeExclusive(
+        path.join(temporaryDir, 'metadata.json'),
+        Buffer.from(JSON.stringify(metadata), 'utf-8')
+      );
+      if (content) {
+        await this.writeExclusive(path.join(temporaryDir, 'payload.bin'), content);
+      }
+      await this.hooks.beforePublish?.(metadata);
+      await rename(temporaryDir, artifactDir);
+      return { metadata, created: true };
+    } catch (error) {
+      const raced = await this.get(this.lookupFor(metadata));
+      if (raced && sameIdentity(raced, metadata)) return { metadata: raced, created: false };
+      throw error;
+    } finally {
+      await rm(temporaryDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  async get(lookup: RunOutputArtifactLookup): Promise<RunOutputArtifactMetadata | null> {
+    const metadataPath = path.join(
+      this.artifactPath(lookup, lookup.artifactId),
+      'metadata.json'
+    );
+    const content = await this.readBoundedFile(metadataPath, MAX_METADATA_BYTES);
+    if (!content) return null;
+    const metadata = RunOutputArtifactMetadataSchema.parse(
+      JSON.parse(Buffer.from(content).toString('utf-8'))
+    );
+    return exactScope(metadata, lookup) ? metadata : null;
+  }
+
+  async readRange(query: RunOutputArtifactRangeQuery): Promise<RunOutputArtifactRange | null> {
+    if (!Number.isInteger(query.offset) || query.offset < 0) {
+      throw new Error('Artifact range offset must be a non-negative integer.');
+    }
+    if (!Number.isInteger(query.length) || query.length < 1 || query.length > MAX_RANGE_BYTES) {
+      throw new Error(`Artifact range length must be between 1 and ${MAX_RANGE_BYTES} bytes.`);
+    }
+    const metadata = await this.get(query);
+    if (!metadata || metadata.state !== 'available') return null;
+    const payloadPath = path.join(this.artifactPath(query, query.artifactId), 'payload.bin');
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(payloadPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.size !== metadata.storedBytes) {
+        throw new Error('Run output artifact payload failed its size integrity check.');
+      }
+      const length = Math.min(query.length, Math.max(0, stat.size - query.offset));
+      const content = Buffer.alloc(length);
+      const result = length > 0 ? await handle.read(content, 0, length, query.offset) : undefined;
+      return {
+        metadata,
+        offset: query.offset,
+        length: result?.bytesRead ?? 0,
+        content: content.subarray(0, result?.bytesRead ?? 0),
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+        throw new Error('Run output artifact payload is not a regular file.', { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  async list(query: RunOutputArtifactListQuery): Promise<RunOutputArtifactMetadata[]> {
+    validatePathSegment(query.workspaceId);
+    const workspaceDir = path.join(this.baseDir, query.workspaceId);
+    ensureWithinBase(this.baseDir, workspaceDir);
+    const records = await this.scanWorkspace(workspaceDir);
+    const states = query.states ? new Set(query.states) : undefined;
+    const limit = Math.min(Math.max(query.limit ?? 100, 1), MAX_LIST_LIMIT);
+    return records
+      .filter((metadata) => metadata.scope.workspaceId === query.workspaceId)
+      .filter((metadata) => !query.taskId || metadata.scope.taskId === query.taskId)
+      .filter((metadata) => !query.runId || metadata.scope.runId === query.runId)
+      .filter((metadata) => !query.attemptId || metadata.scope.attemptId === query.attemptId)
+      .filter((metadata) => !states || states.has(metadata.state))
+      .sort(
+        (left, right) =>
+          Date.parse(right.retention.createdAt) - Date.parse(left.retention.createdAt) ||
+          left.id.localeCompare(right.id)
+      )
+      .slice(0, limit);
+  }
+
+  async cleanup(input: RunOutputArtifactCleanupInput): Promise<RunOutputArtifactCleanupResult> {
+    const limit = Math.min(Math.max(input.limit ?? 100, 1), MAX_CLEANUP_LIMIT);
+    const workspaces = input.workspaceId
+      ? [input.workspaceId]
+      : await this.childDirectories(this.baseDir);
+    const now = Date.parse(input.now);
+    if (!Number.isFinite(now)) throw new Error('Cleanup time must be a valid ISO timestamp.');
+    const eligible: RunOutputArtifactMetadata[] = [];
+    let retainedByLease = 0;
+    for (const workspaceId of workspaces) {
+      validatePathSegment(workspaceId);
+      const workspaceDir = path.join(this.baseDir, workspaceId);
+      for (const metadata of await this.scanWorkspace(workspaceDir)) {
+        if (metadata.state !== 'available') continue;
+        if (Date.parse(metadata.retention.expiresAt) > now) continue;
+        if (
+          metadata.retention.activeLeaseUntil &&
+          Date.parse(metadata.retention.activeLeaseUntil) > now
+        ) {
+          retainedByLease += 1;
+          continue;
+        }
+        eligible.push(metadata);
+      }
+    }
+    eligible.sort(
+      (left, right) =>
+        Date.parse(left.retention.expiresAt) - Date.parse(right.retention.expiresAt) ||
+        left.id.localeCompare(right.id)
+    );
+    let reclaimedBytes = 0;
+    const expiredArtifactIds: string[] = [];
+    for (const metadata of eligible.slice(0, limit)) {
+      await this.expire(metadata, input.now);
+      reclaimedBytes += metadata.storedBytes;
+      expiredArtifactIds.push(metadata.id);
+    }
+    return {
+      expiredArtifactIds,
+      reclaimedBytes,
+      retainedByLease,
+      hasMore: eligible.length > limit,
+    };
+  }
+
+  async quarantine(
+    lookup: RunOutputArtifactLookup,
+    reason: RunOutputQuarantineReason,
+    now: string
+  ): Promise<RunOutputArtifactMetadata | null> {
+    const metadata = await this.get(lookup);
+    if (!metadata) return null;
+    if (metadata.state === 'quarantined') return metadata;
+    if (metadata.state !== 'available') return metadata;
+    return this.transitionBodyState(metadata, 'quarantined', now, reason);
+  }
+
+  private validateContent(metadata: RunOutputArtifactMetadata, content: Uint8Array | null): void {
+    if (metadata.state === 'available') {
+      if (!content) throw new Error('Available run output artifacts require persisted content.');
+      if (content.byteLength !== metadata.storedBytes || contentHash(content) !== metadata.sha256) {
+        throw new Error('Run output artifact content does not match its integrity metadata.');
+      }
+      return;
+    }
+    if (content || metadata.storedBytes !== 0) {
+      throw new Error('Unavailable run output artifacts cannot persist a payload body.');
+    }
+  }
+
+  private lookupFor(metadata: RunOutputArtifactMetadata): RunOutputArtifactLookup {
+    return { ...metadata.scope, artifactId: metadata.id };
+  }
+
+  private artifactPath(
+    scope: Pick<
+      RunOutputArtifactLookup,
+      'workspaceId' | 'taskId' | 'runId' | 'attemptId'
+    >,
+    artifactId: string
+  ): string {
+    for (const segment of [
+      scope.workspaceId,
+      scope.taskId,
+      scope.runId,
+      scope.attemptId,
+      artifactId,
+    ]) {
+      validatePathSegment(segment);
+    }
+    const resolved = path.join(
+      this.baseDir,
+      scope.workspaceId,
+      scope.taskId,
+      scope.runId,
+      scope.attemptId,
+      artifactId
+    );
+    ensureWithinBase(this.baseDir, resolved);
+    return resolved;
+  }
+
+  private async prepareScope(scope: RunOutputArtifactMetadata['scope']): Promise<string> {
+    await mkdir(this.baseDir, { recursive: true, mode: 0o700 });
+    await this.assertPrivateDirectory(this.baseDir);
+    let current = this.baseDir;
+    for (const segment of [scope.workspaceId, scope.taskId, scope.runId, scope.attemptId]) {
+      validatePathSegment(segment);
+      const next = path.join(current, segment);
+      ensureWithinBase(this.baseDir, next);
+      await mkdir(next, { mode: 0o700 }).catch((error) => {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      });
+      await this.assertPrivateDirectory(next);
+      current = next;
+    }
+    return current;
+  }
+
+  private async assertPrivateDirectory(directory: string): Promise<void> {
+    const stat = await lstat(directory);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error('Run output artifact path is not a private regular directory.');
+    }
+  }
+
+  private async writeExclusive(filePath: string, content: Uint8Array): Promise<void> {
+    const handle = await open(
+      filePath,
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+      0o600
+    );
+    try {
+      await handle.writeFile(content);
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  private async readBoundedFile(
+    filePath: string,
+    maxBytes: number
+  ): Promise<Uint8Array | null> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.size > maxBytes) {
+        throw new Error('Run output artifact metadata is not a bounded regular file.');
+      }
+      return await handle.readFile();
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+        throw new Error('Run output artifact metadata is not a bounded regular file.', {
+          cause: error,
+        });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private async childDirectories(parent: string): Promise<string[]> {
+    try {
+      const entries = await readdir(parent, { withFileTypes: true });
+      return entries
+        .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
+        .map((entry) => entry.name)
+        .filter((entry) => !entry.startsWith('.'));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+  }
+
+  private async scanWorkspace(workspaceDir: string): Promise<RunOutputArtifactMetadata[]> {
+    const records: RunOutputArtifactMetadata[] = [];
+    const taskIds = await this.childDirectories(workspaceDir);
+    for (const taskId of taskIds) {
+      const taskDir = path.join(workspaceDir, taskId);
+      for (const runId of await this.childDirectories(taskDir)) {
+        const runDir = path.join(taskDir, runId);
+        for (const attemptId of await this.childDirectories(runDir)) {
+          const attemptDir = path.join(runDir, attemptId);
+          for (const artifactId of await this.childDirectories(attemptDir)) {
+            if (records.length >= MAX_SCAN_RECORDS) {
+              throw new Error('Run output artifact scan reached its bounded record limit.');
+            }
+            const content = await this.readBoundedFile(
+              path.join(attemptDir, artifactId, 'metadata.json'),
+              MAX_METADATA_BYTES
+            );
+            if (!content) continue;
+            records.push(
+              RunOutputArtifactMetadataSchema.parse(
+                JSON.parse(Buffer.from(content).toString('utf-8'))
+              )
+            );
+          }
+        }
+      }
+    }
+    return records;
+  }
+
+  private async expire(metadata: RunOutputArtifactMetadata, now: string): Promise<void> {
+    await this.transitionBodyState(metadata, 'expired', now);
+  }
+
+  private async transitionBodyState(
+    metadata: RunOutputArtifactMetadata,
+    state: 'expired' | 'quarantined',
+    now: string,
+    quarantineReason?: RunOutputQuarantineReason
+  ): Promise<RunOutputArtifactMetadata> {
+    const artifactDir = this.artifactPath(metadata.scope, metadata.id);
+    const payloadPath = path.join(artifactDir, 'payload.bin');
+    await unlink(payloadPath).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    });
+    const transitioned = RunOutputArtifactMetadataSchema.parse({
+      ...metadata,
+      state,
+      quarantineReason,
+      redaction: {
+        ...metadata.redaction,
+        state: state === 'quarantined' ? 'quarantined' : metadata.redaction.state,
+        validatedAt: now,
+      },
+    });
+    const temporaryPath = path.join(artifactDir, `.metadata-${nanoid(8)}.tmp`);
+    await this.writeExclusive(temporaryPath, Buffer.from(JSON.stringify(transitioned), 'utf-8'));
+    await rename(temporaryPath, path.join(artifactDir, 'metadata.json'));
+    return transitioned;
+  }
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -1447,6 +1447,34 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON reflection_extraction_jobs(state, lease_expires_at);
     `,
   },
+  {
+    version: 29,
+    name: '0029_run_output_artifacts',
+    up: `
+      CREATE TABLE run_output_artifacts (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        task_id TEXT NOT NULL,
+        run_id TEXT NOT NULL,
+        attempt_id TEXT NOT NULL,
+        turn_id TEXT,
+        state TEXT NOT NULL
+          CHECK (state IN ('available', 'quarantined', 'expired', 'deleted')),
+        expires_at TEXT NOT NULL,
+        active_lease_until TEXT,
+        stored_bytes INTEGER NOT NULL CHECK (stored_bytes >= 0),
+        metadata_json TEXT NOT NULL,
+        content BLOB,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX idx_run_output_artifacts_scope
+        ON run_output_artifacts(workspace_id, task_id, run_id, attempt_id, created_at DESC);
+
+      CREATE INDEX idx_run_output_artifacts_expiry
+        ON run_output_artifacts(state, expires_at, active_lease_until);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/storage/sqlite/run-output-artifact-repository.ts
+++ b/server/src/storage/sqlite/run-output-artifact-repository.ts
@@ -1,0 +1,332 @@
+import { createHash } from 'node:crypto';
+import type {
+  RunOutputArtifactCleanupInput,
+  RunOutputArtifactCleanupResult,
+  RunOutputArtifactCreateResult,
+  RunOutputArtifactListQuery,
+  RunOutputArtifactLookup,
+  RunOutputArtifactMetadata,
+  RunOutputArtifactRange,
+  RunOutputArtifactRangeQuery,
+  RunOutputQuarantineReason,
+} from '@veritas-kanban/shared';
+import { RunOutputArtifactMetadataSchema } from '../../schemas/run-output-artifact-schemas.js';
+import type { RunOutputArtifactRepository } from '../interfaces.js';
+import type { SqliteDatabase } from './database.js';
+
+const MAX_RANGE_BYTES = 4 * 1024 * 1024;
+const MAX_LIST_LIMIT = 2_000;
+const MAX_CLEANUP_LIMIT = 2_000;
+
+interface ArtifactRow {
+  metadata_json: string;
+}
+
+interface ArtifactRangeRow extends ArtifactRow {
+  content: Uint8Array | null;
+}
+
+interface CountRow {
+  count: number;
+}
+
+function contentHash(content: Uint8Array): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function sameIdentity(
+  left: RunOutputArtifactMetadata,
+  right: RunOutputArtifactMetadata
+): boolean {
+  return (
+    left.id === right.id &&
+    left.sha256 === right.sha256 &&
+    left.scope.workspaceId === right.scope.workspaceId &&
+    left.scope.taskId === right.scope.taskId &&
+    left.scope.runId === right.scope.runId &&
+    left.scope.attemptId === right.scope.attemptId
+  );
+}
+
+export class SqliteRunOutputArtifactRepository implements RunOutputArtifactRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async create(
+    candidate: RunOutputArtifactMetadata,
+    content: Uint8Array | null
+  ): Promise<RunOutputArtifactCreateResult> {
+    const metadata = RunOutputArtifactMetadataSchema.parse(candidate);
+    this.validateContent(metadata, content);
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      const existing = connection
+        .prepare('SELECT metadata_json FROM run_output_artifacts WHERE id = ?')
+        .get(metadata.id) as ArtifactRow | undefined;
+      if (existing) {
+        const persisted = RunOutputArtifactMetadataSchema.parse(JSON.parse(existing.metadata_json));
+        if (!sameIdentity(persisted, metadata)) {
+          throw new Error(`Run output artifact ${metadata.id} has conflicting identity.`);
+        }
+        connection.exec('COMMIT');
+        return { metadata: persisted, created: false };
+      }
+      connection
+        .prepare(
+          `INSERT INTO run_output_artifacts (
+             id, workspace_id, task_id, run_id, attempt_id, turn_id, state,
+             expires_at, active_lease_until, stored_bytes, metadata_json, content, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          metadata.id,
+          metadata.scope.workspaceId,
+          metadata.scope.taskId,
+          metadata.scope.runId,
+          metadata.scope.attemptId,
+          metadata.scope.turnId ?? null,
+          metadata.state,
+          metadata.retention.expiresAt,
+          metadata.retention.activeLeaseUntil ?? null,
+          metadata.storedBytes,
+          JSON.stringify(metadata),
+          content ? Buffer.from(content) : null,
+          metadata.retention.createdAt
+        );
+      connection.exec('COMMIT');
+      return { metadata, created: true };
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  async get(lookup: RunOutputArtifactLookup): Promise<RunOutputArtifactMetadata | null> {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `SELECT metadata_json
+         FROM run_output_artifacts
+         WHERE id = ? AND workspace_id = ? AND task_id = ? AND run_id = ? AND attempt_id = ?`
+      )
+      .get(
+        lookup.artifactId,
+        lookup.workspaceId,
+        lookup.taskId,
+        lookup.runId,
+        lookup.attemptId
+      ) as ArtifactRow | undefined;
+    if (!row) return null;
+    const metadata = RunOutputArtifactMetadataSchema.parse(JSON.parse(row.metadata_json));
+    if (lookup.turnId !== undefined && metadata.scope.turnId !== lookup.turnId) return null;
+    return metadata;
+  }
+
+  async readRange(query: RunOutputArtifactRangeQuery): Promise<RunOutputArtifactRange | null> {
+    if (!Number.isInteger(query.offset) || query.offset < 0) {
+      throw new Error('Artifact range offset must be a non-negative integer.');
+    }
+    if (!Number.isInteger(query.length) || query.length < 1 || query.length > MAX_RANGE_BYTES) {
+      throw new Error(`Artifact range length must be between 1 and ${MAX_RANGE_BYTES} bytes.`);
+    }
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `SELECT metadata_json, substr(content, ?, ?) AS content
+         FROM run_output_artifacts
+         WHERE id = ? AND workspace_id = ? AND task_id = ? AND run_id = ?
+           AND attempt_id = ? AND state = 'available'`
+      )
+      .get(
+        query.offset + 1,
+        query.length,
+        query.artifactId,
+        query.workspaceId,
+        query.taskId,
+        query.runId,
+        query.attemptId
+      ) as ArtifactRangeRow | undefined;
+    if (!row || row.content === null) return null;
+    const metadata = RunOutputArtifactMetadataSchema.parse(JSON.parse(row.metadata_json));
+    if (query.turnId !== undefined && metadata.scope.turnId !== query.turnId) return null;
+    const content = new Uint8Array(row.content);
+    return {
+      metadata,
+      offset: query.offset,
+      length: content.byteLength,
+      content,
+    };
+  }
+
+  async list(query: RunOutputArtifactListQuery): Promise<RunOutputArtifactMetadata[]> {
+    const clauses = ['workspace_id = ?'];
+    const parameters: Array<string | number> = [query.workspaceId];
+    if (query.taskId) {
+      clauses.push('task_id = ?');
+      parameters.push(query.taskId);
+    }
+    if (query.runId) {
+      clauses.push('run_id = ?');
+      parameters.push(query.runId);
+    }
+    if (query.attemptId) {
+      clauses.push('attempt_id = ?');
+      parameters.push(query.attemptId);
+    }
+    if (query.states?.length) {
+      clauses.push(`state IN (${query.states.map(() => '?').join(', ')})`);
+      parameters.push(...query.states);
+    }
+    parameters.push(Math.min(Math.max(query.limit ?? 100, 1), MAX_LIST_LIMIT));
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `SELECT metadata_json
+         FROM run_output_artifacts
+         WHERE ${clauses.join(' AND ')}
+         ORDER BY created_at DESC, id
+         LIMIT ?`
+      )
+      .all(...parameters) as unknown as ArtifactRow[];
+    return rows.map((row) =>
+      RunOutputArtifactMetadataSchema.parse(JSON.parse(row.metadata_json))
+    );
+  }
+
+  async cleanup(input: RunOutputArtifactCleanupInput): Promise<RunOutputArtifactCleanupResult> {
+    const limit = Math.min(Math.max(input.limit ?? 100, 1), MAX_CLEANUP_LIMIT);
+    const workspaceClause = input.workspaceId ? ' AND workspace_id = ?' : '';
+    const parameters = input.workspaceId
+      ? [input.now, input.now, input.workspaceId, limit + 1]
+      : [input.now, input.now, limit + 1];
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      const rows = connection
+        .prepare(
+          `SELECT metadata_json
+           FROM run_output_artifacts
+           WHERE state = 'available' AND expires_at <= ?
+             AND (active_lease_until IS NULL OR active_lease_until <= ?)
+             ${workspaceClause}
+           ORDER BY expires_at, id
+           LIMIT ?`
+        )
+        .all(...parameters) as unknown as ArtifactRow[];
+      const retainedParameters = input.workspaceId
+        ? [input.now, input.now, input.workspaceId]
+        : [input.now, input.now];
+      const retained = connection
+        .prepare(
+          `SELECT COUNT(*) AS count
+           FROM run_output_artifacts
+           WHERE state = 'available' AND expires_at <= ? AND active_lease_until > ?
+             ${workspaceClause}`
+        )
+        .get(...retainedParameters) as unknown as CountRow;
+      let reclaimedBytes = 0;
+      const expiredArtifactIds: string[] = [];
+      for (const row of rows.slice(0, limit)) {
+        const metadata = RunOutputArtifactMetadataSchema.parse(JSON.parse(row.metadata_json));
+        const expired = RunOutputArtifactMetadataSchema.parse({
+          ...metadata,
+          state: 'expired',
+          redaction: { ...metadata.redaction, validatedAt: input.now },
+        });
+        const result = connection
+          .prepare(
+            `UPDATE run_output_artifacts
+             SET state = 'expired', metadata_json = ?, content = NULL
+             WHERE id = ? AND state = 'available'`
+          )
+          .run(JSON.stringify(expired), metadata.id);
+        if (result.changes === 1) {
+          reclaimedBytes += metadata.storedBytes;
+          expiredArtifactIds.push(metadata.id);
+        }
+      }
+      connection.exec('COMMIT');
+      return {
+        expiredArtifactIds,
+        reclaimedBytes,
+        retainedByLease: Number(retained.count),
+        hasMore: rows.length > limit,
+      };
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  async quarantine(
+    lookup: RunOutputArtifactLookup,
+    reason: RunOutputQuarantineReason,
+    now: string
+  ): Promise<RunOutputArtifactMetadata | null> {
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      const row = connection
+        .prepare(
+          `SELECT metadata_json
+           FROM run_output_artifacts
+           WHERE id = ? AND workspace_id = ? AND task_id = ? AND run_id = ? AND attempt_id = ?`
+        )
+        .get(
+          lookup.artifactId,
+          lookup.workspaceId,
+          lookup.taskId,
+          lookup.runId,
+          lookup.attemptId
+        ) as ArtifactRow | undefined;
+      if (!row) {
+        connection.exec('COMMIT');
+        return null;
+      }
+      const metadata = RunOutputArtifactMetadataSchema.parse(JSON.parse(row.metadata_json));
+      if (lookup.turnId !== undefined && metadata.scope.turnId !== lookup.turnId) {
+        connection.exec('COMMIT');
+        return null;
+      }
+      if (metadata.state !== 'available') {
+        connection.exec('COMMIT');
+        return metadata;
+      }
+      const quarantined = RunOutputArtifactMetadataSchema.parse({
+        ...metadata,
+        state: 'quarantined',
+        quarantineReason: reason,
+        redaction: {
+          ...metadata.redaction,
+          state: 'quarantined',
+          validatedAt: now,
+        },
+      });
+      connection
+        .prepare(
+          `UPDATE run_output_artifacts
+           SET state = 'quarantined', metadata_json = ?, content = NULL
+           WHERE id = ? AND state = 'available'`
+        )
+        .run(JSON.stringify(quarantined), metadata.id);
+      connection.exec('COMMIT');
+      return quarantined;
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  private validateContent(metadata: RunOutputArtifactMetadata, content: Uint8Array | null): void {
+    if (metadata.state === 'available') {
+      if (!content) throw new Error('Available run output artifacts require persisted content.');
+      if (content.byteLength !== metadata.storedBytes || contentHash(content) !== metadata.sha256) {
+        throw new Error('Run output artifact content does not match its integrity metadata.');
+      }
+      return;
+    }
+    if (content || metadata.storedBytes !== 0) {
+      throw new Error('Unavailable run output artifacts cannot persist a payload body.');
+    }
+  }
+}

--- a/server/src/storage/sqlite/sqlite-storage.ts
+++ b/server/src/storage/sqlite/sqlite-storage.ts
@@ -19,6 +19,7 @@ import { SqliteDurableGoalRepository } from './durable-goal-repository.js';
 import { SqliteReflectionExtractionJobRepository } from './reflection-extraction-job-repository.js';
 import { SqliteAdmissionReservationRepository } from './admission-reservation-repository.js';
 import { SqliteToolControlPlaneRepository } from './tool-control-plane-repository.js';
+import { SqliteRunOutputArtifactRepository } from './run-output-artifact-repository.js';
 import { createDefaultConfig, normalizeAppConfig } from '../../services/config-service.js';
 
 export interface SqliteStorageOptions {
@@ -45,6 +46,7 @@ export class SqliteStorageProvider implements StorageProvider {
   readonly reflectionExtractionJobs: SqliteReflectionExtractionJobRepository;
   readonly admissionReservations: SqliteAdmissionReservationRepository;
   readonly toolControlPlane: SqliteToolControlPlaneRepository;
+  readonly runOutputArtifacts: SqliteRunOutputArtifactRepository;
 
   private readonly sqlite: SqliteDatabase;
 
@@ -72,6 +74,7 @@ export class SqliteStorageProvider implements StorageProvider {
     this.reflectionExtractionJobs = new SqliteReflectionExtractionJobRepository(this.sqlite);
     this.admissionReservations = new SqliteAdmissionReservationRepository(this.sqlite);
     this.toolControlPlane = new SqliteToolControlPlaneRepository(this.sqlite);
+    this.runOutputArtifacts = new SqliteRunOutputArtifactRepository(this.sqlite);
   }
 
   getDatabase(): SqliteDatabase {

--- a/shared/src/types/run-output-artifact.types.ts
+++ b/shared/src/types/run-output-artifact.types.ts
@@ -41,11 +41,19 @@ export const RUN_OUTPUT_QUERY_OPERATIONS = [
   'download',
 ] as const;
 
+export const RUN_OUTPUT_QUARANTINE_REASONS = [
+  'content-policy',
+  'secret-validation',
+  'integrity-mismatch',
+  'unsupported-query',
+] as const;
+
 export type RunOutputSourceKind = (typeof RUN_OUTPUT_SOURCE_KINDS)[number];
 export type RunOutputContentClass = (typeof RUN_OUTPUT_CONTENT_CLASSES)[number];
 export type RunOutputTruncationReason = (typeof RUN_OUTPUT_TRUNCATION_REASONS)[number];
 export type RunOutputArtifactState = (typeof RUN_OUTPUT_ARTIFACT_STATES)[number];
 export type RunOutputQueryOperation = (typeof RUN_OUTPUT_QUERY_OPERATIONS)[number];
+export type RunOutputQuarantineReason = (typeof RUN_OUTPUT_QUARANTINE_REASONS)[number];
 export type RunOutputRedactionState = 'none' | 'redacted' | 'quarantined' | 'dropped';
 
 export interface RunOutputArtifactSource {
@@ -79,6 +87,7 @@ export interface RunOutputArtifactRetention {
 export interface RunOutputArtifactReference {
   artifactId: string;
   state: RunOutputArtifactState;
+  quarantineReason?: RunOutputQuarantineReason;
   operations: RunOutputQueryOperation[];
 }
 
@@ -129,4 +138,63 @@ export interface RunOutputSpillPolicy {
   activeLeaseSeconds: number;
   allowBinaryPersistence: boolean;
   allowCompressedPersistence: boolean;
+}
+
+export interface RunOutputArtifactLookup extends RunOutputArtifactScope {
+  artifactId: string;
+}
+
+export interface RunOutputArtifactListQuery {
+  workspaceId: string;
+  taskId?: string;
+  runId?: string;
+  attemptId?: string;
+  states?: RunOutputArtifactState[];
+  limit?: number;
+}
+
+export interface RunOutputArtifactRangeQuery extends RunOutputArtifactLookup {
+  offset: number;
+  length: number;
+}
+
+export interface RunOutputArtifactRange {
+  metadata: RunOutputArtifactMetadata;
+  offset: number;
+  length: number;
+  content: Uint8Array;
+}
+
+export interface RunOutputArtifactCreateResult {
+  metadata: RunOutputArtifactMetadata;
+  created: boolean;
+}
+
+export interface RunOutputArtifactCleanupInput {
+  now: string;
+  workspaceId?: string;
+  limit?: number;
+}
+
+export interface RunOutputArtifactCleanupResult {
+  expiredArtifactIds: string[];
+  reclaimedBytes: number;
+  retainedByLease: number;
+  hasMore: boolean;
+}
+
+export type RunOutputArtifactQuery =
+  | { operation: 'metadata' }
+  | { operation: 'byte-range'; offset: number; length: number }
+  | { operation: 'line-range'; startLine: number; lineCount: number }
+  | { operation: 'json-path'; path: string };
+
+export interface RunOutputArtifactQueryResult {
+  metadata: RunOutputArtifactMetadata;
+  operation: RunOutputArtifactQuery['operation'];
+  content?: string;
+  encoding?: 'utf-8' | 'base64' | 'json';
+  offset?: number;
+  length?: number;
+  truncated: boolean;
 }


### PR DESCRIPTION
Part of #876. Adds file and SQLite repositories with atomic writes, exact scope validation, symlink refusal, idempotent creation, bounded reads, leases, tombstones, and retention cleanup. Verified by 20 focused tests, shared/server typecheck, and targeted lint.