### PR TITLE
feat: coordinate run terminal handles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,9 +272,9 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
 - Run-owned commands use `run-terminal-handle/v1`, never a provider's generic
   stdin channel. The current runtime supports background pipe mode with
   manifest-approved executable, cwd, and environment posture, bounded
-  cursor-addressable redacted output, and process-group termination. PTY,
-  foreground detachment, interactive stdin, restart reattachment, and
-  multi-handle waits fail closed until their typed controls ship.
+  cursor-addressable redacted output, bounded single/any/all waits,
+  foreground detachment, and process-group termination. PTY, interactive
+  stdin, and restart reattachment fail closed until their typed controls ship.
 
 ---
 

--- a/docs/architecture/RUN-TERMINAL-V1.md
+++ b/docs/architecture/RUN-TERMINAL-V1.md
@@ -8,12 +8,12 @@ The first implementation supports background pipe-mode commands with:
 
 - one opaque handle bound to workspace, task, attempt, and launch-manifest digest;
 - a manifest-approved executable, relative cwd, and environment-key subset;
-- immediate background return, bounded wait, status inspection, and attempt cleanup;
+- immediate background return, bounded single/any/all waits, foreground detachment without changing ownership, status inspection, and attempt cleanup;
 - redacted byte-bounded stdout/stderr chunks with monotonic cursors, explicit gap metadata, and a total-volume circuit that terminates noisy jobs before they flood the journal;
 - graceful process-group termination followed by bounded forced termination;
 - causal `command.started`, `stream.stdout`, `stream.stderr`, and `command.completed` journal events.
 
-PTY mode, foreground detachment, interactive stdin, restart reattachment, `wait_any`, `wait_all`, external API/CLI/MCP exposure, and persistent handles are explicitly unsupported in this slice. Callers receive typed blockers instead of an implicit downgrade.
+PTY mode, interactive stdin, restart reattachment, external API/CLI/MCP exposure, and persistent handles are explicitly unsupported in this slice. Callers receive typed blockers instead of an implicit downgrade.
 
 ## Authority boundary
 

--- a/server/src/__tests__/run-terminal-service.test.ts
+++ b/server/src/__tests__/run-terminal-service.test.ts
@@ -148,6 +148,73 @@ describe('RunTerminalService', () => {
     });
   });
 
