### PR TITLE
feat: checkpoint agent turn boundaries

### DIFF
--- a/docs/architecture/WORKSPACE-CHECKPOINTS-V1.md
+++ b/docs/architecture/WORKSPACE-CHECKPOINTS-V1.md
@@ -23,13 +23,22 @@ Blobs are written under a SHA-256 content address and verified on reuse. Metadat
 
 Caller operation IDs are persisted only as digests. Repeating the same exact capture operation returns the original checkpoint. Reusing that operation identity with changed boundary, scope, cursor, parent, worktree, or policy evidence returns conflict.
 
+## Runtime boundaries and ownership
+
+The workspace checkpoint coordinator captures immediately before the first provider turn, a native steered operator turn, and provider-native compaction. Recovery launches are labeled `before-retry`; cross-provider execution-tree edges are labeled `before-provider-handoff`; other launches and native steering are labeled `before-user-turn`.
+
+Only worktrees with a complete Veritas manifest and lease are eligible. The coordinator re-reads the durable manifest and requires exact task, attempt, path, branch, lease, lifecycle, rebase, and unexpired ownership evidence before each capture. Unmanaged worktrees are skipped, while partial, stale, expired, or conflicting ownership fails closed.
+
+Captures are serialized per attempt and chained through `parentCheckpointId`. Every published boundary emits a deduplicated `workspace.checkpoint.created` run event containing checkpoint identity, digest, boundary, counts, and a digest of any provider conversation cursor.
+
 ## Deliberate next boundaries
 
-This foundation does not yet claim turn hooks, hunk attribution, preview, restore, or retention cleanup. Those layers must consume this immutable repository and remain preview-first. Rewind cannot write until current HEAD, index, file hashes, worktree ownership, external changes, and approval evidence all match the checkpoint descendant it intends to replace.
+This foundation does not yet claim hunk attribution, preview, restore, or retention cleanup. Those layers must consume this immutable repository and remain preview-first. Rewind cannot write until current HEAD, index, file hashes, worktree ownership, external changes, and approval evidence all match the checkpoint descendant it intends to replace.
 
 ## Code
 
 - Shared contract: `shared/src/types/workspace-checkpoint.types.ts`
 - Validation: `server/src/schemas/workspace-checkpoint-schemas.ts`
 - File repository: `server/src/storage/workspace-checkpoint-repository.ts`
+- Ownership and boundary coordination: `server/src/services/workspace-checkpoint-service.ts`
 - Focused verification: `server/src/__tests__/workspace-checkpoint-repository.test.ts`

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -219,6 +219,7 @@ import type { SandboxPolicyService } from '../services/sandbox-policy-service.js
 import type { WorkspaceExecutionTrustService } from '../services/workspace-execution-trust-service.js';
 import type { AdmissionControlService } from '../services/admission-control-service.js';
 import type { RunTerminalService } from '../services/run-terminal-service.js';
+import type { WorkspaceCheckpointService } from '../services/workspace-checkpoint-service.js';
 
 const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'codex');
 
@@ -271,7 +272,11 @@ function testableService(
   runTerminals: Pick<
     RunTerminalService,
     'execute' | 'list' | 'cleanupAttempt' | 'reconcileAttempt'
-  > = testRunTerminals()
+  > = testRunTerminals(),
+  workspaceCheckpoints: Pick<
+    WorkspaceCheckpointService,
+    'captureBoundary'
+  > = testWorkspaceCheckpoints()
 ): TestableClawdbotAgentService {
   const completionEvidence = testCompletionEvidence();
   const taskEnvelopes = new TaskEnvelopeService(completionEvidence);
@@ -303,10 +308,20 @@ function testableService(
     },
     undefined,
     undefined,
-    runTerminals
+    runTerminals,
+    workspaceCheckpoints
   ) as unknown as TestableClawdbotAgentService;
   service.logsDir = tmpDir;
   return service;
+}
+
+function testWorkspaceCheckpoints(): Pick<WorkspaceCheckpointService, 'captureBoundary'> {
+  return {
+    captureBoundary: vi.fn(async () => ({
+      status: 'skipped' as const,
+      reason: 'unmanaged-worktree' as const,
+    })),
+  };
 }
 
 function testRunTerminals(): Pick<
