### PR TITLE
feat: bind terminal handles to run lifecycle

### DIFF
--- a/docs/architecture/RUN-TERMINAL-V1.md
+++ b/docs/architecture/RUN-TERMINAL-V1.md
@@ -9,6 +9,8 @@ The first implementation supports background pipe-mode commands with:
 - one opaque handle bound to workspace, task, attempt, and launch-manifest digest;
 - a manifest-approved executable, relative cwd, and environment-key subset;
 - immediate background return, bounded single/any/all waits, foreground detachment without changing ownership, status inspection, and attempt cleanup;
+- active run status includes only handles owned by that workspace, task, and attempt;
+- run completion and cancellation terminate all still-active attempt handles, including detached jobs, before the terminal run result is committed;
 - fail-closed ownership persistence before a new handle is returned;
 - redacted byte-bounded stdout/stderr chunks with monotonic cursors, explicit gap metadata, and a total-volume circuit that terminates noisy jobs before they flood the journal;
 - graceful process-group termination followed by bounded forced termination;
@@ -22,6 +24,10 @@ PTY mode, interactive stdin, restart reattachment, and external API/CLI/MCP expo
 The service accepts a server-owned launch context and an untrusted command request. The launch context contains the exact workspace, task, attempt, launch-manifest digest, worktree root, approved environment values, and approved executable list. The request may select only an approved command, arguments without credential material, a canonical cwd within the worktree, and environment keys already present in that context. Lexical traversal and symlink escapes fail closed before spawn.
 
 The child is launched without a shell. On Unix-like systems it owns a detached process group; on Windows it remains an exact child until the platform-specific tree supervisor is added. The service never exposes a writable stdin stream.
+
+Terminal children are subordinate to their owning run. Detaching changes foreground coordination only; it does not outlive the attempt. Attempt cleanup terminates matching live handles in parallel and verifies that already-terminal handles have complete journal evidence before allowing the run completion to commit.
+
+When a provider completion arrives after a server restart, Veritas reconciles the attempt's durable terminal journal before cleanup. Handles that cannot be safely reattached are recorded as interrupted before the provider's terminal result is committed.
 
 ## Output and replay
 

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -218,6 +218,7 @@ import type { FilesystemSandboxService } from '../services/filesystem-sandbox-se
 import type { SandboxPolicyService } from '../services/sandbox-policy-service.js';
 import type { WorkspaceExecutionTrustService } from '../services/workspace-execution-trust-service.js';
 import type { AdmissionControlService } from '../services/admission-control-service.js';
+import type { RunTerminalService } from '../services/run-terminal-service.js';
 
 const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'codex');
 
@@ -266,7 +267,11 @@ function testableService(
     WorkspaceExecutionTrustService,
     'scan' | 'evaluateForLaunch' | 'assertFresh'
   > = testWorkspaceExecutionTrust(),
-  admission: AdmissionControlService = testAdmissionControl()
+  admission: AdmissionControlService = testAdmissionControl(),
+  runTerminals: Pick<
+    RunTerminalService,
+    'list' | 'cleanupAttempt' | 'reconcileAttempt'
+  > = testRunTerminals()
 ): TestableClawdbotAgentService {
   const completionEvidence = testCompletionEvidence();
   const taskEnvelopes = new TaskEnvelopeService(completionEvidence);
@@ -295,10 +300,32 @@ function testableService(
     {
       handleRunCompletion: mockHandleDurableGoalCompletion,
       reconcilePlannedForTask: mockReconcileDurableGoalContinuation,
-    }
+    },
+    undefined,
+    undefined,
+    runTerminals
   ) as unknown as TestableClawdbotAgentService;
   service.logsDir = tmpDir;
   return service;
