### PR TITLE
feat: route around unhealthy dependencies

### DIFF
--- a/server/src/__tests__/dependency-circuit-routing-service.test.ts
+++ b/server/src/__tests__/dependency-circuit-routing-service.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  DependencyCircuitAdmission,
+  DependencyCircuitPolicy,
+  DependencyIdentity,
+  DependencyRetryBudgetKind,
+  DependencyRouteCandidate,
+} from '@veritas-kanban/shared';
+import {
+  DependencyCircuitExecutionService,
+  DependencyCircuitRoutingService,
+  DependencyRouteUnavailableError,
+} from '../services/dependency-circuit-routing-service.js';
+import { DependencyCircuitRegistryService } from '../services/dependency-circuit-registry-service.js';
+import { DependencyRetryBudgetService } from '../services/dependency-retry-budget-service.js';
+import { InMemoryDependencyCircuitStateRepository } from '../storage/dependency-circuit-state-repository.js';
+
+const circuitPolicy: DependencyCircuitPolicy = {
+  schemaVersion: 'dependency-circuit-policy/v1',
+  minimumSamples: 1,
+  rollingWindowMs: 10_000,
+  failureRateThreshold: 1,
+  slowCallDurationMs: 1_000,
+  slowCallRateThreshold: 1,
+  openDurationMs: 2_000,
+  openDurationJitterRatio: 0,
+  halfOpenMaxConcurrent: 1,
+  probeSuccessThreshold: 1,
+};
+
+const primary: DependencyIdentity = {
+  kind: 'model-endpoint',
+  id: 'openai-primary',
+  workspaceId: 'workspace_1',
+  provider: 'codex-cli',
+  model: 'gpt-5.6',
+};
+
+const fallback: DependencyIdentity = {
+  kind: 'model-endpoint',
+  id: 'anthropic-fallback',
+  workspaceId: 'workspace_1',
+  provider: 'claude-code',
+  model: 'claude-opus-4-5',
+};
+
+function candidates(): DependencyRouteCandidate[] {
+  return [
+    { id: 'primary', label: 'Primary model', dependency: primary, priority: 0, policy: circuitPolicy },
+    {
+      id: 'fallback',
+      label: 'Fallback model',
+      dependency: fallback,
+      priority: 10,
+      policy: circuitPolicy,
+    },
+  ];
+}
+
+function admitted(admission: DependencyCircuitAdmission) {
+  if (!admission.allowed) throw new Error('Expected dependency circuit admission.');
+  return admission.lease;
+}
+
+async function open(
+  registry: DependencyCircuitRegistryService,
+  dependency: DependencyIdentity
+) {
+  const lease = admitted(await registry.acquire(dependency, circuitPolicy));
+  await registry.record(lease, 'timeout', 2_000);
+}
+
+describe('DependencyCircuitRoutingService', () => {
+  it('selects the primary route and returns its exact admission lease', async () => {
+    const registry = new DependencyCircuitRegistryService({
+      repository: new InMemoryDependencyCircuitStateRepository(),
+    });
+    const routing = new DependencyCircuitRoutingService(registry);
+
+    const decision = await routing.require(candidates(), {
+      allowFallback: true,
+      noMatchAction: 'reject',
+    });
+
+    expect(decision).toMatchObject({
+      candidate: { id: 'primary' },
+      fallback: false,
+      admission: { decision: 'allow' },
+      exclusions: [],
+    });
+    await registry.record(decision.admission.lease, 'success', 10);
+  });
+
+  it('selects an explicit fallback and explains the open primary', async () => {
+    const registry = new DependencyCircuitRegistryService({
+      repository: new InMemoryDependencyCircuitStateRepository(),
+    });
+    await open(registry, primary);
+    const decision = await new DependencyCircuitRoutingService(registry).require(candidates(), {
+      allowFallback: true,
+      noMatchAction: 'reject',
+    });
+
+    expect(decision).toMatchObject({
+      candidate: { id: 'fallback' },
+      fallback: true,
+      exclusions: [{ candidateId: 'primary', reason: 'circuit-open' }],
+    });
+    expect(decision.reason).toContain('Selected fallback');
+    await registry.record(decision.admission.lease, 'success', 10);
+  });
+
+  it('fails closed with the configured queue action when fallback is forbidden', async () => {
+    const registry = new DependencyCircuitRegistryService({
+      repository: new InMemoryDependencyCircuitStateRepository(),
+    });
+    await open(registry, primary);
+    const routing = new DependencyCircuitRoutingService(registry);
+
+    const decision = await routing.select(candidates(), {
+      allowFallback: false,
+      noMatchAction: 'queue',
+    });
+
+    expect(decision).toMatchObject({
+      selected: false,
+      action: 'queue',
+      exclusions: [{ candidateId: 'primary', reason: 'circuit-open' }],
+    });
+    await expect(
+      routing.require(candidates(), {
+        allowFallback: false,
+        noMatchAction: 'operator-approval',
+      })
+    ).rejects.toBeInstanceOf(DependencyRouteUnavailableError);
+  });
+
+  it('single-flights a half-open probe and routes the concurrent caller to fallback', async () => {
+    let now = Date.parse('2026-07-25T12:00:00.000Z');
+    const registry = new DependencyCircuitRegistryService({
+      repository: new InMemoryDependencyCircuitStateRepository(),
+      now: () => now,
+      jitter: () => 0.5,
+    });
+    await open(registry, primary);
+    now += 2_000;
+    const routing = new DependencyCircuitRoutingService(registry);
+
+    const probe = await routing.require(candidates(), {
+      allowFallback: true,
+      noMatchAction: 'reject',
+    });
+    const concurrent = await routing.require(candidates(), {
+      allowFallback: true,
+      noMatchAction: 'reject',
+    });
+
+    expect(probe).toMatchObject({ candidate: { id: 'primary' }, admission: { decision: 'probe' } });
+    expect(concurrent).toMatchObject({
+      candidate: { id: 'fallback' },
+      exclusions: [{ reason: 'probe-concurrency-exhausted' }],
+    });
+    await registry.record(probe.admission.lease, 'success', 10);
+    await registry.record(concurrent.admission.lease, 'success', 10);
+  });
+});
+
+describe('DependencyCircuitExecutionService', () => {
+  it('records timeout failures and rejects the next operation', async () => {
+    const registry = new DependencyCircuitRegistryService({
+      repository: new InMemoryDependencyCircuitStateRepository(),
+    });
+    const execution = new DependencyCircuitExecutionService(registry);
+    const timeout = Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' });
+
+    await expect(
+      execution.execute(primary, async () => Promise.reject(timeout), { policy: circuitPolicy })
+    ).rejects.toBe(timeout);
+    await expect(
+      execution.execute(primary, async () => 'unreachable', { policy: circuitPolicy })
+    ).rejects.toBeInstanceOf(DependencyRouteUnavailableError);
+  });
+
+  it('excludes caller cancellation from dependency failure evidence', async () => {
+    const registry = new DependencyCircuitRegistryService({
+      repository: new InMemoryDependencyCircuitStateRepository(),
+    });
+    const execution = new DependencyCircuitExecutionService(registry);
+    const abort = new DOMException('cancelled', 'AbortError');
+
+    await expect(
+      execution.execute(fallback, async () => Promise.reject(abort), { policy: circuitPolicy })
+    ).rejects.toBe(abort);
+
+    const snapshots = await registry.listSnapshots();
+    expect(snapshots[0]).toMatchObject({
+      state: 'closed',
+      sampleCount: 0,
+      failureCount: 0,
+      lastOutcome: 'caller-cancellation',
+    });
+  });
+
+  it('records successful slow calls against the slow-call threshold', async () => {
+    let now = 1_000;
+    const registry = new DependencyCircuitRegistryService({
+      repository: new InMemoryDependencyCircuitStateRepository(),
+      now: () => now,
+      jitter: () => 0.5,
+    });
+    const execution = new DependencyCircuitExecutionService(registry, () => now);
+
+    await execution.execute(
+      primary,
+      async () => {
+        now += 1_000;
+        return 'ok';
+      },
+      { policy: circuitPolicy }
+    );
+
+    expect((await registry.listSnapshots())[0]).toMatchObject({
+      state: 'open',
+      slowCallCount: 1,
+      reason: { code: 'slow-call-rate' },
+    });
+  });
+});
+
+describe('DependencyRetryBudgetService', () => {
+  it('accounts for each retry class independently', () => {
+    const kinds: DependencyRetryBudgetKind[] = [
+      'transport-retry',
+      'throttling-backoff',
+      'circuit-rejection',
+      'model-resample',
+      'watchdog-recovery',
+      'provider-fallback',
+    ];
+    const budgets = new DependencyRetryBudgetService({
+      limits: Object.fromEntries(kinds.map((kind) => [kind, kind === 'transport-retry' ? 1 : 2])) as Record<
+        DependencyRetryBudgetKind,
+        number
+      >,
+    });
+
+    expect(budgets.consume('transport-retry')).toMatchObject({ allowed: true, remaining: 1 });
+    expect(budgets.consume('transport-retry')).toMatchObject({ allowed: false, remaining: 0 });
+    expect(budgets.inspect('provider-fallback')).toMatchObject({
+      allowed: true,
+      used: 0,
+      remaining: 2,
+    });
+    expect(budgets.snapshot().used['transport-retry']).toBe(1);
+  });
+});

