### PR TITLE
feat: approve run terminal execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,12 +271,20 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   launch credential broker is active.
 - Run-owned commands use `run-terminal-handle/v1`, never a provider's generic
   stdin channel. The current runtime supports background pipe mode with
-  manifest-approved executable, cwd, and environment posture, bounded
+  exact-action approval, stable request IDs, manifest-approved executable,
+  cwd, and environment posture, bounded
   cursor-addressable redacted output, bounded single/any/all waits,
   foreground detachment, process-group termination, and durable journal
   reconstruction. A dangling handle becomes `interrupted` after restart
   because inherited pipes cannot be reattached safely. PTY, interactive stdin,
   and restart reattachment fail closed until their typed controls ship.
+- Harnesses start a run-owned command with
+  `POST /api/v1/run-terminals/runs/:taskId/:attemptId/execute`. Send one stable
+  `requestId`, a command plus argument array, `mode: "pipe"`, start mode,
+  optional worktree-relative cwd, and environment names only. A `202`
+  response requires an operator decision through `run-approvals`; retry the
+  identical request after approval to receive the `201` handle. Never place
+  credential values in arguments or environment fields.
 
 ---
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1624,24 +1624,41 @@ Subscribers to the `run-sessions` WebSocket channel receive
 
 ## Run Terminal Control
 
-Provider-neutral supervision for command handles already owned by an active run attempt. Mounted at `/api/v1/run-terminals` with the standard `/api/run-terminals` compatibility alias.
+Provider-neutral execution and supervision for commands owned by an active run attempt. Mounted at `/api/v1/run-terminals` with the standard `/api/run-terminals` compatibility alias.
 
-| Method | Path                                                                       | Description                                      | Permissions   |
-| ------ | -------------------------------------------------------------------------- | ------------------------------------------------ | ------------- |
-| `GET`  | `/api/v1/run-terminals/runs/:taskId/:attemptId`                            | List handles for the exact active attempt.       | `agent:read`  |
-| `GET`  | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId`          | Read one scoped handle.                          | `agent:read`  |
-| `GET`  | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/output`   | Read bounded output after a cursor.               | `agent:read`  |
-| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/wait`     | Wait up to 300 seconds for one handle.            | `agent:write` |
-| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/wait-any`                   | Wait for any of up to 64 unique handles.          | `agent:write` |
-| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/wait-all`                   | Wait for all of up to 64 unique handles.          | `agent:write` |
-| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/detach`   | Detach a foreground handle without disowning it.  | `agent:write` |
+| Method | Path                                                                        | Description                                       | Permissions   |
+| ------ | --------------------------------------------------------------------------- | ------------------------------------------------- | ------------- |
+| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/execute`                     | Request approval or start one exact command.      | `agent:write` |
+| `GET`  | `/api/v1/run-terminals/runs/:taskId/:attemptId`                             | List handles for the exact active attempt.        | `agent:read`  |
+| `GET`  | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId`           | Read one scoped handle.                           | `agent:read`  |
+| `GET`  | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/output`    | Read bounded output after a cursor.               | `agent:read`  |
+| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/wait`      | Wait up to 300 seconds for one handle.            | `agent:write` |
+| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/wait-any`                    | Wait for any of up to 64 unique handles.          | `agent:write` |
+| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/wait-all`                    | Wait for all of up to 64 unique handles.          | `agent:write` |
+| `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/detach`    | Detach a foreground handle without disowning it.  | `agent:write` |
 | `POST` | `/api/v1/run-terminals/runs/:taskId/:attemptId/handles/:handleId/terminate` | Gracefully terminate, then escalate if necessary. | `agent:write` |
 
 Output accepts `afterCursor` and `limit` query parameters. Single waits accept `{"timeoutMs": 25000}`. Multi-handle waits accept `{"handleIds": ["terminal_1", "terminal_2"], "timeoutMs": 25000}`.
 
 Every route resolves the current active attempt before checking the handle's workspace, task, and attempt identity. Stale attempts and cross-scope handles return `404`. Output and wait limits return `400` when invalid.
 
-This control surface cannot start commands. Externally initiated execution remains fail-closed until exact shell approval and the run's filesystem and network policy are applied to the terminal child.
+Execution accepts a stable caller-owned request ID, an executable plus argument array, explicit pipe or PTY posture, start mode, optional worktree-relative cwd, and environment names only:
+
+```json
+{
+  "requestId": "verify-build-1",
+  "command": "pnpm",
+  "args": ["build"],
+  "mode": "pipe",
+  "startMode": "background",
+  "cwd": ".",
+  "environmentKeys": ["PATH"]
+}
+```
+
+The first valid request returns `202` with `status: "approval-required"` and an exact-action run approval. Resolve that approval through `/api/v1/run-approvals/:approvalId/decision`, then retry the identical request. An approved retry returns `201` with `status: "started"` and the run-owned handle. Reusing `requestId` with a changed command returns `409`; retrying an already-started exact request returns the original handle.
+
+The server, not the caller, supplies environment values and applies the active run's filesystem wrapper and network-egress environment. Commands are launched without a shell. Missing process authority, stale manifest or phase evidence, unenforceable required sandbox posture, cwd escape, credential-shaped arguments, unapproved environment names, and unsupported PTY mode fail closed before spawn.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2206,7 +2206,7 @@ RESTful API designed for both human and AI agent consumption.
 | `/api/v1/changes`                    | Efficient polling change feed                                 |
 | `/api/v1/agents/register`            | Agent registry (register, list, heartbeat, stats, deregister) |
 | `/api/v1/agents/permissions`         | Agent permission levels and approval workflows                |
-| `/api/v1/run-terminals`              | Active run terminal handles, output, waits, and control        |
+| `/api/v1/run-terminals`              | Approved run commands, handles, output, waits, and control    |
 | `/api/v1/hooks`                      | Task lifecycle hooks (list, create, update, delete, events)   |
 | `/api/v1/errors`                     | Error learning (record, search, stats)                        |
 | `/api/v1/docs`                       | Documentation freshness (list, staleness, verify)             |

