### PR TITLE
feat: reconcile durable run terminal handles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,8 +273,10 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   stdin channel. The current runtime supports background pipe mode with
   manifest-approved executable, cwd, and environment posture, bounded
   cursor-addressable redacted output, bounded single/any/all waits,
-  foreground detachment, and process-group termination. PTY, interactive
-  stdin, and restart reattachment fail closed until their typed controls ship.
+  foreground detachment, process-group termination, and durable journal
+  reconstruction. A dangling handle becomes `interrupted` after restart
+  because inherited pipes cannot be reattached safely. PTY, interactive stdin,
+  and restart reattachment fail closed until their typed controls ship.
 
 ---
 

--- a/docs/architecture/RUN-TERMINAL-V1.md
+++ b/docs/architecture/RUN-TERMINAL-V1.md
@@ -9,11 +9,13 @@ The first implementation supports background pipe-mode commands with:
 - one opaque handle bound to workspace, task, attempt, and launch-manifest digest;
 - a manifest-approved executable, relative cwd, and environment-key subset;
 - immediate background return, bounded single/any/all waits, foreground detachment without changing ownership, status inspection, and attempt cleanup;
+- fail-closed ownership persistence before a new handle is returned;
 - redacted byte-bounded stdout/stderr chunks with monotonic cursors, explicit gap metadata, and a total-volume circuit that terminates noisy jobs before they flood the journal;
 - graceful process-group termination followed by bounded forced termination;
-- causal `command.started`, `stream.stdout`, `stream.stderr`, and `command.completed` journal events.
+- causal `command.started`, `command.detached`, `stream.stdout`, `stream.stderr`, and `command.completed` journal events; and
+- bounded handle and retained-output reconstruction from the durable causal journal.
 
-PTY mode, interactive stdin, restart reattachment, external API/CLI/MCP exposure, and persistent handles are explicitly unsupported in this slice. Callers receive typed blockers instead of an implicit downgrade.
+PTY mode, interactive stdin, restart reattachment, and external API/CLI/MCP exposure are explicitly unsupported in this slice. Callers receive typed blockers instead of an implicit downgrade.
 
 ## Authority boundary
 
@@ -23,9 +25,9 @@ The child is launched without a shell. On Unix-like systems it owns a detached p
 
 ## Output and replay
 
-Each redacted chunk receives a handle-local cursor. Retention is byte-bounded; when older chunks are dropped, `retainedFromCursor`, `droppedBytes`, `truncated`, and the query page's `gap` flag make the loss explicit. Completion waits for the terminal journal queue, so callers that observe a completed wait can replay the corresponding terminal event.
+Each redacted chunk receives a handle-local cursor. Chunks are capped below the journal spill threshold so the cursor, stream, and content remain directly replayable. Retention is byte-bounded; when older chunks are dropped, `retainedFromCursor`, `droppedBytes`, `truncated`, and the query page's `gap` flag make the loss explicit. Completion waits for successful terminal journal persistence, so callers never receive a durable-completion claim when causal evidence is incomplete.
 
-The in-memory buffer is not restart evidence. Durable handle metadata, platform reattachment, and conservative restart reconciliation remain required before the service can advertise `restartReattachment: enforced`.
+`reconcileAttempt(workspaceId, taskId, attemptId)` replays at most 20,000 system-authored run-terminal events and validates each persisted handle before making it visible. Terminal handles and retained output remain queryable after a service restart. A handle without durable completion evidence is marked `interrupted` and receives a deduplicated `command.completed` reconciliation event. The runtime does not claim that it can inherit stdout/stderr pipes from the prior server process, so `restartReattachment` remains `unsupported` rather than pretending the process is safely controlled.
 
 ## Code
 