--- a/server/src/schemas/dependency-circuit-schemas.ts
+++ b/server/src/schemas/dependency-circuit-schemas.ts
@@ -6,12 +6,17 @@ import {
   DEPENDENCY_CIRCUIT_STATE_SCHEMA_VERSION,
   DEPENDENCY_KINDS,
   DEPENDENCY_OUTCOMES,
+  DEPENDENCY_RETRY_BUDGET_KINDS,
+  DEPENDENCY_ROUTE_NO_MATCH_ACTIONS,
   type DependencyCircuitPolicy,
   type DependencyCircuitPersistedState,
   type DependencyCircuitReason,
   type DependencyCircuitSample,
   type DependencyCircuitSnapshot,
   type DependencyIdentity,
+  type DependencyRetryBudgetPolicy,
+  type DependencyRetryBudgetUsage,
+  type DependencyRoutePolicy,
 } from '@veritas-kanban/shared';
 
 const IdentifierSchema = z.string().trim().min(1).max(240);
@@ -100,5 +105,31 @@ export const DependencyCircuitPersistedStateSchema: z.ZodType<DependencyCircuitP
     snapshot: DependencyCircuitSnapshotSchema,
     samples: z.array(DependencyCircuitSampleSchema).max(100_000),
     capturedAt: TimestampSchema,