@@ -483,7 +498,7 @@ function createControllableChild() {
 
 function createFakeCodexAppServerChild(
   received: Array<Record<string, unknown>>,
-  options: { requestApproval?: boolean } = {}
+  options: { requestApproval?: boolean; holdTurnOpen?: boolean } = {}
 ) {
   const child = new EventEmitter() as EventEmitter & {
     stdin: PassThrough;
@@ -625,9 +640,18 @@ function createFakeCodexAppServerChild(
               },
             })}\n`
           );
-        } else {
+        } else if (!options.holdTurnOpen) {
           writeCompletion();
         }
+      } else if (request.method === 'turn/steer') {
+        child.stdout.write(
+          `${JSON.stringify({
+            id,
+            result: { turnId: 'turn-app-server-fixture' },
+          })}\n`
+        );
+      } else if (request.method === 'thread/compact/start' || request.method === 'turn/interrupt') {
+        child.stdout.write(`${JSON.stringify({ id, result: {} })}\n`);
       }
     }
   });
@@ -1551,6 +1575,93 @@ describe('ClawdbotAgentService Codex providers', () => {
       );
     }
   );
+
+  it('captures workspace boundaries before launch, steering, and compaction', async () => {
+    const received: Array<Record<string, unknown>> = [];
+    const child = createFakeCodexAppServerChild(received, { holdTurnOpen: true });
+    mockSpawn.mockReturnValue(child);
+    mockGetConfig.mockResolvedValue({
+      agents: [
+        {
+          type: 'codex-app-server',
+          name: 'OpenAI Codex app-server',
+          command: 'codex',
+          args: [],
+          enabled: true,
+          provider: 'codex-app-server',
+          model: 'gpt-5.6',
+        },
+      ],
+    });
+    mockCheckAgent.mockImplementation(async (agent: AgentConfig) => ({
+      type: agent.type,
+      name: agent.name,
+      enabled: agent.enabled,
+      configured: true,
+      command: agent.command,
+      executableFound: true,
+      executablePath: '/opt/homebrew/bin/codex',
+      providerVersion: 'codex-cli 0.145.0',
+      providerVersionSource: 'codex --version',
+      authenticated: true,
+      healthy: true,
+      checkedAt: '2026-07-23T00:00:00.000Z',
+    }));
+    const workspaceCheckpoints = testWorkspaceCheckpoints();
+    const captureBoundary = vi.mocked(workspaceCheckpoints.captureBoundary);
+    const service = testableService(
+      tmpDir,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      testWorkspaceExecutionTrust(),
+      testAdmissionControl(),
+      testRunTerminals(),
+      workspaceCheckpoints
+    );
+
+    const status = await service.startAgent(task.id, 'codex-app-server');
+    await waitFor(() => {
+      expect(received.some(({ method }) => method === 'turn/start')).toBe(true);
+    });
+    expect(captureBoundary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: task.id,
+        attemptId: status.attemptId,
+        boundary: 'before-user-turn',
+        operationId: `launch:${status.attemptId}:before-user-turn`,
+      })
+    );
+
+    captureBoundary.mockClear();
+    await service.sendMessage(task.id, 'Please check the focused regression.', {
+      expectedAttemptId: status.attemptId,
+      actor: 'operator',
+    });
+    expect(captureBoundary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundary: 'before-user-turn',
+        operationId: expect.stringMatching(/^operator-turn:/),
+        turnId: 'turn-app-server-fixture',
+      })
+    );
+    expect(received.some(({ method }) => method === 'turn/steer')).toBe(true);
+
+    captureBoundary.mockClear();
+    await service.compactConversation(task.id, status.attemptId);
+    expect(captureBoundary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundary: 'before-compaction',
+        operationId: expect.stringMatching(/^compact:/),
+        turnId: 'turn-app-server-fixture',
+      })
+    );
+    expect(received.some(({ method }) => method === 'thread/compact/start')).toBe(true);
+
+    await service.stopAgent(task.id, status.attemptId);
+  });
 
   it(
     'pauses a Codex app-server action until the correlated broker decision resumes it',

--- a/server/src/__tests__/workspace-checkpoint-service.test.ts
+++ b/server/src/__tests__/workspace-checkpoint-service.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskEnvelope, WorkspaceCheckpoint, WorktreeManifest } from '@veritas-kanban/shared';
+import type { WorkspaceCheckpointRepository } from '../storage/workspace-checkpoint-repository.js';
+import { WorkspaceCheckpointService } from '../services/workspace-checkpoint-service.js';
+
+const checkpoint = {
+  schemaVersion: 'workspace-checkpoint/v1',
+  id: 'checkpoint_123456789012345678901234',
+  workspaceId: 'workspace-872',
+  taskId: 'task-872',
+  attemptId: 'attempt-872',
+  boundary: 'before-user-turn',
+  operationIdDigest: `sha256:${'1'.repeat(64)}`,
+  captureRequestDigest: `sha256:${'2'.repeat(64)}`,
+  worktreeRootDigest: `sha256:${'3'.repeat(64)}`,
+  worktreeManifestId: 'worktree-872',
+  git: {
+    head: 'a'.repeat(40),
+    branch: 'feat/checkpoints',
+    indexDigest: `sha256:${'4'.repeat(64)}`,
+    indexBlobDigest: `sha256:${'5'.repeat(64)}`,
+    indexBytes: 10,
+    statusDigest: `sha256:${'6'.repeat(64)}`,
+    dirty: false,
+  },
+  policy: {
+    ignoredFiles: 'excluded',
+    sensitiveFiles: 'excluded',
+    binaryFiles: 'excluded',
+    symlinks: 'excluded',
+    maxFiles: 10_000,
+    maxBytes: 64 * 1_024 * 1_024,
+    maxFileBytes: 8 * 1_024 * 1_024,
+    maxExclusions: 2_000,
+  },
+  files: [],
+  exclusions: [],
+  excludedCount: 0,
+  exclusionsTruncated: false,
+  fileCount: 0,
+  contentBytes: 0,
+  storedBytes: 10,
+  createdAt: '2026-07-26T06:00:00.000Z',
+  digest: `sha256:${'7'.repeat(64)}`,
+} satisfies WorkspaceCheckpoint;
+
+function envelope(managed = true): TaskEnvelope {
+  return {
+    schemaVersion: 'task-envelope/v1',
+    digest: `sha256:${'8'.repeat(64)}`,
+    subject: {
+      id: 'task-872',
+      title: 'Checkpoint task',
+      objective: 'Checkpoint task',
+      background: [],
+      constraints: [],
+      acceptanceCriteria: [],
+    },
+    attempt: {
+      id: 'attempt-872',
+      createdAt: '2026-07-26T06:00:00.000Z',
+    },
+    workspace: {
+      workspaceId: 'workspace-872',
+      worktreeId: 'task-872',
+      ...(managed
+        ? {
+            worktreeManifestId: 'worktree-872',
+            ownershipLeaseId: 'lease-872',
+            ownershipAttemptId: 'attempt-872',
+          }
+        : {}),
+      repo: 'BradGroux/veritas-kanban',
+      branch: 'feat/checkpoints',
+      baseBranch: 'main',
+      worktreePath: '/tmp/worktree-872',
+      baseline: {
+        capturedAt: '2026-07-26T06:00:00.000Z',
+        headSha: 'a'.repeat(40),
+        dirty: false,
+        files: [],
+      },
+    },
+    commitPolicy: 'allowed',
+    allowedSideEffects: [],
+    expectedOutputs: [],
+    verificationGates: [],
+    launchManifest: {
+      schemaVersion: 'provider-runtime-manifest/v1',
+      digest: `sha256:${'9'.repeat(64)}`,
+      provider: 'codex-cli',
+      adapter: 'codex-cli',
+      protocolVersion: 'codex-jsonl/v1',
+    },
+    completionContract: {
+      schemaVersion: 'completion-result/v1',
+      evidenceRequirements: [],
+    },
+  };
+}
+
+function manifest(): WorktreeManifest {
+  return {
+    schemaVersion: 'worktree-manifest/v1',
+    id: 'worktree-872',
+    revision: 2,
+    taskId: 'task-872',
+    repository: {
+      name: 'veritas-kanban',
+      rootPath: '/tmp/veritas-kanban',
+      commonGitDir: '/tmp/veritas-kanban/.git',
+      originFingerprint: 'origin',
+    },
+    path: '/tmp/worktree-872',
+    branch: 'feat/checkpoints',
+    base: {
+      branch: 'main',
+      commit: 'a'.repeat(40),
+      source: 'remote',
+      resolvedAt: '2026-07-26T05:00:00.000Z',
+    },
+    lease: {
+      id: 'lease-872',
+      ownerTaskId: 'task-872',
+      ownerAttemptId: 'attempt-872',
+      acquiredAt: '2026-07-26T06:00:00.000Z',
+      expiresAt: '2026-07-26T07:00:00.000Z',
+    },
+    lifecycle: {
+      creation: 'ready',
+      integration: 'idle',
+      cleanup: 'active',
+    },
+    rebase: { state: 'idle' },
+    integration: {},
+    createdAt: '2026-07-26T05:00:00.000Z',
+    updatedAt: '2026-07-26T06:00:00.000Z',
+    overrides: [],
+  };
+}
+
+describe('WorkspaceCheckpointService', () => {
+  it('skips worktrees without Veritas ownership evidence', async () => {
+    const repository = {
+      capture: vi.fn(),
+      get: vi.fn(),
+      list: vi.fn(),
+    } as unknown as WorkspaceCheckpointRepository;
+    const ownership = { getManifest: vi.fn() };
+    const service = new WorkspaceCheckpointService({
+      repository,
+      ownership,
+      now: () => new Date('2026-07-26T06:30:00.000Z'),
+    });
+
+    await expect(
+      service.captureBoundary({
+        taskEnvelope: envelope(false),
+        taskId: 'task-872',
+        attemptId: 'attempt-872',
+        operationId: 'launch:attempt-872',
+        boundary: 'before-user-turn',
+      })
+    ).resolves.toEqual({ status: 'skipped', reason: 'unmanaged-worktree' });
+    expect(ownership.getManifest).not.toHaveBeenCalled();
+    expect(repository.capture).not.toHaveBeenCalled();
+  });
+
+  it('captures only after exact current manifest and lease ownership is proven', async () => {
+    const repository = {
+      capture: vi.fn(async () => checkpoint),
+      get: vi.fn(async () => null),
+      list: vi.fn(async () => []),
+    } as unknown as WorkspaceCheckpointRepository;
+    const ownership = { getManifest: vi.fn(async () => manifest()) };
+    const service = new WorkspaceCheckpointService({
+      repository,
+      ownership,
+      now: () => new Date('2026-07-26T06:30:00.000Z'),
+    });
+
+    await expect(
+      service.captureBoundary({
+        taskEnvelope: envelope(),
+        taskId: 'task-872',
+        attemptId: 'attempt-872',
+        operationId: 'launch:attempt-872',
+        boundary: 'before-user-turn',
+        turnId: 'turn-872',
+        conversationCursor: '{"conversationId":"thread-872"}',
+      })
+    ).resolves.toEqual({ status: 'captured', checkpoint });
+    expect(repository.capture).toHaveBeenCalledWith({
+      workspaceId: 'workspace-872',
+      taskId: 'task-872',
+      attemptId: 'attempt-872',
+      operationId: 'launch:attempt-872',
+      boundary: 'before-user-turn',
+      worktreePath: '/tmp/worktree-872',
+      worktreeManifestId: 'worktree-872',
+      parentCheckpointId: undefined,
+      turnId: 'turn-872',
+      conversationCursor: '{"conversationId":"thread-872"}',
+    });
+  });
+
+  it('preserves the original parent when an old operation is retried', async () => {
+    const existing = {
+      ...checkpoint,
+      parentCheckpointId: 'checkpoint_parent12345678901234',
+    };
+    const repository = {
+      capture: vi.fn(async () => existing),
+      get: vi.fn(async () => existing),
+      list: vi.fn(),
+    } as unknown as WorkspaceCheckpointRepository;
+    const service = new WorkspaceCheckpointService({
+      repository,
+      ownership: { getManifest: vi.fn(async () => manifest()) },
+      now: () => new Date('2026-07-26T06:30:00.000Z'),
+    });
+
+    await service.captureBoundary({
+      taskEnvelope: envelope(),
+      taskId: 'task-872',
+      attemptId: 'attempt-872',
+      operationId: 'launch:attempt-872',
+      boundary: 'before-user-turn',
+    });
+
+    expect(repository.list).not.toHaveBeenCalled();
+    expect(repository.capture).toHaveBeenCalledWith(
+      expect.objectContaining({ parentCheckpointId: existing.parentCheckpointId })
+    );
+  });
+
+  it('fails closed when durable ownership moved to another attempt', async () => {
+    const repository = {
+      capture: vi.fn(),
+      get: vi.fn(),
+      list: vi.fn(),
+    } as unknown as WorkspaceCheckpointRepository;
+    const ownership = {
+      getManifest: vi.fn(async () => ({
+        ...manifest(),
+        lease: { ...manifest().lease, ownerAttemptId: 'attempt-other' },
+      })),
+    };
+    const service = new WorkspaceCheckpointService({
+      repository,
+      ownership,
+      now: () => new Date('2026-07-26T06:30:00.000Z'),
+    });
+
+    await expect(
+      service.captureBoundary({
+        taskEnvelope: envelope(),
+        taskId: 'task-872',
+        attemptId: 'attempt-872',
+        operationId: 'launch:attempt-872',
+        boundary: 'before-user-turn',
+      })
+    ).rejects.toThrow('cannot prove current run-owned worktree authority');
+    expect(repository.capture).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -165,6 +165,8 @@ import type {
   ExecutionTreeIdentity,
   RunTerminalExecuteRequest,
   RunTerminalHandle,
+  WorkspaceCheckpoint,
+  WorkspaceCheckpointBoundary,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { redactString } from '../lib/redact.js';
@@ -263,6 +265,10 @@ import {
   ConversationLifecycleService,
   type ConversationSource,
 } from './conversation-lifecycle-service.js';
+import {
+  getWorkspaceCheckpointService,
+  type WorkspaceCheckpointService,
+} from './workspace-checkpoint-service.js';
 import {
   assertGrokBuildVersionEvidence,
   buildCopilotAcpArgs,
@@ -670,6 +676,7 @@ export class ClawdbotAgentService {
     RunTerminalService,
     'execute' | 'list' | 'cleanupAttempt' | 'reconcileAttempt'
   >;
+  private workspaceCheckpoints: Pick<WorkspaceCheckpointService, 'captureBoundary'>;
   private logsDir: string;
 
   constructor(
@@ -719,7 +726,11 @@ export class ClawdbotAgentService {
     runTerminals: Pick<
       RunTerminalService,
       'execute' | 'list' | 'cleanupAttempt' | 'reconcileAttempt'
-    > = getRunTerminalService()
+    > = getRunTerminalService(),
+    workspaceCheckpoints: Pick<
+      WorkspaceCheckpointService,
+      'captureBoundary'
+    > = getWorkspaceCheckpointService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -751,6 +762,7 @@ export class ClawdbotAgentService {
     this.reflectionExtractionJobs = reflectionExtractionJobs;
     this.dependencyExecution = dependencyExecution;
     this.runTerminals = runTerminals;
+    this.workspaceCheckpoints = workspaceCheckpoints;
     this.workspaceExecutionTrust = workspaceExecutionTrust;
     this.phaseAuthority = phaseAuthority;
     this.phaseTransitions = phaseTransitions;
@@ -3169,6 +3181,25 @@ export class ClawdbotAgentService {
       };
       await this.admission.assertExecutionTreeLaunchAllowed(executionTree.rootObjectiveId);
       this.assertProviderAdmissionEvidence(providerAdmission, attempt);
+      const launchCheckpointBoundary: WorkspaceCheckpointBoundary = runRetry
+        ? 'before-retry'
+        : executionTree.edge === 'provider-handoff'
+          ? 'before-provider-handoff'
+          : 'before-user-turn';
+      const launchPending = pendingAgents.get(taskId);
+      if (!launchPending || launchPending.attemptId !== attemptId) {
+        throw new ConflictError('Workspace checkpoint no longer matches the pending launch.', {
+          taskId,
+          attemptId,
+        });
+      }
+      await this.capturePendingWorkspaceCheckpoint(
+        taskId,
+        launchPending,
+        launchCheckpointBoundary,
+        `launch:${attemptId}:${launchCheckpointBoundary}`,
+        startedEvent.eventId
+      );
       await this.dependencyExecution.executeAll(
         [
           providerDependencyIdentity(
@@ -4729,6 +4760,13 @@ export class ClawdbotAgentService {
     });
 
     if (pending.provider === 'codex-app-server' && pending.codexAppServerControl) {
+      await this.capturePendingWorkspaceCheckpoint(
+        taskId,
+        pending,
+        'before-user-turn',
+        `operator-turn:${journalEvent.eventId}`,
+        journalEvent.eventId
+      );
       const turnId = await pending.codexAppServerControl.steer(content);
       const conversation = await this.recordConversationIdentity(taskId, pending.attemptId, {
         turnId,
@@ -4941,6 +4979,12 @@ export class ClawdbotAgentService {
     if (!pending.codexAppServerControl) {
       throw new ConflictError('The active provider has no native compaction control.');
     }
+    await this.capturePendingWorkspaceCheckpoint(
+      taskId,
+      pending,
+      'before-compaction',
+      `compact:${pending.conversation.updatedAt}`
+    );
     await pending.codexAppServerControl.compact();
     const conversation = await this.transitionPendingConversation(taskId, pending, 'compacted');
     await this.recordConversationControlEvent(taskId, pending, 'compact', actor, conversation);
@@ -8620,6 +8664,68 @@ export class ClawdbotAgentService {
     traceService.endStep(attemptId, stepType);
   }
 
+  private async capturePendingWorkspaceCheckpoint(
+    taskId: string,
+    pending: PendingAgent,
+    boundary: WorkspaceCheckpointBoundary,
+    operationId: string,
+    causalEventId?: string
+  ): Promise<WorkspaceCheckpoint | null> {
+    if (pendingAgents.get(taskId) !== pending) {
+      throw new ConflictError('Workspace checkpoint no longer matches the active run.', {
+        taskId,
+        attemptId: pending.attemptId,
+      });
+    }
+    const result = await this.workspaceCheckpoints.captureBoundary({
+      taskEnvelope: pending.taskEnvelope,
+      taskId,
+      attemptId: pending.attemptId,
+      operationId,
+      boundary,
+      turnId: pending.conversation.currentTurnId,
+      conversationCursor: workspaceConversationCursor(pending.conversation),
+    });
+    if (result.status === 'skipped') return null;
+
+    const { checkpoint } = result;
+    const event = await this.appendRunEvent(
+      taskId,
+      pending.attemptId,
+      'workspace.checkpoint.created',
+      {
+        checkpointId: checkpoint.id,
+        boundary: checkpoint.boundary,
+        checkpointDigest: checkpoint.digest,
+        worktreeManifestId: checkpoint.worktreeManifestId,
+        fileCount: checkpoint.fileCount,
+        contentBytes: checkpoint.contentBytes,
+        excludedCount: checkpoint.excludedCount,
+        ...(checkpoint.conversationCursor
+          ? {
+              conversationCursorDigest: digestRunLaunchValue(checkpoint.conversationCursor),
+            }
+          : {}),
+      },
+      {
+        provider: 'system',
+        adapter: 'workspace-checkpoint',
+        agent: pending.agent,
+        model: pending.model,
+        causalEventId,
+        dedupeKey: `workspace.checkpoint.created:${checkpoint.id}`,
+      }
+    );
+    this.emitJournalOutput(event);
+    this.recordTraceStep(pending.attemptId, 'execute', {
+      eventType: 'workspace.checkpoint.created',
+      checkpointId: checkpoint.id,
+      boundary: checkpoint.boundary,
+      checkpointDigest: checkpoint.digest,
+    });
+    return checkpoint;
+  }
+
   private async appendRunEvent(
     taskId: string,
     attemptId: string,
@@ -11550,6 +11656,25 @@ function conversationLaunchCapabilities(
 ): ProviderRuntimeCapabilityId[] {
   if (mode === 'fresh') return [];
   return mode === 'resume' ? ['run.resume', 'run.follow-up'] : ['run.fork', 'run.follow-up'];
+}
+
+function workspaceConversationCursor(
+  conversation: ConversationLifecycleRecord
+): string | undefined {
+  const conversationId = conversation.conversationId ?? conversation.parentConversationId;
+  const turnId = conversation.currentTurnId ?? conversation.forkTurnId;
+  const itemId = conversation.lastItemId;
+  if (!conversationId && !turnId && !itemId) return undefined;
+  const cursor = JSON.stringify({
+    schemaVersion: 'provider-conversation-cursor/v1',
+    ...(conversationId ? { conversationId } : {}),
+    ...(turnId ? { turnId } : {}),
+    ...(itemId ? { itemId } : {}),
+  });
+  if (cursor.length > 2_048) {
+    throw new ConflictError('Provider conversation cursor exceeds the checkpoint integrity bound.');
+  }
+  return cursor;
 }
 
 function manifestConversation(

--- a/server/src/services/workspace-checkpoint-service.ts
+++ b/server/src/services/workspace-checkpoint-service.ts
@@ -1,0 +1,191 @@
+import type {
+  TaskEnvelope,
+  WorkspaceCheckpoint,
+  WorkspaceCheckpointBoundary,
+  WorktreeManifest,
+} from '@veritas-kanban/shared';
+import { ConflictError } from '../middleware/error-handler.js';
+import {
+  FileWorkspaceCheckpointRepository,
+  getWorkspaceCheckpointIdForOperation,
+  type WorkspaceCheckpointRepository,
+} from '../storage/workspace-checkpoint-repository.js';
+import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
+import { WorktreeService } from './worktree-service.js';
+
+export interface WorkspaceCheckpointOwnershipSource {
+  getManifest(taskId: string): Promise<WorktreeManifest | null>;
+}
+
+export interface WorkspaceCheckpointBoundaryInput {
+  taskEnvelope: TaskEnvelope;
+  taskId: string;
+  attemptId: string;
+  operationId: string;
+  boundary: WorkspaceCheckpointBoundary;
+  turnId?: string;
+  conversationCursor?: string;
+}
+
+export type WorkspaceCheckpointBoundaryResult =
+  | {
+      status: 'captured';
+      checkpoint: WorkspaceCheckpoint;
+    }
+  | {
+      status: 'skipped';
+      reason: 'unmanaged-worktree';
+    };
+
+export interface WorkspaceCheckpointServiceOptions {
+  repository?: WorkspaceCheckpointRepository;
+  ownership?: WorkspaceCheckpointOwnershipSource;
+  now?: () => Date;
+}
+
+export class WorkspaceCheckpointService {
+  private readonly repository: WorkspaceCheckpointRepository;
+  private readonly ownership: WorkspaceCheckpointOwnershipSource;
+  private readonly now: () => Date;
+  private readonly captureQueues = new Map<string, Promise<void>>();
+
+  constructor(options: WorkspaceCheckpointServiceOptions = {}) {
+    this.repository = options.repository ?? new FileWorkspaceCheckpointRepository();
+    this.ownership = options.ownership ?? new WorktreeService();
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async captureBoundary(
+    input: WorkspaceCheckpointBoundaryInput
+  ): Promise<WorkspaceCheckpointBoundaryResult> {
+    const workspace = input.taskEnvelope.workspace;
+    if (!workspace.worktreeManifestId && !workspace.ownershipLeaseId) {
+      return { status: 'skipped', reason: 'unmanaged-worktree' };
+    }
+    if (!workspace.worktreeManifestId || !workspace.ownershipLeaseId) {
+      throw new ConflictError(
+        'Workspace checkpoint requires complete managed-worktree ownership evidence.',
+        {
+          taskId: input.taskId,
+          attemptId: input.attemptId,
+          hasManifestId: Boolean(workspace.worktreeManifestId),
+          hasLeaseId: Boolean(workspace.ownershipLeaseId),
+        }
+      );
+    }
+    if (
+      input.taskEnvelope.subject.id !== input.taskId ||
+      input.taskEnvelope.attempt.id !== input.attemptId ||
+      workspace.ownershipAttemptId !== input.attemptId
+    ) {
+      throw new ConflictError(
+        'Workspace checkpoint request does not match its task-envelope ownership.',
+        {
+          taskId: input.taskId,
+          attemptId: input.attemptId,
+          envelopeTaskId: input.taskEnvelope.subject.id,
+          envelopeAttemptId: input.taskEnvelope.attempt.id,
+          ownershipAttemptId: workspace.ownershipAttemptId,
+        }
+      );
+    }
+
+    const scopeKey = digestRunLaunchValue([workspace.workspaceId, input.taskId, input.attemptId]);
+    return this.serializeCapture(scopeKey, async () => {
+      const manifest = await this.ownership.getManifest(input.taskId);
+      if (
+        !manifest ||
+        manifest.id !== workspace.worktreeManifestId ||
+        manifest.taskId !== input.taskId ||
+        manifest.path !== workspace.worktreePath ||
+        manifest.branch !== workspace.branch ||
+        manifest.lease.id !== workspace.ownershipLeaseId ||
+        manifest.lease.ownerTaskId !== input.taskId ||
+        manifest.lease.ownerAttemptId !== input.attemptId ||
+        Date.parse(manifest.lease.expiresAt) <= this.now().getTime() ||
+        manifest.lifecycle.creation !== 'ready' ||
+        manifest.lifecycle.integration !== 'idle' ||
+        manifest.lifecycle.cleanup !== 'active' ||
+        manifest.rebase.state !== 'idle'
+      ) {
+        throw new ConflictError(
+          'Workspace checkpoint cannot prove current run-owned worktree authority.',
+          {
+            taskId: input.taskId,
+            attemptId: input.attemptId,
+            manifestId: workspace.worktreeManifestId,
+            activeManifestId: manifest?.id,
+            activeOwnerAttemptId: manifest?.lease.ownerAttemptId,
+            leaseExpiresAt: manifest?.lease.expiresAt,
+            lifecycle: manifest?.lifecycle,
+            rebaseState: manifest?.rebase.state,
+          }
+        );
+      }
+
+      const operationIdDigest = digestRunLaunchValue(input.operationId);
+      const checkpointId = getWorkspaceCheckpointIdForOperation({
+        workspaceId: workspace.workspaceId,
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        operationIdDigest,
+      });
+      const existing = await this.repository.get({
+        workspaceId: workspace.workspaceId,
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        checkpointId,
+      });
+      const latest = existing
+        ? undefined
+        : (
+            await this.repository.list({
+              workspaceId: workspace.workspaceId,
+              taskId: input.taskId,
+              attemptId: input.attemptId,
+              limit: 1,
+            })
+          )[0];
+      const checkpoint = await this.repository.capture({
+        workspaceId: workspace.workspaceId,
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        operationId: input.operationId,
+        boundary: input.boundary,
+        worktreePath: workspace.worktreePath,
+        worktreeManifestId: workspace.worktreeManifestId,
+        parentCheckpointId: existing?.parentCheckpointId ?? latest?.id,
+        turnId: input.turnId,
+        conversationCursor: input.conversationCursor,
+      });
+      return { status: 'captured', checkpoint };
+    });
+  }
+
+  private async serializeCapture<T>(scopeKey: string, capture: () => Promise<T>): Promise<T> {
+    const previous = this.captureQueues.get(scopeKey) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.captureQueues.set(scopeKey, current);
+    await previous;
+    try {
+      return await capture();
+    } finally {
+      if (this.captureQueues.get(scopeKey) === current) this.captureQueues.delete(scopeKey);
+      release();
+    }
+  }
+}
+
+let singleton: WorkspaceCheckpointService | null = null;
+
+export function getWorkspaceCheckpointService(): WorkspaceCheckpointService {
+  singleton ??= new WorkspaceCheckpointService();
+  return singleton;
+}
+
+export function resetWorkspaceCheckpointServiceForTests(): void {
+  singleton = null;
+}

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -50,6 +50,7 @@ export {
 } from './worktree-manifest-repository.js';
 export {
   FileWorkspaceCheckpointRepository,
+  getWorkspaceCheckpointIdForOperation,
   getWorkspaceCheckpointsDir,
   type FileWorkspaceCheckpointRepositoryOptions,
   type WorkspaceCheckpointCaptureInput,
@@ -57,6 +58,7 @@ export {
   type WorkspaceCheckpointCommandRunner,
   type WorkspaceCheckpointListQuery,
   type WorkspaceCheckpointLookup,
+  type WorkspaceCheckpointOperationLookup,
   type WorkspaceCheckpointRepository,
 } from './workspace-checkpoint-repository.js';
 export {

--- a/server/src/storage/workspace-checkpoint-repository.ts
+++ b/server/src/storage/workspace-checkpoint-repository.ts
@@ -58,6 +58,13 @@ export interface WorkspaceCheckpointLookup {
   checkpointId: string;
 }
 
+export interface WorkspaceCheckpointOperationLookup {
+  workspaceId: string;
+  taskId: string;
+  attemptId: string;
+  operationIdDigest: string;
+}
+
 export interface WorkspaceCheckpointListQuery {
   workspaceId: string;
   taskId: string;
@@ -149,12 +156,12 @@ export class FileWorkspaceCheckpointRepository implements WorkspaceCheckpointRep
       conversationCursor: input.conversationCursor,
       policy: this.policy,
     });
-    const checkpointId = checkpointIdFor(
-      input.workspaceId,
-      input.taskId,
-      input.attemptId,
-      operationIdDigest
-    );
+    const checkpointId = getWorkspaceCheckpointIdForOperation({
+      workspaceId: input.workspaceId,
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+      operationIdDigest,
+    });
     const lookup = {
       workspaceId: input.workspaceId,
       taskId: input.taskId,
@@ -709,17 +716,18 @@ function normalizePolicy(
   return policy;
 }
 
-function checkpointIdFor(
-  workspaceId: string,
-  taskId: string,
-  attemptId: string,
-  operationIdDigest: string
+export function getWorkspaceCheckpointIdForOperation(
+  lookup: WorkspaceCheckpointOperationLookup
 ): string {
+  validateScope(lookup);
+  if (!/^sha256:[a-f0-9]{64}$/.test(lookup.operationIdDigest)) {
+    throw new Error('Workspace checkpoint operation digest is invalid.');
+  }
   return `checkpoint_${digestRunLaunchValue({
-    workspaceId,
-    taskId,
-    attemptId,
-    operationIdDigest,
+    workspaceId: lookup.workspaceId,
+    taskId: lookup.taskId,
+    attemptId: lookup.attemptId,
+    operationIdDigest: lookup.operationIdDigest,
   })
     .slice('sha256:'.length)
     .slice(0, 24)}`;

--- a/shared/src/types/run-event.types.ts
+++ b/shared/src/types/run-event.types.ts
@@ -28,6 +28,7 @@ export const RUN_EVENT_KINDS = [
   'command.detached',
   'command.completed',
   'file.changed',
+  'workspace.checkpoint.created',
   'tool.started',
   'tool.completed',
   'approval.requested',


### PR DESCRIPTION
## Summary

- add a central workspace checkpoint coordinator that revalidates the durable manifest and unexpired attempt lease before every capture
- skip unmanaged worktrees and fail closed on partial, stale, rebasing, integrating, or conflicting ownership evidence
- serialize captures per attempt and preserve deterministic parent chains across old-operation retries
- capture before initial provider turns, recovery retries, provider handoffs, native steering, and provider-native compaction
- persist a versioned provider conversation cursor and emit deduplicated `workspace.checkpoint.created` run events
- document the runtime boundaries and remaining attribution, rewind, and retention work

## Verification

- `node_modules/.bin/tsc -p shared/tsconfig.json`
- `node_modules/.bin/tsc -p server/tsconfig.json --noEmit`
- 10 focused repository, coordinator, and provider boundary tests
- targeted ESLint on changed TypeScript files (no new errors; one pre-existing warning)
- `git diff --check`

Refs #872