+}
+
+function testRunTerminals(): Pick<
+  RunTerminalService,
+  'list' | 'cleanupAttempt' | 'reconcileAttempt'
+> {
+  return {
+    list: vi.fn(() => []),
+    cleanupAttempt: vi.fn(async () => []),
+    reconcileAttempt: vi.fn(async (workspaceId, taskId, attemptId) => ({
+      schemaVersion: 'run-terminal-reconciliation/v1',
+      workspaceId,
+      taskId,
+      attemptId,
+      handles: [],
+      recoveredHandleIds: [],
+      interruptedHandleIds: [],
+    })),
+  };
 }
 
 function testAdmissionControl(): AdmissionControlService {
@@ -3114,6 +3141,85 @@ describe('ClawdbotAgentService Codex providers', () => {
     await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
   });
 
+  it('reports attempt-scoped terminals and cleans them up before completion commits', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const runTerminals = testRunTerminals();
+    const service = testableService(
+      tmpDir,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      runTerminals
+    );
+    const active = await service.startAgent(task.id, 'codex');
+    const handle = {
+      schemaVersion: 'run-terminal-handle/v1' as const,
+      id: 'terminal_status_test',
+      workspaceId: active.taskEnvelope.workspace.workspaceId,
+      taskId: task.id,
+      attemptId: active.attemptId,
+      launchManifestDigest: active.runLaunchManifest.digest,
+      mode: 'pipe' as const,
+      startMode: 'background' as const,
+      state: 'running' as const,
+      commandId: `sha256:${'a'.repeat(64)}`,
+      startedAt: '2026-07-25T12:00:00.000Z',
+      output: {
+        nextCursor: 0,
+        retainedFromCursor: 1,
+        observedBytes: 0,
+        retainedBytes: 0,
+        droppedBytes: 0,
+        truncated: false,
+        volumeCircuitTripped: false,
+      },
+      capabilities: {
+        pipe: 'enforced' as const,
+        pty: 'unsupported' as const,
+        interactiveStdin: 'unsupported' as const,
+        restartReattachment: 'unsupported' as const,
+      },
+    };
+    vi.mocked(runTerminals.list).mockReturnValue([handle]);
+
+    await expect(service.getAgentStatus(task.id)).resolves.toMatchObject({
+      attemptId: active.attemptId,
+      terminals: [{ id: handle.id, attemptId: active.attemptId }],
+    });
+    expect(runTerminals.list).toHaveBeenCalledWith(
+      active.taskEnvelope.workspace.workspaceId,
+      task.id,
+      active.attemptId
+    );
+
+    await service.completeAgent(
+      task.id,
+      { success: true, summary: 'Terminal lifecycle complete.' },
+      {
+        attemptId: active.attemptId,
+        terminalSource: 'process',
+        providerRuntimeManifestDigest: active.providerRuntimeManifest.digest,
+      }
+    );
+
+    expect(runTerminals.cleanupAttempt).toHaveBeenCalledWith(
+      active.taskEnvelope.workspace.workspaceId,
+      task.id,
+      active.attemptId
+    );
+    const completionWrite = mockUpdateTask.mock.invocationCallOrder.find(
+      (_, index) => mockUpdateTask.mock.calls[index]?.[1]?.attempt?.ended
+    );
+    expect(vi.mocked(runTerminals.cleanupAttempt).mock.invocationCallOrder[0]).toBeLessThan(
+      completionWrite as number
+    );
+  });
+
   it('does not let a competing terminal claim poison an in-flight finalizer', async () => {
     const child = createControllableChild();
     mockSpawn.mockReturnValue(child);
@@ -3221,17 +3327,17 @@ describe('ClawdbotAgentService Codex providers', () => {
       return task;
     });
     const revokeRun = vi.fn(async () => 1);
-    const service = new ClawdbotAgentService(
-      undefined,
-      undefined,
-      taskEnvelopes,
-      undefined,
-      new ProviderCompletionService(completionEvidence),
+    const runTerminals = testRunTerminals();
+    const service = testableService(
+      tmpDir,
       { revokeRun },
       undefined,
       undefined,
       undefined,
-      testRunSupervisor()
+      undefined,
+      undefined,
+      undefined,
+      runTerminals
     );
     const provenance = {
       attemptId,
@@ -3259,6 +3365,16 @@ describe('ClawdbotAgentService Codex providers', () => {
     ).toHaveLength(2);
     expect(task.revision).toBe(2);
     expect(task.attempts).toHaveLength(1);
+    expect(runTerminals.reconcileAttempt).toHaveBeenCalledWith(
+      taskEnvelope.workspace.workspaceId,
+      task.id,
+      attemptId
+    );
+    expect(runTerminals.cleanupAttempt).toHaveBeenCalledWith(
+      taskEnvelope.workspace.workspaceId,
+      task.id,
+      attemptId
+    );
     expect(revokeRun).toHaveBeenCalledTimes(2);
     expect(revokeRun).toHaveBeenCalledWith({
       taskId: task.id,

--- a/server/src/__tests__/run-terminal-service.test.ts
+++ b/server/src/__tests__/run-terminal-service.test.ts
@@ -335,6 +335,31 @@ describe('RunTerminalService', () => {
     expect(events.map((event) => event.kind)).toContain('command.detached');
   });
 
+  it('terminates detached jobs when their owning attempt is cleaned up', async () => {
+    const { service, context } = await fixture({ terminationGraceMs: 100 });
+    const started = await service.execute(context, {
+      ...request('setInterval(() => process.stdout.write("detached\\n"), 20)'),
+      startMode: 'foreground',
+    });
+    await service.detach(started.id);
+
+    const results = await service.cleanupAttempt(
+      context.workspaceId,
+      context.taskId,
+      context.attemptId
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      handle: {
+        id: started.id,
+        startMode: 'background',
+        state: 'terminated',
+        signal: 'SIGTERM',
+      },
+    });
+  });
+
   it('reconstructs terminal handles and retained output from the durable journal', async () => {
     const { service, context, journal } = await fixture();
     const started = await service.execute(

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -162,6 +162,7 @@ import type {
   ExecutionTreeBudgetPolicy,
   ExecutionTreeEdgeKind,
   ExecutionTreeIdentity,
+  RunTerminalHandle,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
@@ -209,6 +210,7 @@ import {
   getRunEventJournalService,
   type RunEventJournalService,
 } from './run-event-journal-service.js';
+import { getRunTerminalService, type RunTerminalService } from './run-terminal-service.js';
 import {
   getProviderRunEventMapper,
   type ProviderMappedRunEvent,
@@ -403,6 +405,7 @@ export interface AgentStatus {
   controls: ProviderRuntimeControlSet;
   admissionReservationId?: string;
   executionTree?: ExecutionTreeIdentity;
+  terminals: RunTerminalHandle[];
 }
 
 export interface AgentQueueStatus {
@@ -642,6 +645,10 @@ export class ClawdbotAgentService {
     Partial<Pick<PhaseTransitionService, 'list'>>;
   private runPhaseAuthority: RunPhaseAuthorityService;
   private dependencyExecution: DependencyCircuitExecutionService;
+  private runTerminals: Pick<
+    RunTerminalService,
+    'list' | 'cleanupAttempt' | 'reconcileAttempt'
+  >;
   private logsDir: string;
 
   constructor(
@@ -687,7 +694,11 @@ export class ClawdbotAgentService {
       ReflectionExtractionJobService,
       'enqueue'
     > = getReflectionExtractionJobService(),
-    dependencyExecution: DependencyCircuitExecutionService = defaultDependencyCircuitExecutionService()
+    dependencyExecution: DependencyCircuitExecutionService = defaultDependencyCircuitExecutionService(),
+    runTerminals: Pick<
+      RunTerminalService,
+      'list' | 'cleanupAttempt' | 'reconcileAttempt'
+    > = getRunTerminalService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -718,6 +729,7 @@ export class ClawdbotAgentService {
     this.durableGoalSupervisor = durableGoalSupervisor;
     this.reflectionExtractionJobs = reflectionExtractionJobs;
     this.dependencyExecution = dependencyExecution;
+    this.runTerminals = runTerminals;
     this.workspaceExecutionTrust = workspaceExecutionTrust;
     this.phaseAuthority = phaseAuthority;
     this.phaseTransitions = phaseTransitions;
@@ -3321,6 +3333,7 @@ export class ClawdbotAgentService {
       controls: providerRuntimeControls(providerRuntimeManifest),
       admissionReservationId: admissionReservation.id,
       executionTree,
+      terminals: this.runTerminals.list(taskEnvelope.workspace.workspaceId, taskId, attemptId),
     };
   }
 
@@ -3777,6 +3790,16 @@ export class ClawdbotAgentService {
         attempt.runLaunchManifest?.phase
       )),
     });
+    await this.runTerminals.reconcileAttempt(
+      attempt.taskEnvelope.workspace.workspaceId,
+      task.id,
+      attempt.id
+    );
+    await this.runTerminals.cleanupAttempt(
+      attempt.taskEnvelope.workspace.workspaceId,
+      task.id,
+      attempt.id
+    );
     const completedAttempt: TaskAttempt = {
       ...attempt,
       status: completionResult.status === 'success' ? 'complete' : 'failed',
@@ -4159,6 +4182,11 @@ export class ClawdbotAgentService {
       })());
     const { status, taskBeforeCompletion, completionResult, dependencyCircuits } =
       preparedCompletion;
+    await this.runTerminals.cleanupAttempt(
+      pending.taskEnvelope.workspace.workspaceId,
+      taskId,
+      attemptId
+    );
     const successful = completionResult.status === 'success';
 
     if (pending.provider === 'openclaw' && completionResult.summary) {
@@ -9311,6 +9339,11 @@ export class ClawdbotAgentService {
       controls: providerRuntimeControls(pending.providerRuntimeManifest),
       admissionReservationId: pending.admissionReservationId,
       executionTree: pending.executionTree,
+      terminals: this.runTerminals.list(
+        pending.taskEnvelope.workspace.workspaceId,
+        taskId,
+        pending.attemptId
+      ),
     };
   }
 

--- a/server/src/services/run-terminal-service.ts
+++ b/server/src/services/run-terminal-service.ts
@@ -427,19 +427,22 @@ export class RunTerminalService {
       taskId: required(taskId, 'taskId'),
       attemptId: required(attemptId, 'attemptId'),
     };
-    const results: RunTerminalTerminationResult[] = [];
-    for (const record of this.records.values()) {
-      if (
-        record.handle.workspaceId !== scope.workspaceId ||
-        record.handle.taskId !== scope.taskId ||
-        record.handle.attemptId !== scope.attemptId ||
-        terminal(record.handle.state)
-      ) {
-        continue;
-      }
-      results.push(await this.terminate(record.handle.id));
-    }
-    return results;
+    const records = [...this.records.values()].filter(
+      (record) =>
+        record.handle.workspaceId === scope.workspaceId &&
+        record.handle.taskId === scope.taskId &&
+        record.handle.attemptId === scope.attemptId
+    );
+    const results = await Promise.all(
+      records.map(async (record) => {
+        if (terminal(record.handle.state)) {
+          await this.awaitJournal(record);
+          return undefined;
+        }
+        return this.terminate(record.handle.id);
+      })
+    );
+    return results.filter((result): result is RunTerminalTerminationResult => result !== undefined);
   }
 
   async reconcileAttempt(


### PR DESCRIPTION
## Summary

- expose attempt-scoped terminal handles in active agent status
- terminate live foreground and detached terminal jobs before run completion or cancellation commits
- reconcile terminal evidence before persisting a late provider callback after restart
- clean matching handles in parallel while failing closed on incomplete journal evidence

## Verification

- 17 focused run-terminal tests passed in 4.49s
- 2 focused agent-lifecycle tests passed in 4.59s
- shared build passed
- server typecheck passed
- targeted lint passed with one pre-existing unused-import warning
- git diff check passed

## Scope

Advances #871. Secure external execute authority and capability-gated PTY support remain follow-up work.