--- a/server/src/__tests__/run-terminal-service.test.ts
+++ b/server/src/__tests__/run-terminal-service.test.ts
@@ -2,7 +2,11 @@ import { mkdtemp, symlink } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import type { RunEventAppendInput, RunTerminalExecuteRequest } from '@veritas-kanban/shared';
+import type {
+  RunEventAppendInput,
+  RunEventEnvelope,
+  RunTerminalExecuteRequest,
+} from '@veritas-kanban/shared';
 import {
   RunTerminalService,
   type RunTerminalLaunchContext,
@@ -10,22 +14,75 @@ import {
 
 const launchManifestDigest = `sha256:${'a'.repeat(64)}`;
 
-async function fixture(options: {
-  outputLimitBytes?: number;
-  maximumOutputBytes?: number;
-  chunkLimitBytes?: number;
-  terminationGraceMs?: number;
-} = {}) {
+async function fixture(
+  options: {
+    outputLimitBytes?: number;
+    maximumOutputBytes?: number;
+    chunkLimitBytes?: number;
+    terminationGraceMs?: number;
+  } = {}
+) {
   const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), 'vk-run-terminal-'));
   const events: RunEventAppendInput[] = [];
+  const persistedEvents: RunEventEnvelope[] = [];
+  const journal = {
+    append: async (event: RunEventAppendInput) => {
+      events.push(event);
+      const duplicate = event.dedupeKey
+        ? persistedEvents.find((candidate) => candidate.dedupeKey === event.dedupeKey)
+        : undefined;
+      if (duplicate) return { event: duplicate, appended: false };
+      const envelope = {
+        schemaVersion: 'run-event/v1',
+        eventId: `event_${persistedEvents.length + 1}`,
+        taskId: event.taskId,
+        runId: event.attemptId,
+        attemptId: event.attemptId,
+        sequence: persistedEvents.length + 1,
+        receivedAt: new Date().toISOString(),
+        kind: event.kind,
+        source: event.source,
+        redaction: {
+          status: 'none',
+          fields: [],
+          originalBytes: 0,
+          persistedBytes: 0,
+        },
+        payload: structuredClone(event.payload),
+        payloadHash: '0'.repeat(64),
+        dedupeKey: event.dedupeKey,
+      } as RunEventEnvelope;
+      persistedEvents.push(envelope);
+      return { event: envelope, appended: true };
+    },
+    list: async (query: {
+      taskId: string;
+      attemptId: string;
+      afterSequence?: number;
+      limit?: number;
+    }) => {
+      const afterSequence = query.afterSequence ?? 0;
+      const limit = query.limit ?? 200;
+      const available = persistedEvents.filter(
+        (event) =>
+          event.taskId === query.taskId &&
+          event.attemptId === query.attemptId &&
+          event.sequence > afterSequence
+      );
+      const page = available.slice(0, limit);
+      return {
+        schemaVersion: 'run-event/v1' as const,
+        taskId: query.taskId,
+        attemptId: query.attemptId,
+        events: page,
+        nextCursor: page.at(-1)?.sequence ?? afterSequence,
+        hasMore: available.length > page.length,
+      };
+    },
+  };
   const service = new RunTerminalService({
     ...options,
-    journal: {
-      append: async (event) => {
-        events.push(event);
-        return {} as never;
-      },
-    },
+    journal,
   });
   const context: RunTerminalLaunchContext = {
     workspaceId: 'workspace_1',
@@ -36,7 +93,7 @@ async function fixture(options: {
     environment: {},
     allowedCommands: [process.execPath],
   };
-  return { service, context, events };
+  return { service, context, events, journal };
 }
 
 function request(script: string): RunTerminalExecuteRequest {
@@ -82,6 +139,55 @@ describe('RunTerminalService', () => {
     ]);
   });
 
+  it('fails closed when ownership cannot be persisted before handle return', async () => {
+    const { context } = await fixture();
+    const service = new RunTerminalService({
+      journal: {
+        append: async () => {
+          throw new Error('journal unavailable');
+        },
+        list: async (query) => ({
+          schemaVersion: 'run-event/v1',
+          taskId: query.taskId,
+          attemptId: query.attemptId,
+          events: [],
+          nextCursor: query.afterSequence ?? 0,
+          hasMore: false,
+        }),
+      },
+    });
+
+    await expect(service.execute(context, request('setInterval(() => {}, 1000)'))).rejects.toThrow(
+      'ownership could not be persisted'
+    );
+    expect(service.list(context.workspaceId, context.taskId, context.attemptId)).toEqual([]);
+  });
+
+  it('does not report a durable completion when terminal evidence cannot be persisted', async () => {
+    const { context } = await fixture();
+    let appendCount = 0;
+    const service = new RunTerminalService({
+      journal: {
+        append: async () => {
+          appendCount += 1;
+          if (appendCount > 1) throw new Error('journal unavailable');
+          return {} as never;
+        },
+        list: async (query) => ({
+          schemaVersion: 'run-event/v1',
+          taskId: query.taskId,
+          attemptId: query.attemptId,
+          events: [],
+          nextCursor: query.afterSequence ?? 0,
+          hasMore: false,
+        }),
+      },
+    });
+    const started = await service.execute(context, request('process.exit(0)'));
+
+    await expect(service.wait(started.id, 5_000)).rejects.toThrow('journal evidence is incomplete');
+  });
+
   it('redacts and truncates bounded output while reporting cursor gaps', async () => {
     const { service, context } = await fixture({
       outputLimitBytes: 4 * 1024,
@@ -107,6 +213,28 @@ describe('RunTerminalService', () => {
     expect(JSON.stringify(page)).not.toContain('secret-value');
   });
 
+  it('keeps durable stream events below the journal spill threshold', async () => {
+    const { service, context, events } = await fixture();
+    const started = await service.execute(
+      context,
+      request('process.stdout.write("safe output line\\n".repeat(500))')
+    );
+    await service.wait(started.id, 5_000);
+
+    const streamEvents = events.filter((event) => event.kind === 'stream.stdout');
+    expect(streamEvents.length).toBeGreaterThan(1);
+    expect(
+      streamEvents.every(
+        (event) => Buffer.byteLength(String(event.payload.content ?? ''), 'utf8') <= 6 * 1024
+      )
+    ).toBe(true);
+    expect(
+      streamEvents.every(
+        (event) => Buffer.byteLength(JSON.stringify(event.payload), 'utf8') < 8 * 1024
+      )
+    ).toBe(true);
+  });
+
   it('trips the volume circuit before output can flood the run journal', async () => {
     const { service, context, events } = await fixture({
       outputLimitBytes: 4 * 1024,
@@ -123,9 +251,7 @@ describe('RunTerminalService', () => {
       volumeCircuitTripped: true,
       observedBytes: expect.any(Number),
     });
-    expect(
-      events.find((event) => event.kind === 'run.error')
-    ).toMatchObject({
+    expect(events.find((event) => event.kind === 'run.error')).toMatchObject({
       payload: { code: 'terminal-output-volume-limit' },
     });
   });
@@ -150,14 +276,8 @@ describe('RunTerminalService', () => {
 
   it('waits for any handle without blocking the remaining process', async () => {
     const { service, context } = await fixture();
-    const fast = await service.execute(
-      context,
-      request('setTimeout(() => process.exit(0), 40)')
-    );
-    const slow = await service.execute(
-      context,
-      request('setTimeout(() => process.exit(0), 1000)')
-    );
+    const fast = await service.execute(context, request('setTimeout(() => process.exit(0), 40)'));
+    const slow = await service.execute(context, request('setTimeout(() => process.exit(0), 1000)'));
 
     expect(await service.waitAny([fast.id, slow.id], 5_000)).toMatchObject({
       mode: 'any',
@@ -172,10 +292,7 @@ describe('RunTerminalService', () => {
 
   it('waits for all handles with a bounded timeout', async () => {
     const { service, context } = await fixture();
-    const first = await service.execute(
-      context,
-      request('setTimeout(() => process.exit(0), 40)')
-    );
+    const first = await service.execute(context, request('setTimeout(() => process.exit(0), 40)'));
     const second = await service.execute(
       context,
       request('setTimeout(() => process.exit(0), 100)')
@@ -203,16 +320,90 @@ describe('RunTerminalService', () => {
     });
 
     expect(started.startMode).toBe('foreground');
-    expect(service.detach(started.id)).toMatchObject({
+    expect(await service.detach(started.id)).toMatchObject({
       id: started.id,
       attemptId: context.attemptId,
       startMode: 'background',
     });
     await service.wait(started.id, 5_000);
-    expect(service.output(started.id).chunks.map((chunk) => chunk.content).join('')).toBe(
-      'detached'
-    );
+    expect(
+      service
+        .output(started.id)
+        .chunks.map((chunk) => chunk.content)
+        .join('')
+    ).toBe('detached');
     expect(events.map((event) => event.kind)).toContain('command.detached');
+  });
+
+  it('reconstructs terminal handles and retained output from the durable journal', async () => {
+    const { service, context, journal } = await fixture();
+    const started = await service.execute(
+      context,
+      request('process.stdout.write("durable output")')
+    );
+    await service.wait(started.id, 5_000);
+
+    await expect(
+      new RunTerminalService({ journal }).reconcileAttempt(
+        'workspace_other',
+        context.taskId,
+        context.attemptId
+      )
+    ).rejects.toThrow('scope does not match');
+    const restarted = new RunTerminalService({ journal });
+    const reconciliation = await restarted.reconcileAttempt(
+      context.workspaceId,
+      context.taskId,
+      context.attemptId
+    );
+
+    expect(reconciliation).toMatchObject({
+      schemaVersion: 'run-terminal-reconciliation/v1',
+      recoveredHandleIds: [started.id],
+      interruptedHandleIds: [],
+      handles: [{ id: started.id, state: 'exited', exitCode: 0 }],
+    });
+    expect(
+      restarted
+        .output(started.id)
+        .chunks.map((chunk) => chunk.content)
+        .join('')
+    ).toBe('durable output');
+  });
+
+  it('fails closed by interrupting a dangling handle after restart', async () => {
+    const { service, context, events, journal } = await fixture();
+    const started = await service.execute(context, request('setInterval(() => {}, 1000)'));
+    try {
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const restarted = new RunTerminalService({ journal });
+      const reconciliation = await restarted.reconcileAttempt(
+        context.workspaceId,
+        context.taskId,
+        context.attemptId
+      );
+
+      expect(reconciliation).toMatchObject({
+        recoveredHandleIds: [started.id],
+        interruptedHandleIds: [started.id],
+        handles: [
+          {
+            id: started.id,
+            state: 'interrupted',
+            capabilities: { restartReattachment: 'unsupported' },
+          },
+        ],
+      });
+      expect(restarted.get(started.id).failure).toContain('cannot reattach inherited pipes');
+      expect(
+        events.filter(
+          (event) => event.dedupeKey === `run-terminal:${started.id}:restart-interrupted`
+        )
+      ).toHaveLength(1);
+    } finally {
+      await service.terminate(started.id);
+    }
   });
 
   it('terminates the owned process group gracefully', async () => {
@@ -234,17 +425,15 @@ describe('RunTerminalService', () => {
   it('fails closed for PTY mode until its controls exist', async () => {
     const { service, context } = await fixture();
 
-    await expect(
-      service.execute(context, { ...request(''), mode: 'pty' })
-    ).rejects.toThrow('PTY mode is not supported');
+    await expect(service.execute(context, { ...request(''), mode: 'pty' })).rejects.toThrow(
+      'PTY mode is not supported'
+    );
   });
 
   it('rejects cwd traversal and unapproved environment keys before spawn', async () => {
     const { service, context } = await fixture();
 
-    await expect(
-      service.execute(context, { ...request(''), cwd: '../outside' })
-    ).rejects.toThrow();
+    await expect(service.execute(context, { ...request(''), cwd: '../outside' })).rejects.toThrow();
     await expect(
       service.execute(context, {
         ...request(''),
@@ -253,13 +442,14 @@ describe('RunTerminalService', () => {
     ).rejects.toThrow('not approved by the run launch manifest');
   });
 
-  it.runIf(process.platform !== 'win32')('rejects a symlinked cwd outside the worktree', async () => {
-    const { service, context } = await fixture();
-    const outside = await mkdtemp(path.join(os.tmpdir(), 'vk-run-terminal-outside-'));
-    await symlink(outside, path.join(context.worktreeRoot, 'escape'));
+  it.runIf(process.platform !== 'win32')(
+    'rejects a symlinked cwd outside the worktree',
+    async () => {
+      const { service, context } = await fixture();
+      const outside = await mkdtemp(path.join(os.tmpdir(), 'vk-run-terminal-outside-'));
+      await symlink(outside, path.join(context.worktreeRoot, 'escape'));
 
-    await expect(
-      service.execute(context, { ...request(''), cwd: 'escape' })
-    ).rejects.toThrow();
-  });
+      await expect(service.execute(context, { ...request(''), cwd: 'escape' })).rejects.toThrow();
+    }
+  );
 });

--- a/server/src/schemas/run-terminal-schemas.ts
+++ b/server/src/schemas/run-terminal-schemas.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { RUN_TERMINAL_MODES, RUN_TERMINAL_START_MODES } from '@veritas-kanban/shared';
+import {
+  RUN_TERMINAL_HANDLE_SCHEMA_VERSION,
+  RUN_TERMINAL_MODES,
+  RUN_TERMINAL_START_MODES,
+  RUN_TERMINAL_STATES,
+} from '@veritas-kanban/shared';
 
 const environmentKeySchema = z
   .string()
@@ -10,13 +15,63 @@ const environmentKeySchema = z
 
 export const RunTerminalExecuteRequestSchema = z
   .object({
-    command: z.string().trim().min(1).max(500).refine((value) => !/[\r\n\0]/.test(value), {
-      message: 'Terminal command contains a forbidden control character.',
-    }),
+    command: z
+      .string()
+      .trim()
+      .min(1)
+      .max(500)
+      .refine((value) => !/[\r\n\0]/.test(value), {
+        message: 'Terminal command contains a forbidden control character.',
+      }),
     args: z.array(z.string().max(1_000)).max(128),
     mode: z.enum(RUN_TERMINAL_MODES),
     startMode: z.enum(RUN_TERMINAL_START_MODES),
     cwd: z.string().trim().min(1).max(1_000).optional(),
     environmentKeys: z.array(environmentKeySchema).max(128),
+  })
+  .strict();
+
+const RunTerminalOutputMetadataSchema = z
+  .object({
+    nextCursor: z.number().int().nonnegative(),
+    retainedFromCursor: z.number().int().positive(),
+    observedBytes: z.number().int().nonnegative(),
+    retainedBytes: z.number().int().nonnegative(),
+    droppedBytes: z.number().int().nonnegative(),
+    truncated: z.boolean(),
+    volumeCircuitTripped: z.boolean(),
+  })
+  .strict();
+
+const RunTerminalCapabilityPostureSchema = z
+  .object({
+    pipe: z.enum(['enforced', 'unsupported']),
+    pty: z.enum(['enforced', 'unsupported']),
+    interactiveStdin: z.enum(['enforced', 'unsupported']),
+    restartReattachment: z.enum(['enforced', 'unsupported']),
+  })
+  .strict();
+
+export const RunTerminalHandleSchema = z
+  .object({
+    schemaVersion: z.literal(RUN_TERMINAL_HANDLE_SCHEMA_VERSION),
+    id: z.string().trim().min(1).max(200),
+    workspaceId: z.string().trim().min(1).max(200),
+    taskId: z.string().trim().min(1).max(200),
+    attemptId: z.string().trim().min(1).max(200),
+    launchManifestDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    mode: z.enum(RUN_TERMINAL_MODES),
+    startMode: z.enum(RUN_TERMINAL_START_MODES),
+    state: z.enum(RUN_TERMINAL_STATES),
+    commandId: z.string().trim().min(1).max(200),
+    processId: z.number().int().positive().optional(),
+    processGroupId: z.number().int().positive().optional(),
+    startedAt: z.string().datetime(),
+    endedAt: z.string().datetime().optional(),
+    exitCode: z.number().int().optional(),
+    signal: z.string().max(100).optional(),
+    failure: z.string().max(1_000).optional(),
+    output: RunTerminalOutputMetadataSchema,
+    capabilities: RunTerminalCapabilityPostureSchema,
   })
   .strict();

--- a/server/src/services/run-terminal-service.ts
+++ b/server/src/services/run-terminal-service.ts
@@ -5,12 +5,15 @@ import { nanoid } from 'nanoid';
 import {
   RUN_TERMINAL_HANDLE_SCHEMA_VERSION,
   RUN_TERMINAL_OUTPUT_SCHEMA_VERSION,
+  RUN_TERMINAL_RECONCILIATION_SCHEMA_VERSION,
   type RunEventAppendInput,
+  type RunEventEnvelope,
   type RunTerminalCapabilityPosture,
   type RunTerminalExecuteRequest,
   type RunTerminalHandle,
   type RunTerminalOutputChunk,
   type RunTerminalOutputPage,
+  type RunTerminalReconciliationResult,
   type RunTerminalStream,
   type RunTerminalTerminationResult,
   type RunTerminalWaitManyResult,
@@ -18,8 +21,16 @@ import {
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { redactString } from '../lib/redact.js';
-import { ConflictError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
-import { RunTerminalExecuteRequestSchema } from '../schemas/run-terminal-schemas.js';
+import {
+  ConflictError,
+  InternalError,
+  NotFoundError,
+  ValidationError,
+} from '../middleware/error-handler.js';
+import {
+  RunTerminalExecuteRequestSchema,
+  RunTerminalHandleSchema,
+} from '../schemas/run-terminal-schemas.js';
 import { realpath } from '../storage/fs-helpers.js';
 import { ensureWithinBase } from '../utils/sanitize.js';
 import {
@@ -30,10 +41,12 @@ import {
 const log = createLogger('run-terminal-service');
 const DEFAULT_OUTPUT_LIMIT_BYTES = 256 * 1024;
 const DEFAULT_MAXIMUM_OUTPUT_BYTES = 4 * 1024 * 1024;
-const DEFAULT_CHUNK_LIMIT_BYTES = 8 * 1024;
+const MAX_PERSISTED_CHUNK_BYTES = 6 * 1024;
+const DEFAULT_CHUNK_LIMIT_BYTES = MAX_PERSISTED_CHUNK_BYTES;
 const DEFAULT_TERMINATION_GRACE_MS = 5_000;
 const MAX_OUTPUT_PAGE_CHUNKS = 200;
 const MAX_WAIT_MS = 300_000;
+const MAX_RECONCILIATION_EVENTS = 20_000;
 
 const CAPABILITIES: RunTerminalCapabilityPosture = {
   pipe: 'enforced',
@@ -53,7 +66,7 @@ export interface RunTerminalLaunchContext {
 }
 
 export interface RunTerminalServiceOptions {
-  journal?: Pick<RunEventJournalService, 'append'>;
+  journal?: Pick<RunEventJournalService, 'append' | 'list'>;
   now?: () => Date;
   outputLimitBytes?: number;
   maximumOutputBytes?: number;
@@ -61,32 +74,37 @@ export interface RunTerminalServiceOptions {
   terminationGraceMs?: number;
 }
 
-interface RuntimeRecord {
-  context: RunTerminalLaunchContext;
+interface TerminalRecord {
   handle: RunTerminalHandle;
-  child: ChildProcessWithoutNullStreams;
   chunks: RunTerminalOutputChunk[];
   retainedBytes: number;
   droppedBytes: number;
   observedBytes: number;
   nextCursor: number;
+  journalQueue: Promise<void>;
+}
+
+interface RuntimeRecord extends TerminalRecord {
+  context: RunTerminalLaunchContext;
+  child: ChildProcessWithoutNullStreams;
   exit: Promise<void>;
   resolveExit(): void;
-  journalQueue: Promise<void>;
   gracefulSignalAt?: string;
   forceSignalAt?: string;
+  journalFailure?: Error;
   completedEventQueued: boolean;
   volumeCircuitTripped: boolean;
 }
 
 export class RunTerminalService {
-  private readonly journal: Pick<RunEventJournalService, 'append'>;
+  private readonly journal: Pick<RunEventJournalService, 'append' | 'list'>;
   private readonly now: () => Date;
   private readonly outputLimitBytes: number;
   private readonly maximumOutputBytes: number;
   private readonly chunkLimitBytes: number;
   private readonly terminationGraceMs: number;
-  private readonly records = new Map<string, RuntimeRecord>();
+  private readonly records = new Map<string, TerminalRecord>();
+  private readonly recoveredHandleIds = new Set<string>();
 
   constructor(options: RunTerminalServiceOptions = {}) {
     this.journal = options.journal ?? getRunEventJournalService();
@@ -101,7 +119,7 @@ export class RunTerminalService {
       options.chunkLimitBytes,
       DEFAULT_CHUNK_LIMIT_BYTES,
       256,
-      64 * 1024
+      MAX_PERSISTED_CHUNK_BYTES
     );
     if (this.chunkLimitBytes > this.outputLimitBytes) {
       throw new Error('Run terminal chunk limit cannot exceed the output limit.');
@@ -203,16 +221,29 @@ export class RunTerminalService {
     });
     child.once('error', (error) => this.fail(record, error));
     child.once('close', (code, signal) => this.close(record, code, signal));
-    this.appendEvent(record, {
-      kind: 'command.started',
-      payload: {
-        handleId: id,
-        commandId: handle.commandId,
-        mode: request.mode,
-        startMode: request.startMode,
-      },
-      dedupeKey: `run-terminal:${id}:started`,
-    });
+    try {
+      await this.appendEvent(record, {
+        kind: 'command.started',
+        payload: {
+          handleId: id,
+          commandId: handle.commandId,
+          mode: request.mode,
+          startMode: request.startMode,
+          handle: cloneHandle(handle),
+        },
+        dedupeKey: `run-terminal:${id}:started`,
+      });
+    } catch (error) {
+      record.completedEventQueued = true;
+      if (!terminal(record.handle.state)) signalProcessGroup(record.child, 'SIGKILL');
+      await record.exit;
+      this.records.delete(id);
+      log.error(
+        { err: error, handleId: id, attemptId: context.attemptId },
+        'Failed to persist run terminal ownership before returning the handle'
+      );
+      throw new InternalError('Run terminal ownership could not be persisted.');
+    }
     return cloneHandle(record.handle);
   }
 
@@ -220,18 +251,24 @@ export class RunTerminalService {
     return cloneHandle(this.require(handleId).handle);
   }
 
-  list(attemptId: string): RunTerminalHandle[] {
+  list(workspaceId: string, taskId: string, attemptId: string): RunTerminalHandle[] {
+    const scope = {
+      workspaceId: required(workspaceId, 'workspaceId'),
+      taskId: required(taskId, 'taskId'),
+      attemptId: required(attemptId, 'attemptId'),
+    };
     return [...this.records.values()]
-      .filter((record) => record.handle.attemptId === attemptId)
+      .filter(
+        (record) =>
+          record.handle.workspaceId === scope.workspaceId &&
+          record.handle.taskId === scope.taskId &&
+          record.handle.attemptId === scope.attemptId
+      )
       .map((record) => cloneHandle(record.handle))
       .sort((left, right) => left.startedAt.localeCompare(right.startedAt));
   }
 
-  output(
-    handleId: string,
-    afterCursor = 0,
-    limit = MAX_OUTPUT_PAGE_CHUNKS
-  ): RunTerminalOutputPage {
+  output(handleId: string, afterCursor = 0, limit = MAX_OUTPUT_PAGE_CHUNKS): RunTerminalOutputPage {
     if (!Number.isInteger(afterCursor) || afterCursor < 0) {
       throw new ValidationError('Terminal output cursor must be a non-negative integer.');
     }
@@ -264,26 +301,27 @@ export class RunTerminalService {
     assertWaitTimeout(timeoutMs);
     const record = this.require(handleId);
     if (terminal(record.handle.state)) {
-      await record.journalQueue;
+      await this.awaitJournal(record);
       return { completed: true, timedOut: false, handle: cloneHandle(record.handle) };
     }
+    const runtime = this.requireRuntime(handleId);
     if (timeoutMs === 0) {
-      return { completed: false, timedOut: true, handle: cloneHandle(record.handle) };
+      return { completed: false, timedOut: true, handle: cloneHandle(runtime.handle) };
     }
     let timer: NodeJS.Timeout | undefined;
     const timedOut = await Promise.race([
-      record.exit.then(() => false),
+      runtime.exit.then(() => false),
       new Promise<boolean>((resolve) => {
         timer = setTimeout(() => resolve(true), timeoutMs);
         timer.unref();
       }),
     ]);
     if (timer) clearTimeout(timer);
-    if (!timedOut) await record.journalQueue;
+    if (!timedOut) await this.awaitJournal(runtime);
     return {
       completed: !timedOut,
       timedOut,
-      handle: cloneHandle(record.handle),
+      handle: cloneHandle(runtime.handle),
     };
   }
 
@@ -292,13 +330,14 @@ export class RunTerminalService {
     const records = this.requireMany(handleIds);
     const alreadyCompleted = records.find((record) => terminal(record.handle.state));
     if (alreadyCompleted) {
-      await alreadyCompleted.journalQueue;
+      await this.awaitJournal(alreadyCompleted);
       return this.waitManyResult('any', records, false, alreadyCompleted.handle.id);
     }
     if (timeoutMs === 0) return this.waitManyResult('any', records, true);
+    const runtimeRecords = records.map((record) => this.requireRuntime(record.handle.id));
     let timer: NodeJS.Timeout | undefined;
     const selectedHandleId = await Promise.race([
-      ...records.map((record) => record.exit.then(() => record.handle.id)),
+      ...runtimeRecords.map((record) => record.exit.then(() => record.handle.id)),
       new Promise<undefined>((resolve) => {
         timer = setTimeout(() => resolve(undefined), timeoutMs);
         timer.unref();
@@ -306,7 +345,7 @@ export class RunTerminalService {
     ]);
     if (timer) clearTimeout(timer);
     if (selectedHandleId) {
-      await this.require(selectedHandleId).journalQueue;
+      await this.awaitJournal(this.require(selectedHandleId));
       return this.waitManyResult('any', records, false, selectedHandleId);
     }
     return this.waitManyResult('any', records, true);
@@ -317,65 +356,277 @@ export class RunTerminalService {
     const records = this.requireMany(handleIds);
     const pending = records.filter((record) => !terminal(record.handle.state));
     if (pending.length === 0) {
-      await Promise.all(records.map((record) => record.journalQueue));
+      await Promise.all(records.map((record) => this.awaitJournal(record)));
       return this.waitManyResult('all', records, false);
     }
     if (timeoutMs === 0) return this.waitManyResult('all', records, true);
+    const runtimePending = pending.map((record) => this.requireRuntime(record.handle.id));
     let timer: NodeJS.Timeout | undefined;
     const timedOut = await Promise.race([
-      Promise.all(pending.map((record) => record.exit)).then(() => false),
+      Promise.all(runtimePending.map((record) => record.exit)).then(() => false),
       new Promise<boolean>((resolve) => {
         timer = setTimeout(() => resolve(true), timeoutMs);
         timer.unref();
       }),
     ]);
     if (timer) clearTimeout(timer);
-    if (!timedOut) await Promise.all(records.map((record) => record.journalQueue));
+    if (!timedOut) await Promise.all(records.map((record) => this.awaitJournal(record)));
     return this.waitManyResult('all', records, timedOut);
   }
 
-  detach(handleId: string): RunTerminalHandle {
+  async detach(handleId: string): Promise<RunTerminalHandle> {
     const record = this.require(handleId);
     if (record.handle.startMode === 'background') return cloneHandle(record.handle);
     if (terminal(record.handle.state)) {
       throw new ConflictError('A terminal command cannot be detached after it exits.');
     }
-    record.handle.startMode = 'background';
-    this.appendEvent(record, {
-      kind: 'command.detached',
-      payload: {
-        handleId: record.handle.id,
-        commandId: record.handle.commandId,
-      },
-      dedupeKey: `run-terminal:${record.handle.id}:detached`,
-    });
-    return cloneHandle(record.handle);
+    const runtime = this.requireRuntime(handleId);
+    runtime.handle.startMode = 'background';
+    try {
+      await this.appendEvent(runtime, {
+        kind: 'command.detached',
+        payload: {
+          handleId: runtime.handle.id,
+          commandId: runtime.handle.commandId,
+          handle: cloneHandle(runtime.handle),
+        },
+        dedupeKey: `run-terminal:${runtime.handle.id}:detached`,
+      });
+    } catch {
+      runtime.handle.startMode = 'foreground';
+      throw new InternalError('Run terminal detachment could not be persisted.');
+    }
+    return cloneHandle(runtime.handle);
   }
 
   async terminate(handleId: string): Promise<RunTerminalTerminationResult> {
     const record = this.require(handleId);
     if (terminal(record.handle.state)) {
-      return this.terminationResult(record);
+      return { handle: cloneHandle(record.handle) };
     }
-    record.handle.state = 'terminating';
-    record.gracefulSignalAt = this.now().toISOString();
-    signalProcessGroup(record.child, 'SIGTERM');
+    const runtime = this.requireRuntime(handleId);
+    runtime.handle.state = 'terminating';
+    runtime.gracefulSignalAt = this.now().toISOString();
+    signalProcessGroup(runtime.child, 'SIGTERM');
     const graceful = await this.wait(handleId, this.terminationGraceMs);
-    if (!graceful.completed && !terminal(record.handle.state)) {
-      record.forceSignalAt = this.now().toISOString();
-      signalProcessGroup(record.child, 'SIGKILL');
-      await record.exit;
+    if (!graceful.completed && !terminal(runtime.handle.state)) {
+      runtime.forceSignalAt = this.now().toISOString();
+      signalProcessGroup(runtime.child, 'SIGKILL');
+      await runtime.exit;
     }
-    return this.terminationResult(record);
+    return this.terminationResult(runtime);
   }
 
-  async cleanupAttempt(attemptId: string): Promise<RunTerminalTerminationResult[]> {
+  async cleanupAttempt(
+    workspaceId: string,
+    taskId: string,
+    attemptId: string
+  ): Promise<RunTerminalTerminationResult[]> {
+    const scope = {
+      workspaceId: required(workspaceId, 'workspaceId'),
+      taskId: required(taskId, 'taskId'),
+      attemptId: required(attemptId, 'attemptId'),
+    };
     const results: RunTerminalTerminationResult[] = [];
     for (const record of this.records.values()) {
-      if (record.handle.attemptId !== attemptId || terminal(record.handle.state)) continue;
+      if (
+        record.handle.workspaceId !== scope.workspaceId ||
+        record.handle.taskId !== scope.taskId ||
+        record.handle.attemptId !== scope.attemptId ||
+        terminal(record.handle.state)
+      ) {
+        continue;
+      }
       results.push(await this.terminate(record.handle.id));
     }
     return results;
+  }
+
+  async reconcileAttempt(
+    inputWorkspaceId: string,
+    inputTaskId: string,
+    inputAttemptId: string
+  ): Promise<RunTerminalReconciliationResult> {
+    const workspaceId = required(inputWorkspaceId, 'workspaceId');
+    const taskId = required(inputTaskId, 'taskId');
+    const attemptId = required(inputAttemptId, 'attemptId');
+    const projected = new Map<string, TerminalRecord>();
+    let afterSequence = 0;
+    let eventCount = 0;
+
+    for (;;) {
+      const page = await this.journal.list({
+        taskId,
+        attemptId,
+        afterSequence,
+        limit: 500,
+      });
+      for (const event of page.events) {
+        if (event.source.provider !== 'system' || event.source.adapter !== 'run-terminal') {
+          continue;
+        }
+        eventCount += 1;
+        if (eventCount > MAX_RECONCILIATION_EVENTS) {
+          throw new ConflictError('Run terminal reconciliation exceeded its event bound.', {
+            taskId,
+            attemptId,
+            maximumEvents: MAX_RECONCILIATION_EVENTS,
+          });
+        }
+        this.projectReconciliationEvent(projected, event, workspaceId, taskId, attemptId);
+      }
+      if (page.hasMore && page.nextCursor <= afterSequence) {
+        throw new ConflictError('Run terminal reconciliation journal cursor did not advance.', {
+          taskId,
+          attemptId,
+          afterSequence,
+        });
+      }
+      afterSequence = page.nextCursor;
+      if (!page.hasMore) break;
+    }
+
+    const interruptedHandleIds: string[] = [];
+    for (const [handleId, record] of projected) {
+      if (this.records.has(handleId)) continue;
+      if (!terminal(record.handle.state)) {
+        const recordedAt = this.now().toISOString();
+        record.handle.state = 'interrupted';
+        record.handle.endedAt = recordedAt;
+        record.handle.failure =
+          'Run terminal ownership was interrupted because this runtime cannot reattach inherited pipes after a server restart.';
+        record.handle.capabilities.restartReattachment = 'unsupported';
+        await this.journal.append({
+          workspaceId: record.handle.workspaceId,
+          taskId,
+          attemptId,
+          kind: 'command.completed',
+          source: {
+            provider: 'system',
+            adapter: 'run-terminal',
+          },
+          payload: {
+            handleId,
+            commandId: record.handle.commandId,
+            state: record.handle.state,
+            failure: record.handle.failure,
+            output: record.handle.output,
+            reconciledAfterRestart: true,
+            handle: cloneHandle(record.handle),
+          },
+          dedupeKey: `run-terminal:${handleId}:restart-interrupted`,
+        });
+        interruptedHandleIds.push(handleId);
+      }
+      this.records.set(handleId, record);
+      this.recoveredHandleIds.add(handleId);
+    }
+
+    const handles = this.list(workspaceId, taskId, attemptId);
+    return {
+      schemaVersion: RUN_TERMINAL_RECONCILIATION_SCHEMA_VERSION,
+      workspaceId,
+      taskId,
+      attemptId,
+      handles,
+      recoveredHandleIds: handles
+        .map((handle) => handle.id)
+        .filter((handleId) => this.recoveredHandleIds.has(handleId)),
+      interruptedHandleIds: interruptedHandleIds.sort(),
+    };
+  }
+
+  private projectReconciliationEvent(
+    projected: Map<string, TerminalRecord>,
+    event: RunEventEnvelope,
+    workspaceId: string,
+    taskId: string,
+    attemptId: string
+  ): void {
+    if (
+      event.kind === 'command.started' ||
+      event.kind === 'command.detached' ||
+      event.kind === 'command.completed'
+    ) {
+      const handle = parsePersistedHandle(event.payload.handle);
+      if (!handle) return;
+      if (
+        handle.workspaceId !== workspaceId ||
+        handle.taskId !== taskId ||
+        handle.attemptId !== attemptId
+      ) {
+        throw new ConflictError('Persisted run terminal handle scope does not match its journal.', {
+          handleId: handle.id,
+          workspaceId,
+          taskId,
+          attemptId,
+        });
+      }
+      const current = projected.get(handle.id);
+      if (event.kind === 'command.started') {
+        if (terminal(handle.state)) {
+          throw new ConflictError('Persisted run terminal start event is already terminal.', {
+            handleId: handle.id,
+          });
+        }
+      } else {
+        if (!current) return;
+        assertSamePersistedHandleIdentity(current.handle, handle);
+        if (event.kind === 'command.detached' && handle.startMode !== 'background') {
+          throw new ConflictError('Persisted run terminal detach event is not detached.', {
+            handleId: handle.id,
+          });
+        }
+        if (event.kind === 'command.completed' && !terminal(handle.state)) {
+          throw new ConflictError('Persisted run terminal completion event is not terminal.', {
+            handleId: handle.id,
+          });
+        }
+      }
+      projected.set(handle.id, {
+        handle,
+        chunks: current?.chunks ?? [],
+        retainedBytes: handle.output.retainedBytes,
+        droppedBytes: handle.output.droppedBytes,
+        observedBytes: handle.output.observedBytes,
+        nextCursor: Math.max(handle.output.nextCursor + 1, current?.nextCursor ?? 1),
+        journalQueue: Promise.resolve(),
+      });
+      return;
+    }
+    if (event.kind !== 'stream.stdout' && event.kind !== 'stream.stderr') return;
+    const handleId = persistedString(event.payload.handleId);
+    if (!handleId) return;
+    const record = projected.get(handleId);
+    if (!record) return;
+    const chunk = parsePersistedChunk(event);
+    if (!chunk) return;
+    const priorChunk = record.chunks.at(-1);
+    if (priorChunk && chunk.cursor <= priorChunk.cursor) {
+      throw new ConflictError('Persisted run terminal output cursors are not monotonic.', {
+        handleId,
+        cursor: chunk.cursor,
+      });
+    }
+    record.chunks.push(chunk);
+    record.retainedBytes += chunk.byteLength;
+    record.observedBytes += chunk.byteLength;
+    record.nextCursor = Math.max(record.nextCursor, chunk.cursor + 1);
+    while (record.retainedBytes > this.outputLimitBytes && record.chunks.length > 0) {
+      const dropped = record.chunks.shift();
+      if (!dropped) break;
+      record.retainedBytes -= dropped.byteLength;
+      record.droppedBytes += dropped.byteLength;
+    }
+    record.handle.output = {
+      nextCursor: record.nextCursor - 1,
+      retainedFromCursor: record.chunks[0]?.cursor ?? record.nextCursor,
+      observedBytes: record.observedBytes,
+      retainedBytes: record.retainedBytes,
+      droppedBytes: record.droppedBytes,
+      truncated: record.droppedBytes > 0,
+      volumeCircuitTripped: record.handle.output.volumeCircuitTripped,
+    };
   }
 
   private acceptOutput(record: RuntimeRecord, stream: RunTerminalStream, raw: string): void {
@@ -394,10 +645,7 @@ export class RunTerminalService {
       };
       record.chunks.push(chunk);
       record.retainedBytes += byteLength;
-      while (
-        record.retainedBytes > this.outputLimitBytes &&
-        record.chunks.length > 0
-      ) {
+      while (record.retainedBytes > this.outputLimitBytes && record.chunks.length > 0) {
         const dropped = record.chunks.shift();
         if (!dropped) break;
         record.retainedBytes -= dropped.byteLength;
@@ -405,7 +653,7 @@ export class RunTerminalService {
       }
       this.refreshOutputMetadata(record);
       if (!volumeExceeded) {
-        this.appendEvent(record, {
+        void this.appendEvent(record, {
           kind: stream === 'stdout' ? 'stream.stdout' : 'stream.stderr',
           payload: {
             handleId: record.handle.id,
@@ -413,6 +661,7 @@ export class RunTerminalService {
             cursor: chunk.cursor,
             content: chunk.content,
             byteLength: chunk.byteLength,
+            occurredAt: chunk.occurredAt,
           },
           dedupeKey: `run-terminal:${record.handle.id}:output:${chunk.cursor}`,
         });
@@ -421,7 +670,7 @@ export class RunTerminalService {
     if (volumeExceeded) {
       record.volumeCircuitTripped = true;
       this.refreshOutputMetadata(record);
-      this.appendEvent(record, {
+      void this.appendEvent(record, {
         kind: 'run.error',
         payload: {
           handleId: record.handle.id,
@@ -457,11 +706,7 @@ export class RunTerminalService {
     if (signal) record.handle.signal = signal;
     if (record.handle.state !== 'failed') {
       record.handle.state =
-        record.handle.state === 'terminating'
-          ? 'terminated'
-          : code === 0
-            ? 'exited'
-            : 'failed';
+        record.handle.state === 'terminating' ? 'terminated' : code === 0 ? 'exited' : 'failed';
     }
     this.refreshOutputMetadata(record);
     record.resolveExit();
@@ -471,34 +716,42 @@ export class RunTerminalService {
   private appendEvent(
     record: RuntimeRecord,
     event: Pick<RunEventAppendInput, 'kind' | 'payload' | 'dedupeKey'>
-  ): void {
-    record.journalQueue = record.journalQueue
-      .then(async () => {
-        await this.journal.append({
-          workspaceId: record.context.workspaceId,
-          taskId: record.context.taskId,
-          attemptId: record.context.attemptId,
-          kind: event.kind,
-          source: {
-            provider: 'system',
-            adapter: 'run-terminal',
-          },
-          payload: event.payload,
-          dedupeKey: event.dedupeKey,
-        });
-      })
-      .catch((error) => {
-        log.error(
-          { err: error, handleId: record.handle.id, attemptId: record.handle.attemptId },
-          'Failed to append run terminal event'
-        );
+  ): Promise<void> {
+    const pending = record.journalQueue.then(async () => {
+      await this.journal.append({
+        workspaceId: record.context.workspaceId,
+        taskId: record.context.taskId,
+        attemptId: record.context.attemptId,
+        kind: event.kind,
+        source: {
+          provider: 'system',
+          adapter: 'run-terminal',
+        },
+        payload: event.payload,
+        dedupeKey: event.dedupeKey,
       });
+    });
+    record.journalQueue = pending.catch((error) => {
+      record.journalFailure = error instanceof Error ? error : new Error(String(error));
+      log.error(
+        { err: error, handleId: record.handle.id, attemptId: record.handle.attemptId },
+        'Failed to append run terminal event'
+      );
+    });
+    return pending;
+  }
+
+  private async awaitJournal(record: TerminalRecord): Promise<void> {
+    await record.journalQueue;
+    if (isRuntimeRecord(record) && record.journalFailure) {
+      throw new InternalError('Run terminal journal evidence is incomplete.');
+    }
   }
 
   private appendCompletedEvent(record: RuntimeRecord): void {
     if (record.completedEventQueued) return;
     record.completedEventQueued = true;
-    this.appendEvent(record, {
+    void this.appendEvent(record, {
       kind: 'command.completed',
       payload: {
         handleId: record.handle.id,
@@ -510,6 +763,7 @@ export class RunTerminalService {
         output: record.handle.output,
         gracefulSignalAt: record.gracefulSignalAt,
         forceSignalAt: record.forceSignalAt,
+        handle: cloneHandle(record.handle),
       },
       dedupeKey: `run-terminal:${record.handle.id}:completed`,
     });
@@ -527,25 +781,31 @@ export class RunTerminalService {
     };
   }
 
-  private require(handleId: string): RuntimeRecord {
+  private require(handleId: string): TerminalRecord {
     const record = this.records.get(handleId);
     if (!record) throw new NotFoundError('Run terminal handle not found.');
     return record;
   }
 
-  private requireMany(handleIds: string[]): RuntimeRecord[] {
+  private requireRuntime(handleId: string): RuntimeRecord {
+    const record = this.require(handleId);
+    if (!isRuntimeRecord(record)) {
+      throw new ConflictError('Run terminal process ownership is no longer attached.');
+    }
+    return record;
+  }
+
+  private requireMany(handleIds: string[]): TerminalRecord[] {
     const unique = [...new Set(handleIds)];
     if (unique.length === 0 || unique.length > 64 || unique.length !== handleIds.length) {
-      throw new ValidationError(
-        'Terminal multi-wait requires between 1 and 64 unique handles.'
-      );
+      throw new ValidationError('Terminal multi-wait requires between 1 and 64 unique handles.');
     }
     return unique.map((handleId) => this.require(handleId));
   }
 
   private waitManyResult(
     mode: RunTerminalWaitManyResult['mode'],
-    records: RuntimeRecord[],
+    records: TerminalRecord[],
     timedOut: boolean,
     selectedHandleId?: string
   ): RunTerminalWaitManyResult {
@@ -621,9 +881,7 @@ function selectEnvironment(
   for (const key of [...new Set(requestedKeys)].sort()) {
     const value = approved[key];
     if (value === undefined) {
-      throw new ConflictError(
-        `Environment key ${key} is not approved by the run launch manifest.`
-      );
+      throw new ConflictError(`Environment key ${key} is not approved by the run launch manifest.`);
     }
     selected[key] = value;
   }
@@ -663,10 +921,7 @@ function splitUtf8(value: string, maximumBytes: number): string[] {
   return chunks;
 }
 
-function signalProcessGroup(
-  child: ChildProcessWithoutNullStreams,
-  signal: NodeJS.Signals
-): void {
+function signalProcessGroup(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {
   if (child.exitCode !== null || child.signalCode !== null) return;
   if (process.platform !== 'win32' && child.pid) {
     try {
@@ -683,6 +938,81 @@ function cloneHandle(handle: RunTerminalHandle): RunTerminalHandle {
   return structuredClone(handle);
 }
 
+function parsePersistedHandle(value: unknown): RunTerminalHandle | null {
+  if (value === undefined) return null;
+  const parsed = RunTerminalHandleSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new ConflictError('Persisted run terminal handle is invalid.');
+  }
+  return parsed.data;
+}
+
+function persistedString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function assertSamePersistedHandleIdentity(
+  current: RunTerminalHandle,
+  next: RunTerminalHandle
+): void {
+  const currentIdentity = [
+    current.id,
+    current.workspaceId,
+    current.taskId,
+    current.attemptId,
+    current.launchManifestDigest,
+    current.mode,
+    current.commandId,
+    current.processId,
+    current.processGroupId,
+    current.startedAt,
+    current.capabilities,
+  ];
+  const nextIdentity = [
+    next.id,
+    next.workspaceId,
+    next.taskId,
+    next.attemptId,
+    next.launchManifestDigest,
+    next.mode,
+    next.commandId,
+    next.processId,
+    next.processGroupId,
+    next.startedAt,
+    next.capabilities,
+  ];
+  if (JSON.stringify(currentIdentity) !== JSON.stringify(nextIdentity)) {
+    throw new ConflictError('Persisted run terminal handle identity changed during replay.', {
+      handleId: current.id,
+    });
+  }
+}
+
+function parsePersistedChunk(event: RunEventEnvelope): RunTerminalOutputChunk | null {
+  const cursor = event.payload.cursor;
+  const content = persistedString(event.payload.content);
+  if (!Number.isInteger(cursor) || (cursor as number) < 1 || !content) return null;
+  if (Buffer.byteLength(content, 'utf8') > 64 * 1024) {
+    throw new ConflictError('Persisted run terminal output chunk exceeds its byte bound.');
+  }
+  const occurredAtValue = persistedString(event.payload.occurredAt);
+  const occurredAt =
+    occurredAtValue && Number.isFinite(Date.parse(occurredAtValue))
+      ? occurredAtValue
+      : event.receivedAt;
+  return {
+    cursor: cursor as number,
+    stream: event.kind === 'stream.stdout' ? 'stdout' : 'stderr',
+    content,
+    byteLength: Buffer.byteLength(content, 'utf8'),
+    occurredAt,
+  };
+}
+
+function isRuntimeRecord(record: TerminalRecord): record is RuntimeRecord {
+  return 'child' in record;
+}
+
 function emptyOutputMetadata(): RunTerminalHandle['output'] {
   return {
     nextCursor: 0,
@@ -696,7 +1026,7 @@ function emptyOutputMetadata(): RunTerminalHandle['output'] {
 }
 
 function terminal(state: RunTerminalHandle['state']): boolean {
-  return ['exited', 'failed', 'terminated'].includes(state);
+  return ['exited', 'failed', 'terminated', 'interrupted'].includes(state);
 }
 
 function required(value: string, label: string): string {

--- a/shared/src/types/run-event.types.ts
+++ b/shared/src/types/run-event.types.ts
@@ -25,6 +25,7 @@ export const RUN_EVENT_KINDS = [
   'stream.stdout',
   'stream.stderr',
   'command.started',
+  'command.detached',
   'command.completed',
   'file.changed',
   'tool.started',

--- a/shared/src/types/run-terminal.types.ts
+++ b/shared/src/types/run-terminal.types.ts
@@ -1,5 +1,6 @@
 export const RUN_TERMINAL_HANDLE_SCHEMA_VERSION = 'run-terminal-handle/v1' as const;
 export const RUN_TERMINAL_OUTPUT_SCHEMA_VERSION = 'run-terminal-output/v1' as const;
+export const RUN_TERMINAL_RECONCILIATION_SCHEMA_VERSION = 'run-terminal-reconciliation/v1' as const;
 
 export const RUN_TERMINAL_MODES = ['pipe', 'pty'] as const;
 export const RUN_TERMINAL_START_MODES = ['background', 'foreground'] as const;
@@ -10,6 +11,7 @@ export const RUN_TERMINAL_STATES = [
   'failed',
   'terminating',
   'terminated',
+  'interrupted',
 ] as const;
 
 export type RunTerminalMode = (typeof RUN_TERMINAL_MODES)[number];
@@ -107,4 +109,14 @@ export interface RunTerminalTerminationResult {
   handle: RunTerminalHandle;
   gracefulSignalAt?: string;
   forceSignalAt?: string;
+}
+
+export interface RunTerminalReconciliationResult {
+  schemaVersion: typeof RUN_TERMINAL_RECONCILIATION_SCHEMA_VERSION;
+  workspaceId: string;
+  taskId: string;
+  attemptId: string;
+  handles: RunTerminalHandle[];
+  recoveredHandleIds: string[];
+  interruptedHandleIds: string[];
 }


### PR DESCRIPTION
## Summary

- persist complete run-terminal handles and bounded output chunks in the causal journal
- rebuild terminal state and retained output after restart with strict scope and identity validation
- mark dangling pipe handles interrupted when inherited streams cannot be safely reattached
- fail closed when ownership or terminal evidence cannot be persisted

## Verification

- 16 focused run-terminal tests passed in 4.60s
- shared build passed
- server typecheck passed
- targeted lint passed
- git diff check passed

## Scope

Advances #871. PTY support and secure externally callable execution remain follow-up work.