### PR TITLE
feat: report runtime dependency health

### DIFF
--- a/server/src/__tests__/tool-control-plane-service.test.ts
+++ b/server/src/__tests__/tool-control-plane-service.test.ts
@@ -29,6 +29,9 @@ import {
 import { SqliteDatabase } from '../storage/sqlite/database.js';
 import { SqliteToolControlPlaneRepository } from '../storage/sqlite/tool-control-plane-repository.js';
 import { calculateCredentialDefinitionDigest } from '../utils/credential-broker-digest.js';
+import { DependencyCircuitExecutionService } from '../services/dependency-circuit-routing-service.js';
+import { DependencyCircuitRegistryService } from '../services/dependency-circuit-registry-service.js';
+import { InMemoryDependencyCircuitStateRepository } from '../storage/dependency-circuit-state-repository.js';
 
 const DIGEST = `sha256:${'a'.repeat(64)}`;
 const MANIFEST_DIGEST = `sha256:${'f'.repeat(64)}`;
@@ -117,6 +120,7 @@ function fixture(
       'getDefinition' | 'issueLease' | 'withCredential'
     >;
     phaseAuthority?: Pick<RunPhaseAuthorityService, 'getActive' | 'assertScopes' | 'binding'>;
+    dependencyExecution?: DependencyCircuitExecutionService;
   } = {}
 ) {
   const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -200,6 +204,9 @@ function fixture(
     now: () => new Date('2026-07-24T12:00:00.000Z'),
     environment: options.environment ?? {},
     ...(options.phaseAuthority ? { phaseAuthority: options.phaseAuthority } : {}),
+    ...(options.dependencyExecution
+      ? { dependencyExecution: options.dependencyExecution }
+      : {}),
   });
   return { service, open, requests, append, requestApproval };
 }
