### PR TITLE
feat: compare workspace checkpoint hunks

### DIFF
--- a/docs/architecture/WORKSPACE-CHECKPOINTS-V1.md
+++ b/docs/architecture/WORKSPACE-CHECKPOINTS-V1.md
@@ -33,7 +33,9 @@ Captures are serialized per attempt and chained through `parentCheckpointId`. Ev
 
 ## Deliberate next boundaries
 
-This foundation does not yet claim hunk attribution, preview, restore, or retention cleanup. Those layers must consume this immutable repository and remain preview-first. Rewind cannot write until current HEAD, index, file hashes, worktree ownership, external changes, and approval evidence all match the checkpoint descendant it intends to replace.
+Direct parent-to-child checkpoints can be compared without touching the worktree. The bounded comparison reports affected captured files, line-numbered unified hunks, content digests, mode changes, and whether HEAD, branch, index, or Git status changed. Comparisons fail closed if either checkpoint is missing, the checkpoints are not directly chained, or their worktree ownership evidence differs.
+
+This foundation does not yet claim hunk attribution, rewind conflict analysis, restore, or retention cleanup. Those layers must consume the immutable repository and remain preview-first. Rewind cannot write until current HEAD, index, file hashes, worktree ownership, external changes, and approval evidence all match the checkpoint descendant it intends to replace.
 
 ## Code
 
@@ -41,4 +43,5 @@ This foundation does not yet claim hunk attribution, preview, restore, or retent
 - Validation: `server/src/schemas/workspace-checkpoint-schemas.ts`
 - File repository: `server/src/storage/workspace-checkpoint-repository.ts`
 - Ownership and boundary coordination: `server/src/services/workspace-checkpoint-service.ts`
-- Focused verification: `server/src/__tests__/workspace-checkpoint-repository.test.ts`
+- Read-only comparison: `server/src/services/workspace-checkpoint-diff-service.ts`
+- Focused verification: `server/src/__tests__/workspace-checkpoint-repository.test.ts` and `server/src/__tests__/workspace-checkpoint-diff-service.test.ts`

