### PR TITLE
feat: persist dependency circuit state

### DIFF
--- a/server/src/__tests__/dependency-circuit-breaker.test.ts
+++ b/server/src/__tests__/dependency-circuit-breaker.test.ts
@@ -230,6 +230,41 @@ describe('DependencyCircuitBreaker', () => {
     });
   });
 
+  it('restores rolling evidence and open-state timing after restart', () => {
+    const { breaker } = fixture({ minimumSamples: 3 });
+    record(breaker, 'dependency-failure');
+    record(breaker, 'success');
+    const state = breaker.exportState();
+    const restored = new DependencyCircuitBreaker({
+      dependency: state.snapshot.dependency,
+      policy: state.snapshot.policy,
+      state,
+      now: () => Date.parse(state.capturedAt),
+      jitter: () => 0.5,
+    });
+
+    record(restored, 'timeout');
+
+    expect(restored.getSnapshot()).toMatchObject({
+      state: 'open',
+      sampleCount: 3,
+      failureCount: 2,
+      reason: { code: 'failure-rate' },
+    });
+    const reopened = new DependencyCircuitBreaker({
+      dependency: restored.dependency,
+      policy: restored.policy,
+      state: restored.exportState(),
+      now: () => Date.parse(state.capturedAt),
+      jitter: () => 0.5,
+    });
+    expect(reopened.acquire()).toMatchObject({
+      allowed: false,
+      reason: 'circuit-open',
+      retryAt: '2026-07-25T12:00:02.000Z',
+    });
+  });
+
   it('rejects duplicate lease settlement', () => {
     const { breaker } = fixture();
     const lease = admitted(breaker.acquire());

--- a/server/src/__tests__/dependency-circuit-registry-service.test.ts
+++ b/server/src/__tests__/dependency-circuit-registry-service.test.ts
@@ -1,0 +1,163 @@
+import { mkdtemp, symlink } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type {
+  DependencyCircuitAdmission,
+  DependencyCircuitPolicy,
+  DependencyIdentity,
+  DependencyOutcome,
+} from '@veritas-kanban/shared';
+import { DependencyCircuitRegistryService } from '../services/dependency-circuit-registry-service.js';
+import {
+  FileDependencyCircuitStateRepository,
+  InMemoryDependencyCircuitStateRepository,
+} from '../storage/dependency-circuit-state-repository.js';
+
+const identity: DependencyIdentity = {
+  kind: 'model-endpoint',
+  id: 'openai-gpt',
+  workspaceId: 'workspace_1',
+  provider: 'codex-cli',
+  model: 'gpt-5.6',
+};
+
+function policy(overrides: Partial<DependencyCircuitPolicy> = {}): DependencyCircuitPolicy {
+  return {
+    schemaVersion: 'dependency-circuit-policy/v1',
+    minimumSamples: 2,
+    rollingWindowMs: 10_000,
+    failureRateThreshold: 0.5,
+    slowCallDurationMs: 1_000,
+    slowCallRateThreshold: 0.5,
+    openDurationMs: 2_000,
+    openDurationJitterRatio: 0,
+    halfOpenMaxConcurrent: 1,
+    probeSuccessThreshold: 1,
+    ...overrides,
+  };
+}
+
+function admitted(admission: DependencyCircuitAdmission) {
+  if (!admission.allowed) throw new Error('Expected dependency circuit admission.');
+  return admission.lease;
+}
+
+async function report(
+  registry: DependencyCircuitRegistryService,
+  outcome: DependencyOutcome,
+  durationMs = 10
+) {
+  const lease = admitted(await registry.acquire(identity, policy()));
+  return registry.record(lease, outcome, durationMs);
+}
+
+describe('DependencyCircuitRegistryService', () => {
+  it('restores open circuits and probe timing from durable state', async () => {
+    let now = Date.parse('2026-07-25T12:00:00.000Z');
+    const repository = new InMemoryDependencyCircuitStateRepository();
+    const first = new DependencyCircuitRegistryService({
+      repository,
+      now: () => now,
+      jitter: () => 0.5,
+    });
+    await report(first, 'dependency-failure');
+    await report(first, 'timeout');
+
+    const restarted = new DependencyCircuitRegistryService({
+      repository,
+      now: () => now,
+      jitter: () => 0.5,
+    });
+    expect(await restarted.acquire(identity, policy())).toMatchObject({
+      allowed: false,
+      reason: 'circuit-open',
+      retryAt: '2026-07-25T12:00:02.000Z',
+    });
+    now += 2_000;
+    expect(await restarted.acquire(identity, policy())).toMatchObject({
+      allowed: true,
+      decision: 'probe',
+    });
+  });
+
+  it('serializes mutations and exposes sorted health snapshots', async () => {
+    const repository = new InMemoryDependencyCircuitStateRepository();
+    const registry = new DependencyCircuitRegistryService({
+      repository,
+      now: () => Date.parse('2026-07-25T12:00:00.000Z'),
+      jitter: () => 0.5,
+    });
+    const alternate = { ...identity, id: 'anthropic-claude', provider: 'claude-code' };
+
+    const firstLease = admitted(await registry.acquire(identity, policy()));
+    const secondLease = admitted(await registry.acquire(alternate, policy()));
+    await Promise.all([
+      registry.record(firstLease, 'success', 10),
+      registry.record(secondLease, 'success', 10),
+    ]);
+
+    const snapshots = await registry.listSnapshots();
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots.map((snapshot) => snapshot.key)).toEqual(
+      [...snapshots.map((snapshot) => snapshot.key)].sort()
+    );
+  });
+
+  it('invalidates persisted evidence when the configured policy changes', async () => {
+    const repository = new InMemoryDependencyCircuitStateRepository();
+    const first = new DependencyCircuitRegistryService({ repository });
+    await report(first, 'dependency-failure');
+
+    const restarted = new DependencyCircuitRegistryService({ repository });
+    const admission = await restarted.acquire(identity, policy({ minimumSamples: 20 }));
+
+    expect(admission).toMatchObject({
+      allowed: true,
+      snapshot: { state: 'closed', sampleCount: 0 },
+    });
+  });
+
+  it('persists operator reset state across restart', async () => {
+    const repository = new InMemoryDependencyCircuitStateRepository();
+    const registry = new DependencyCircuitRegistryService({ repository });
+    await report(registry, 'dependency-failure');
+    const opened = await report(registry, 'timeout');
+
+    expect(await registry.reset(opened.key)).toBe(true);
+    const restarted = new DependencyCircuitRegistryService({ repository });
+
+    expect(await restarted.getSnapshot(opened.key)).toMatchObject({
+      state: 'closed',
+      sampleCount: 0,
+      reason: { code: 'operator-reset' },
+    });
+  });
+
+  it('persists bounded state to a file repository', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'vk-dependency-circuits-'));
+    const repository = new FileDependencyCircuitStateRepository(directory);
+    const registry = new DependencyCircuitRegistryService({
+      repository,
+      now: () => Date.parse('2026-07-25T12:00:00.000Z'),
+      jitter: () => 0.5,
+    });
+    const lease = admitted(await registry.acquire(identity, policy()));
+    await registry.record(lease, 'success', 10);
+
+    const states = await repository.list();
+    expect(states).toHaveLength(1);
+    expect(await repository.read(states[0].snapshot.key)).toEqual(states[0]);
+    expect(await repository.delete(states[0].snapshot.key)).toBe(true);
+    expect(await repository.list()).toEqual([]);
+  });
+
+  it.runIf(process.platform !== 'win32')('refuses symlinked state entries', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'vk-dependency-circuits-'));
+    const target = path.join(directory, 'target');
+    await symlink(target, path.join(directory, `${'a'.repeat(64)}.json`));
+    const repository = new FileDependencyCircuitStateRepository(directory);
+
+    await expect(repository.list()).rejects.toThrow('non-regular state entry');
+  });
+});