@@ -236,6 +243,47 @@ async function catalog(
 }
 
 describe('ToolControlPlaneService', () => {
+  it('reports discovery and invocation through scoped dependency circuits', async () => {
+    const registry = new DependencyCircuitRegistryService({
+      repository: new InMemoryDependencyCircuitStateRepository(),
+    });
+    const dependencyExecution = new DependencyCircuitExecutionService(registry);
+    const { service } = fixture({ dependencyExecution });
+
+    await catalog(service);
+    await service.invoke(
+      {
+        taskId: 'task-tools',
+        attemptId: 'attempt-tools',
+        serverId: 'fixture',
+        tool: 'search',
+        arguments: { query: 'bounded' },
+        operationId: 'circuit-call',
+      },
+      'agent-a'
+    );
+
+    expect(await registry.listSnapshots()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          dependency: expect.objectContaining({ kind: 'mcp-server' }),
+          state: 'closed',
+          sampleCount: 1,
+          lastOutcome: 'success',
+        }),
+        expect.objectContaining({
+          dependency: expect.objectContaining({
+            kind: 'mcp-server',
+            provider: 'codex-app-server',
+          }),
+          state: 'closed',
+          sampleCount: 1,
+          lastOutcome: 'success',
+        }),
+      ])
+    );
+  });
+
   it('verifies runtime health before reusing cached schemas and invalidates on definition change', async () => {
     const { service, open, requests } = fixture();
     const created = await service.createDefinition(definition());

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -12,6 +12,11 @@ import path from 'path';
 import { createLogger } from '../lib/logger.js';
 import { authenticate, authorize } from '../middleware/auth.js';
 import { getAllStatus as getCircuitBreakerStatus } from '../services/circuit-registry.js';
+import {
+  getDependencyCircuitExecutionService,
+  getDependencyCircuitRegistryService,
+  storageDependencyIdentity,
+} from '../services/dependency-circuit-runtime.js';
 import { getSqliteStorageDiagnostics } from '../storage/sqlite/database.js';
 import type { WebSocketServer } from 'ws';
 
@@ -59,6 +64,21 @@ async function checkStorage(): Promise<'ok' | 'fail'> {
     return 'ok';
   } catch (err) {
     log.warn({ err, dataDir }, 'Storage check failed');
+    return 'fail';
+  }
+}
+
+async function checkStorageThroughCircuit(): Promise<'ok' | 'fail'> {
+  try {
+    return await getDependencyCircuitExecutionService().execute(
+      storageDependencyIdentity(process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file'),
+      async () => {
+        const status = await checkStorage();
+        if (status === 'fail') throw new Error('Storage health check failed.');
+        return status;
+      }
+    );
+  } catch {
     return 'fail';
   }
 }
@@ -182,7 +202,7 @@ healthRouter.get('/live', (_req, res) => {
 healthRouter.get('/ready', async (_req, res) => {
   try {
     const [storage, disk, tasksFile] = await Promise.all([
-      checkStorage(),
+      checkStorageThroughCircuit(),
       checkDisk(),
       checkTasksFile(),
     ]);
@@ -233,7 +253,7 @@ healthRouter.get('/ready', async (_req, res) => {
  */
 async function buildDeepHealthPayload() {
   const [storage, disk, tasksFile] = await Promise.all([
-    checkStorage(),
+    checkStorageThroughCircuit(),
     checkDisk(),
     checkTasksFile(),
   ]);
@@ -266,11 +286,30 @@ async function buildDeepHealthPayload() {
 
   // Get circuit breaker status for all registered services
   const circuitBreakers = getCircuitBreakerStatus();
+  let dependencyCircuits: Awaited<
+    ReturnType<ReturnType<typeof getDependencyCircuitRegistryService>['listSnapshots']>
+  > = [];
+  let dependencyCircuitError: string | undefined;
+  try {
+    dependencyCircuits = await getDependencyCircuitRegistryService().listSnapshots();
+  } catch (error) {
+    dependencyCircuitError = error instanceof Error ? error.message : 'Unknown persistence error';
+    log.warn({ err: error }, 'Dependency circuit diagnostics failed');
+  }
+  const dependencyCircuitSummary = {
+    total: dependencyCircuits.length,
+    closed: dependencyCircuits.filter((circuit) => circuit.state === 'closed').length,
+    open: dependencyCircuits.filter((circuit) => circuit.state === 'open').length,
+    halfOpen: dependencyCircuits.filter((circuit) => circuit.state === 'half-open').length,
+  };
 
   return {
     status:
       storageStatus === 'fail' ||
       disk === 'fail' ||
+      dependencyCircuitSummary.open > 0 ||
+      dependencyCircuitSummary.halfOpen > 0 ||
+      dependencyCircuitError !== undefined ||
       (process.env.VERITAS_STORAGE === 'sqlite' && sqlite?.healthPosture !== 'healthy')
         ? 'degraded'
         : 'ok',
@@ -289,6 +328,11 @@ async function buildDeepHealthPayload() {
     },
     wsConnections,
     circuitBreakers,
+    dependencyCircuits: {
+      summary: dependencyCircuitSummary,
+      circuits: dependencyCircuits,
+      error: dependencyCircuitError,
+    },
     sqlite,
     node: {
       version: process.version,

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -292,6 +292,14 @@ import {
   type PhaseTransitionService,
 } from './phase-transition-service.js';
 import { verifyPhaseCapabilityEvidenceDigest } from './phase-capability-service.js';
+import {
+  defaultDependencyCircuitExecutionService,
+  providerDependencyIdentity,
+} from './dependency-circuit-runtime.js';
+import {
+  DependencyCircuitExecutionService,
+  type DependencyCircuitExecutionOptions,
+} from './dependency-circuit-routing-service.js';
 const log = createLogger('clawdbot-agent-service');
 
 const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -306,6 +314,23 @@ const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
   [/\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*([^\s"'`,}]+)/gi, '$1=[REDACTED]'],
 ];
 const CLAUDE_CODE_MAX_STDERR_BUFFER_BYTES = 64 * 1024;
+const providerDependencyExecutionOptions = {
+  signalsForError: (error: unknown) => {
+    const candidate =
+      error instanceof Error
+        ? (error as Error & { code?: string; status?: number; statusCode?: number })
+        : undefined;
+    return {
+      callerCancelled: candidate?.name === 'AbortError',
+      timedOut:
+        candidate?.name === 'TimeoutError' ||
+        candidate?.code === 'ETIMEDOUT' ||
+        /\\btime(?:d)?\\s*out\\b/i.test(candidate?.message ?? ''),
+      statusCode: candidate?.statusCode ?? candidate?.status,
+      errorCode: candidate?.code,
+    };
+  },
+} satisfies DependencyCircuitExecutionOptions;
 
 export interface AgentProviderStartContext {
   task: Task;
@@ -610,6 +635,7 @@ export class ClawdbotAgentService {
   private phaseTransitions?: Pick<PhaseTransitionService, 'getCurrent'> &
     Partial<Pick<PhaseTransitionService, 'list'>>;
   private runPhaseAuthority: RunPhaseAuthorityService;
+  private dependencyExecution: DependencyCircuitExecutionService;
   private logsDir: string;
 
   constructor(
@@ -654,7 +680,8 @@ export class ClawdbotAgentService {
     reflectionExtractionJobs: Pick<
       ReflectionExtractionJobService,
       'enqueue'
-    > = getReflectionExtractionJobService()
+    > = getReflectionExtractionJobService(),
+    dependencyExecution: DependencyCircuitExecutionService = defaultDependencyCircuitExecutionService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -684,6 +711,7 @@ export class ClawdbotAgentService {
     this.runEgressGateway = runEgressGateway;
     this.durableGoalSupervisor = durableGoalSupervisor;
     this.reflectionExtractionJobs = reflectionExtractionJobs;
+    this.dependencyExecution = dependencyExecution;
     this.workspaceExecutionTrust = workspaceExecutionTrust;
     this.phaseAuthority = phaseAuthority;
     this.phaseTransitions = phaseTransitions;
@@ -1888,11 +1916,17 @@ export class ClawdbotAgentService {
       budgetEvaluation.modelOverride && profileAgentConfig
         ? { ...profileAgentConfig, model: budgetEvaluation.modelOverride }
         : profileAgentConfig;
-    const providerRuntimeManifest = await adapter.probe({
-      agentConfig: launchAgentConfig,
-      health: agentHealth,
-      cwd: this.expandPath(task.git.worktreePath),
-    });
+    const providerProbeCwd = this.expandPath(task.git.worktreePath);
+    const providerRuntimeManifest = await this.dependencyExecution.execute(
+      providerDependencyIdentity(provider, launchAgentConfig?.model, task.project),
+      () =>
+        adapter.probe({
+          agentConfig: launchAgentConfig,
+          health: agentHealth,
+          cwd: providerProbeCwd,
+        }),
+      providerDependencyExecutionOptions
+    );
     const harnessSupport = evaluateHarnessSupportStatus(
       launchAgentConfig as AgentConfig,
       agentHealth,
@@ -2192,11 +2226,17 @@ export class ClawdbotAgentService {
       budgetEvaluation.modelOverride && profileAgentConfig
         ? { ...profileAgentConfig, model: budgetEvaluation.modelOverride }
         : profileAgentConfig;
-    const providerRuntimeManifest = await adapter.probe({
-      agentConfig: launchAgentConfig,
-      health: agentHealth,
-      cwd: this.expandPath(task.git.worktreePath),
-    });
+    const providerProbeCwd = this.expandPath(task.git.worktreePath);
+    const providerRuntimeManifest = await this.dependencyExecution.execute(
+      providerDependencyIdentity(provider, launchAgentConfig?.model, task.project),
+      () =>
+        adapter.probe({
+          agentConfig: launchAgentConfig,
+          health: agentHealth,
+          cwd: providerProbeCwd,
+        }),
+      providerDependencyExecutionOptions
+    );
     const harnessSupport = evaluateHarnessSupportStatus(
       launchAgentConfig as AgentConfig,
       agentHealth,
@@ -3075,20 +3115,31 @@ export class ClawdbotAgentService {
       };
       await this.admission.assertExecutionTreeLaunchAllowed(executionTree.rootObjectiveId);
       this.assertProviderAdmissionEvidence(providerAdmission, attempt);
-      await adapter.start({
-        task,
-        agentConfig: launchAgentConfig,
-        transport: providerTransport,
-        logPath,
-        attemptId,
-        startedAt,
-        emitter,
-        attempt,
-        sandboxPolicy: trustSandbox.policy,
-        runLaunchManifest,
-        conversation,
-        admission: providerAdmission,
-      });
+      await this.dependencyExecution.execute(
+        providerDependencyIdentity(
+          provider,
+          launchAgentConfig?.model,
+          taskEnvelope.workspace.workspaceId
+        ),
+        () =>
+          Promise.resolve(
+            adapter.start({
+              task,
+              agentConfig: launchAgentConfig,
+              transport: providerTransport,
+              logPath,
+              attemptId,
+              startedAt,
+              emitter,
+              attempt,
+              sandboxPolicy: trustSandbox.policy,
+              runLaunchManifest,
+              conversation,
+              admission: providerAdmission,
+            })
+          ),
+        providerDependencyExecutionOptions
+      );
     } catch (error: unknown) {
       const startError = error instanceof Error ? error : new Error(String(error));
       await this.releaseAdmission(
@@ -5170,7 +5221,11 @@ export class ClawdbotAgentService {
   ): Promise<ProviderRuntimeManifest> {
     const provider = this.resolveAgentProvider(agentConfig, agent);
     const health = await this.assertAgentAvailable(agent, agentConfig);
-    return this.resolveProviderAdapter(provider, surface).probe({ agentConfig, health });
+    return this.dependencyExecution.execute(
+      providerDependencyIdentity(provider, agentConfig.model),
+      () => this.resolveProviderAdapter(provider, surface).probe({ agentConfig, health }),
+      providerDependencyExecutionOptions
+    );
   }
 
   private async assertAgentAvailable(

--- a/server/src/services/dependency-circuit-runtime.ts
+++ b/server/src/services/dependency-circuit-runtime.ts
@@ -1,0 +1,90 @@
+import path from 'node:path';
+import type { DependencyIdentity } from '@veritas-kanban/shared';
+import {
+  FileDependencyCircuitStateRepository,
+  InMemoryDependencyCircuitStateRepository,
+} from '../storage/dependency-circuit-state-repository.js';
+import { getDataDir } from '../utils/paths.js';
+import { opaqueDependencyId } from './dependency-circuit-breaker.js';
+import { DependencyCircuitRegistryService } from './dependency-circuit-registry-service.js';
+import { DependencyCircuitExecutionService } from './dependency-circuit-routing-service.js';
+
+let registry: DependencyCircuitRegistryService | undefined;
+let execution: DependencyCircuitExecutionService | undefined;
+
+export function getDependencyCircuitRegistryService(): DependencyCircuitRegistryService {
+  registry ??= new DependencyCircuitRegistryService({
+    repository: new FileDependencyCircuitStateRepository(
+      path.join(getDataDir(), 'dependency-circuits')
+    ),
+  });
+  return registry;
+}
+
+export function getDependencyCircuitExecutionService(): DependencyCircuitExecutionService {
+  execution ??= new DependencyCircuitExecutionService(getDependencyCircuitRegistryService());
+  return execution;
+}
+
+export function defaultDependencyCircuitExecutionService(): DependencyCircuitExecutionService {
+  if (process.env.NODE_ENV === 'test') {
+    return new DependencyCircuitExecutionService(
+      new DependencyCircuitRegistryService({
+        repository: new InMemoryDependencyCircuitStateRepository(),
+      })
+    );
+  }
+  return getDependencyCircuitExecutionService();
+}
+
+export function providerDependencyIdentity(
+  provider: string,
+  model?: string,
+  workspaceId = 'local'
+): DependencyIdentity {
+  return {
+    kind: 'model-endpoint',
+    id: opaqueDependencyId(`provider:${provider}:model:${model ?? 'default'}`),
+    workspaceId,
+    provider,
+    ...(model ? { model } : {}),
+  };
+}
+
+export function toolServerDependencyIdentity(
+  serverId: string,
+  provider?: string,
+  workspaceId = 'local'
+): DependencyIdentity {
+  return {
+    kind: 'mcp-server',
+    id: opaqueDependencyId(`mcp:${serverId}`),
+    workspaceId,
+    ...(provider ? { provider } : {}),
+  };
+}
+
+export function integrationDependencyIdentity(
+  endpointId: string,
+  integrationType?: string,
+  workspaceId = 'local'
+): DependencyIdentity {
+  return {
+    kind: 'integration',
+    id: opaqueDependencyId(`integration:${endpointId}`),
+    workspaceId,
+    ...(integrationType ? { provider: integrationType } : {}),
+  };
+}
+
+export function storageDependencyIdentity(
+  backend: string,
+  workspaceId = 'local'
+): DependencyIdentity {
+  return {
+    kind: 'storage',
+    id: opaqueDependencyId(`storage:${backend}`),
+    workspaceId,
+    provider: backend,
+  };
+}

--- a/server/src/services/outbound-integration-service.ts
+++ b/server/src/services/outbound-integration-service.ts
@@ -9,6 +9,14 @@ import {
   type UrlValidationOptions,
 } from '../utils/url-validation.js';
 import { getRuntimeDir } from '../utils/paths.js';
+import {
+  defaultDependencyCircuitExecutionService,
+  integrationDependencyIdentity,
+} from './dependency-circuit-runtime.js';
+import {
+  DependencyCircuitExecutionService,
+  DependencyRouteUnavailableError,
+} from './dependency-circuit-routing-service.js';
 
 export type OutboundEndpointType =
   | 'broadcast-webhook'
@@ -104,11 +112,29 @@ export interface OutboundIntegrationServiceOptions {
   storageDir?: string;
   persist?: boolean;
   audit?: (event: AuditEvent) => Promise<void>;
+  dependencyExecution?: DependencyCircuitExecutionService;
 }
 
 const DEFAULT_AUTH: OutboundEndpointAuth = { type: 'none' };
 const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_DELIVERIES = 500;
+
+class OutboundDependencyResponseError extends Error {
+  constructor(
+    readonly statusCode: number,
+    readonly responseText?: string
+  ) {
+    super(`Outbound dependency returned HTTP ${statusCode}.`);
+    this.name = 'OutboundDependencyResponseError';
+  }
+}
+
+class OutboundPolicyBlockError extends Error {
+  constructor() {
+    super('URL blocked by outbound URL policy');
+    this.name = 'OutboundPolicyBlockError';
+  }
+}
 
 function openClawGatewayValidationOptions(): UrlValidationOptions {
   return {
@@ -178,6 +204,7 @@ export class OutboundIntegrationService {
   private readonly storageDir: string;
   private readonly persist: boolean;
   private readonly audit: (event: AuditEvent) => Promise<void>;
+  private readonly dependencyExecution: DependencyCircuitExecutionService;
   private loaded = false;
   private endpoints = new Map<string, OutboundEndpointRecord>();
   private deliveries: OutboundDeliveryAttempt[] = [];
@@ -186,6 +213,8 @@ export class OutboundIntegrationService {
     this.storageDir = options.storageDir || path.join(getRuntimeDir(), 'outbound-integrations');
     this.persist = options.persist ?? process.env.VITEST !== 'true';
     this.audit = options.audit || auditLog;
+    this.dependencyExecution =
+      options.dependencyExecution ?? defaultDependencyCircuitExecutionService();
   }
 
   async registerEndpoint(input: OutboundEndpointInput): Promise<OutboundEndpointRecord> {
@@ -278,15 +307,42 @@ export class OutboundIntegrationService {
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
-      const response = await safeFetch(
-        endpoint.url,
-        {
-          method,
-          headers: request.headers,
-          body: request.body,
-          signal: controller.signal,
+      const response = await this.dependencyExecution.execute(
+        integrationDependencyIdentity(registered.id, registered.type),
+        async () => {
+          const candidate = await safeFetch(
+            endpoint.url,
+            {
+              method,
+              headers: request.headers,
+              body: request.body,
+              signal: controller.signal,
+            },
+            endpoint.validationOptions
+          );
+          if (!candidate) throw new OutboundPolicyBlockError();
+          if (candidate.status === 429 || candidate.status >= 500) {
+            throw new OutboundDependencyResponseError(
+              candidate.status,
+              await readLimitedResponseText(candidate, request.responseBodyLimit)
+            );
+          }
+          return candidate;
         },
-        endpoint.validationOptions
+        {
+          signalsForError: (error) => {
+            if (error instanceof OutboundPolicyBlockError) return { policyBlocked: true };
+            if (error instanceof OutboundDependencyResponseError) {
+              return { statusCode: error.statusCode };
+            }
+            const candidate =
+              error instanceof Error ? (error as Error & { code?: string }) : undefined;
+            return {
+              timedOut: candidate?.name === 'AbortError' || candidate?.code === 'ETIMEDOUT',
+              errorCode: candidate?.code,
+            };
+          },
+        }
       );
 
       if (!response) {
@@ -330,8 +386,16 @@ export class OutboundIntegrationService {
       };
     } catch (err) {
       const message = this.sanitizeError(err, endpoint.url);
+      const circuitRejected = err instanceof DependencyRouteUnavailableError;
+      const policyBlocked = err instanceof OutboundPolicyBlockError;
+      const dependencyResponse =
+        err instanceof OutboundDependencyResponseError ? err : undefined;
       const status: OutboundDeliveryStatus =
-        err instanceof Error && err.name === 'AbortError' ? 'timeout' : 'failed';
+        circuitRejected || policyBlocked
+          ? 'blocked'
+          : err instanceof Error && err.name === 'AbortError'
+            ? 'timeout'
+            : 'failed';
       const attempt = await this.recordDelivery({
         endpoint: registered,
         method,
@@ -340,12 +404,22 @@ export class OutboundIntegrationService {
         durationMs: Math.round(performance.now() - start),
         retryOf: request.retryOf,
         attempt: request.attempt,
-        error: status === 'timeout' ? `Timed out after ${timeoutMs}ms` : message,
+        responseStatus: dependencyResponse?.statusCode,
+        error:
+          status === 'timeout'
+            ? `Timed out after ${timeoutMs}ms`
+            : circuitRejected
+              ? 'Dependency circuit rejected outbound delivery.'
+              : policyBlocked
+                ? err.message
+              : message,
       });
       return {
         ok: false,
         status,
         attemptId: attempt.id,
+        responseStatus: dependencyResponse?.statusCode,
+        responseText: dependencyResponse?.responseText,
         error: attempt.error,
       };
     } finally {

--- a/server/src/services/tool-control-plane-service.ts
+++ b/server/src/services/tool-control-plane-service.ts
@@ -53,6 +53,14 @@ import {
   type CredentialBrokerService,
 } from './credential-broker-service.js';
 import {
+  defaultDependencyCircuitExecutionService,
+  toolServerDependencyIdentity,
+} from './dependency-circuit-runtime.js';
+import {
+  DependencyCircuitExecutionService,
+  type DependencyCircuitExecutionOptions,
+} from './dependency-circuit-routing-service.js';
+import {
   getRunPhaseAuthorityService,
   type RunPhaseAuthorityService,
 } from './run-phase-authority-service.js';
@@ -64,6 +72,23 @@ const MAX_SCHEMA_BYTES = 128 * 1024;
 const MAX_DISCOVERY_PAGES = 20;
 const MAX_DISCOVERED_TOOLS = 1_000;
 const STDIO_TERMINATION_GRACE_MS = 2_000;
+const dependencyExecutionOptions = {
+  signalsForError: (error: unknown) => {
+    const candidate =
+      error instanceof Error
+        ? (error as Error & { code?: string; status?: number; statusCode?: number })
+        : undefined;
+    return {
+      callerCancelled: candidate?.name === 'AbortError',
+      timedOut:
+        candidate?.name === 'TimeoutError' ||
+        candidate?.code === 'ETIMEDOUT' ||
+        /\\btime(?:d)?\\s*out\\b/i.test(candidate?.message ?? ''),
+      statusCode: candidate?.statusCode ?? candidate?.status,
+      errorCode: candidate?.code,
+    };
+  },
+} satisfies DependencyCircuitExecutionOptions;
 const CREDENTIAL_ENV_KEY_PATTERN =
   /(?:^|_)(?:API_KEYS?|AUTHORIZATION|AUTH_TOKEN|BEARER|BEARER_TOKEN|COOKIE|CREDENTIALS?|DATABASE_URL|DB_URL|PASSWORD|PASS|PRIVATE_KEY|SECRET|SESSION|SESSION_TOKEN|TOKEN|WEBHOOK)(?:_|$)/i;
 
@@ -112,6 +137,7 @@ export interface ToolControlPlaneServiceOptions {
   now?: () => Date;
   environment?: NodeJS.ProcessEnv;
   phaseAuthority?: Pick<RunPhaseAuthorityService, 'getActive' | 'assertScopes' | 'binding'>;
+  dependencyExecution?: DependencyCircuitExecutionService;
 }
 
 let fileRepository: FileToolControlPlaneRepository | undefined;
@@ -138,6 +164,7 @@ export class ToolControlPlaneService {
     RunPhaseAuthorityService,
     'getActive' | 'assertScopes' | 'binding'
   >;
+  private readonly dependencyExecution: DependencyCircuitExecutionService;
   private readonly sessions = new Map<string, Promise<RpcSession>>();
   private readonly validators = new Map<string, ValidateFunction>();
 
@@ -150,6 +177,8 @@ export class ToolControlPlaneService {
     this.credentialBroker = options.credentialBroker ?? getCredentialBrokerService();
     this.now = options.now ?? (() => new Date());
     this.phaseAuthority = options.phaseAuthority ?? getRunPhaseAuthorityService();
+    this.dependencyExecution =
+      options.dependencyExecution ?? defaultDependencyCircuitExecutionService();
   }
 
   async listDefinitions(): Promise<ToolServerDefinition[]> {
@@ -212,38 +241,44 @@ export class ToolControlPlaneService {
     let session: RpcSession | undefined;
     let discovery: ToolServerDiscovery;
     try {
-      session = await this.runtime.open(runtimeDefinition, cwd);
-      const protocolVersion = await initializeSession(
-        session,
-        definition.startupTimeoutMs,
-        definition.version
+      discovery = await this.dependencyExecution.execute(
+        toolServerDependencyIdentity(definition.id),
+        async () => {
+          session = await this.runtime.open(runtimeDefinition, cwd);
+          const protocolVersion = await initializeSession(
+            session,
+            definition.startupTimeoutMs,
+            definition.version
+          );
+          if (cached?.status === 'ready' && !force) return cached;
+          const tools = await listAllTools(session, definition.startupTimeoutMs);
+          const normalizedTools = tools
+            .map((tool) => normalizeDiscoveredTool(tool))
+            .sort((left, right) => left.name.localeCompare(right.name));
+          if (new Set(normalizedTools.map((tool) => tool.name)).size !== normalizedTools.length) {
+            throw new Error('MCP tools/list returned duplicate tool names.');
+          }
+          for (const tool of normalizedTools) {
+            this.validatorFor(tool.inputSchemaDigest, tool.inputSchema);
+          }
+          const payload: ToolServerDiscovery = {
+            schemaVersion: TOOL_DISCOVERY_SCHEMA_VERSION,
+            serverId: definition.id,
+            serverVersion: definition.version,
+            definitionDigest: definition.digest,
+            protocolVersion,
+            status: 'ready',
+            tools: normalizedTools,
+            discoveredAt: this.now().toISOString(),
+            digest: 'sha256:'.padEnd(71, '0'),
+          };
+          return toolServerDiscoverySchema.parse({
+            ...payload,
+            digest: calculateToolDiscoveryDigest(payload),
+          });
+        },
+        dependencyExecutionOptions
       );
-      if (cached?.status === 'ready' && !force) return cached;
-      const tools = await listAllTools(session, definition.startupTimeoutMs);
-      const normalizedTools = tools
-        .map((tool) => normalizeDiscoveredTool(tool))
-        .sort((left, right) => left.name.localeCompare(right.name));
-      if (new Set(normalizedTools.map((tool) => tool.name)).size !== normalizedTools.length) {
-        throw new Error('MCP tools/list returned duplicate tool names.');
-      }
-      for (const tool of normalizedTools) {
-        this.validatorFor(tool.inputSchemaDigest, tool.inputSchema);
-      }
-      const payload: ToolServerDiscovery = {
-        schemaVersion: TOOL_DISCOVERY_SCHEMA_VERSION,
-        serverId: definition.id,
-        serverVersion: definition.version,
-        definitionDigest: definition.digest,
-        protocolVersion,
-        status: 'ready',
-        tools: normalizedTools,
-        discoveredAt: this.now().toISOString(),
-        digest: 'sha256:'.padEnd(71, '0'),
-      };
-      discovery = toolServerDiscoverySchema.parse({
-        ...payload,
-        digest: calculateToolDiscoveryDigest(payload),
-      });
     } catch (error) {
       const payload: ToolServerDiscovery = {
         schemaVersion: TOOL_DISCOVERY_SCHEMA_VERSION,
@@ -588,46 +623,50 @@ export class ToolControlPlaneService {
     let sessionPromise: Promise<RpcSession> | undefined;
     let session: RpcSession | undefined;
     try {
-      let response: unknown;
-      if (credentialBound && credentialAction) {
-        if (!runLaunchManifestDigest) {
-          throw new ConflictError(
-            'Credential-bound tool calls require the server-owned launch manifest digest.'
-          );
-        }
-        response = await this.withCredentialDelivery({
-          request,
-          entry,
-          action: credentialAction,
-          runLaunchManifestDigest,
-          approvalId: approvedRequestId,
-          dispatch: async (credentials) => {
-            session = await this.openSession(definition, cwd, credentials);
-            try {
-              return await session.request(
-                'tools/call',
-                { name: tool.name, arguments: request.arguments },
-                definition.toolTimeoutMs
+      const response = await this.dependencyExecution.execute(
+        toolServerDependencyIdentity(entry.serverId, catalog.provider),
+        async () => {
+          if (credentialBound && credentialAction) {
+            if (!runLaunchManifestDigest) {
+              throw new ConflictError(
+                'Credential-bound tool calls require the server-owned launch manifest digest.'
               );
-            } finally {
-              await session.close().catch(() => undefined);
-              session = undefined;
             }
-          },
-        });
-      } else {
-        sessionPromise = this.sessions.get(sessionKey);
-        if (!sessionPromise) {
-          sessionPromise = this.openSession(definition, cwd);
-          this.sessions.set(sessionKey, sessionPromise);
-        }
-        session = await sessionPromise;
-        response = await session.request(
-          'tools/call',
-          { name: tool.name, arguments: request.arguments },
-          definition.toolTimeoutMs
-        );
-      }
+            return this.withCredentialDelivery({
+              request,
+              entry,
+              action: credentialAction,
+              runLaunchManifestDigest,
+              approvalId: approvedRequestId,
+              dispatch: async (credentials) => {
+                session = await this.openSession(definition, cwd, credentials);
+                try {
+                  return await session.request(
+                    'tools/call',
+                    { name: tool.name, arguments: request.arguments },
+                    definition.toolTimeoutMs
+                  );
+                } finally {
+                  await session.close().catch(() => undefined);
+                  session = undefined;
+                }
+              },
+            });
+          }
+          sessionPromise = this.sessions.get(sessionKey);
+          if (!sessionPromise) {
+            sessionPromise = this.openSession(definition, cwd);
+            this.sessions.set(sessionKey, sessionPromise);
+          }
+          session = await sessionPromise;
+          return session.request(
+            'tools/call',
+            { name: tool.name, arguments: request.arguments },
+            definition.toolTimeoutMs
+          );
+        },
+        dependencyExecutionOptions
+      );
       assertBoundedJson(response, MAX_RPC_BYTES, 'Tool result');
       const resultRecord =
         response && typeof response === 'object' && !Array.isArray(response)


### PR DESCRIPTION
Part of #879. Wires provider/model probes and starts, MCP discovery and invocation, outbound integrations, and storage health through the shared circuit control plane. Uses opaque dependency IDs, excludes policy blocks and cancellation, classifies timeouts/throttling/overload, and exposes redacted circuit posture in admin deep health. Verified by 19 provider adapter tests, focused MCP circuit coverage, shared/server typecheck, targeted lint, and the non-listener tool/outbound tests; listener-only cases remain delegated to CI because local socket bind is sandbox-blocked.