--- a/server/src/__tests__/workspace-checkpoint-diff-service.test.ts
+++ b/server/src/__tests__/workspace-checkpoint-diff-service.test.ts
@@ -1,0 +1,230 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceCheckpoint, WorkspaceCheckpointFile } from '@veritas-kanban/shared';
+import {
+  WorkspaceCheckpointDiffService,
+  parseWorkspaceCheckpointUnifiedDiff,
+} from '../services/workspace-checkpoint-diff-service.js';
+import { GitWorkspaceCheckpointDiffRunner } from '../storage/workspace-checkpoint-diff-runner.js';
+import type { WorkspaceCheckpointRepository } from '../storage/workspace-checkpoint-repository.js';
+
+const roots: string[] = [];
+const digest = (character: string) => `sha256:${character.repeat(64)}`;
+
+function file(
+  filePath: string,
+  contentDigest: string,
+  overrides: Partial<WorkspaceCheckpointFile> = {}
+): WorkspaceCheckpointFile {
+  return {
+    path: filePath,
+    source: 'tracked',
+    state: 'present',
+    mode: 0o644,
+    size: 10,
+    contentDigest,
+    blobDigest: contentDigest,
+    ...overrides,
+  };
+}
+
+function checkpoint(
+  id: string,
+  files: WorkspaceCheckpointFile[],
+  overrides: Partial<WorkspaceCheckpoint> = {}
+): WorkspaceCheckpoint {
+  return {
+    schemaVersion: 'workspace-checkpoint/v1',
+    id,
+    workspaceId: 'workspace-872',
+    taskId: 'task-872',
+    attemptId: 'attempt-872',
+    boundary: 'before-user-turn',
+    operationIdDigest: digest('1'),
+    captureRequestDigest: digest('2'),
+    worktreeRootDigest: digest('3'),
+    worktreeManifestId: 'worktree-872',
+    git: {
+      head: 'a'.repeat(40),
+      branch: 'feat/checkpoints',
+      indexDigest: digest('4'),
+      indexBlobDigest: digest('5'),
+      indexBytes: 10,
+      statusDigest: digest('6'),
+      dirty: true,
+    },
+    policy: {
+      ignoredFiles: 'excluded',
+      sensitiveFiles: 'excluded',
+      binaryFiles: 'excluded',
+      symlinks: 'excluded',
+      maxFiles: 10_000,
+      maxBytes: 64 * 1_024 * 1_024,
+      maxFileBytes: 8 * 1_024 * 1_024,
+      maxExclusions: 2_000,
+    },
+    files,
+    exclusions: [],
+    excludedCount: 0,
+    exclusionsTruncated: false,
+    fileCount: files.length,
+    contentBytes: files.reduce((total, entry) => total + entry.size, 0),
+    storedBytes: 10,
+    createdAt: '2026-07-26T06:00:00.000Z',
+    digest: digest('7'),
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe('WorkspaceCheckpointDiffService', () => {
+  it('compares direct checkpoints without touching the worktree', async () => {
+    const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-checkpoint-preview-test-'));
+    roots.push(temporaryRoot);
+    const blobs = new Map([
+      [digest('a'), Buffer.from('old\nsame\n')],
+      [digest('b'), Buffer.from('new\nsame\n')],
+      [digest('c'), Buffer.from('deleted\n')],
+      [digest('d'), Buffer.from('added\n')],
+      [digest('e'), Buffer.from('mode only\n')],
+    ]);
+    const from = checkpoint('checkpoint_from1234567890123456', [
+      file('modified.txt', digest('a')),
+      file('deleted.txt', digest('c')),
+      file('mode.txt', digest('e')),
+    ]);
+    const to = checkpoint(
+      'checkpoint_to123456789012345678',
+      [
+        file('modified.txt', digest('b')),
+        file('deleted.txt', digest('c'), {
+          state: 'absent',
+          size: 0,
+          mode: undefined,
+          contentDigest: undefined,
+          blobDigest: undefined,
+        }),
+        file('added.txt', digest('d'), { source: 'untracked' }),
+        file('mode.txt', digest('e'), { mode: 0o755 }),
+      ],
+      {
+        parentCheckpointId: from.id,
+        git: {
+          ...from.git,
+          indexDigest: digest('8'),
+          statusDigest: digest('9'),
+        },
+        createdAt: '2026-07-26T06:05:00.000Z',
+      }
+    );
+    const repository = {
+      get: vi.fn(async ({ checkpointId }) =>
+        checkpointId === from.id ? from : checkpointId === to.id ? to : null
+      ),
+      readBlob: vi.fn(async (blobDigest: string) => blobs.get(blobDigest) ?? Buffer.alloc(0)),
+    } as unknown as WorkspaceCheckpointRepository;
+    const service = new WorkspaceCheckpointDiffService({
+      repository,
+      diffRunner: new GitWorkspaceCheckpointDiffRunner({ temporaryRoot }),
+    });
+
+    const result = await service.compare({
+      workspaceId: from.workspaceId,
+      taskId: from.taskId,
+      attemptId: from.attemptId,
+      fromCheckpointId: from.id,
+      toCheckpointId: to.id,
+    });
+
+    expect(result).toMatchObject({
+      schemaVersion: 'workspace-checkpoint-diff/v1',
+      directParent: true,
+      git: {
+        headChanged: false,
+        branchChanged: false,
+        indexChanged: true,
+        statusChanged: true,
+      },
+      summary: {
+        filesChanged: 4,
+        additions: 2,
+        deletions: 2,
+      },
+    });
+    expect(result.files.map(({ path: filePath, kind }) => [filePath, kind])).toEqual([
+      ['added.txt', 'added'],
+      ['deleted.txt', 'deleted'],
+      ['mode.txt', 'mode-changed'],
+      ['modified.txt', 'modified'],
+    ]);
+    expect(result.files.find((entry) => entry.path === 'modified.txt')?.hunks).toEqual([
+      expect.objectContaining({
+        oldStart: 1,
+        newStart: 1,
+        lines: [
+          { kind: 'deletion', content: 'old', oldLineNumber: 1 },
+          { kind: 'addition', content: 'new', newLineNumber: 1 },
+          { kind: 'context', content: 'same', oldLineNumber: 2, newLineNumber: 2 },
+        ],
+      }),
+    ]);
+    expect(await fs.readdir(temporaryRoot)).toEqual([]);
+  });
+
+  it('fails closed across non-direct or differently owned checkpoint chains', async () => {
+    const from = checkpoint('checkpoint_from1234567890123456', []);
+    const to = checkpoint('checkpoint_to123456789012345678', [], {
+      parentCheckpointId: 'checkpoint_other12345678901234',
+    });
+    const repository = {
+      get: vi.fn(async ({ checkpointId }) => (checkpointId === from.id ? from : to)),
+    } as unknown as WorkspaceCheckpointRepository;
+    const service = new WorkspaceCheckpointDiffService({ repository });
+    const input = {
+      workspaceId: from.workspaceId,
+      taskId: from.taskId,
+      attemptId: from.attemptId,
+      fromCheckpointId: from.id,
+      toCheckpointId: to.id,
+    };
+
+    await expect(service.compare(input)).rejects.toThrow('direct parent-child chain');
+
+    to.parentCheckpointId = from.id;
+    to.worktreeRootDigest = digest('f');
+    await expect(service.compare(input)).rejects.toThrow('worktree ownership boundaries');
+  });
+});
+
+describe('parseWorkspaceCheckpointUnifiedDiff', () => {
+  it('preserves hunk line numbers while ignoring Git file headers and newline markers', () => {
+    const hunks = parseWorkspaceCheckpointUnifiedDiff(
+      [
+        'diff --git a/before b/after',
+        '--- a/before',
+        '+++ b/after',
+        '@@ -2,2 +2,2 @@',
+        ' keep',
+        '-old',
+        '\\ No newline at end of file',
+        '+new',
+        '\\ No newline at end of file',
+        '',
+      ].join('\n')
+    );
+
+    expect(hunks[0]?.lines).toEqual([
+      { kind: 'context', content: 'keep', oldLineNumber: 2, newLineNumber: 2 },
+      { kind: 'deletion', content: 'old', oldLineNumber: 3 },
+      { kind: 'addition', content: 'new', newLineNumber: 3 },
+    ]);
+    expect(() => parseWorkspaceCheckpointUnifiedDiff('@@ -1 +1 @@\n-old\n')).toThrow(
+      'incomplete hunk'
+    );
+  });
+});

--- a/server/src/services/workspace-checkpoint-diff-service.ts
+++ b/server/src/services/workspace-checkpoint-diff-service.ts
@@ -1,0 +1,265 @@
+import type {
+  WorkspaceCheckpoint,
+  WorkspaceCheckpointDiff,
+  WorkspaceCheckpointDiffHunk,
+  WorkspaceCheckpointDiffLine,
+  WorkspaceCheckpointFile,
+  WorkspaceCheckpointFileDiff,
+} from '@veritas-kanban/shared';
+import { ConflictError } from '../middleware/error-handler.js';
+import {
+  FileWorkspaceCheckpointRepository,
+  type WorkspaceCheckpointRepository,
+} from '../storage/workspace-checkpoint-repository.js';
+import {
+  GitWorkspaceCheckpointDiffRunner,
+  type WorkspaceCheckpointDiffRunner,
+} from '../storage/workspace-checkpoint-diff-runner.js';
+
+export interface WorkspaceCheckpointDiffInput {
+  workspaceId: string;
+  taskId: string;
+  attemptId: string;
+  fromCheckpointId: string;
+  toCheckpointId: string;
+}
+
+export interface WorkspaceCheckpointDiffServiceOptions {
+  repository?: WorkspaceCheckpointRepository;
+  diffRunner?: WorkspaceCheckpointDiffRunner;
+}
+
+export class WorkspaceCheckpointDiffService {
+  private readonly repository: WorkspaceCheckpointRepository;
+  private readonly diffRunner: WorkspaceCheckpointDiffRunner;
+
+  constructor(options: WorkspaceCheckpointDiffServiceOptions = {}) {
+    this.repository = options.repository ?? new FileWorkspaceCheckpointRepository();
+    this.diffRunner = options.diffRunner ?? new GitWorkspaceCheckpointDiffRunner();
+  }
+
+  async compare(input: WorkspaceCheckpointDiffInput): Promise<WorkspaceCheckpointDiff> {
+    const scope = {
+      workspaceId: input.workspaceId,
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+    };
+    const [from, to] = await Promise.all([
+      this.repository.get({ ...scope, checkpointId: input.fromCheckpointId }),
+      this.repository.get({ ...scope, checkpointId: input.toCheckpointId }),
+    ]);
+    if (!from || !to) {
+      throw new ConflictError('Workspace checkpoint comparison requires both checkpoints.', {
+        fromCheckpointFound: Boolean(from),
+        toCheckpointFound: Boolean(to),
+      });
+    }
+    this.assertDirectChain(from, to);
+
+    const fromFiles = new Map(from.files.map((file) => [file.path, file]));
+    const toFiles = new Map(to.files.map((file) => [file.path, file]));
+    const paths = [...new Set([...fromFiles.keys(), ...toFiles.keys()])].sort((left, right) =>
+      left.localeCompare(right)
+    );
+    const files: WorkspaceCheckpointFileDiff[] = [];
+    for (const filePath of paths) {
+      const file = await this.compareFile(filePath, fromFiles.get(filePath), toFiles.get(filePath));
+      if (file) files.push(file);
+    }
+
+    return {
+      schemaVersion: 'workspace-checkpoint-diff/v1',
+      ...scope,
+      fromCheckpoint: checkpointReference(from),
+      toCheckpoint: checkpointReference(to),
+      directParent: true,
+      git: {
+        headChanged: from.git.head !== to.git.head,
+        branchChanged: from.git.branch !== to.git.branch,
+        indexChanged: from.git.indexDigest !== to.git.indexDigest,
+        statusChanged: from.git.statusDigest !== to.git.statusDigest,
+      },
+      summary: {
+        filesChanged: files.length,
+        additions: files.reduce((total, file) => total + file.additions, 0),
+        deletions: files.reduce((total, file) => total + file.deletions, 0),
+      },
+      files,
+    };
+  }
+
+  private assertDirectChain(from: WorkspaceCheckpoint, to: WorkspaceCheckpoint): void {
+    if (to.parentCheckpointId !== from.id) {
+      throw new ConflictError(
+        'Workspace checkpoint comparison requires a direct parent-child chain.',
+        {
+          fromCheckpointId: from.id,
+          toCheckpointId: to.id,
+          actualParentCheckpointId: to.parentCheckpointId,
+        }
+      );
+    }
+    if (
+      from.worktreeRootDigest !== to.worktreeRootDigest ||
+      from.worktreeManifestId !== to.worktreeManifestId
+    ) {
+      throw new ConflictError(
+        'Workspace checkpoint comparison cannot cross worktree ownership boundaries.',
+        {
+          fromCheckpointId: from.id,
+          toCheckpointId: to.id,
+        }
+      );
+    }
+  }
+
+  private async compareFile(
+    filePath: string,
+    fromFile: WorkspaceCheckpointFile | undefined,
+    toFile: WorkspaceCheckpointFile | undefined
+  ): Promise<WorkspaceCheckpointFileDiff | null> {
+    const fromState = fromFile?.state ?? 'absent';
+    const toState = toFile?.state ?? 'absent';
+    const contentChanged = fromFile?.contentDigest !== toFile?.contentDigest;
+    const modeChanged = fromFile?.mode !== toFile?.mode;
+    if (fromState === toState && !contentChanged && !modeChanged) return null;
+
+    let hunks: WorkspaceCheckpointDiffHunk[] = [];
+    if (contentChanged) {
+      const before = await this.readFileContent(fromFile);
+      const after = await this.readFileContent(toFile);
+      hunks = parseWorkspaceCheckpointUnifiedDiff(await this.diffRunner.diff(before, after));
+    }
+    if (contentChanged && hunks.length === 0) {
+      throw new ConflictError(
+        'Workspace checkpoint content changed without a complete text diff.',
+        {
+          path: filePath,
+        }
+      );
+    }
+    const additions = countLines(hunks, 'addition');
+    const deletions = countLines(hunks, 'deletion');
+    return {
+      path: filePath,
+      kind:
+        fromState === 'absent'
+          ? 'added'
+          : toState === 'absent'
+            ? 'deleted'
+            : contentChanged
+              ? 'modified'
+              : 'mode-changed',
+      source: toFile?.source ?? fromFile?.source ?? 'tracked',
+      fromState,
+      toState,
+      ...(fromFile?.mode === undefined ? {} : { fromMode: fromFile.mode }),
+      ...(toFile?.mode === undefined ? {} : { toMode: toFile.mode }),
+      ...(fromFile?.contentDigest ? { fromContentDigest: fromFile.contentDigest } : {}),
+      ...(toFile?.contentDigest ? { toContentDigest: toFile.contentDigest } : {}),
+      additions,
+      deletions,
+      hunks,
+    };
+  }
+
+  private async readFileContent(file: WorkspaceCheckpointFile | undefined): Promise<Buffer> {
+    if (!file || file.state === 'absent') return Buffer.alloc(0);
+    if (!file.blobDigest) {
+      throw new ConflictError('Present workspace checkpoint file is missing blob evidence.', {
+        path: file.path,
+      });
+    }
+    return this.repository.readBlob(file.blobDigest);
+  }
+}
+
+export function parseWorkspaceCheckpointUnifiedDiff(
+  unifiedDiff: string
+): WorkspaceCheckpointDiffHunk[] {
+  const hunks: WorkspaceCheckpointDiffHunk[] = [];
+  let current: WorkspaceCheckpointDiffHunk | undefined;
+  let oldLineNumber = 0;
+  let newLineNumber = 0;
+  for (const line of unifiedDiff.split('\n')) {
+    const match = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/.exec(line);
+    if (match) {
+      if (current) assertCompleteHunk(current);
+      oldLineNumber = Number(match[1]);
+      newLineNumber = Number(match[3]);
+      current = {
+        header: line,
+        oldStart: oldLineNumber,
+        oldLines: Number(match[2] ?? 1),
+        newStart: newLineNumber,
+        newLines: Number(match[4] ?? 1),
+        lines: [],
+      };
+      hunks.push(current);
+      continue;
+    }
+    if (!current || line === '\\ No newline at end of file') continue;
+
+    let parsed: WorkspaceCheckpointDiffLine | undefined;
+    if (line.startsWith(' ')) {
+      parsed = {
+        kind: 'context',
+        content: line.slice(1),
+        oldLineNumber,
+        newLineNumber,
+      };
+      oldLineNumber += 1;
+      newLineNumber += 1;
+    } else if (line.startsWith('+')) {
+      parsed = {
+        kind: 'addition',
+        content: line.slice(1),
+        newLineNumber,
+      };
+      newLineNumber += 1;
+    } else if (line.startsWith('-')) {
+      parsed = {
+        kind: 'deletion',
+        content: line.slice(1),
+        oldLineNumber,
+      };
+      oldLineNumber += 1;
+    }
+    if (parsed) current.lines.push(parsed);
+  }
+  if (current) assertCompleteHunk(current);
+  return hunks;
+}
+
+function checkpointReference(checkpoint: WorkspaceCheckpoint) {
+  return {
+    id: checkpoint.id,
+    boundary: checkpoint.boundary,
+    createdAt: checkpoint.createdAt,
+    digest: checkpoint.digest,
+  };
+}
+
+function countLines(
+  hunks: WorkspaceCheckpointDiffHunk[],
+  kind: WorkspaceCheckpointDiffLine['kind']
+): number {
+  return hunks.reduce(
+    (total, hunk) => total + hunk.lines.filter((line) => line.kind === kind).length,
+    0
+  );
+}
+
+function assertCompleteHunk(hunk: WorkspaceCheckpointDiffHunk): void {
+  const oldLines = countLines([hunk], 'context') + countLines([hunk], 'deletion');
+  const newLines = countLines([hunk], 'context') + countLines([hunk], 'addition');
+  if (oldLines !== hunk.oldLines || newLines !== hunk.newLines) {
+    throw new ConflictError('Workspace checkpoint text comparison produced an incomplete hunk.', {
+      header: hunk.header,
+      expectedOldLines: hunk.oldLines,
+      actualOldLines: oldLines,
+      expectedNewLines: hunk.newLines,
+      actualNewLines: newLines,
+    });
+  }
+}

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -62,6 +62,13 @@ export {
   type WorkspaceCheckpointRepository,
 } from './workspace-checkpoint-repository.js';
 export {
+  GitWorkspaceCheckpointDiffRunner,
+  type GitWorkspaceCheckpointDiffRunnerOptions,
+  type WorkspaceCheckpointDiffCommandResult,
+  type WorkspaceCheckpointDiffCommandRunner,
+  type WorkspaceCheckpointDiffRunner,
+} from './workspace-checkpoint-diff-runner.js';
+export {
   FileDependencyCircuitStateRepository,
   InMemoryDependencyCircuitStateRepository,
   type DependencyCircuitStateRepository,

--- a/server/src/storage/workspace-checkpoint-diff-runner.ts
+++ b/server/src/storage/workspace-checkpoint-diff-runner.ts
@@ -1,0 +1,115 @@
+import { execFile } from 'node:child_process';
+import { constants } from 'node:fs';
+import { mkdir, mkdtemp, open, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { ConflictError } from '../middleware/error-handler.js';
+
+const MAX_DIFF_OUTPUT_BYTES = 32 * 1_024 * 1_024;
+
+export interface WorkspaceCheckpointDiffCommandResult {
+  exitCode: number;
+  stdout: Buffer;
+  stderr: Buffer;
+}
+
+export type WorkspaceCheckpointDiffCommandRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string; maxBuffer: number }
+) => Promise<WorkspaceCheckpointDiffCommandResult>;
+
+export interface GitWorkspaceCheckpointDiffRunnerOptions {
+  temporaryRoot?: string;
+  runCommand?: WorkspaceCheckpointDiffCommandRunner;
+}
+
+export interface WorkspaceCheckpointDiffRunner {
+  diff(before: Buffer, after: Buffer): Promise<string>;
+}
+
+export class GitWorkspaceCheckpointDiffRunner implements WorkspaceCheckpointDiffRunner {
+  private readonly temporaryRoot: string;
+  private readonly runCommand: WorkspaceCheckpointDiffCommandRunner;
+
+  constructor(options: GitWorkspaceCheckpointDiffRunnerOptions = {}) {
+    this.temporaryRoot = path.resolve(options.temporaryRoot ?? os.tmpdir());
+    this.runCommand = options.runCommand ?? defaultCommandRunner;
+  }
+
+  async diff(before: Buffer, after: Buffer): Promise<string> {
+    await mkdir(this.temporaryRoot, { recursive: true, mode: 0o700 });
+    const temporary = await mkdtemp(path.join(this.temporaryRoot, 'vk-checkpoint-diff-'));
+    const beforePath = path.join(temporary, 'before');
+    const afterPath = path.join(temporary, 'after');
+    try {
+      await writePrivateFile(beforePath, before);
+      await writePrivateFile(afterPath, after);
+      const result = await this.runCommand(
+        'git',
+        [
+          'diff',
+          '--no-index',
+          '--no-color',
+          '--no-ext-diff',
+          '--text',
+          '--unified=3',
+          '--',
+          beforePath,
+          afterPath,
+        ],
+        { cwd: temporary, maxBuffer: MAX_DIFF_OUTPUT_BYTES }
+      );
+      if (result.exitCode !== 0 && result.exitCode !== 1) {
+        throw new ConflictError('Workspace checkpoint text comparison failed.', {
+          exitCode: result.exitCode,
+        });
+      }
+      if (result.stdout.byteLength > MAX_DIFF_OUTPUT_BYTES) {
+        throw new ConflictError('Workspace checkpoint text comparison exceeded its output bound.');
+      }
+      return result.stdout.toString('utf8');
+    } finally {
+      await rm(temporary, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+}
+
+async function writePrivateFile(filePath: string, content: Buffer): Promise<void> {
+  const handle = await open(
+    filePath,
+    constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0),
+    0o600
+  );
+  try {
+    await handle.writeFile(content);
+  } finally {
+    await handle.close();
+  }
+}
+
+async function defaultCommandRunner(
+  command: string,
+  args: string[],
+  options: { cwd: string; maxBuffer: number }
+): Promise<WorkspaceCheckpointDiffCommandResult> {
+  return new Promise((resolve) => {
+    execFile(
+      command,
+      args,
+      {
+        cwd: options.cwd,
+        encoding: 'buffer',
+        maxBuffer: options.maxBuffer,
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        resolve({
+          exitCode: typeof error?.code === 'number' ? error.code : error ? 2 : 0,
+          stdout: Buffer.from(stdout),
+          stderr: Buffer.from(stderr),
+        });
+      }
+    );
+  });
+}

--- a/shared/src/types/workspace-checkpoint.types.ts
+++ b/shared/src/types/workspace-checkpoint.types.ts
@@ -1,4 +1,5 @@
 export const WORKSPACE_CHECKPOINT_SCHEMA_VERSION = 'workspace-checkpoint/v1' as const;
+export const WORKSPACE_CHECKPOINT_DIFF_SCHEMA_VERSION = 'workspace-checkpoint-diff/v1' as const;
 
 export const WORKSPACE_CHECKPOINT_BOUNDARIES = [
   'before-user-turn',
@@ -88,4 +89,60 @@ export interface WorkspaceCheckpoint {
   storedBytes: number;
   createdAt: string;
   digest: string;
+}
+
+export type WorkspaceCheckpointDiffLineKind = 'context' | 'addition' | 'deletion';
+export type WorkspaceCheckpointFileChangeKind = 'added' | 'modified' | 'deleted' | 'mode-changed';
+
+export interface WorkspaceCheckpointDiffLine {
+  kind: WorkspaceCheckpointDiffLineKind;
+  content: string;
+  oldLineNumber?: number;
+  newLineNumber?: number;
+}
+
+export interface WorkspaceCheckpointDiffHunk {
+  header: string;
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: WorkspaceCheckpointDiffLine[];
+}
+
+export interface WorkspaceCheckpointFileDiff {
+  path: string;
+  kind: WorkspaceCheckpointFileChangeKind;
+  source: WorkspaceCheckpointFileSource;
+  fromState: WorkspaceCheckpointFileState;
+  toState: WorkspaceCheckpointFileState;
+  fromMode?: number;
+  toMode?: number;
+  fromContentDigest?: string;
+  toContentDigest?: string;
+  additions: number;
+  deletions: number;
+  hunks: WorkspaceCheckpointDiffHunk[];
+}
+
+export interface WorkspaceCheckpointDiff {
+  schemaVersion: typeof WORKSPACE_CHECKPOINT_DIFF_SCHEMA_VERSION;
+  workspaceId: string;
+  taskId: string;
+  attemptId: string;
+  fromCheckpoint: Pick<WorkspaceCheckpoint, 'id' | 'boundary' | 'createdAt' | 'digest'>;
+  toCheckpoint: Pick<WorkspaceCheckpoint, 'id' | 'boundary' | 'createdAt' | 'digest'>;
+  directParent: true;
+  git: {
+    headChanged: boolean;
+    branchChanged: boolean;
+    indexChanged: boolean;
+    statusChanged: boolean;
+  };
+  summary: {
+    filesChanged: number;
+    additions: number;
+    deletions: number;
+  };
+  files: WorkspaceCheckpointFileDiff[];
 }


### PR DESCRIPTION
## Summary

- Add a versioned direct checkpoint comparison contract with file, hunk, line-number, mode, and Git posture evidence.
- Compare content-addressed text blobs through bounded private temporary files without touching the run worktree.
- Fail closed for missing, non-direct, differently owned, incomplete, or oversized comparisons.
- Document this read-only layer as the next checkpoint foundation slice.

## Verification

- Shared and server TypeScript checks
- Targeted ESLint and Prettier checks
- 12 focused checkpoint repository, coordinator, and comparison tests
- Git diff integrity check

## Scope

This is the read-only comparison foundation. Causal hunk attribution, current-state conflict preview, rewind writes, and retention remain follow-up slices.

Refs #872