+  })
+  .strict();
+
+export const DependencyRoutePolicySchema: z.ZodType<DependencyRoutePolicy> = z
+  .object({
+    allowFallback: z.boolean(),
+    noMatchAction: z.enum(DEPENDENCY_ROUTE_NO_MATCH_ACTIONS),
+  })
+  .strict();
+
+const retryBudgetShape = Object.fromEntries(
+  DEPENDENCY_RETRY_BUDGET_KINDS.map((kind) => [
+    kind,
+    z.number().int().min(0).max(1_000_000),
+  ])
+) as Record<(typeof DEPENDENCY_RETRY_BUDGET_KINDS)[number], z.ZodNumber>;
+
+export const DependencyRetryBudgetPolicySchema: z.ZodType<DependencyRetryBudgetPolicy> = z
+  .object({
+    limits: z.object(retryBudgetShape).strict(),
+  })
+  .strict();
+
+export const DependencyRetryBudgetUsageSchema: z.ZodType<DependencyRetryBudgetUsage> = z
+  .object({
+    used: z.object(retryBudgetShape).strict(),
   })
   .strict();

--- a/server/src/services/dependency-circuit-registry-service.ts
+++ b/server/src/services/dependency-circuit-registry-service.ts
@@ -111,7 +111,11 @@ export class DependencyCircuitRegistryService {
   ): DependencyCircuitBreaker {
     const key = dependencyCircuitKey(dependency);
     const existing = this.breakers.get(key);
-    if (existing) return existing;
+    if (existing && JSON.stringify(existing.policy) === JSON.stringify(policy)) return existing;
+    if (existing) {
+      this.breakers.delete(key);
+      this.persisted.delete(key);
+    }
     const state = this.persisted.get(key);
     const matchingState =
       state && JSON.stringify(state.snapshot.policy) === JSON.stringify(policy)

--- a/server/src/services/dependency-circuit-routing-service.ts
+++ b/server/src/services/dependency-circuit-routing-service.ts
@@ -1,0 +1,175 @@
+import type {
+  DependencyCircuitAdmission,
+  DependencyCircuitLease,
+  DependencyCircuitPolicy,
+  DependencyCircuitSnapshot,
+  DependencyIdentity,
+  DependencyOutcomeSignals,
+  DependencyRetryBudgetKind,
+  DependencyRouteCandidate,
+  DependencyRouteDecision,
+  DependencyRoutePolicy,
+} from '@veritas-kanban/shared';
+import { DependencyRoutePolicySchema } from '../schemas/dependency-circuit-schemas.js';
+import { classifyDependencyOutcome } from './dependency-circuit-breaker.js';
+import { DependencyCircuitRegistryService } from './dependency-circuit-registry-service.js';
+
+export class DependencyRouteUnavailableError extends Error {
+  readonly retryClass: DependencyRetryBudgetKind = 'circuit-rejection';
+
+  constructor(readonly decision: Extract<DependencyRouteDecision, { selected: false }>) {
+    super(decision.reason);
+    this.name = 'DependencyRouteUnavailableError';
+  }
+}
+
+export class DependencyCircuitRoutingService {
+  constructor(private readonly registry: DependencyCircuitRegistryService) {}
+
+  async select(
+    candidates: DependencyRouteCandidate[],
+    inputPolicy: DependencyRoutePolicy
+  ): Promise<DependencyRouteDecision> {
+    const policy = DependencyRoutePolicySchema.parse(inputPolicy);
+    const ordered = [...candidates].sort(
+      (left, right) => left.priority - right.priority || left.id.localeCompare(right.id)
+    );
+    const eligible = policy.allowFallback ? ordered : ordered.slice(0, 1);
+    const exclusions: Extract<
+      DependencyRouteDecision,
+      { selected: false }
+    >['exclusions'] = [];
+    for (const candidate of eligible) {
+      const admission = await this.registry.acquire(candidate.dependency, candidate.policy);
+      if (!admission.allowed) {
+        exclusions.push({
+          candidateId: candidate.id,
+          dependencyKey: admission.snapshot.key,
+          reason: admission.reason,
+          retryAt: admission.retryAt,
+          snapshot: admission.snapshot,
+        });
+        continue;
+      }
+      const fallback = candidate !== ordered[0];
+      return {
+        selected: true,
+        candidate,
+        admission,
+        fallback,
+        reason: fallback
+          ? `Selected fallback ${candidate.label} after excluding ${exclusions.length} unavailable dependency route(s).`
+          : admission.decision === 'probe'
+            ? `Selected ${candidate.label} for a bounded half-open probe.`
+            : `Selected primary dependency route ${candidate.label}.`,
+        exclusions,
+      };
+    }
+    return {
+      selected: false,
+      action: policy.noMatchAction,
+      reason:
+        eligible.length === 0
+          ? 'No dependency routes were configured.'
+          : `No policy-compliant dependency route is available; action=${policy.noMatchAction}.`,
+      exclusions,
+    };
+  }
+
+  async require(
+    candidates: DependencyRouteCandidate[],
+    policy: DependencyRoutePolicy
+  ): Promise<Extract<DependencyRouteDecision, { selected: true }>> {
+    const decision = await this.select(candidates, policy);
+    if (!decision.selected) throw new DependencyRouteUnavailableError(decision);
+    return decision;
+  }
+}
+
+export interface DependencyCircuitExecutionOptions {
+  signal?: AbortSignal;
+  policy?: DependencyCircuitPolicy;
+  signalsForError?: (error: unknown) => DependencyOutcomeSignals;
+}
+
+export class DependencyCircuitExecutionService {
+  constructor(
+    private readonly registry: DependencyCircuitRegistryService,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  async execute<T>(
+    dependency: DependencyIdentity,
+    operation: () => Promise<T>,
+    options: DependencyCircuitExecutionOptions = {}
+  ): Promise<T> {
+    const admission = await this.registry.acquire(dependency, options.policy);
+    if (!admission.allowed) {
+      throw new DependencyRouteUnavailableError({
+        selected: false,
+        action: 'reject',
+        reason: `Dependency circuit rejected ${admission.snapshot.key}.`,
+        exclusions: [
+          {
+            candidateId: admission.snapshot.key,
+            dependencyKey: admission.snapshot.key,
+            reason: admission.reason,
+            retryAt: admission.retryAt,
+            snapshot: admission.snapshot,
+          },
+        ],
+      });
+    }
+    return this.executeAdmission(admission, operation, options);
+  }
+
+  async executeAdmission<T>(
+    admission: Extract<DependencyCircuitAdmission, { allowed: true }>,
+    operation: () => Promise<T>,
+    options: DependencyCircuitExecutionOptions = {}
+  ): Promise<T> {
+    const startedAt = this.now();
+    try {
+      const result = await operation();
+      await this.registry.record(admission.lease, 'success', this.elapsed(startedAt));
+      return result;
+    } catch (error) {
+      const signals = options.signalsForError?.(error) ?? defaultSignals(error, options.signal);
+      await this.registry.record(
+        admission.lease,
+        classifyDependencyOutcome(signals),
+        this.elapsed(startedAt)
+      );
+      throw error;
+    }
+  }
+
+  async settleCancellation(lease: DependencyCircuitLease, startedAt: number): Promise<void> {
+    await this.registry.record(lease, 'caller-cancellation', this.elapsed(startedAt));
+  }
+
+  async snapshot(key: string): Promise<DependencyCircuitSnapshot | null> {
+    return this.registry.getSnapshot(key);
+  }
+
+  private elapsed(startedAt: number): number {
+    return Math.max(0, this.now() - startedAt);
+  }
+}
+
+function defaultSignals(error: unknown, signal?: AbortSignal): DependencyOutcomeSignals {
+  if (signal?.aborted) return { callerCancelled: true };
+  if (!(error instanceof Error)) return {};
+  const candidate = error as Error & {
+    code?: string;
+    status?: number;
+    statusCode?: number;
+  };
+  return {
+    callerCancelled: candidate.name === 'AbortError',
+    validationFailed: candidate.name === 'ZodError',
+    timedOut: candidate.name === 'TimeoutError' || candidate.code === 'ETIMEDOUT',
+    statusCode: candidate.statusCode ?? candidate.status,
+    errorCode: candidate.code,
+  };
+}

--- a/server/src/services/dependency-retry-budget-service.ts
+++ b/server/src/services/dependency-retry-budget-service.ts
@@ -1,0 +1,47 @@
+import {
+  DEPENDENCY_RETRY_BUDGET_KINDS,
+  type DependencyRetryBudgetDecision,
+  type DependencyRetryBudgetKind,
+  type DependencyRetryBudgetPolicy,
+  type DependencyRetryBudgetUsage,
+} from '@veritas-kanban/shared';
+import {
+  DependencyRetryBudgetPolicySchema,
+  DependencyRetryBudgetUsageSchema,
+} from '../schemas/dependency-circuit-schemas.js';
+
+export class DependencyRetryBudgetService {
+  private readonly policy: DependencyRetryBudgetPolicy;
+  private readonly usage: DependencyRetryBudgetUsage;
+
+  constructor(policy: DependencyRetryBudgetPolicy, usage?: DependencyRetryBudgetUsage) {
+    this.policy = DependencyRetryBudgetPolicySchema.parse(policy);
+    this.usage = DependencyRetryBudgetUsageSchema.parse(
+      usage ?? {
+        used: Object.fromEntries(DEPENDENCY_RETRY_BUDGET_KINDS.map((kind) => [kind, 0])),
+      }
+    );
+  }
+
+  consume(kind: DependencyRetryBudgetKind): DependencyRetryBudgetDecision {
+    const decision = this.inspect(kind);
+    if (decision.allowed) this.usage.used[kind] += 1;
+    return decision;
+  }
+
+  inspect(kind: DependencyRetryBudgetKind): DependencyRetryBudgetDecision {
+    const limit = this.policy.limits[kind];
+    const used = this.usage.used[kind];
+    return {
+      kind,
+      allowed: used < limit,
+      limit,
+      used,
+      remaining: Math.max(0, limit - used),
+    };
+  }
+
+  snapshot(): DependencyRetryBudgetUsage {
+    return structuredClone(this.usage);
+  }
+}

--- a/shared/src/types/dependency-circuit.types.ts
+++ b/shared/src/types/dependency-circuit.types.ts
@@ -27,10 +27,25 @@ export const DEPENDENCY_OUTCOMES = [
 ] as const;
 
 export const DEPENDENCY_CIRCUIT_STATES = ['closed', 'open', 'half-open'] as const;
+export const DEPENDENCY_ROUTE_NO_MATCH_ACTIONS = [
+  'reject',
+  'queue',
+  'operator-approval',
+] as const;
+export const DEPENDENCY_RETRY_BUDGET_KINDS = [
+  'transport-retry',
+  'throttling-backoff',
+  'circuit-rejection',
+  'model-resample',
+  'watchdog-recovery',
+  'provider-fallback',
+] as const;
 
 export type DependencyKind = (typeof DEPENDENCY_KINDS)[number];
 export type DependencyOutcome = (typeof DEPENDENCY_OUTCOMES)[number];
 export type DependencyCircuitState = (typeof DEPENDENCY_CIRCUIT_STATES)[number];
+export type DependencyRouteNoMatchAction = (typeof DEPENDENCY_ROUTE_NO_MATCH_ACTIONS)[number];
+export type DependencyRetryBudgetKind = (typeof DEPENDENCY_RETRY_BUDGET_KINDS)[number];
 
 export interface DependencyIdentity {
   kind: DependencyKind;
@@ -135,4 +150,57 @@ export interface DependencyOutcomeSignals {
   timedOut?: boolean;
   statusCode?: number;
   errorCode?: string;
+}
+
+export interface DependencyRouteCandidate {
+  id: string;
+  label: string;
+  dependency: DependencyIdentity;
+  priority: number;
+  policy?: DependencyCircuitPolicy;
+}
+
+export interface DependencyRoutePolicy {
+  allowFallback: boolean;
+  noMatchAction: DependencyRouteNoMatchAction;
+}
+
+export interface DependencyRouteExclusion {
+  candidateId: string;
+  dependencyKey: string;
+  reason: 'circuit-open' | 'probe-concurrency-exhausted';
+  retryAt?: string;
+  snapshot: DependencyCircuitSnapshot;
+}
+
+export type DependencyRouteDecision =
+  | {
+      selected: true;
+      candidate: DependencyRouteCandidate;
+      admission: Extract<DependencyCircuitAdmission, { allowed: true }>;
+      fallback: boolean;
+      reason: string;
+      exclusions: DependencyRouteExclusion[];
+    }
+  | {
+      selected: false;
+      action: DependencyRouteNoMatchAction;
+      reason: string;
+      exclusions: DependencyRouteExclusion[];
+    };
+
+export interface DependencyRetryBudgetPolicy {
+  limits: Record<DependencyRetryBudgetKind, number>;
+}
+
+export interface DependencyRetryBudgetUsage {
+  used: Record<DependencyRetryBudgetKind, number>;
+}
+
+export interface DependencyRetryBudgetDecision {
+  kind: DependencyRetryBudgetKind;
+  allowed: boolean;
+  limit: number;
+  used: number;
+  remaining: number;
 }


### PR DESCRIPTION
Part of #879. Adds policy-controlled primary and fallback routing, exact exclusion evidence, bounded half-open probe selection, fail-closed reject/queue/operator-approval outcomes, execution outcome reporting, cancellation-safe classification, and independent budgets for transport retry, throttling backoff, circuit rejection, model resample, watchdog recovery, and provider fallback. Verified by 35 focused circuit tests, shared/server typecheck, targeted lint, and 8 post-rebase routing tests.