+  it('waits for any handle without blocking the remaining process', async () => {
+    const { service, context } = await fixture();
+    const fast = await service.execute(
+      context,
+      request('setTimeout(() => process.exit(0), 40)')
+    );
+    const slow = await service.execute(
+      context,
+      request('setTimeout(() => process.exit(0), 1000)')
+    );
+
+    expect(await service.waitAny([fast.id, slow.id], 5_000)).toMatchObject({
+      mode: 'any',
+      completed: true,
+      timedOut: false,
+      selectedHandleId: fast.id,
+      completedHandleIds: [fast.id],
+      pendingHandleIds: [slow.id],
+    });
+    await service.terminate(slow.id);
+  });
+
+  it('waits for all handles with a bounded timeout', async () => {
+    const { service, context } = await fixture();
+    const first = await service.execute(
+      context,
+      request('setTimeout(() => process.exit(0), 40)')
+    );
+    const second = await service.execute(
+      context,
+      request('setTimeout(() => process.exit(0), 100)')
+    );
+
+    expect(await service.waitAll([first.id, second.id], 0)).toMatchObject({
+      mode: 'all',
+      completed: false,
+      timedOut: true,
+    });
+    expect(await service.waitAll([first.id, second.id], 5_000)).toMatchObject({
+      mode: 'all',
+      completed: true,
+      timedOut: false,
+      completedHandleIds: expect.arrayContaining([first.id, second.id]),
+      pendingHandleIds: [],
+    });
+  });
+
+  it('detaches a foreground handle without losing output or ownership', async () => {
+    const { service, context, events } = await fixture();
+    const started = await service.execute(context, {
+      ...request('setTimeout(() => process.stdout.write("detached"), 40)'),
+      startMode: 'foreground',
+    });
+
+    expect(started.startMode).toBe('foreground');
+    expect(service.detach(started.id)).toMatchObject({
+      id: started.id,
+      attemptId: context.attemptId,
+      startMode: 'background',
+    });
+    await service.wait(started.id, 5_000);
+    expect(service.output(started.id).chunks.map((chunk) => chunk.content).join('')).toBe(
+      'detached'
+    );
+    expect(events.map((event) => event.kind)).toContain('command.detached');
+  });
+
   it('terminates the owned process group gracefully', async () => {
     const { service, context } = await fixture({ terminationGraceMs: 100 });
     const started = await service.execute(
@@ -164,15 +231,12 @@ describe('RunTerminalService', () => {
     expect(result.forceSignalAt).toBeUndefined();
   });
 
-  it('fails closed for PTY and foreground modes until their controls exist', async () => {
+  it('fails closed for PTY mode until its controls exist', async () => {
     const { service, context } = await fixture();
 
     await expect(
       service.execute(context, { ...request(''), mode: 'pty' })
     ).rejects.toThrow('PTY mode is not supported');
-    await expect(
-      service.execute(context, { ...request(''), startMode: 'foreground' })
-    ).rejects.toThrow('Foreground-to-background handoff is not supported');
   });
 
   it('rejects cwd traversal and unapproved environment keys before spawn', async () => {

--- a/server/src/services/run-terminal-service.ts
+++ b/server/src/services/run-terminal-service.ts
@@ -13,6 +13,7 @@ import {
   type RunTerminalOutputPage,
   type RunTerminalStream,
   type RunTerminalTerminationResult,
+  type RunTerminalWaitManyResult,
   type RunTerminalWaitResult,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
@@ -133,14 +134,6 @@ export class RunTerminalService {
         mode: request.mode,
         capability: CAPABILITIES.pty,
       });
-    }
-    if (request.startMode !== 'background') {
-      throw new ConflictError(
-        'Foreground-to-background handoff is not supported by the current run terminal runtime.',
-        {
-          startMode: request.startMode,
-        }
-      );
     }
     if (!context.allowedCommands.includes(request.command)) {
       throw new ConflictError('Terminal command is not approved by the run launch manifest.', {
@@ -268,9 +261,7 @@ export class RunTerminalService {
   }
 
   async wait(handleId: string, timeoutMs: number): Promise<RunTerminalWaitResult> {
-    if (!Number.isInteger(timeoutMs) || timeoutMs < 0 || timeoutMs > MAX_WAIT_MS) {
-      throw new ValidationError(`Terminal wait timeout must be between 0 and ${MAX_WAIT_MS} ms.`);
-    }
+    assertWaitTimeout(timeoutMs);
     const record = this.require(handleId);
     if (terminal(record.handle.state)) {
       await record.journalQueue;
@@ -294,6 +285,71 @@ export class RunTerminalService {
       timedOut,
       handle: cloneHandle(record.handle),
     };
+  }
+
+  async waitAny(handleIds: string[], timeoutMs: number): Promise<RunTerminalWaitManyResult> {
+    assertWaitTimeout(timeoutMs);
+    const records = this.requireMany(handleIds);
+    const alreadyCompleted = records.find((record) => terminal(record.handle.state));
+    if (alreadyCompleted) {
+      await alreadyCompleted.journalQueue;
+      return this.waitManyResult('any', records, false, alreadyCompleted.handle.id);
+    }
+    if (timeoutMs === 0) return this.waitManyResult('any', records, true);
+    let timer: NodeJS.Timeout | undefined;
+    const selectedHandleId = await Promise.race([
+      ...records.map((record) => record.exit.then(() => record.handle.id)),
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), timeoutMs);
+        timer.unref();
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    if (selectedHandleId) {
+      await this.require(selectedHandleId).journalQueue;
+      return this.waitManyResult('any', records, false, selectedHandleId);
+    }
+    return this.waitManyResult('any', records, true);
+  }
+
+  async waitAll(handleIds: string[], timeoutMs: number): Promise<RunTerminalWaitManyResult> {
+    assertWaitTimeout(timeoutMs);
+    const records = this.requireMany(handleIds);
+    const pending = records.filter((record) => !terminal(record.handle.state));
+    if (pending.length === 0) {
+      await Promise.all(records.map((record) => record.journalQueue));
+      return this.waitManyResult('all', records, false);
+    }
+    if (timeoutMs === 0) return this.waitManyResult('all', records, true);
+    let timer: NodeJS.Timeout | undefined;
+    const timedOut = await Promise.race([
+      Promise.all(pending.map((record) => record.exit)).then(() => false),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(true), timeoutMs);
+        timer.unref();
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    if (!timedOut) await Promise.all(records.map((record) => record.journalQueue));
+    return this.waitManyResult('all', records, timedOut);
+  }
+
+  detach(handleId: string): RunTerminalHandle {
+    const record = this.require(handleId);
+    if (record.handle.startMode === 'background') return cloneHandle(record.handle);
+    if (terminal(record.handle.state)) {
+      throw new ConflictError('A terminal command cannot be detached after it exits.');
+    }
+    record.handle.startMode = 'background';
+    this.appendEvent(record, {
+      kind: 'command.detached',
+      payload: {
+        handleId: record.handle.id,
+        commandId: record.handle.commandId,
+      },
+      dedupeKey: `run-terminal:${record.handle.id}:detached`,
+    });
+    return cloneHandle(record.handle);
   }
 
   async terminate(handleId: string): Promise<RunTerminalTerminationResult> {
@@ -477,6 +533,40 @@ export class RunTerminalService {
     return record;
   }
 
+  private requireMany(handleIds: string[]): RuntimeRecord[] {
+    const unique = [...new Set(handleIds)];
+    if (unique.length === 0 || unique.length > 64 || unique.length !== handleIds.length) {
+      throw new ValidationError(
+        'Terminal multi-wait requires between 1 and 64 unique handles.'
+      );
+    }
+    return unique.map((handleId) => this.require(handleId));
+  }
+
+  private waitManyResult(
+    mode: RunTerminalWaitManyResult['mode'],
+    records: RuntimeRecord[],
+    timedOut: boolean,
+    selectedHandleId?: string
+  ): RunTerminalWaitManyResult {
+    const handles = records.map((record) => cloneHandle(record.handle));
+    const completedHandleIds = handles
+      .filter((handle) => terminal(handle.state))
+      .map((handle) => handle.id);
+    const pendingHandleIds = handles
+      .filter((handle) => !terminal(handle.state))
+      .map((handle) => handle.id);
+    return {
+      mode,
+      completed: mode === 'any' ? completedHandleIds.length > 0 : pendingHandleIds.length === 0,
+      timedOut,
+      ...(selectedHandleId ? { selectedHandleId } : {}),
+      completedHandleIds,
+      pendingHandleIds,
+      handles,
+    };
+  }
+
   private terminationResult(record: RuntimeRecord): RunTerminalTerminationResult {
     return {
       handle: cloneHandle(record.handle),
@@ -626,6 +716,12 @@ function boundedPositive(
     throw new Error(`Run terminal bound must be an integer between ${minimum} and ${maximum}.`);
   }
   return resolved;
+}
+
+function assertWaitTimeout(timeoutMs: number): void {
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 0 || timeoutMs > MAX_WAIT_MS) {
+    throw new ValidationError(`Terminal wait timeout must be between 0 and ${MAX_WAIT_MS} ms.`);
+  }
 }
 
 let singleton: RunTerminalService | undefined;

--- a/shared/src/types/run-terminal.types.ts
+++ b/shared/src/types/run-terminal.types.ts
@@ -93,6 +93,16 @@ export interface RunTerminalWaitResult {
   handle: RunTerminalHandle;
 }
 
+export interface RunTerminalWaitManyResult {
+  mode: 'any' | 'all';
+  completed: boolean;
+  timedOut: boolean;
+  selectedHandleId?: string;
+  completedHandleIds: string[];
+  pendingHandleIds: string[];
+  handles: RunTerminalHandle[];
+}
+
 export interface RunTerminalTerminationResult {
   handle: RunTerminalHandle;
   gracefulSignalAt?: string;


### PR DESCRIPTION
## Summary

- add bounded wait-any and wait-all coordination for up to 64 unique handles
- allow foreground pipe commands to detach without losing ownership, output, or cancellation
- persist command.detached evidence and document coordination semantics

## Verification

- 11 focused run-terminal tests passed in 2.11s
- shared build passed
- server typecheck passed
- git diff check passed

## Scope

Advances #871. Durable restart reconciliation, external API/CLI/MCP access, cleanup integration, and PTY support remain in follow-up slices.