--- a/server/src/schemas/dependency-circuit-schemas.ts
+++ b/server/src/schemas/dependency-circuit-schemas.ts
@@ -1,8 +1,16 @@
 import { z } from 'zod';
 import {
   DEPENDENCY_CIRCUIT_POLICY_SCHEMA_VERSION,
+  DEPENDENCY_CIRCUIT_SCHEMA_VERSION,
+  DEPENDENCY_CIRCUIT_STATES,
+  DEPENDENCY_CIRCUIT_STATE_SCHEMA_VERSION,
   DEPENDENCY_KINDS,
+  DEPENDENCY_OUTCOMES,
   type DependencyCircuitPolicy,
+  type DependencyCircuitPersistedState,
+  type DependencyCircuitReason,
+  type DependencyCircuitSample,
+  type DependencyCircuitSnapshot,
   type DependencyIdentity,
 } from '@veritas-kanban/shared';
 
@@ -31,5 +39,66 @@ export const DependencyCircuitPolicySchema: z.ZodType<DependencyCircuitPolicy> =
     openDurationJitterRatio: z.number().min(0).max(0.5),
     halfOpenMaxConcurrent: z.number().int().min(1).max(1_000),
     probeSuccessThreshold: z.number().int().min(1).max(10_000),
+  })
+  .strict();
+
+const TimestampSchema = z.string().datetime({ offset: true });
+
+const DependencyCircuitReasonSchema: z.ZodType<DependencyCircuitReason> = z
+  .object({
+    code: z.enum([
+      'failure-rate',
+      'slow-call-rate',
+      'probe-failed',
+      'operator-reset',
+      'probe-window-opened',
+      'probe-succeeded',
+    ]),
+    observedAt: TimestampSchema,
+    sampleCount: z.number().int().nonnegative(),
+    failureCount: z.number().int().nonnegative(),
+    slowCallCount: z.number().int().nonnegative(),
+    failureRate: z.number().min(0).max(1),
+    slowCallRate: z.number().min(0).max(1),
+  })
+  .strict();
+
+export const DependencyCircuitSnapshotSchema: z.ZodType<DependencyCircuitSnapshot> = z
+  .object({
+    schemaVersion: z.literal(DEPENDENCY_CIRCUIT_SCHEMA_VERSION),
+    key: z.string().trim().min(1).max(2_000),
+    dependency: DependencyIdentitySchema,
+    policy: DependencyCircuitPolicySchema,
+    state: z.enum(DEPENDENCY_CIRCUIT_STATES),
+    reason: DependencyCircuitReasonSchema.optional(),
+    sampleCount: z.number().int().nonnegative(),
+    failureCount: z.number().int().nonnegative(),
+    slowCallCount: z.number().int().nonnegative(),
+    failureRate: z.number().min(0).max(1),
+    slowCallRate: z.number().min(0).max(1),
+    openedAt: TimestampSchema.optional(),
+    nextProbeAt: TimestampSchema.optional(),
+    halfOpenInFlight: z.number().int().nonnegative(),
+    halfOpenSuccesses: z.number().int().nonnegative(),
+    lastOutcome: z.enum(DEPENDENCY_OUTCOMES).optional(),
+    lastOutcomeAt: TimestampSchema.optional(),
+    updatedAt: TimestampSchema,
+  })
+  .strict();
+
+const DependencyCircuitSampleSchema: z.ZodType<DependencyCircuitSample> = z
+  .object({
+    occurredAt: TimestampSchema,
+    outcome: z.enum(DEPENDENCY_OUTCOMES),
+    durationMs: z.number().finite().nonnegative(),
+  })
+  .strict();
+
+export const DependencyCircuitPersistedStateSchema: z.ZodType<DependencyCircuitPersistedState> = z
+  .object({
+    schemaVersion: z.literal(DEPENDENCY_CIRCUIT_STATE_SCHEMA_VERSION),
+    snapshot: DependencyCircuitSnapshotSchema,
+    samples: z.array(DependencyCircuitSampleSchema).max(100_000),
+    capturedAt: TimestampSchema,
   })
   .strict();

