### PR TITLE
feat: expose scoped run terminal controls

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,7 +1,7 @@
 # Veritas Kanban — API Reference
 
 **Version**: 6.0.2
-**Last Updated**: 2026-07-24
+**Last Updated**: 2026-07-25
 **Base URL**: `http://localhost:3001/api`
 **Canonical prefix**: `/api/v1` (alias: `/api`)
 
@@ -30,40 +30,41 @@
 17. [WebSocket](#websocket)
 18. [Shared Run Sessions](#shared-run-sessions)
 19. [Run Approvals](#run-approvals)
-20. [Task Verification](#task-verification)
-21. [Task Comments](#task-comments)
-22. [Task Subtasks](#task-subtasks)
-23. [Task Deliverables](#task-deliverables)
-24. [Recurring Work Scheduler](#recurring-work-scheduler)
-25. [Queue Intake Monitors](#queue-intake-monitors)
-26. [Task Archive](#task-archive)
-27. [Attachments](#attachments)
-28. [Agent Permissions](#agent-permissions)
-29. [Workspace Execution Trust](#workspace-execution-trust)
-30. [Agent Routing](#agent-routing)
-31. [Sandbox Policies](#sandbox-policies)
-32. [Shared Resources](#shared-resources)
-33. [Skill Capability Profiles](#skill-capability-profiles-apiskillscapabilities)
-34. [Skill Security Scanner](#skill-security-scanner-apiskillssecurity)
-35. [Doc Freshness](#doc-freshness)
-36. [Cost Prediction](#cost-prediction)
-37. [Error Learning](#error-learning)
-38. [Reflection-to-Memory Promotion](#reflection-to-memory-promotion)
-39. [External Tracker Introspection](#external-tracker-introspection)
-40. [Run-scoped Tool Control Plane](#run-scoped-tool-control-plane)
-41. [Tool Policies](#tool-policies)
-42. [Watcher Continuation Policies](#watcher-continuation-policies)
-43. [Traces](#traces)
-44. [Ceremony Requirements](#ceremony-requirements-apiceremonies)
-45. [Governance Decision Traces](#governance-decision-traces-apigovernancetraces)
-46. [Audit](#audit)
-47. [Maintenance Center](#maintenance-center-apiv1maintenance)
-48. [Common Workflows](#common-workflows)
-49. [Versioning & Deprecation](#versioning--deprecation)
-50. [Rate Limits](#rate-limits)
-51. [Additional Endpoint Groups](#additional-endpoint-groups)
-52. [Execution Admission](#execution-admission)
-53. [Durable Goals](#durable-goals)
+20. [Run Terminal Control](#run-terminal-control)
+21. [Task Verification](#task-verification)
+22. [Task Comments](#task-comments)
+23. [Task Subtasks](#task-subtasks)
+24. [Task Deliverables](#task-deliverables)
+25. [Recurring Work Scheduler](#recurring-work-scheduler)
+26. [Queue Intake Monitors](#queue-intake-monitors)
+27. [Task Archive](#task-archive)
+28. [Attachments](#attachments)
+29. [Agent Permissions](#agent-permissions)
+30. [Workspace Execution Trust](#workspace-execution-trust)
+31. [Agent Routing](#agent-routing)
+32. [Sandbox Policies](#sandbox-policies)
+33. [Shared Resources](#shared-resources)
+34. [Skill Capability Profiles](#skill-capability-profiles-apiskillscapabilities)
+35. [Skill Security Scanner](#skill-security-scanner-apiskillssecurity)
+36. [Doc Freshness](#doc-freshness)
+37. [Cost Prediction](#cost-prediction)
+38. [Error Learning](#error-learning)
+39. [Reflection-to-Memory Promotion](#reflection-to-memory-promotion)
+40. [External Tracker Introspection](#external-tracker-introspection)
+41. [Run-scoped Tool Control Plane](#run-scoped-tool-control-plane)
+42. [Tool Policies](#tool-policies)
+43. [Watcher Continuation Policies](#watcher-continuation-policies)
+44. [Traces](#traces)
+45. [Ceremony Requirements](#ceremony-requirements-apiceremonies)
+46. [Governance Decision Traces](#governance-decision-traces-apigovernancetraces)
+47. [Audit](#audit)
+48. [Maintenance Center](#maintenance-center-apiv1maintenance)
+49. [Common Workflows](#common-workflows)
+50. [Versioning & Deprecation](#versioning--deprecation)
+51. [Rate Limits](#rate-limits)
+52. [Additional Endpoint Groups](#additional-endpoint-groups)
+53. [Execution Admission](#execution-admission)
+54. [Durable Goals](#durable-goals)
 
 ---
 
@@ -1618,6 +1619,29 @@ Subscribers to the `run-sessions` WebSocket channel receive
   "timestamp": "2026-07-23T12:01:00.000Z"
 }
 ```
+
+---
+
+## Run Terminal Control
+
+Provider-neutral supervision for command handles already owned by an active run attempt. Mounted at `/api/v1/run-terminals` with the standard `/api/run-terminals` compatibility alias.
+
+| Method | Path                                                                       | Description                                      | Permissions   |
+| ------ | -------------------------------------------------------------------------- | ------------------------------------------------ | ------------- |
+| `GET`  | `/api/v1/run-terminals/runs/:taskId/:attemptId`                            | List handles for the exact active attempt.       | `agent:read`  |
+| `GET`  | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId`          | Read one scoped handle.                          | `agent:read`  |
+| `GET`  | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/output`   | Read bounded output after a cursor.               | `agent:read`  |
+| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/wait`     | Wait up to 300 seconds for one handle.            | `agent:write` |
+| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/wait-any`                   | Wait for any of up to 64 unique handles.          | `agent:write` |
+| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/wait-all`                   | Wait for all of up to 64 unique handles.          | `agent:write` |
+| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/detach`   | Detach a foreground handle without disowning it.  | `agent:write` |
+| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/terminate` | Gracefully terminate, then escalate if necessary. | `agent:write` |
+
+Output accepts `afterCursor` and `limit` query parameters. Single waits accept `{"timeoutMs": 25000}`. Multi-handle waits accept `{"handleIds": ["terminal_1", "terminal_2"], "timeoutMs": 25000}`.
+
+Every route resolves the current active attempt before checking the handle's workspace, task, and attempt identity. Stale attempts and cross-scope handles return `404`. Output and wait limits return `400` when invalid.
+
+This control surface cannot start commands. Externally initiated execution remains fail-closed until exact shell approval and the run's filesystem and network policy are applied to the terminal child.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2206,6 +2206,7 @@ RESTful API designed for both human and AI agent consumption.
 | `/api/v1/changes`                    | Efficient polling change feed                                 |
 | `/api/v1/agents/register`            | Agent registry (register, list, heartbeat, stats, deregister) |
 | `/api/v1/agents/permissions`         | Agent permission levels and approval workflows                |
+| `/api/v1/run-terminals`              | Active run terminal handles, output, waits, and control        |
 | `/api/v1/hooks`                      | Task lifecycle hooks (list, create, update, delete, events)   |
 | `/api/v1/errors`                     | Error learning (record, search, stats)                        |
 | `/api/v1/docs`                       | Documentation freshness (list, staleness, verify)             |

--- a/docs/architecture/RUN-TERMINAL-V1.md
+++ b/docs/architecture/RUN-TERMINAL-V1.md
@@ -17,7 +17,7 @@ The first implementation supports background pipe-mode commands with:
 - causal `command.started`, `command.detached`, `stream.stdout`, `stream.stderr`, and `command.completed` journal events; and
 - bounded handle and retained-output reconstruction from the durable causal journal.
 
-PTY mode, interactive stdin, restart reattachment, and external API/CLI/MCP exposure are explicitly unsupported in this slice. Callers receive typed blockers instead of an implicit downgrade.
+PTY mode, interactive stdin, restart reattachment, and externally initiated execution are explicitly unsupported in this slice. Callers receive typed blockers instead of an implicit downgrade.
 
 ## Authority boundary
 
@@ -28,6 +28,12 @@ The child is launched without a shell. On Unix-like systems it owns a detached p
 Terminal children are subordinate to their owning run. Detaching changes foreground coordination only; it does not outlive the attempt. Attempt cleanup terminates matching live handles in parallel and verifies that already-terminal handles have complete journal evidence before allowing the run completion to commit.
 
 When a provider completion arrives after a server restart, Veritas reconciles the attempt's durable terminal journal before cleanup. Handles that cannot be safely reattached are recorded as interrupted before the provider's terminal result is committed.
+
+## Control API
+
+Authenticated clients with `agent:read` can list active attempt handles and retrieve cursor-addressed output. Clients with `agent:write` can perform bounded single/any/all waits, detach a foreground handle, and terminate a handle. Every operation resolves the active task attempt first and then verifies the opaque handle's workspace, task, and attempt identity. Scope mismatches return not found rather than leaking another run's handle.
+
+The canonical routes live under `/api/v1/run-terminals/runs/:taskId/:attemptId`. The `/api` compatibility mount exposes the same routes. Execution is intentionally absent from this public surface until exact command approval and the run's filesystem and network posture are applied to the terminal child.
 
 ## Output and replay
 

--- a/server/src/__tests__/routes/run-terminals.test.ts
+++ b/server/src/__tests__/routes/run-terminals.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentStatus } from '../../services/clawdbot-agent-service.js';
+import { RunTerminalController } from '../../routes/run-terminals.js';
+import {
+  RunTerminalOutputQuerySchema,
+  RunTerminalWaitManyRequestSchema,
+  RunTerminalWaitRequestSchema,
+} from '../../schemas/run-terminal-schemas.js';
+
+const workspaceId = 'workspace-871';
+const taskId = 'task-871';
+const attemptId = 'attempt-871';
+const handleId = 'terminal-871';
+
+function activeStatus(): AgentStatus {
+  return {
+    attemptId,
+    taskEnvelope: {
+      workspace: { workspaceId },
+    },
+  } as AgentStatus;
+}
+
+function createFixture() {
+  const terminals = {
+    assertScope: vi.fn(() => ({ id: handleId })),
+    list: vi.fn(() => [{ id: handleId }]),
+    output: vi.fn(() => ({ handleId, chunks: [] })),
+    wait: vi.fn(async () => ({ completed: false, timedOut: true, handle: { id: handleId } })),
+    waitAny: vi.fn(async () => ({ mode: 'any', timedOut: true })),
+    waitAll: vi.fn(async () => ({ mode: 'all', timedOut: true })),
+    detach: vi.fn(async () => ({ id: handleId, startMode: 'background' })),
+    terminate: vi.fn(async () => ({ handle: { id: handleId, state: 'terminated' } })),
+  };
+  const activeRuns = {
+    getAgentStatus: vi.fn(async () => activeStatus()),
+  };
+  const controller = new RunTerminalController({
+    terminals,
+    activeRuns,
+  });
+  return { controller, terminals, activeRuns };
+}
+
+describe('run terminal routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists and reads output only through the active attempt scope', async () => {
+    const { controller, terminals, activeRuns } = createFixture();
+
+    const list = await controller.list(taskId, attemptId);
+    const output = await controller.output(taskId, attemptId, handleId, 4, 20);
+
+    expect(list).toEqual([{ id: handleId }]);
+    expect(output).toEqual({ handleId, chunks: [] });
+    expect(activeRuns.getAgentStatus).toHaveBeenCalledWith(taskId);
+    expect(terminals.list).toHaveBeenCalledWith(workspaceId, taskId, attemptId);
+    expect(terminals.assertScope).toHaveBeenCalledWith(handleId, workspaceId, taskId, attemptId);
+    expect(terminals.output).toHaveBeenCalledWith(handleId, 4, 20);
+  });
+
+  it('coordinates and controls scoped handles with bounded requests', async () => {
+    const { controller, terminals } = createFixture();
+
+    await controller.wait(taskId, attemptId, handleId, 25);
+    await controller.waitAny(taskId, attemptId, [handleId, 'terminal-872'], 50);
+    await controller.waitAll(taskId, attemptId, [handleId], 50);
+    await controller.detach(taskId, attemptId, handleId);
+    await controller.terminate(taskId, attemptId, handleId);
+
+    expect(terminals.wait).toHaveBeenCalledWith(handleId, 25);
+    expect(terminals.waitAny).toHaveBeenCalledWith([handleId, 'terminal-872'], 50);
+    expect(terminals.waitAll).toHaveBeenCalledWith([handleId], 50);
+    expect(terminals.detach).toHaveBeenCalledWith(handleId);
+    expect(terminals.terminate).toHaveBeenCalledWith(handleId);
+    expect(terminals.assertScope).toHaveBeenCalledWith(
+      'terminal-872',
+      workspaceId,
+      taskId,
+      attemptId
+    );
+  });
+
+  it('rejects stale attempts and duplicate or unbounded waits before control', async () => {
+    const { controller, terminals, activeRuns } = createFixture();
+    activeRuns.getAgentStatus.mockResolvedValueOnce({
+      ...activeStatus(),
+      attemptId: 'attempt-new',
+    });
+
+    await expect(controller.get(taskId, attemptId, handleId)).rejects.toThrow(
+      'Active run terminal scope not found'
+    );
+    const duplicate = RunTerminalWaitManyRequestSchema.safeParse({
+      handleIds: [handleId, handleId],
+      timeoutMs: 10,
+    });
+    const unbounded = RunTerminalWaitRequestSchema.safeParse({ timeoutMs: 300_001 });
+    const defaults = RunTerminalOutputQuerySchema.parse({});
+
+    expect(duplicate.success).toBe(false);
+    expect(unbounded.success).toBe(false);
+    expect(defaults).toEqual({ afterCursor: 0, limit: 200 });
+    expect(terminals.waitAny).not.toHaveBeenCalled();
+    expect(terminals.wait).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/run-terminal-service.test.ts
+++ b/server/src/__tests__/run-terminal-service.test.ts
@@ -121,6 +121,12 @@ describe('RunTerminalService', () => {
       mode: 'pipe',
       startMode: 'background',
     });
+    expect(
+      service.assertScope(started.id, context.workspaceId, context.taskId, context.attemptId)
+    ).toMatchObject({ id: started.id });
+    expect(() =>
+      service.assertScope(started.id, 'workspace_other', context.taskId, context.attemptId)
+    ).toThrow('not found');
     expect(await service.wait(started.id, 5_000)).toMatchObject({
       completed: true,
       timedOut: false,

--- a/server/src/__tests__/shared-api-permissions.test.ts
+++ b/server/src/__tests__/shared-api-permissions.test.ts
@@ -140,4 +140,15 @@ describe('shared API permission metadata', () => {
       getApiPermissionRequirement('/api/tool-servers/call', { method: 'POST' }).permissions
     ).toEqual(['agent:write']);
   });
+
+  it('separates run-terminal observation from control', () => {
+    expect(
+      getApiPermissionRequirement('/api/v1/run-terminals/runs/task_1/attempt_1').permissions
+    ).toEqual(['agent:read']);
+    expect(
+      getApiPermissionRequirement('/api/run-terminals/runs/task_1/attempt_1/wait-any', {
+        method: 'POST',
+      }).permissions
+    ).toEqual(['agent:write']);
+  });
 });

--- a/server/src/routes/run-terminals.ts
+++ b/server/src/routes/run-terminals.ts
@@ -1,0 +1,231 @@
+import { Router, type Router as RouterType } from 'express';
+import { z } from 'zod';
+import { asyncHandler } from '../middleware/async-handler.js';
+import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import {
+  RunTerminalHandleParamsSchema,
+  RunTerminalOutputQuerySchema,
+  RunTerminalScopeParamsSchema,
+  RunTerminalWaitManyRequestSchema,
+  RunTerminalWaitRequestSchema,
+} from '../schemas/run-terminal-schemas.js';
+import {
+  clawdbotAgentService,
+  type ClawdbotAgentService,
+} from '../services/clawdbot-agent-service.js';
+import {
+  getRunTerminalService,
+  type RunTerminalService,
+} from '../services/run-terminal-service.js';
+
+type RunTerminalApi = Pick<
+  RunTerminalService,
+  'assertScope' | 'list' | 'output' | 'wait' | 'waitAny' | 'waitAll' | 'detach' | 'terminate'
+>;
+
+export interface RunTerminalRouteDependencies {
+  terminals: RunTerminalApi;
+  activeRuns: Pick<ClawdbotAgentService, 'getAgentStatus'>;
+}
+
+interface ActiveTerminalScope {
+  workspaceId: string;
+  taskId: string;
+  attemptId: string;
+}
+
+function parseOrThrow<T>(schema: z.ZodType<T>, value: unknown): T {
+  try {
+    return schema.parse(value);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new ValidationError('Validation failed.', error.issues);
+    }
+    throw error;
+  }
+}
+
+async function requireActiveScope(
+  dependencies: RunTerminalRouteDependencies,
+  taskId: string,
+  attemptId: string
+): Promise<ActiveTerminalScope> {
+  const status = await dependencies.activeRuns.getAgentStatus(taskId);
+  if (!status || status.attemptId !== attemptId) {
+    throw new NotFoundError('Active run terminal scope not found.');
+  }
+  return {
+    workspaceId: status.taskEnvelope.workspace.workspaceId,
+    taskId,
+    attemptId,
+  };
+}
+
+function assertScopedHandle(
+  dependencies: RunTerminalRouteDependencies,
+  scope: ActiveTerminalScope,
+  handleId: string
+): void {
+  dependencies.terminals.assertScope(handleId, scope.workspaceId, scope.taskId, scope.attemptId);
+}
+
+export class RunTerminalController {
+  constructor(private readonly dependencies: RunTerminalRouteDependencies) {}
+
+  async list(taskId: string, attemptId: string) {
+    const scope = await requireActiveScope(this.dependencies, taskId, attemptId);
+    return this.dependencies.terminals.list(scope.workspaceId, scope.taskId, scope.attemptId);
+  }
+
+  async get(taskId: string, attemptId: string, handleId: string) {
+    const scope = await requireActiveScope(this.dependencies, taskId, attemptId);
+    return this.dependencies.terminals.assertScope(
+      handleId,
+      scope.workspaceId,
+      scope.taskId,
+      scope.attemptId
+    );
+  }
+
+  async output(
+    taskId: string,
+    attemptId: string,
+    handleId: string,
+    afterCursor: number,
+    limit: number
+  ) {
+    const scope = await requireActiveScope(this.dependencies, taskId, attemptId);
+    assertScopedHandle(this.dependencies, scope, handleId);
+    return this.dependencies.terminals.output(handleId, afterCursor, limit);
+  }
+
+  async wait(taskId: string, attemptId: string, handleId: string, timeoutMs: number) {
+    const scope = await requireActiveScope(this.dependencies, taskId, attemptId);
+    assertScopedHandle(this.dependencies, scope, handleId);
+    return this.dependencies.terminals.wait(handleId, timeoutMs);
+  }
+
+  async waitAny(taskId: string, attemptId: string, handleIds: string[], timeoutMs: number) {
+    const scope = await requireActiveScope(this.dependencies, taskId, attemptId);
+    for (const handleId of handleIds) {
+      assertScopedHandle(this.dependencies, scope, handleId);
+    }
+    return this.dependencies.terminals.waitAny(handleIds, timeoutMs);
+  }
+
+  async waitAll(taskId: string, attemptId: string, handleIds: string[], timeoutMs: number) {
+    const scope = await requireActiveScope(this.dependencies, taskId, attemptId);
+    for (const handleId of handleIds) {
+      assertScopedHandle(this.dependencies, scope, handleId);
+    }
+    return this.dependencies.terminals.waitAll(handleIds, timeoutMs);
+  }
+
+  async detach(taskId: string, attemptId: string, handleId: string) {
+    const scope = await requireActiveScope(this.dependencies, taskId, attemptId);
+    assertScopedHandle(this.dependencies, scope, handleId);
+    return this.dependencies.terminals.detach(handleId);
+  }
+
+  async terminate(taskId: string, attemptId: string, handleId: string) {
+    const scope = await requireActiveScope(this.dependencies, taskId, attemptId);
+    assertScopedHandle(this.dependencies, scope, handleId);
+    return this.dependencies.terminals.terminate(handleId);
+  }
+}
+
+export function createRunTerminalRoutes(
+  dependencies: RunTerminalRouteDependencies = {
+    terminals: getRunTerminalService(),
+    activeRuns: clawdbotAgentService,
+  }
+): RouterType {
+  const router: RouterType = Router();
+  const controller = new RunTerminalController(dependencies);
+
+  router.get(
+    '/runs/:taskId/:attemptId',
+    asyncHandler(async (req, res) => {
+      const params = parseOrThrow(RunTerminalScopeParamsSchema, req.params);
+      res.json(await controller.list(params.taskId, params.attemptId));
+    })
+  );
+
+  router.post(
+    '/runs/:taskId/:attemptId/wait-any',
+    asyncHandler(async (req, res) => {
+      const params = parseOrThrow(RunTerminalScopeParamsSchema, req.params);
+      const body = parseOrThrow(RunTerminalWaitManyRequestSchema, req.body);
+      res.json(
+        await controller.waitAny(params.taskId, params.attemptId, body.handleIds, body.timeoutMs)
+      );
+    })
+  );
+
+  router.post(
+    '/runs/:taskId/:attemptId/wait-all',
+    asyncHandler(async (req, res) => {
+      const params = parseOrThrow(RunTerminalScopeParamsSchema, req.params);
+      const body = parseOrThrow(RunTerminalWaitManyRequestSchema, req.body);
+      res.json(
+        await controller.waitAll(params.taskId, params.attemptId, body.handleIds, body.timeoutMs)
+      );
+    })
+  );
+
+  router.get(
+    '/runs/:taskId/:attemptId/handles/:handleId',
+    asyncHandler(async (req, res) => {
+      const params = parseOrThrow(RunTerminalHandleParamsSchema, req.params);
+      res.json(await controller.get(params.taskId, params.attemptId, params.handleId));
+    })
+  );
+
+  router.get(
+    '/runs/:taskId/:attemptId/handles/:handleId/output',
+    asyncHandler(async (req, res) => {
+      const params = parseOrThrow(RunTerminalHandleParamsSchema, req.params);
+      const query = parseOrThrow(RunTerminalOutputQuerySchema, req.query);
+      res.json(
+        await controller.output(
+          params.taskId,
+          params.attemptId,
+          params.handleId,
+          query.afterCursor,
+          query.limit
+        )
+      );
+    })
+  );
+
+  router.post(
+    '/runs/:taskId/:attemptId/handles/:handleId/wait',
+    asyncHandler(async (req, res) => {
+      const params = parseOrThrow(RunTerminalHandleParamsSchema, req.params);
+      const body = parseOrThrow(RunTerminalWaitRequestSchema, req.body);
+      res.json(
+        await controller.wait(params.taskId, params.attemptId, params.handleId, body.timeoutMs)
+      );
+    })
+  );
+
+  router.post(
+    '/runs/:taskId/:attemptId/handles/:handleId/detach',
+    asyncHandler(async (req, res) => {
+      const params = parseOrThrow(RunTerminalHandleParamsSchema, req.params);
+      res.json(await controller.detach(params.taskId, params.attemptId, params.handleId));
+    })
+  );
+
+  router.post(
+    '/runs/:taskId/:attemptId/handles/:handleId/terminate',
+    asyncHandler(async (req, res) => {
+      const params = parseOrThrow(RunTerminalHandleParamsSchema, req.params);
+      res.json(await controller.terminate(params.taskId, params.attemptId, params.handleId));
+    })
+  );
+
+  return router;
+}
+
+export const runTerminalRoutes = createRunTerminalRoutes();

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -44,6 +44,7 @@ import {
   promptRegistryAccess,
   reportAccess,
   reportRoutesAccess,
+  runTerminalAccess,
   sandboxPolicyAccess,
   schedulerAccess,
   scoringAccess,
@@ -144,6 +145,7 @@ import sandboxPolicyRoutes from '../sandbox-policies.js';
 import credentialBrokerRoutes from '../credential-broker.js';
 import { runSessionRoutes } from '../run-sessions.js';
 import { runApprovalRoutes } from '../run-approvals.js';
+import { runTerminalRoutes } from '../run-terminals.js';
 import { workspaceCapabilityRoutes } from '../workspace-capabilities.js';
 import { schedulerRoutes } from '../scheduler.js';
 import { queueMonitorRoutes } from '../queue-monitors.js';
@@ -265,6 +267,7 @@ v1Router.use('/workspace-capabilities', workspaceCapabilityAccess, workspaceCapa
 v1Router.use('/decisions', taskAccess, decisionRoutes);
 v1Router.use('/run-sessions', taskAccess, runSessionRoutes);
 v1Router.use('/run-approvals', taskAccess, runApprovalRoutes);
+v1Router.use('/run-terminals', runTerminalAccess, runTerminalRoutes);
 v1Router.use('/governance/traces', policyAccess, governanceTraceRoutes);
 v1Router.use('/feedback', feedbackAccess, feedbackRoutes);
 v1Router.use('/prompt-registry', promptRegistryAccess, promptRegistryRoutes);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -51,6 +51,7 @@ export const agentTaskAccess = routeAccess('agent:read', 'task:write', [
   },
 ]);
 export const agentStatusAccess = routeAccess('agent:read', 'telemetry:write');
+export const runTerminalAccess = routeAccess('agent:read', 'agent:write');
 export const admissionAccess = routeAccess('agent:read', 'admin:manage');
 export const goalAccess = routeAccess('agent:read', 'admin:manage');
 export const reportAccess = routeAccess('report:read', 'report:read');

--- a/server/src/schemas/run-terminal-schemas.ts
+++ b/server/src/schemas/run-terminal-schemas.ts
@@ -13,6 +13,13 @@ const environmentKeySchema = z
   .max(120)
   .regex(/^[A-Za-z_][A-Za-z0-9_]*$/);
 
+const terminalIdentifierSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(240)
+  .regex(/^[A-Za-z0-9._:-]+$/);
+
 export const RunTerminalExecuteRequestSchema = z
   .object({
     command: z
@@ -28,6 +35,43 @@ export const RunTerminalExecuteRequestSchema = z
     startMode: z.enum(RUN_TERMINAL_START_MODES),
     cwd: z.string().trim().min(1).max(1_000).optional(),
     environmentKeys: z.array(environmentKeySchema).max(128),
+  })
+  .strict();
+
+export const RunTerminalScopeParamsSchema = z
+  .object({
+    taskId: terminalIdentifierSchema,
+    attemptId: terminalIdentifierSchema,
+  })
+  .strict();
+
+export const RunTerminalHandleParamsSchema = RunTerminalScopeParamsSchema.extend({
+  handleId: terminalIdentifierSchema,
+}).strict();
+
+export const RunTerminalOutputQuerySchema = z
+  .object({
+    afterCursor: z.coerce.number().int().nonnegative().default(0),
+    limit: z.coerce.number().int().min(1).max(200).default(200),
+  })
+  .strict();
+
+export const RunTerminalWaitRequestSchema = z
+  .object({
+    timeoutMs: z.number().int().min(0).max(300_000),
+  })
+  .strict();
+
+export const RunTerminalWaitManyRequestSchema = z
+  .object({
+    handleIds: z
+      .array(terminalIdentifierSchema)
+      .min(1)
+      .max(64)
+      .refine((handleIds) => new Set(handleIds).size === handleIds.length, {
+        message: 'Terminal handle IDs must be unique.',
+      }),
+    timeoutMs: z.number().int().min(0).max(300_000),
   })
   .strict();
 

--- a/server/src/services/run-terminal-service.ts
+++ b/server/src/services/run-terminal-service.ts
@@ -251,6 +251,23 @@ export class RunTerminalService {
     return cloneHandle(this.require(handleId).handle);
   }
 
+  assertScope(
+    handleId: string,
+    workspaceId: string,
+    taskId: string,
+    attemptId: string
+  ): RunTerminalHandle {
+    const handle = this.get(handleId);
+    if (
+      handle.workspaceId !== required(workspaceId, 'workspaceId') ||
+      handle.taskId !== required(taskId, 'taskId') ||
+      handle.attemptId !== required(attemptId, 'attemptId')
+    ) {
+      throw new NotFoundError('Run terminal handle not found.');
+    }
+    return handle;
+  }
+
   list(workspaceId: string, taskId: string, attemptId: string): RunTerminalHandle[] {
     const scope = {
       workspaceId: required(workspaceId, 'workspaceId'),

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -397,6 +397,11 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     read: 'task:read',
     write: 'admin:manage',
   },
+  {
+    prefix: '/api/run-terminals',
+    read: 'agent:read',
+    write: 'agent:write',
+  },
   { prefix: '/api/governance/traces', read: 'policy:read' },
   { prefix: '/api/feedback', read: 'report:read', write: 'comment:write' },
   {


### PR DESCRIPTION
## Summary

- add active-attempt REST controls for terminal list, handle, cursor output, bounded waits, detach, and terminate
- enforce workspace, task, and attempt identity before every handle operation
- map read and write permissions consistently across server and clients
- document the control contract and keep externally initiated execution explicitly closed

## Verification

- 18 focused controller and permission tests passed in 5.29s
- 17 focused terminal runtime tests passed in 5.14s
- shared build passed
- server typecheck passed
- targeted lint passed
- permission coverage parity passed for 219 classified surfaces
- git diff check passed

## Scope

Advances #871. Command execution remains internal until exact approval and filesystem/network enforcement are applied to the child.