--- a/docs/architecture/RUN-TERMINAL-V1.md
+++ b/docs/architecture/RUN-TERMINAL-V1.md
@@ -7,6 +7,7 @@
 The first implementation supports background pipe-mode commands with:
 
 - one opaque handle bound to workspace, task, attempt, and launch-manifest digest;
+- one stable request identity and digest for exact approval binding and retry deduplication;
 - a manifest-approved executable, relative cwd, and environment-key subset;
 - immediate background return, bounded single/any/all waits, foreground detachment without changing ownership, status inspection, and attempt cleanup;
 - active run status includes only handles owned by that workspace, task, and attempt;
@@ -17,11 +18,13 @@ The first implementation supports background pipe-mode commands with:
 - causal `command.started`, `command.detached`, `stream.stdout`, `stream.stderr`, and `command.completed` journal events; and
 - bounded handle and retained-output reconstruction from the durable causal journal.
 
-PTY mode, interactive stdin, restart reattachment, and externally initiated execution are explicitly unsupported in this slice. Callers receive typed blockers instead of an implicit downgrade.
+Externally initiated pipe execution is available only through the active-run API and an exact high-risk shell approval. PTY mode, interactive stdin, and restart reattachment remain explicitly unsupported. Callers receive typed blockers instead of an implicit downgrade.
 
 ## Authority boundary
 
-The service accepts a server-owned launch context and an untrusted command request. The launch context contains the exact workspace, task, attempt, launch-manifest digest, worktree root, approved environment values, and approved executable list. The request may select only an approved command, arguments without credential material, a canonical cwd within the worktree, and environment keys already present in that context. Lexical traversal and symlink escapes fail closed before spawn.
+The service accepts a server-owned launch context and an untrusted command request. The launch context contains the exact workspace, task, attempt, launch-manifest digest, worktree root, approved environment values, approved executable list, and optional server-owned launch wrapper. The request may select only an approved command, arguments without credential material, a canonical cwd within the worktree, and environment keys already present in that context. Lexical traversal and symlink escapes fail closed before spawn.
+
+The active-run layer first reconciles durable handles, verifies the immutable task envelope still authorizes execution in the exact worktree, confirms the persisted launch manifest and phase authority, and rejects required filesystem posture that the terminal child cannot inherit. It then creates an exact-action `run-approval/v1` request. Only an approved identical retry reaches the terminal service. The server-owned wrapper applies filesystem enforcement and mandatory egress variables after caller-selectable environment values, so omitting a proxy name cannot bypass the run's network posture.
 
 The child is launched without a shell. On Unix-like systems it owns a detached process group; on Windows it remains an exact child until the platform-specific tree supervisor is added. The service never exposes a writable stdin stream.
 
@@ -31,9 +34,9 @@ When a provider completion arrives after a server restart, Veritas reconciles th
 
 ## Control API
 
-Authenticated clients with `agent:read` can list active attempt handles and retrieve cursor-addressed output. Clients with `agent:write` can perform bounded single/any/all waits, detach a foreground handle, and terminate a handle. Every operation resolves the active task attempt first and then verifies the opaque handle's workspace, task, and attempt identity. Scope mismatches return not found rather than leaking another run's handle.
+Authenticated clients with `agent:read` can list active attempt handles and retrieve cursor-addressed output. Clients with `agent:write` can request exact execution, perform bounded single/any/all waits, detach a foreground handle, and terminate a handle. Every operation resolves the active task attempt first and then verifies the opaque handle's workspace, task, and attempt identity. Scope mismatches return not found rather than leaking another run's handle.
 