--- a/server/src/services/dependency-circuit-breaker.ts
+++ b/server/src/services/dependency-circuit-breaker.ts
@@ -3,9 +3,11 @@ import { nanoid } from 'nanoid';
 import {
   DEPENDENCY_CIRCUIT_POLICY_SCHEMA_VERSION,
   DEPENDENCY_CIRCUIT_SCHEMA_VERSION,
+  DEPENDENCY_CIRCUIT_STATE_SCHEMA_VERSION,
   type DependencyCircuitAdmission,
   type DependencyCircuitLease,
   type DependencyCircuitPolicy,
+  type DependencyCircuitPersistedState,
   type DependencyCircuitReason,
   type DependencyCircuitSnapshot,
   type DependencyIdentity,
@@ -13,6 +15,7 @@ import {
   type DependencyOutcomeSignals,
 } from '@veritas-kanban/shared';
 import {
+  DependencyCircuitPersistedStateSchema,
   DependencyCircuitPolicySchema,
   DependencyIdentitySchema,
 } from '../schemas/dependency-circuit-schemas.js';
@@ -44,6 +47,7 @@ interface ActiveLease {
 export interface DependencyCircuitBreakerOptions {
   dependency: DependencyIdentity;
   policy?: DependencyCircuitPolicy;
+  state?: DependencyCircuitPersistedState;
   now?: () => number;
   jitter?: () => number;
 }
@@ -114,6 +118,7 @@ export class DependencyCircuitBreaker {
     this.key = dependencyCircuitKey(this.dependency);
     this.now = options.now ?? Date.now;
     this.jitter = options.jitter ?? Math.random;
+    if (options.state) this.restore(options.state);
   }
 
   acquire(): DependencyCircuitAdmission {
@@ -220,6 +225,48 @@ export class DependencyCircuitBreaker {
     const now = this.now();
     this.prune(now);
     return this.snapshot(now);
+  }
+
+  exportState(): DependencyCircuitPersistedState {
+    const now = this.now();
+    this.prune(now);
+    return DependencyCircuitPersistedStateSchema.parse({
+      schemaVersion: DEPENDENCY_CIRCUIT_STATE_SCHEMA_VERSION,
+      snapshot: this.snapshot(now),
+      samples: this.samples.map((sample) => ({
+        occurredAt: new Date(sample.occurredAt).toISOString(),
+        outcome: sample.outcome,
+        durationMs: sample.durationMs,
+      })),
+      capturedAt: new Date(now).toISOString(),
+    });
+  }
+
+  private restore(input: DependencyCircuitPersistedState): void {
+    const state = DependencyCircuitPersistedStateSchema.parse(input);
+    if (state.snapshot.key !== this.key) {
+      throw new Error('Persisted dependency circuit state belongs to another circuit.');
+    }
+    if (JSON.stringify(state.snapshot.policy) !== JSON.stringify(this.policy)) {
+      throw new Error('Persisted dependency circuit policy does not match the configured policy.');
+    }
+    this.stateValue = state.snapshot.state;
+    this.samples = state.samples.map((sample) => ({
+      occurredAt: Date.parse(sample.occurredAt),
+      outcome: sample.outcome,
+      durationMs: sample.durationMs,
+    }));
+    this.reason = state.snapshot.reason;
+    this.openedAt = state.snapshot.openedAt ? Date.parse(state.snapshot.openedAt) : undefined;
+    this.nextProbeAt = state.snapshot.nextProbeAt
+      ? Date.parse(state.snapshot.nextProbeAt)
+      : undefined;
+    this.halfOpenSuccesses = state.snapshot.halfOpenSuccesses;
+    this.lastOutcome = state.snapshot.lastOutcome;
+    this.lastOutcomeAt = state.snapshot.lastOutcomeAt
+      ? Date.parse(state.snapshot.lastOutcomeAt)
+      : undefined;
+    this.prune(this.now());
   }
 
   private evaluateClosed(now: number): void {

--- a/server/src/services/dependency-circuit-registry-service.ts
+++ b/server/src/services/dependency-circuit-registry-service.ts
@@ -1,0 +1,170 @@
+import type {
+  DependencyCircuitAdmission,
+  DependencyCircuitLease,
+  DependencyCircuitPolicy,
+  DependencyCircuitPersistedState,
+  DependencyCircuitSnapshot,
+  DependencyIdentity,
+  DependencyOutcome,
+} from '@veritas-kanban/shared';
+import type { DependencyCircuitStateRepository } from '../storage/dependency-circuit-state-repository.js';
+import {
+  DEFAULT_DEPENDENCY_CIRCUIT_POLICY,
+  DependencyCircuitBreaker,
+  dependencyCircuitKey,
+} from './dependency-circuit-breaker.js';
+
+export interface DependencyCircuitRegistryOptions {
+  repository: DependencyCircuitStateRepository;
+  now?: () => number;
+  jitter?: () => number;
+}
+
+export class DependencyCircuitRegistryService {
+  private readonly repository: DependencyCircuitStateRepository;
+  private readonly now?: () => number;
+  private readonly jitter?: () => number;
+  private readonly breakers = new Map<string, DependencyCircuitBreaker>();
+  private readonly persisted = new Map<string, DependencyCircuitPersistedState>();
+  private readonly queues = new Map<string, Promise<void>>();
+  private initialization?: Promise<void>;
+
+  constructor(options: DependencyCircuitRegistryOptions) {
+    this.repository = options.repository;
+    this.now = options.now;
+    this.jitter = options.jitter;
+  }
+
+  async acquire(
+    dependency: DependencyIdentity,
+    policy: DependencyCircuitPolicy = DEFAULT_DEPENDENCY_CIRCUIT_POLICY
+  ): Promise<DependencyCircuitAdmission> {
+    const key = dependencyCircuitKey(dependency);
+    return this.withKey(key, async () => {
+      const breaker = this.getOrCreate(dependency, policy);
+      const before = breaker.getSnapshot();
+      const missingDurableState = !this.persisted.has(key);
+      const admission = breaker.acquire();
+      if (
+        missingDurableState ||
+        before.state !== admission.snapshot.state ||
+        before.nextProbeAt !== admission.snapshot.nextProbeAt
+      ) {
+        await this.persist(breaker);
+      }
+      return admission;
+    });
+  }
+
+  async record(
+    lease: DependencyCircuitLease,
+    outcome: DependencyOutcome,
+    durationMs: number
+  ): Promise<DependencyCircuitSnapshot> {
+    return this.withKey(lease.circuitKey, async () => {
+      const breaker = this.getByKey(lease.circuitKey);
+      if (!breaker) {
+        throw new Error('Dependency circuit is not registered for this lease.');
+      }
+      breaker.record(lease, outcome, durationMs);
+      await this.persist(breaker);
+      return breaker.getSnapshot();
+    });
+  }
+
+  async reset(key: string): Promise<boolean> {
+    return this.withKey(key, async () => {
+      const breaker = this.getByKey(key);
+      if (!breaker) return false;
+      breaker.reset();
+      await this.persist(breaker);
+      return true;
+    });
+  }
+
+  async getSnapshot(key: string): Promise<DependencyCircuitSnapshot | null> {
+    await this.initialize();
+    return this.getByKey(key)?.getSnapshot() ?? null;
+  }
+
+  async listSnapshots(): Promise<DependencyCircuitSnapshot[]> {
+    await this.initialize();
+    const keys = new Set([...this.persisted.keys(), ...this.breakers.keys()]);
+    return [...keys]
+      .map((key) => this.getByKey(key)?.getSnapshot())
+      .filter((snapshot): snapshot is DependencyCircuitSnapshot => Boolean(snapshot))
+      .sort((left, right) => left.key.localeCompare(right.key));
+  }
+
+  private async initialize(): Promise<void> {
+    this.initialization ??= (async () => {
+      for (const state of await this.repository.list()) {
+        this.persisted.set(state.snapshot.key, state);
+      }
+    })();
+    await this.initialization;
+  }
+
+  private getOrCreate(
+    dependency: DependencyIdentity,
+    policy: DependencyCircuitPolicy
+  ): DependencyCircuitBreaker {
+    const key = dependencyCircuitKey(dependency);
+    const existing = this.breakers.get(key);
+    if (existing) return existing;
+    const state = this.persisted.get(key);
+    const matchingState =
+      state && JSON.stringify(state.snapshot.policy) === JSON.stringify(policy)
+        ? state
+        : undefined;
+    const breaker = new DependencyCircuitBreaker({
+      dependency,
+      policy,
+      state: matchingState,
+      now: this.now,
+      jitter: this.jitter,
+    });
+    this.breakers.set(key, breaker);
+    if (!matchingState) this.persisted.delete(key);
+    return breaker;
+  }
+
+  private getByKey(key: string): DependencyCircuitBreaker | undefined {
+    const existing = this.breakers.get(key);
+    if (existing) return existing;
+    const state = this.persisted.get(key);
+    if (!state) return undefined;
+    const breaker = new DependencyCircuitBreaker({
+      dependency: state.snapshot.dependency,
+      policy: state.snapshot.policy,
+      state,
+      now: this.now,
+      jitter: this.jitter,
+    });
+    this.breakers.set(key, breaker);
+    return breaker;
+  }
+
+  private async persist(breaker: DependencyCircuitBreaker): Promise<void> {
+    const state = breaker.exportState();
+    await this.repository.save(state);
+    this.persisted.set(breaker.key, state);
+  }
+
+  private async withKey<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    await this.initialize();
+    const previous = this.queues.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.queues.set(key, current);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      if (this.queues.get(key) === current) this.queues.delete(key);
+      release();
+    }
+  }
+}

--- a/server/src/storage/dependency-circuit-state-repository.ts
+++ b/server/src/storage/dependency-circuit-state-repository.ts
@@ -1,0 +1,177 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { constants, type Dirent } from 'node:fs';
+import path from 'node:path';
+import { lstat, mkdir, open, readdir, rename, unlink } from 'node:fs/promises';
+import type { DependencyCircuitPersistedState } from '@veritas-kanban/shared';
+import { DependencyCircuitPersistedStateSchema } from '../schemas/dependency-circuit-schemas.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+
+const MAX_STATE_BYTES = 512 * 1024;
+const MAX_CIRCUITS = 10_000;
+
+export interface DependencyCircuitStateRepository {
+  read(key: string): Promise<DependencyCircuitPersistedState | null>;
+  list(): Promise<DependencyCircuitPersistedState[]>;
+  save(state: DependencyCircuitPersistedState): Promise<void>;
+  delete(key: string): Promise<boolean>;
+}
+
+export class FileDependencyCircuitStateRepository
+  implements DependencyCircuitStateRepository
+{
+  private readonly directory: string;
+
+  constructor(directory: string) {
+    this.directory = path.resolve(directory);
+  }
+
+  async read(key: string): Promise<DependencyCircuitPersistedState | null> {
+    const filePath = this.pathForKey(key);
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.size > MAX_STATE_BYTES) {
+        throw new Error('Dependency circuit state is not a bounded regular file.');
+      }
+      const state = DependencyCircuitPersistedStateSchema.parse(
+        JSON.parse(await handle.readFile({ encoding: 'utf8' }))
+      );
+      if (state.snapshot.key !== key) {
+        throw new Error('Dependency circuit state key does not match its requested identity.');
+      }
+      return state;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return null;
+      if (code === 'ELOOP') {
+        throw new Error('Dependency circuit state is not a bounded regular file.', {
+          cause: error,
+        });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  async list(): Promise<DependencyCircuitPersistedState[]> {
+    let entries: Dirent[];
+    try {
+      entries = await readdir(this.directory, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+    const candidates = entries.filter((entry) => entry.name.endsWith('.json'));
+    if (candidates.length > MAX_CIRCUITS) {
+      throw new Error('Dependency circuit state directory exceeded its bounded entry limit.');
+    }
+    const states: DependencyCircuitPersistedState[] = [];
+    for (const entry of candidates.sort((left, right) => left.name.localeCompare(right.name))) {
+      if (!entry.isFile()) {
+        throw new Error('Dependency circuit state directory contains a non-regular state entry.');
+      }
+      const state = await this.readPath(
+        ensureWithinBase(this.directory, path.join(this.directory, entry.name))
+      );
+      if (this.pathForKey(state.snapshot.key) !== path.join(this.directory, entry.name)) {
+        throw new Error('Dependency circuit state filename does not match its circuit key.');
+      }
+      states.push(state);
+    }
+    return states;
+  }
+
+  async save(input: DependencyCircuitPersistedState): Promise<void> {
+    const state = DependencyCircuitPersistedStateSchema.parse(input);
+    await mkdir(this.directory, { recursive: true, mode: 0o700 });
+    const directoryStat = await lstat(this.directory);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+      throw new Error('Dependency circuit state directory must be a private regular directory.');
+    }
+    const content = `${JSON.stringify(state)}\n`;
+    if (Buffer.byteLength(content, 'utf8') > MAX_STATE_BYTES) {
+      throw new Error('Dependency circuit state exceeded its bounded byte limit.');
+    }
+    const destination = this.pathForKey(state.snapshot.key);
+    const temporaryPath = ensureWithinBase(
+      this.directory,
+      `${destination}.replace-${process.pid}-${randomUUID()}`
+    );
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(
+        temporaryPath,
+        constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+        0o600
+      );
+      await handle.writeFile(content, 'utf8');
+      await handle.sync();
+      await handle.close();
+      handle = undefined;
+      await rename(temporaryPath, destination);
+    } catch (error) {
+      await handle?.close().catch(() => {});
+      await unlink(temporaryPath).catch(() => {});
+      throw error;
+    }
+  }
+
+  async delete(key: string): Promise<boolean> {
+    try {
+      await unlink(this.pathForKey(key));
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      throw error;
+    }
+  }
+
+  private async readPath(filePath: string): Promise<DependencyCircuitPersistedState> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.size > MAX_STATE_BYTES) {
+        throw new Error('Dependency circuit state is not a bounded regular file.');
+      }
+      return DependencyCircuitPersistedStateSchema.parse(
+        JSON.parse(await handle.readFile({ encoding: 'utf8' }))
+      );
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private pathForKey(key: string): string {
+    const digest = createHash('sha256').update(key).digest('hex');
+    return ensureWithinBase(this.directory, path.join(this.directory, `${digest}.json`));
+  }
+}
+
+export class InMemoryDependencyCircuitStateRepository
+  implements DependencyCircuitStateRepository
+{
+  private readonly states = new Map<string, DependencyCircuitPersistedState>();
+
+  async read(key: string): Promise<DependencyCircuitPersistedState | null> {
+    const state = this.states.get(key);
+    return state ? structuredClone(state) : null;
+  }
+
+  async list(): Promise<DependencyCircuitPersistedState[]> {
+    return [...this.states.values()]
+      .sort((left, right) => left.snapshot.key.localeCompare(right.snapshot.key))
+      .map((state) => structuredClone(state));
+  }
+
+  async save(input: DependencyCircuitPersistedState): Promise<void> {
+    const state = DependencyCircuitPersistedStateSchema.parse(input);
+    this.states.set(state.snapshot.key, structuredClone(state));
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.states.delete(key);
+  }
+}

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -49,6 +49,11 @@ export {
   type WorktreeManifestRepository,
 } from './worktree-manifest-repository.js';
 export {
+  FileDependencyCircuitStateRepository,
+  InMemoryDependencyCircuitStateRepository,
+  type DependencyCircuitStateRepository,
+} from './dependency-circuit-state-repository.js';
+export {
   FileStorageProvider,
   FileTaskRepository,
   FileSettingsRepository,

--- a/shared/src/types/dependency-circuit.types.ts
+++ b/shared/src/types/dependency-circuit.types.ts
@@ -1,6 +1,8 @@
 export const DEPENDENCY_CIRCUIT_SCHEMA_VERSION = 'dependency-circuit/v1' as const;
 export const DEPENDENCY_CIRCUIT_POLICY_SCHEMA_VERSION =
   'dependency-circuit-policy/v1' as const;
+export const DEPENDENCY_CIRCUIT_STATE_SCHEMA_VERSION =
+  'dependency-circuit-state/v1' as const;
 
 export const DEPENDENCY_KINDS = [
   'provider',
@@ -87,6 +89,19 @@ export interface DependencyCircuitSnapshot {
   lastOutcome?: DependencyOutcome;
   lastOutcomeAt?: string;
   updatedAt: string;
+}
+
+export interface DependencyCircuitSample {
+  occurredAt: string;
+  outcome: DependencyOutcome;
+  durationMs: number;
+}
+
+export interface DependencyCircuitPersistedState {
+  schemaVersion: typeof DEPENDENCY_CIRCUIT_STATE_SCHEMA_VERSION;
+  snapshot: DependencyCircuitSnapshot;
+  samples: DependencyCircuitSample[];
+  capturedAt: string;
 }
 
 export interface DependencyCircuitLease {


### PR DESCRIPTION
Part of #879. Adds versioned restart state, rolling-evidence restoration, policy-change invalidation, serialized per-circuit mutations, bounded atomic file persistence, operator reset durability, and sorted health-ready snapshots. Rejected open calls avoid unnecessary persistence writes. Verified by 27 focused tests, shared/server typecheck, and targeted lint.