-The canonical routes live under `/api/v1/run-terminals/runs/:taskId/:attemptId`. The `/api` compatibility mount exposes the same routes. Execution is intentionally absent from this public surface until exact command approval and the run's filesystem and network posture are applied to the terminal child.
+The canonical routes live under `/api/v1/run-terminals/runs/:taskId/:attemptId`. The `/api` compatibility mount exposes the same routes. `POST .../execute` returns `202 approval-required` until the exact request is approved, then returns `201 started` with the opaque handle. A stable `requestId` deduplicates concurrent and post-restart retries; changing any approved field under that identity returns conflict.
 
 ## Output and replay
 

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -270,7 +270,7 @@ function testableService(
   admission: AdmissionControlService = testAdmissionControl(),
   runTerminals: Pick<
     RunTerminalService,
-    'list' | 'cleanupAttempt' | 'reconcileAttempt'
+    'execute' | 'list' | 'cleanupAttempt' | 'reconcileAttempt'
   > = testRunTerminals()
 ): TestableClawdbotAgentService {
   const completionEvidence = testCompletionEvidence();
@@ -311,9 +311,10 @@ function testableService(
 
 function testRunTerminals(): Pick<
   RunTerminalService,
-  'list' | 'cleanupAttempt' | 'reconcileAttempt'
+  'execute' | 'list' | 'cleanupAttempt' | 'reconcileAttempt'
 > {
   return {
+    execute: vi.fn(),
     list: vi.fn(() => []),
     cleanupAttempt: vi.fn(async () => []),
     reconcileAttempt: vi.fn(async (workspaceId, taskId, attemptId) => ({
@@ -3164,6 +3165,8 @@ describe('ClawdbotAgentService Codex providers', () => {
       taskId: task.id,
       attemptId: active.attemptId,
       launchManifestDigest: active.runLaunchManifest.digest,
+      requestId: 'terminal-status-request',
+      requestDigest: `sha256:${'b'.repeat(64)}`,
       mode: 'pipe' as const,
       startMode: 'background' as const,
       state: 'running' as const,
@@ -3218,6 +3221,194 @@ describe('ClawdbotAgentService Codex providers', () => {
     expect(vi.mocked(runTerminals.cleanupAttempt).mock.invocationCallOrder[0]).toBeLessThan(
       completionWrite as number
     );
+  });
+
+  it('requires exact approval before starting a sandbox-bound run terminal', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const runTerminals = testRunTerminals();
+    let approvalStatus: RunApprovalRequest['status'] = 'pending';
+    const approvalRequest = vi.fn(async (input: CreateRunApprovalRequestInput) => {
+      return {
+        schemaVersion: 'run-approval/v1' as const,
+        id: 'runapproval_terminal_execute',
+        workspaceId: input.workspaceId ?? 'local',
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        provider: input.provider,
+        agentId: input.agentId,
+        requestKind: input.requestKind,
+        actionClass: input.actionClass,
+        action: input.action,
+        actionHash: 'a'.repeat(64),
+        details: input.details,
+        resourceScope: input.resourceScope,
+        workingDirectory: input.workingDirectory,
+        riskClass: input.riskClass,
+        policyReason: input.policyReason,
+        evidenceRevision: input.evidenceRevision,
+        providerRequestId: input.providerRequestId,
+        mobileSafe: input.mobileSafe ?? false,
+        status: approvalStatus,
+        revision: approvalStatus === 'approved' ? 2 : 1,
+        createdAt: '2026-07-25T12:00:00.000Z',
+        updatedAt: '2026-07-25T12:00:00.000Z',
+        expiresAt: '2026-07-25T12:05:00.000Z',
+      } as RunApprovalRequest;
+    });
+    const approvalBroker = {
+      request: approvalRequest,
+      get: vi.fn(async () => {
+        const input = approvalRequest.mock.calls.at(-1)?.[0];
+        if (!input) throw new Error('Approval was not requested.');
+        return approvalRequest(input);
+      }),
+      cancelAttempt: vi.fn(async () => []),
+    } as unknown as RunApprovalBrokerService;
+    const service = testableService(
+      tmpDir,
+      undefined,
+      approvalBroker,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      runTerminals
+    );
+    const active = await service.startAgent(task.id, 'codex');
+    const request = {
+      requestId: 'terminal-execute-request',
+      command: process.execPath,
+      args: ['--version'],
+      mode: 'pipe' as const,
+      startMode: 'background' as const,
+      cwd: '.',
+      environmentKeys: [],
+    };
+    const handle = {
+      schemaVersion: 'run-terminal-handle/v1' as const,
+      id: 'terminal_execute_test',
+      workspaceId: active.taskEnvelope.workspace.workspaceId,
+      taskId: task.id,
+      attemptId: active.attemptId,
+      launchManifestDigest: active.runLaunchManifest.digest,
+      requestId: request.requestId,
+      requestDigest: `sha256:${'b'.repeat(64)}`,
+      mode: request.mode,
+      startMode: request.startMode,
+      state: 'running' as const,
+      commandId: `sha256:${'c'.repeat(64)}`,
+      startedAt: '2026-07-25T12:00:00.000Z',
+      output: {
+        nextCursor: 0,
+        retainedFromCursor: 1,
+        observedBytes: 0,
+        retainedBytes: 0,
+        droppedBytes: 0,
+        truncated: false,
+        volumeCircuitTripped: false,
+      },
+      capabilities: {
+        pipe: 'enforced' as const,
+        pty: 'unsupported' as const,
+        interactiveStdin: 'unsupported' as const,
+        restartReattachment: 'unsupported' as const,
+      },
+    };
+    vi.mocked(runTerminals.execute).mockResolvedValue(handle);
+
+    await expect(
+      service.executeRunTerminal(task.id, active.attemptId, {
+        ...request,
+        requestId: 'terminal-secret-request',
+        args: ['sk_test_secret_value'],
+      })
+    ).rejects.toThrow('Credential-shaped values are not allowed');
+    expect(approvalRequest).not.toHaveBeenCalled();
+
+    await expect(
+      service.executeRunTerminal(task.id, active.attemptId, request)
+    ).resolves.toMatchObject({
+      status: 'approval-required',
+      approval: { id: 'runapproval_terminal_execute', status: 'pending' },
+    });
+    expect(runTerminals.execute).not.toHaveBeenCalled();
+    expect(approvalRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: task.id,
+        attemptId: active.attemptId,
+        providerRequestId: request.requestId,
+        riskClass: 'high',
+        exactAction: request,
+      })
+    );
+
+    approvalStatus = 'approved';
+    await expect(
+      service.executeRunTerminal(task.id, active.attemptId, request)
+    ).resolves.toMatchObject({
+      status: 'started',
+      approval: { status: 'approved' },
+      handle: { id: handle.id, requestId: request.requestId },
+    });
+    expect(runTerminals.reconcileAttempt).toHaveBeenCalledWith(
+      active.taskEnvelope.workspace.workspaceId,
+      task.id,
+      active.attemptId
+    );
+    expect(runTerminals.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: active.taskEnvelope.workspace.workspaceId,
+        taskId: task.id,
+        attemptId: active.attemptId,
+        launchManifestDigest: active.runLaunchManifest.digest,
+        worktreeRoot: tmpDir,
+        allowedCommands: [process.execPath],
+        wrap: expect.any(Function),
+      }),
+      request
+    );
+
+    let resolveLaunch: (() => void) | undefined;
+    let launchSettled = false;
+    const launchGate = new Promise<void>((resolve) => {
+      resolveLaunch = resolve;
+    });
+    vi.mocked(runTerminals.execute).mockImplementationOnce(async (_context, input) => {
+      await launchGate;
+      launchSettled = true;
+      return {
+        ...handle,
+        id: 'terminal_finalization_race',
+        requestId: input.requestId,
+      };
+    });
+    vi.mocked(runTerminals.cleanupAttempt).mockImplementationOnce(async () => {
+      expect(launchSettled).toBe(true);
+      return [];
+    });
+    const racingRequest = {
+      ...request,
+      requestId: 'terminal-finalization-race',
+    };
+    const racingExecution = service.executeRunTerminal(
+      task.id,
+      active.attemptId,
+      racingRequest
+    );
+    await waitFor(() => expect(runTerminals.execute).toHaveBeenCalledTimes(2));
+    const stopping = service.stopAgent(task.id, active.attemptId);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(runTerminals.cleanupAttempt).not.toHaveBeenCalled();
+
+    resolveLaunch?.();
+    await expect(racingExecution).resolves.toMatchObject({
+      status: 'started',
+      handle: { id: 'terminal_finalization_race' },
+    });
+    await stopping;
+    expect(runTerminals.cleanupAttempt).toHaveBeenCalledOnce();
   });
 
   it('does not let a competing terminal claim poison an in-flight finalizer', async () => {

--- a/server/src/__tests__/routes/run-terminals.test.ts
+++ b/server/src/__tests__/routes/run-terminals.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentStatus } from '../../services/clawdbot-agent-service.js';
 import { RunTerminalController } from '../../routes/run-terminals.js';
 import {
+  RunTerminalExecuteRequestSchema,
   RunTerminalOutputQuerySchema,
   RunTerminalWaitManyRequestSchema,
   RunTerminalWaitRequestSchema,
@@ -33,6 +34,10 @@ function createFixture() {
     terminate: vi.fn(async () => ({ handle: { id: handleId, state: 'terminated' } })),
   };
   const activeRuns = {
+    executeRunTerminal: vi.fn(async () => ({
+      status: 'approval-required' as const,
+      approval: { id: 'runapproval-terminal-871' },
+    })),
     getAgentStatus: vi.fn(async () => activeStatus()),
   };
   const controller = new RunTerminalController({
@@ -59,6 +64,25 @@ describe('run terminal routes', () => {
     expect(terminals.list).toHaveBeenCalledWith(workspaceId, taskId, attemptId);
     expect(terminals.assertScope).toHaveBeenCalledWith(handleId, workspaceId, taskId, attemptId);
     expect(terminals.output).toHaveBeenCalledWith(handleId, 4, 20);
+  });
+
+  it('submits an exact idempotent execution request through the active run service', async () => {
+    const { controller, activeRuns } = createFixture();
+    const request = RunTerminalExecuteRequestSchema.parse({
+      requestId: 'terminal-request-871',
+      command: 'pnpm',
+      args: ['test', '--runInBand'],
+      mode: 'pipe',
+      startMode: 'background',
+      cwd: '.',
+      environmentKeys: ['PATH'],
+    });
+
+    await expect(controller.execute(taskId, attemptId, request)).resolves.toMatchObject({
+      status: 'approval-required',
+      approval: { id: 'runapproval-terminal-871' },
+    });
+    expect(activeRuns.executeRunTerminal).toHaveBeenCalledWith(taskId, attemptId, request);
   });
 
   it('coordinates and controls scoped handles with bounded requests', async () => {
@@ -98,10 +122,19 @@ describe('run terminal routes', () => {
       timeoutMs: 10,
     });
     const unbounded = RunTerminalWaitRequestSchema.safeParse({ timeoutMs: 300_001 });
+    const duplicateEnvironment = RunTerminalExecuteRequestSchema.safeParse({
+      requestId: 'terminal-request-duplicate-env',
+      command: 'pnpm',
+      args: ['test'],
+      mode: 'pipe',
+      startMode: 'background',
+      environmentKeys: ['PATH', 'PATH'],
+    });
     const defaults = RunTerminalOutputQuerySchema.parse({});
 
     expect(duplicate.success).toBe(false);
     expect(unbounded.success).toBe(false);
+    expect(duplicateEnvironment.success).toBe(false);
     expect(defaults).toEqual({ afterCursor: 0, limit: 200 });
     expect(terminals.waitAny).not.toHaveBeenCalled();
     expect(terminals.wait).not.toHaveBeenCalled();

--- a/server/src/__tests__/run-terminal-service.test.ts
+++ b/server/src/__tests__/run-terminal-service.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, symlink } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type {
   RunEventAppendInput,
   RunEventEnvelope,
@@ -13,6 +13,7 @@ import {
 } from '../services/run-terminal-service.js';
 
 const launchManifestDigest = `sha256:${'a'.repeat(64)}`;
+let requestSequence = 0;
 
 async function fixture(
   options: {
@@ -93,11 +94,12 @@ async function fixture(
     environment: {},
     allowedCommands: [process.execPath],
   };
-  return { service, context, events, journal };
+  return { service, context, events, persistedEvents, journal };
 }
 
 function request(script: string): RunTerminalExecuteRequest {
   return {
+    requestId: `terminal-request-${++requestSequence}`,
     command: process.execPath,
     args: ['-e', script],
     mode: 'pipe',
@@ -143,6 +145,42 @@ describe('RunTerminalService', () => {
       'stream.stdout',
       'command.completed',
     ]);
+  });
+
+  it('deduplicates approved request retries and applies the server-owned launch wrapper', async () => {
+    const { service, context, events } = await fixture();
+    const wrap = vi.fn((command: string, args: string[], cwd: string) => ({
+      command,
+      args,
+      cwd,
+      environment: { WRAPPED_FLAG: 'enforced' },
+    }));
+    const approvedRequest = request(
+      'setTimeout(() => process.stdout.write(process.env.WRAPPED_FLAG || "missing"), 25)'
+    );
+
+    const [first, retried] = await Promise.all([
+      service.execute({ ...context, wrap }, approvedRequest),
+      service.execute({ ...context, wrap }, approvedRequest),
+    ]);
+
+    expect(retried.id).toBe(first.id);
+    expect(first).toMatchObject({
+      requestId: approvedRequest.requestId,
+      requestDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+    });
+    await service.wait(first.id, 5_000);
+    expect(
+      service
+        .output(first.id)
+        .chunks.map((chunk) => chunk.content)
+        .join('')
+    ).toBe('enforced');
+    expect(wrap).toHaveBeenCalledTimes(1);
+    expect(events.filter((event) => event.kind === 'command.started')).toHaveLength(1);
+    await expect(
+      service.execute({ ...context, wrap }, { ...approvedRequest, args: ['-e', 'process.exit(1)'] })
+    ).rejects.toThrow('reused for a changed command');
   });
 
   it('fails closed when ownership cannot be persisted before handle return', async () => {
@@ -400,6 +438,33 @@ describe('RunTerminalService', () => {
         .chunks.map((chunk) => chunk.content)
         .join('')
     ).toBe('durable output');
+  });
+
+  it('migrates pre-request-identity v1 handles during durable replay', async () => {
+    const { service, context, persistedEvents, journal } = await fixture();
+    const started = await service.execute(context, request('process.stdout.write("legacy")'));
+    await service.wait(started.id, 5_000);
+    for (const event of persistedEvents) {
+      const handle = event.payload.handle;
+      if (!handle || typeof handle !== 'object' || Array.isArray(handle)) continue;
+      delete (handle as Record<string, unknown>).requestId;
+      delete (handle as Record<string, unknown>).requestDigest;
+    }
+
+    const restarted = new RunTerminalService({ journal });
+    const reconciliation = await restarted.reconcileAttempt(
+      context.workspaceId,
+      context.taskId,
+      context.attemptId
+    );
+
+    expect(reconciliation.handles).toContainEqual(
+      expect.objectContaining({
+        id: started.id,
+        requestId: `legacy:${started.id}`,
+        requestDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      })
+    );
   });
 
   it('fails closed by interrupting a dangling handle after restart', async () => {

--- a/server/src/__tests__/shared-api-permissions.test.ts
+++ b/server/src/__tests__/shared-api-permissions.test.ts
@@ -150,5 +150,10 @@ describe('shared API permission metadata', () => {
         method: 'POST',
       }).permissions
     ).toEqual(['agent:write']);
+    expect(
+      getApiPermissionRequirement('/api/v1/run-terminals/runs/task_1/attempt_1/execute', {
+        method: 'POST',
+      }).permissions
+    ).toEqual(['agent:write']);
   });
 });

--- a/server/src/routes/run-terminals.ts
+++ b/server/src/routes/run-terminals.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import {
+  RunTerminalExecuteRequestSchema,
   RunTerminalHandleParamsSchema,
   RunTerminalOutputQuerySchema,
   RunTerminalScopeParamsSchema,
@@ -25,7 +26,7 @@ type RunTerminalApi = Pick<
 
 export interface RunTerminalRouteDependencies {
   terminals: RunTerminalApi;
-  activeRuns: Pick<ClawdbotAgentService, 'getAgentStatus'>;
+  activeRuns: Pick<ClawdbotAgentService, 'executeRunTerminal' | 'getAgentStatus'>;
 }
 
 interface ActiveTerminalScope {
@@ -71,6 +72,14 @@ function assertScopedHandle(
 
 export class RunTerminalController {
   constructor(private readonly dependencies: RunTerminalRouteDependencies) {}
+
+  async execute(
+    taskId: string,
+    attemptId: string,
+    request: z.infer<typeof RunTerminalExecuteRequestSchema>
+  ) {
+    return this.dependencies.activeRuns.executeRunTerminal(taskId, attemptId, request);
+  }
 
   async list(taskId: string, attemptId: string) {
     const scope = await requireActiveScope(this.dependencies, taskId, attemptId);
@@ -142,6 +151,16 @@ export function createRunTerminalRoutes(
 ): RouterType {
   const router: RouterType = Router();
   const controller = new RunTerminalController(dependencies);
+
+  router.post(
+    '/runs/:taskId/:attemptId/execute',
+    asyncHandler(async (req, res) => {
+      const params = parseOrThrow(RunTerminalScopeParamsSchema, req.params);
+      const body = parseOrThrow(RunTerminalExecuteRequestSchema, req.body);
+      const result = await controller.execute(params.taskId, params.attemptId, body);
+      res.status(result.status === 'started' ? 201 : 202).json(result);
+    })
+  );
 
   router.get(
     '/runs/:taskId/:attemptId',

--- a/server/src/schemas/run-terminal-schemas.ts
+++ b/server/src/schemas/run-terminal-schemas.ts
@@ -22,6 +22,7 @@ const terminalIdentifierSchema = z
 
 export const RunTerminalExecuteRequestSchema = z
   .object({
+    requestId: terminalIdentifierSchema,
     command: z
       .string()
       .trim()
@@ -34,7 +35,12 @@ export const RunTerminalExecuteRequestSchema = z
     mode: z.enum(RUN_TERMINAL_MODES),
     startMode: z.enum(RUN_TERMINAL_START_MODES),
     cwd: z.string().trim().min(1).max(1_000).optional(),
-    environmentKeys: z.array(environmentKeySchema).max(128),
+    environmentKeys: z
+      .array(environmentKeySchema)
+      .max(128)
+      .refine((keys) => new Set(keys).size === keys.length, {
+        message: 'Terminal environment keys must be unique.',
+      }),
   })
   .strict();
 
@@ -104,6 +110,8 @@ export const RunTerminalHandleSchema = z
     taskId: z.string().trim().min(1).max(200),
     attemptId: z.string().trim().min(1).max(200),
     launchManifestDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    requestId: terminalIdentifierSchema,
+    requestDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
     mode: z.enum(RUN_TERMINAL_MODES),
     startMode: z.enum(RUN_TERMINAL_START_MODES),
     state: z.enum(RUN_TERMINAL_STATES),

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -150,6 +150,7 @@ import type {
   AcpStopReason,
   ProviderRuntimeCapabilityEvidence,
   RunApprovalActionClass,
+  RunApprovalRequest,
   RunApprovalRiskClass,
   WorkspaceExecutionTrustEvaluation,
   WorkspaceExecutionTrustScanResult,
@@ -162,10 +163,17 @@ import type {
   ExecutionTreeBudgetPolicy,
   ExecutionTreeEdgeKind,
   ExecutionTreeIdentity,
+  RunTerminalExecuteRequest,
   RunTerminalHandle,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
-import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
+import { redactString } from '../lib/redact.js';
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from '../middleware/error-handler.js';
 import type { AgentBudgetThresholdEvent } from '@veritas-kanban/shared';
 import { getAgentProfilePackageService } from './agent-profile-package-service.js';
 import {
@@ -198,6 +206,7 @@ import {
   parseTaskEnvelope,
 } from '../schemas/task-envelope-schemas.js';
 import { parseRunLaunchManifest } from '../schemas/run-launch-manifest-schemas.js';
+import { RunTerminalExecuteRequestSchema } from '../schemas/run-terminal-schemas.js';
 import {
   ProviderCompletionService,
   type ProviderCompletionArtifactClaim,
@@ -408,6 +417,17 @@ export interface AgentStatus {
   terminals: RunTerminalHandle[];
 }
 
+export type RunTerminalExecutionResult =
+  | {
+      status: 'approval-required';
+      approval: RunApprovalRequest;
+    }
+  | {
+      status: 'started';
+      approval: RunApprovalRequest;
+      handle: RunTerminalHandle;
+    };
+
 export interface AgentQueueStatus {
   taskId: string;
   attemptId: string;
@@ -566,6 +586,7 @@ interface AgentTerminalResult {
 const pendingAgents = new Map<string, PendingAgent>();
 const startingAgents = new Set<string>();
 const finalizingAgents = new Map<PendingAgent, Promise<void>>();
+const pendingRunTerminalLaunches = new Map<PendingAgent, Set<Promise<RunTerminalHandle>>>();
 const budgetEvaluations = new Map<PendingAgent, Promise<void>>();
 const recoveredProcessMonitors = new Map<string, NodeJS.Timeout>();
 const scheduledRecoveries = new Map<
@@ -647,7 +668,7 @@ export class ClawdbotAgentService {
   private dependencyExecution: DependencyCircuitExecutionService;
   private runTerminals: Pick<
     RunTerminalService,
-    'list' | 'cleanupAttempt' | 'reconcileAttempt'
+    'execute' | 'list' | 'cleanupAttempt' | 'reconcileAttempt'
   >;
   private logsDir: string;
 
@@ -697,7 +718,7 @@ export class ClawdbotAgentService {
     dependencyExecution: DependencyCircuitExecutionService = defaultDependencyCircuitExecutionService(),
     runTerminals: Pick<
       RunTerminalService,
-      'list' | 'cleanupAttempt' | 'reconcileAttempt'
+      'execute' | 'list' | 'cleanupAttempt' | 'reconcileAttempt'
     > = getRunTerminalService()
   ) {
     this.configService = new ConfigService();
@@ -4182,6 +4203,10 @@ export class ClawdbotAgentService {
       })());
     const { status, taskBeforeCompletion, completionResult, dependencyCircuits } =
       preparedCompletion;
+    const terminalLaunches = [...(pendingRunTerminalLaunches.get(pending) ?? [])];
+    if (terminalLaunches.length > 0) {
+      await Promise.allSettled(terminalLaunches);
+    }
     await this.runTerminals.cleanupAttempt(
       pending.taskEnvelope.workspace.workspaceId,
       taskId,
@@ -9345,6 +9370,181 @@ export class ClawdbotAgentService {
         pending.attemptId
       ),
     };
+  }
+
+  async executeRunTerminal(
+    taskId: string,
+    attemptId: string,
+    inputRequest: RunTerminalExecuteRequest
+  ): Promise<RunTerminalExecutionResult> {
+    const request = RunTerminalExecuteRequestSchema.parse(inputRequest);
+    const pending = pendingAgents.get(taskId);
+    if (!pending || pending.attemptId !== attemptId) {
+      throw new NotFoundError('Active run terminal scope not found.');
+    }
+    await this.assertPendingManifestSnapshotForAttempt(taskId, attemptId);
+    const worktreeRoot = this.expandPath(pending.taskEnvelope.workspace.worktreePath);
+    const executeScope = pending.taskEnvelope.allowedSideEffects.find(
+      (sideEffect) =>
+        sideEffect.kind === 'process-execute' &&
+        path.resolve(this.expandPath(sideEffect.scope)) === path.resolve(worktreeRoot)
+    );
+    if (!executeScope) {
+      throw new ForbiddenError('The immutable task envelope does not allow process execution.', {
+        taskId,
+        attemptId,
+      });
+    }
+    const filesystemPlan = pending.filesystemSandboxPlan;
+    if (!filesystemPlan || !pending.runLaunchManifest.sandbox.filesystem) {
+      throw new ConflictError('Run terminal execution has no compiled filesystem posture.', {
+        taskId,
+        attemptId,
+      });
+    }
+    if (pending.runLaunchManifest.sandbox.enforcement === 'required' && !filesystemPlan.wrapper) {
+      throw new ConflictError(
+        'Run terminal execution cannot inherit the provider-native filesystem sandbox.',
+        {
+          taskId,
+          attemptId,
+          filesystemState: filesystemPlan.evidence.state,
+          remediation:
+            'Use a run with a host-wrappable filesystem posture or keep terminal execution disabled.',
+        }
+      );
+    }
+    for (const value of [request.command, ...request.args]) {
+      if (redactString(value) !== value) {
+        throw new ValidationError(
+          'Credential-shaped values are not allowed in terminal command arguments.'
+        );
+      }
+    }
+    await this.runTerminals.reconcileAttempt(
+      pending.taskEnvelope.workspace.workspaceId,
+      taskId,
+      attemptId
+    );
+
+    const commandClass = classifyPhaseCommand([request.command, ...request.args]);
+    const credentialScopes = request.environmentKeys
+      .map((key) => `env:${key}`)
+      .filter((reference) =>
+        pending.runLaunchManifest.runtime.credentialReferences.includes(reference)
+      );
+    const phase = await this.bindPhaseApproval(taskId, attemptId, pending.runLaunchManifest, [
+      { dimension: 'filesystem.read', requestedScopes: ['<workspace>'] },
+      { dimension: 'command.execute', requestedScopes: [commandClass] },
+      ...(commandClass === 'inspect'
+        ? []
+        : [
+            {
+              dimension: 'filesystem.write' as const,
+              requestedScopes: ['<workspace>'],
+            },
+          ]),
+      ...(credentialScopes.length > 0
+        ? [
+            {
+              dimension: 'credential.access' as const,
+              requestedScopes: credentialScopes,
+            },
+          ]
+        : []),
+      ...(commandClass === 'publish'
+        ? [
+            {
+              dimension: 'external.action' as const,
+              requestedScopes: ['mutate'],
+            },
+          ]
+        : []),
+    ]);
+    const requestedApproval = await this.approvalBroker.request({
+      workspaceId: pending.taskEnvelope.workspace.workspaceId,
+      taskId,
+      attemptId,
+      provider: pending.provider,
+      agentId: pending.agent,
+      providerRequestId: request.requestId,
+      requestKind: 'approval',
+      actionClass: 'shell',
+      action: `Execute ${request.command}`,
+      details: this.redactTraceText(JSON.stringify(request.args)).slice(0, 4_000),
+      resourceScope: [
+        `command:${commandClass}`,
+        `cwd:${request.cwd ?? '.'}`,
+        ...request.environmentKeys.map((key) => `env:${key}`),
+      ],
+      workingDirectory: request.cwd ?? '.',
+      riskClass: 'high',
+      policyReason:
+        'A provider-neutral terminal child requires exact operator approval before launch.',
+      evidenceRevision: pending.runLaunchManifest.digest,
+      mobileSafe: false,
+      exactAction: request,
+      ...(phase ? { phase } : {}),
+    });
+    const approval = await this.approvalBroker.get(
+      requestedApproval.id,
+      pending.taskEnvelope.workspace.workspaceId
+    );
+    if (approval.status === 'pending') {
+      return { status: 'approval-required', approval };
+    }
+    if (approval.status !== 'approved') {
+      throw new ForbiddenError('Run terminal execution was not approved.', {
+        approvalId: approval.id,
+        status: approval.status,
+      });
+    }
+    const approvedEnvironment = Object.fromEntries(
+      pending.runLaunchManifest.runtime.environmentKeys.flatMap((key) => {
+        const value = process.env[key];
+        return typeof value === 'string' ? [[key, value]] : [];
+      })
+    );
+    if (pendingAgents.get(taskId) !== pending || finalizingAgents.has(pending)) {
+      throw new ConflictError('Run terminal execution raced with run finalization.', {
+        taskId,
+        attemptId,
+      });
+    }
+    const launch = this.runTerminals.execute(
+      {
+        workspaceId: pending.taskEnvelope.workspace.workspaceId,
+        taskId,
+        attemptId,
+        launchManifestDigest: pending.runLaunchManifest.digest,
+        worktreeRoot,
+        environment: approvedEnvironment,
+        allowedCommands: [request.command],
+        wrap: (command, args, cwd) => {
+          const launch = this.filesystemSandboxLaunch(pending, command, args, cwd);
+          return {
+            ...launch,
+            environment: this.withRunEgressEnvironment(pending, launch.environment),
+          };
+        },
+      },
+      request
+    );
+    const launches = pendingRunTerminalLaunches.get(pending) ?? new Set();
+    launches.add(launch);
+    pendingRunTerminalLaunches.set(pending, launches);
+    void launch.then(
+      () => {
+        launches.delete(launch);
+        if (launches.size === 0) pendingRunTerminalLaunches.delete(pending);
+      },
+      () => {
+        launches.delete(launch);
+        if (launches.size === 0) pendingRunTerminalLaunches.delete(pending);
+      }
+    );
+    const handle = await launch;
+    return { status: 'started', approval, handle };
   }
 
   async assertRunControl(

--- a/server/src/services/run-terminal-service.ts
+++ b/server/src/services/run-terminal-service.ts
@@ -63,6 +63,16 @@ export interface RunTerminalLaunchContext {
   worktreeRoot: string;
   environment: Record<string, string>;
   allowedCommands: string[];
+  wrap?: (
+    command: string,
+    args: string[],
+    cwd: string
+  ) => {
+    command: string;
+    args: string[];
+    cwd: string;
+    environment: Record<string, string>;
+  };
 }
 
 export interface RunTerminalServiceOptions {
@@ -105,6 +115,10 @@ export class RunTerminalService {
   private readonly terminationGraceMs: number;
   private readonly records = new Map<string, TerminalRecord>();
   private readonly recoveredHandleIds = new Set<string>();
+  private readonly pendingExecutions = new Map<
+    string,
+    { requestDigest: string; promise: Promise<RunTerminalHandle> }
+  >();
 
   constructor(options: RunTerminalServiceOptions = {}) {
     this.journal = options.journal ?? getRunEventJournalService();
@@ -147,6 +161,54 @@ export class RunTerminalService {
   ): Promise<RunTerminalHandle> {
     const context = normalizeContext(inputContext);
     const request = RunTerminalExecuteRequestSchema.parse(inputRequest);
+    const requestDigest = digestTerminalRequest(request);
+    const existing = [...this.records.values()].find(
+      (record) =>
+        record.handle.workspaceId === context.workspaceId &&
+        record.handle.taskId === context.taskId &&
+        record.handle.attemptId === context.attemptId &&
+        record.handle.requestId === request.requestId
+    );
+    if (existing) {
+      if (existing.handle.requestDigest !== requestDigest) {
+        throw new ConflictError('Terminal request identity was reused for a changed command.', {
+          requestId: request.requestId,
+          handleId: existing.handle.id,
+        });
+      }
+      return cloneHandle(existing.handle);
+    }
+    const executionKey = [
+      context.workspaceId,
+      context.taskId,
+      context.attemptId,
+      request.requestId,
+    ].join('\0');
+    const pending = this.pendingExecutions.get(executionKey);
+    if (pending) {
+      if (pending.requestDigest !== requestDigest) {
+        throw new ConflictError('Terminal request identity was reused for a changed command.', {
+          requestId: request.requestId,
+        });
+      }
+      return pending.promise.then(cloneHandle);
+    }
+    const promise = this.executeNew(context, request, requestDigest);
+    this.pendingExecutions.set(executionKey, { requestDigest, promise });
+    try {
+      return await promise;
+    } finally {
+      if (this.pendingExecutions.get(executionKey)?.promise === promise) {
+        this.pendingExecutions.delete(executionKey);
+      }
+    }
+  }
+
+  private async executeNew(
+    context: RunTerminalLaunchContext,
+    request: RunTerminalExecuteRequest,
+    requestDigest: string
+  ): Promise<RunTerminalHandle> {
     if (request.mode !== 'pipe') {
       throw new ConflictError('PTY mode is not supported by the current run terminal runtime.', {
         mode: request.mode,
@@ -159,11 +221,23 @@ export class RunTerminalService {
       });
     }
     assertNoCredentialArguments(request.command, request.args);
-    const cwd = await resolveCwd(context.worktreeRoot, request.cwd);
-    const environment = selectEnvironment(context.environment, request.environmentKeys);
+    const requestedCwd = await resolveCwd(context.worktreeRoot, request.cwd);
+    const launch = context.wrap
+      ? context.wrap(request.command, request.args, requestedCwd)
+      : {
+          command: request.command,
+          args: request.args,
+          cwd: requestedCwd,
+          environment: {},
+        };
+    const cwd = await resolveWrappedCwd(context.worktreeRoot, launch.cwd);
+    const environment = {
+      ...selectEnvironment(context.environment, request.environmentKeys),
+      ...launch.environment,
+    };
     const id = `terminal_${nanoid(18)}`;
     const startedAt = this.now().toISOString();
-    const child = spawn(request.command, request.args, {
+    const child = spawn(launch.command, launch.args, {
       cwd,
       env: environment,
       shell: false,
@@ -181,6 +255,8 @@ export class RunTerminalService {
       taskId: context.taskId,
       attemptId: context.attemptId,
       launchManifestDigest: context.launchManifestDigest,
+      requestId: request.requestId,
+      requestDigest,
       mode: request.mode,
       startMode: request.startMode,
       state: child.pid ? 'running' : 'starting',
@@ -879,12 +955,23 @@ function normalizeContext(input: RunTerminalLaunchContext): RunTerminalLaunchCon
     worktreeRoot,
     environment: { ...input.environment },
     allowedCommands,
+    ...(input.wrap ? { wrap: input.wrap } : {}),
   };
 }
 
 async function resolveCwd(worktreeRoot: string, requested: string | undefined): Promise<string> {
   const resolved = path.resolve(worktreeRoot, requested ?? '.');
   ensureWithinBase(worktreeRoot, resolved);
+  const [canonicalRoot, canonicalCwd] = await Promise.all([
+    realpath(worktreeRoot),
+    realpath(resolved),
+  ]);
+  ensureWithinBase(canonicalRoot, canonicalCwd);
+  return canonicalCwd;
+}
+
+async function resolveWrappedCwd(worktreeRoot: string, wrappedCwd: string): Promise<string> {
+  const resolved = path.resolve(wrappedCwd);
   const [canonicalRoot, canonicalCwd] = await Promise.all([
     realpath(worktreeRoot),
     realpath(resolved),
@@ -925,6 +1012,22 @@ function commandId(command: string, args: string[]): string {
     .slice(0, 24)}`;
 }
 
+function digestTerminalRequest(request: RunTerminalExecuteRequest): string {
+  return `sha256:${createHash('sha256')
+    .update(
+      JSON.stringify({
+        requestId: request.requestId,
+        command: request.command,
+        args: request.args,
+        mode: request.mode,
+        startMode: request.startMode,
+        cwd: request.cwd ?? '.',
+        environmentKeys: [...request.environmentKeys].sort(),
+      })
+    )
+    .digest('hex')}`;
+}
+
 function splitUtf8(value: string, maximumBytes: number): string[] {
   if (Buffer.byteLength(value, 'utf8') <= maximumBytes) return value ? [value] : [];
   const chunks: string[] = [];
@@ -960,7 +1063,22 @@ function cloneHandle(handle: RunTerminalHandle): RunTerminalHandle {
 
 function parsePersistedHandle(value: unknown): RunTerminalHandle | null {
   if (value === undefined) return null;
-  const parsed = RunTerminalHandleSchema.safeParse(value);
+  const legacy =
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).id === 'string' &&
+    typeof (value as Record<string, unknown>).requestId !== 'string' &&
+    typeof (value as Record<string, unknown>).requestDigest !== 'string'
+      ? {
+          ...(value as Record<string, unknown>),
+          requestId: `legacy:${(value as Record<string, unknown>).id as string}`,
+          requestDigest: `sha256:${createHash('sha256')
+            .update(`legacy-run-terminal:${(value as Record<string, unknown>).id as string}`)
+            .digest('hex')}`,
+        }
+      : value;
+  const parsed = RunTerminalHandleSchema.safeParse(legacy);
   if (!parsed.success) {
     throw new ConflictError('Persisted run terminal handle is invalid.');
   }
@@ -981,6 +1099,8 @@ function assertSamePersistedHandleIdentity(
     current.taskId,
     current.attemptId,
     current.launchManifestDigest,
+    current.requestId,
+    current.requestDigest,
     current.mode,
     current.commandId,
     current.processId,
@@ -994,6 +1114,8 @@ function assertSamePersistedHandleIdentity(
     next.taskId,
     next.attemptId,
     next.launchManifestDigest,
+    next.requestId,
+    next.requestDigest,
     next.mode,
     next.commandId,
     next.processId,

--- a/shared/src/types/run-terminal.types.ts
+++ b/shared/src/types/run-terminal.types.ts
@@ -28,6 +28,8 @@ export interface RunTerminalCapabilityPosture {
 }
 
 export interface RunTerminalExecuteRequest {
+  /** Stable caller identity used for exact approval binding and retry deduplication. */
+  requestId: string;
   command: string;
   args: string[];
   mode: RunTerminalMode;
@@ -55,6 +57,8 @@ export interface RunTerminalHandle {
   taskId: string;
   attemptId: string;
   launchManifestDigest: string;
+  requestId: string;
+  requestDigest: string;
   mode: RunTerminalMode;
   startMode: RunTerminalStartMode;
   state: RunTerminalState;


### PR DESCRIPTION
## Summary

- expose provider-neutral run terminal execution through an exact active-attempt API
- bind every request to a stable ID, high-risk shell approval, immutable run authority, filesystem sandbox, and mandatory egress posture
- deduplicate concurrent and replayed requests, migrate older v1 handles, and coordinate launches with run finalization cleanup
- document the contract in the canonical harness instructions, API reference, feature index, and architecture guide

## Verification

- shared and server TypeScript checks
- 38 focused run-terminal, route, replay, and permission tests
- 2 focused provider lifecycle and approval tests
- diff whitespace check

## Remaining scope

PTY and interactive stdin remain capability-gated and unsupported, so #871 stays open.

Refs #871