### PR TITLE
feat: preview safe workspace checkpoint rewinds

### DIFF
--- a/docs/architecture/WORKSPACE-CHECKPOINTS-V1.md
+++ b/docs/architecture/WORKSPACE-CHECKPOINTS-V1.md
@@ -37,7 +37,9 @@ Direct parent-to-child checkpoints can be compared without touching the worktree
 
 Provider event mappers normalize bounded relative file paths and tool names into the causal journal. The attribution service considers only evidence between the two checkpoint-created events. Explicit provider file events and known path-bearing write tools are agent evidence; operator file events are operator evidence; system file events are external evidence. Every changed hunk inherits the conservative file-window attribution. Missing or mixed evidence is `unknown`, and missing checkpoint event boundaries mark the evidence window incomplete.
 
-This foundation does not yet claim exact overlapping-hunk attribution, rewind conflict analysis, restore, or retention cleanup. Those layers must consume the immutable repository and remain preview-first. Rewind cannot write until current HEAD, index, file hashes, worktree ownership, external changes, and approval evidence all match the checkpoint descendant it intends to replace.
+Rewind preview revalidates the durable worktree lease before and after a no-follow current-state inspection. It compares the current worktree root, HEAD, branch, index, status, affected file hashes, modes, exclusions, and attribution against the expected descendant checkpoint. The result lists reverse file actions, Git and conversation-cursor changes, estimated discarded bytes, and explicit blockers. Automatic rewind is safe only when every current-state and ownership check matches and every changed file is exclusively supported by high-confidence agent evidence.
+
+This foundation does not yet claim exact overlapping-hunk attribution, selective conflict resolution, restore, recoverable transaction execution, or retention cleanup. Those layers must consume the immutable repository and remain preview-first. A later rewind write must revalidate the same evidence plus exact approval immediately before mutation.
 
 ## Code
 
@@ -47,4 +49,5 @@ This foundation does not yet claim exact overlapping-hunk attribution, rewind co
 - Ownership and boundary coordination: `server/src/services/workspace-checkpoint-service.ts`
 - Read-only comparison: `server/src/services/workspace-checkpoint-diff-service.ts`
 - Conservative causal attribution: `server/src/services/workspace-checkpoint-attribution-service.ts`
-- Focused verification: `server/src/__tests__/workspace-checkpoint-repository.test.ts`, `server/src/__tests__/workspace-checkpoint-diff-service.test.ts`, and `server/src/__tests__/workspace-checkpoint-attribution-service.test.ts`
+- Conflict-aware rewind preview: `server/src/services/workspace-checkpoint-rewind-preview-service.ts`
+- Focused verification: `server/src/__tests__/workspace-checkpoint-repository.test.ts`, `server/src/__tests__/workspace-checkpoint-diff-service.test.ts`, `server/src/__tests__/workspace-checkpoint-attribution-service.test.ts`, and `server/src/__tests__/workspace-checkpoint-rewind-preview-service.test.ts`

--- a/server/src/__tests__/workspace-checkpoint-repository.test.ts
+++ b/server/src/__tests__/workspace-checkpoint-repository.test.ts
@@ -246,4 +246,66 @@ describe('FileWorkspaceCheckpointRepository', () => {
 
     await expect(repository.readBlob(digest)).rejects.toThrow('blob is not a bounded regular file');
   });
+
+  it('inspects current affected paths without persisting another checkpoint', async () => {
+    const { worktreePath, storePath } = await fixture();
+    await fs.writeFile(path.join(worktreePath, 'large.txt'), 'x'.repeat(64));
+    const repository = new FileWorkspaceCheckpointRepository({
+      baseDir: storePath,
+      policy: {
+        maxFiles: 100,
+        maxBytes: 1_024,
+        maxFileBytes: 32,
+        maxExclusions: 100,
+      },
+      now: () => new Date('2026-07-26T06:00:00.000Z'),
+    });
+    const request = {
+      workspaceId: 'workspace-inspect',
+      taskId: 'task-inspect',
+      attemptId: 'attempt-inspect',
+      operationId: 'capture-inspect',
+      boundary: 'manual' as const,
+      worktreePath,
+    };
+    const checkpoint = await repository.capture(request);
+
+    const current = await repository.inspectCurrent({
+      worktreePath,
+      paths: ['tracked.txt', 'deleted.txt', 'linked.txt', 'large.txt'],
+      maxFileBytes: 32,
+      maxBytes: 1_024,
+    });
+
+    expect(current).toMatchObject({
+      schemaVersion: 'workspace-checkpoint-current-state/v1',
+      worktreeRootDigest: checkpoint.worktreeRootDigest,
+      git: {
+        head: checkpoint.git.head,
+        branch: checkpoint.git.branch,
+        indexDigest: checkpoint.git.indexDigest,
+        statusDigest: checkpoint.git.statusDigest,
+      },
+      digest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+    });
+    expect(current.files).toEqual([
+      { path: 'deleted.txt', state: 'absent' },
+      { path: 'large.txt', state: 'too-large', size: 64 },
+      { path: 'linked.txt', state: 'symlink', size: expect.any(Number) },
+      expect.objectContaining({
+        path: 'tracked.txt',
+        state: 'present',
+        contentDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      }),
+    ]);
+    await expect(repository.list(request)).resolves.toEqual([checkpoint]);
+    await expect(
+      repository.inspectCurrent({
+        worktreePath,
+        paths: ['../outside.txt'],
+        maxFileBytes: 32,
+        maxBytes: 1_024,
+      })
+    ).rejects.toThrow('inspection path is invalid');
+  });
 });

--- a/server/src/__tests__/workspace-checkpoint-rewind-preview-service.test.ts
+++ b/server/src/__tests__/workspace-checkpoint-rewind-preview-service.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  TaskEnvelope,
+  WorkspaceCheckpoint,
+  WorkspaceCheckpointCurrentState,
+  WorkspaceCheckpointDiff,
+  WorktreeManifest,
+} from '@veritas-kanban/shared';
+import type { WorkspaceCheckpointRepository } from '../storage/workspace-checkpoint-repository.js';
+import { WorkspaceCheckpointRewindPreviewService } from '../services/workspace-checkpoint-rewind-preview-service.js';
+
+const hash = (character: string) => `sha256:${character.repeat(64)}`;
+const targetId = 'checkpoint_target12345678901234';
+const descendantId = 'checkpoint_descendant1234567890';
+
+function checkpoint(
+  id: string,
+  contentDigest: string,
+  overrides: Partial<WorkspaceCheckpoint> = {}
+): WorkspaceCheckpoint {
+  return {
+    schemaVersion: 'workspace-checkpoint/v1',
+    id,
+    workspaceId: 'workspace-872',
+    taskId: 'task-872',
+    attemptId: 'attempt-872',
+    boundary: 'before-user-turn',
+    operationIdDigest: hash('1'),
+    captureRequestDigest: hash('2'),
+    worktreeRootDigest: hash('3'),
+    worktreeManifestId: 'worktree-872',
+    git: {
+      head: 'a'.repeat(40),
+      branch: 'feat/checkpoints',
+      indexDigest: hash('4'),
+      indexBlobDigest: hash('5'),
+      indexBytes: 10,
+      statusDigest: hash('6'),
+      dirty: true,
+    },
+    policy: {
+      ignoredFiles: 'excluded',
+      sensitiveFiles: 'excluded',
+      binaryFiles: 'excluded',
+      symlinks: 'excluded',
+      maxFiles: 10_000,
+      maxBytes: 64 * 1_024 * 1_024,
+      maxFileBytes: 8 * 1_024 * 1_024,
+      maxExclusions: 2_000,
+    },
+    files: [
+      {
+        path: 'file.ts',
+        source: 'tracked',
+        state: 'present',
+        mode: 0o644,
+        size: 12,
+        contentDigest,
+        blobDigest: contentDigest,
+      },
+    ],
+    exclusions: [],
+    excludedCount: 0,
+    exclusionsTruncated: false,
+    fileCount: 1,
+    contentBytes: 12,
+    storedBytes: 22,
+    conversationCursor: `{"thread":"${id}"}`,
+    createdAt: '2026-07-26T06:00:00.000Z',
+    digest: id === targetId ? hash('7') : hash('8'),
+    ...overrides,
+  };
+}
+
+function envelope(): TaskEnvelope {
+  return {
+    schemaVersion: 'task-envelope/v1',
+    digest: hash('8'),
+    subject: {
+      id: 'task-872',
+      title: 'Checkpoint task',
+      objective: 'Checkpoint task',
+      background: [],
+      constraints: [],
+      acceptanceCriteria: [],
+    },
+    attempt: { id: 'attempt-872', createdAt: '2026-07-26T06:00:00.000Z' },
+    workspace: {
+      workspaceId: 'workspace-872',
+      worktreeId: 'task-872',
+      worktreeManifestId: 'worktree-872',
+      ownershipLeaseId: 'lease-872',
+      ownershipAttemptId: 'attempt-872',
+      repo: 'BradGroux/veritas-kanban',
+      branch: 'feat/checkpoints',
+      baseBranch: 'main',
+      worktreePath: '/tmp/worktree-872',
+      baseline: {
+        capturedAt: '2026-07-26T05:00:00.000Z',
+        headSha: 'a'.repeat(40),
+        dirty: false,
+        files: [],
+      },
+    },
+    commitPolicy: 'allowed',
+    allowedSideEffects: [],
+    expectedOutputs: [],
+    verificationGates: [],
+    launchManifest: {
+      schemaVersion: 'provider-runtime-manifest/v1',
+      digest: hash('9'),
+      provider: 'codex-cli',
+      adapter: 'codex-cli',
+      protocolVersion: 'codex-jsonl/v1',
+    },
+    completionContract: {
+      schemaVersion: 'completion-result/v1',
+      evidenceRequirements: [],
+    },
+  };
+}
+
+function manifest(): WorktreeManifest {
+  return {
+    schemaVersion: 'worktree-manifest/v1',
+    id: 'worktree-872',
+    revision: 2,
+    taskId: 'task-872',
+    repository: {
+      name: 'veritas-kanban',
+      rootPath: '/tmp/veritas-kanban',
+      commonGitDir: '/tmp/veritas-kanban/.git',
+      originFingerprint: 'origin',
+    },
+    path: '/tmp/worktree-872',
+    branch: 'feat/checkpoints',
+    base: {
+      branch: 'main',
+      commit: 'a'.repeat(40),
+      source: 'remote',
+      resolvedAt: '2026-07-26T05:00:00.000Z',
+    },
+    lease: {
+      id: 'lease-872',
+      ownerTaskId: 'task-872',
+      ownerAttemptId: 'attempt-872',
+      acquiredAt: '2026-07-26T06:00:00.000Z',
+      expiresAt: '2026-07-26T07:00:00.000Z',
+    },
+    lifecycle: { creation: 'ready', integration: 'idle', cleanup: 'active' },
+    rebase: { state: 'idle' },
+    integration: {},
+    createdAt: '2026-07-26T05:00:00.000Z',
+    updatedAt: '2026-07-26T06:00:00.000Z',
+    overrides: [],
+  };
+}
+
+function checkpointDiff(source: 'agent-tool' | 'operator'): WorkspaceCheckpointDiff {
+  const attribution = {
+    source,
+    confidence: 'high' as const,
+    basis:
+      source === 'agent-tool' ? ('provider-file-event' as const) : ('operator-file-event' as const),
+    scope: 'checkpoint-file-window' as const,
+    evidenceEventIds: ['event-2'],
+  };
+  return {
+    schemaVersion: 'workspace-checkpoint-diff/v1',
+    workspaceId: 'workspace-872',
+    taskId: 'task-872',
+    attemptId: 'attempt-872',
+    fromCheckpoint: {
+      id: targetId,
+      boundary: 'before-user-turn',
+      createdAt: '2026-07-26T06:00:00.000Z',
+      digest: hash('a'),
+    },
+    toCheckpoint: {
+      id: descendantId,
+      boundary: 'before-user-turn',
+      createdAt: '2026-07-26T06:05:00.000Z',
+      digest: hash('b'),
+    },
+    directParent: true,
+    git: {
+      headChanged: false,
+      branchChanged: false,
+      indexChanged: true,
+      statusChanged: true,
+    },
+    summary: { filesChanged: 1, additions: 1, deletions: 1 },
+    attribution: {
+      evidenceComplete: true,
+      fromEventSequence: 1,
+      toEventSequence: 3,
+      eventsConsidered: 1,
+    },
+    files: [
+      {
+        path: 'file.ts',
+        kind: 'modified',
+        source: 'tracked',
+        fromState: 'present',
+        toState: 'present',
+        additions: 1,
+        deletions: 1,
+        attribution,
+        hunks: [],
+      },
+    ],
+  };
+}
+
+function current(descendant: WorkspaceCheckpoint): WorkspaceCheckpointCurrentState {
+  const file = descendant.files[0];
+  return {
+    schemaVersion: 'workspace-checkpoint-current-state/v1',
+    worktreeRootDigest: descendant.worktreeRootDigest,
+    git: {
+      head: descendant.git.head,
+      branch: descendant.git.branch,
+      indexDigest: descendant.git.indexDigest,
+      statusDigest: descendant.git.statusDigest,
+      dirty: descendant.git.dirty,
+    },
+    files: [
+      {
+        path: file.path,
+        state: 'present',
+        mode: file.mode,
+        size: file.size,
+        contentDigest: file.contentDigest,
+      },
+    ],
+    inspectedAt: '2026-07-26T06:10:00.000Z',
+    digest: hash('c'),
+  };
+}
+
+function service(
+  target: WorkspaceCheckpoint,
+  descendant: WorkspaceCheckpoint,
+  diff: WorkspaceCheckpointDiff,
+  currentState: WorkspaceCheckpointCurrentState
+) {
+  const boundDiff = {
+    ...diff,
+    fromCheckpoint: { ...diff.fromCheckpoint, digest: target.digest },
+    toCheckpoint: { ...diff.toCheckpoint, digest: descendant.digest },
+  };
+  const repository = {
+    get: vi.fn(async ({ checkpointId }) => (checkpointId === target.id ? target : descendant)),
+    inspectCurrent: vi.fn(async () => currentState),
+  } as unknown as WorkspaceCheckpointRepository;
+  const ownership = { getManifest: vi.fn(async () => manifest()) };
+  return {
+    preview: new WorkspaceCheckpointRewindPreviewService({
+      repository,
+      diffs: { compare: vi.fn(async () => boundDiff) },
+      ownership,
+      now: () => new Date('2026-07-26T06:15:00.000Z'),
+    }),
+    repository,
+    ownership,
+  };
+}
+
+describe('WorkspaceCheckpointRewindPreviewService', () => {
+  it('reports a safe automatic rewind only when current evidence matches the descendant', async () => {
+    const target = checkpoint(targetId, hash('d'));
+    const descendant = checkpoint(descendantId, hash('e'), {
+      parentCheckpointId: target.id,
+    });
+    const fixture = service(target, descendant, checkpointDiff('agent-tool'), current(descendant));
+
+    const result = await fixture.preview.preview({
+      taskEnvelope: envelope(),
+      taskId: 'task-872',
+      attemptId: 'attempt-872',
+      targetCheckpointId: target.id,
+      descendantCheckpointId: descendant.id,
+    });
+
+    expect(result).toMatchObject({
+      schemaVersion: 'workspace-checkpoint-rewind-preview/v1',
+      safeForAutomaticRewind: true,
+      conflicts: [],
+      estimatedDataLossBytes: 12,
+      git: { headWillChange: false, branchWillChange: false, indexWillChange: false },
+      conversation: { cursorWillChange: true, targetCursorAvailable: true },
+      files: [{ path: 'file.ts', action: 'restore', conflicts: [] }],
+    });
+    expect(fixture.ownership.getManifest).toHaveBeenCalledTimes(2);
+  });
+
+  it('blocks divergent, excluded, incomplete, or non-agent changes with explicit conflicts', async () => {
+    const target = checkpoint(targetId, hash('d'), {
+      files: [],
+      fileCount: 0,
+      contentBytes: 0,
+      exclusions: [{ path: 'file.ts', source: 'tracked', reason: 'binary', size: 12 }],
+      exclusionsTruncated: true,
+      excludedCount: 2,
+    });
+    const descendant = checkpoint(descendantId, hash('e'), {
+      parentCheckpointId: target.id,
+      git: { ...target.git, indexDigest: hash('f'), indexBlobDigest: hash('0') },
+    });
+    const currentState = current(descendant);
+    currentState.git.statusDigest = hash('0');
+    currentState.files[0].contentDigest = hash('f');
+    const unsafeDiff = checkpointDiff('operator');
+    unsafeDiff.files[0].kind = 'added';
+    unsafeDiff.files[0].fromState = 'absent';
+    const fixture = service(target, descendant, unsafeDiff, currentState);
+
+    const result = await fixture.preview.preview({
+      taskEnvelope: envelope(),
+      taskId: 'task-872',
+      attemptId: 'attempt-872',
+      targetCheckpointId: target.id,
+      descendantCheckpointId: descendant.id,
+    });
+
+    expect(result.safeForAutomaticRewind).toBe(false);
+    expect(result.conflicts.map((conflict) => conflict.kind)).toEqual(
+      expect.arrayContaining([
+        'status-diverged',
+        'index-posture-change',
+        'file-diverged',
+        'excluded-path-overlap',
+        'inventory-incomplete',
+        'attribution-ambiguous',
+      ])
+    );
+    expect(result.exclusions).toMatchObject({
+      overlappingPaths: ['file.ts'],
+      inventoryIncomplete: true,
+    });
+  });
+});

--- a/server/src/services/workspace-checkpoint-ownership-service.ts
+++ b/server/src/services/workspace-checkpoint-ownership-service.ts
@@ -1,0 +1,100 @@
+import type { TaskEnvelope, WorktreeManifest } from '@veritas-kanban/shared';
+import { ConflictError } from '../middleware/error-handler.js';
+import { WorktreeService } from './worktree-service.js';
+
+export interface WorkspaceCheckpointOwnershipSource {
+  getManifest(taskId: string): Promise<WorktreeManifest | null>;
+}
+
+export interface WorkspaceCheckpointOwnershipInput {
+  taskEnvelope: TaskEnvelope;
+  taskId: string;
+  attemptId: string;
+}
+
+export type WorkspaceCheckpointOwnershipResult =
+  | { status: 'verified'; manifest: WorktreeManifest }
+  | { status: 'skipped'; reason: 'unmanaged-worktree' };
+
+export interface WorkspaceCheckpointOwnershipServiceOptions {
+  ownership?: WorkspaceCheckpointOwnershipSource;
+  now?: () => Date;
+}
+
+export class WorkspaceCheckpointOwnershipService {
+  private readonly ownership: WorkspaceCheckpointOwnershipSource;
+  private readonly now: () => Date;
+
+  constructor(options: WorkspaceCheckpointOwnershipServiceOptions = {}) {
+    this.ownership = options.ownership ?? new WorktreeService();
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async verify(
+    input: WorkspaceCheckpointOwnershipInput
+  ): Promise<WorkspaceCheckpointOwnershipResult> {
+    const workspace = input.taskEnvelope.workspace;
+    if (!workspace.worktreeManifestId && !workspace.ownershipLeaseId) {
+      return { status: 'skipped', reason: 'unmanaged-worktree' };
+    }
+    if (!workspace.worktreeManifestId || !workspace.ownershipLeaseId) {
+      throw new ConflictError(
+        'Workspace checkpoint requires complete managed-worktree ownership evidence.',
+        {
+          taskId: input.taskId,
+          attemptId: input.attemptId,
+          hasManifestId: Boolean(workspace.worktreeManifestId),
+          hasLeaseId: Boolean(workspace.ownershipLeaseId),
+        }
+      );
+    }
+    if (
+      input.taskEnvelope.subject.id !== input.taskId ||
+      input.taskEnvelope.attempt.id !== input.attemptId ||
+      workspace.ownershipAttemptId !== input.attemptId
+    ) {
+      throw new ConflictError(
+        'Workspace checkpoint request does not match its task-envelope ownership.',
+        {
+          taskId: input.taskId,
+          attemptId: input.attemptId,
+          envelopeTaskId: input.taskEnvelope.subject.id,
+          envelopeAttemptId: input.taskEnvelope.attempt.id,
+          ownershipAttemptId: workspace.ownershipAttemptId,
+        }
+      );
+    }
+
+    const manifest = await this.ownership.getManifest(input.taskId);
+    if (
+      !manifest ||
+      manifest.id !== workspace.worktreeManifestId ||
+      manifest.taskId !== input.taskId ||
+      manifest.path !== workspace.worktreePath ||
+      manifest.branch !== workspace.branch ||
+      manifest.lease.id !== workspace.ownershipLeaseId ||
+      manifest.lease.ownerTaskId !== input.taskId ||
+      manifest.lease.ownerAttemptId !== input.attemptId ||
+      Date.parse(manifest.lease.expiresAt) <= this.now().getTime() ||
+      manifest.lifecycle.creation !== 'ready' ||
+      manifest.lifecycle.integration !== 'idle' ||
+      manifest.lifecycle.cleanup !== 'active' ||
+      manifest.rebase.state !== 'idle'
+    ) {
+      throw new ConflictError(
+        'Workspace checkpoint cannot prove current run-owned worktree authority.',
+        {
+          taskId: input.taskId,
+          attemptId: input.attemptId,
+          manifestId: workspace.worktreeManifestId,
+          activeManifestId: manifest?.id,
+          activeOwnerAttemptId: manifest?.lease.ownerAttemptId,
+          leaseExpiresAt: manifest?.lease.expiresAt,
+          lifecycle: manifest?.lifecycle,
+          rebaseState: manifest?.rebase.state,
+        }
+      );
+    }
+    return { status: 'verified', manifest };
+  }
+}

--- a/server/src/services/workspace-checkpoint-rewind-preview-service.ts
+++ b/server/src/services/workspace-checkpoint-rewind-preview-service.ts
@@ -1,0 +1,316 @@
+import type {
+  TaskEnvelope,
+  WorkspaceCheckpointCurrentFile,
+  WorkspaceCheckpointFile,
+  WorkspaceCheckpointFileChangeKind,
+  WorkspaceCheckpointRewindAction,
+  WorkspaceCheckpointRewindConflict,
+  WorkspaceCheckpointRewindFilePreview,
+  WorkspaceCheckpointRewindPreview,
+} from '@veritas-kanban/shared';
+import { ConflictError } from '../middleware/error-handler.js';
+import {
+  FileWorkspaceCheckpointRepository,
+  type WorkspaceCheckpointRepository,
+} from '../storage/workspace-checkpoint-repository.js';
+import { WorkspaceCheckpointAttributionService } from './workspace-checkpoint-attribution-service.js';
+import {
+  WorkspaceCheckpointOwnershipService,
+  type WorkspaceCheckpointOwnershipSource,
+} from './workspace-checkpoint-ownership-service.js';
+
+export interface WorkspaceCheckpointRewindPreviewInput {
+  taskEnvelope: TaskEnvelope;
+  taskId: string;
+  attemptId: string;
+  targetCheckpointId: string;
+  descendantCheckpointId: string;
+}
+
+export interface WorkspaceCheckpointRewindPreviewServiceOptions {
+  repository?: WorkspaceCheckpointRepository;
+  diffs?: Pick<WorkspaceCheckpointAttributionService, 'compare'>;
+  ownership?: WorkspaceCheckpointOwnershipSource;
+  now?: () => Date;
+}
+
+export class WorkspaceCheckpointRewindPreviewService {
+  private readonly repository: WorkspaceCheckpointRepository;
+  private readonly diffs: Pick<WorkspaceCheckpointAttributionService, 'compare'>;
+  private readonly authority: WorkspaceCheckpointOwnershipService;
+  private readonly now: () => Date;
+
+  constructor(options: WorkspaceCheckpointRewindPreviewServiceOptions = {}) {
+    this.repository = options.repository ?? new FileWorkspaceCheckpointRepository();
+    this.diffs = options.diffs ?? new WorkspaceCheckpointAttributionService();
+    this.authority = new WorkspaceCheckpointOwnershipService(options);
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async preview(
+    input: WorkspaceCheckpointRewindPreviewInput
+  ): Promise<WorkspaceCheckpointRewindPreview> {
+    const firstAuthority = await this.authority.verify(input);
+    if (firstAuthority.status === 'skipped') {
+      throw new ConflictError('Workspace rewind preview requires a managed run-owned worktree.');
+    }
+    const scope = {
+      workspaceId: input.taskEnvelope.workspace.workspaceId,
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+    };
+    const [target, descendant, checkpointDiff] = await Promise.all([
+      this.repository.get({ ...scope, checkpointId: input.targetCheckpointId }),
+      this.repository.get({ ...scope, checkpointId: input.descendantCheckpointId }),
+      this.diffs.compare({
+        ...scope,
+        fromCheckpointId: input.targetCheckpointId,
+        toCheckpointId: input.descendantCheckpointId,
+      }),
+    ]);
+    if (!target || !descendant) {
+      throw new ConflictError('Workspace rewind preview requires both checkpoints.');
+    }
+    if (
+      target.worktreeManifestId !== firstAuthority.manifest.id ||
+      descendant.worktreeManifestId !== firstAuthority.manifest.id ||
+      descendant.parentCheckpointId !== target.id ||
+      target.worktreeRootDigest !== descendant.worktreeRootDigest ||
+      checkpointDiff.fromCheckpoint.id !== target.id ||
+      checkpointDiff.fromCheckpoint.digest !== target.digest ||
+      checkpointDiff.toCheckpoint.id !== descendant.id ||
+      checkpointDiff.toCheckpoint.digest !== descendant.digest
+    ) {
+      throw new ConflictError(
+        'Workspace rewind checkpoints do not match the direct owned checkpoint chain.'
+      );
+    }
+    const current = await this.repository.inspectCurrent({
+      worktreePath: input.taskEnvelope.workspace.worktreePath,
+      paths: checkpointDiff.files.map((file) => file.path),
+      maxFileBytes: Math.max(target.policy.maxFileBytes, descendant.policy.maxFileBytes),
+      maxBytes: Math.max(target.policy.maxBytes, descendant.policy.maxBytes),
+    });
+    const secondAuthority = await this.authority.verify(input);
+    if (
+      secondAuthority.status === 'skipped' ||
+      secondAuthority.manifest.id !== firstAuthority.manifest.id ||
+      secondAuthority.manifest.lease.id !== firstAuthority.manifest.lease.id
+    ) {
+      throw new ConflictError('Workspace ownership changed during rewind preview.');
+    }
+
+    const conflicts: WorkspaceCheckpointRewindConflict[] = [];
+    addGitConflict(
+      conflicts,
+      'worktree-root-changed',
+      'Worktree root no longer matches the descendant checkpoint.',
+      descendant.worktreeRootDigest,
+      current.worktreeRootDigest
+    );
+    addGitConflict(
+      conflicts,
+      'head-diverged',
+      'Git HEAD changed after the descendant checkpoint.',
+      descendant.git.head,
+      current.git.head
+    );
+    addGitConflict(
+      conflicts,
+      'branch-diverged',
+      'Git branch changed after the descendant checkpoint.',
+      descendant.git.branch,
+      current.git.branch
+    );
+    addGitConflict(
+      conflicts,
+      'index-diverged',
+      'Git index changed after the descendant checkpoint.',
+      descendant.git.indexDigest,
+      current.git.indexDigest
+    );
+    addGitConflict(
+      conflicts,
+      'status-diverged',
+      'Git worktree status changed after the descendant checkpoint.',
+      descendant.git.statusDigest,
+      current.git.statusDigest
+    );
+    if (target.git.head !== descendant.git.head || target.git.branch !== descendant.git.branch) {
+      conflicts.push({
+        kind: 'git-history-change',
+        message:
+          'The rewind would change Git history or branch posture without causal Git ownership evidence.',
+      });
+    }
+    if (target.git.indexDigest !== descendant.git.indexDigest) {
+      conflicts.push({
+        kind: 'index-posture-change',
+        message: 'The rewind would change the Git index without causal staging ownership evidence.',
+      });
+    }
+    if (!target.conversationCursor) {
+      conflicts.push({
+        kind: 'conversation-cursor-unavailable',
+        message: 'The target checkpoint does not contain a restorable conversation cursor.',
+      });
+    }
+
+    const targetExclusions = new Set(target.exclusions.map((entry) => entry.path));
+    const descendantExclusions = new Set(descendant.exclusions.map((entry) => entry.path));
+    const overlappingPaths = checkpointDiff.files
+      .map((file) => file.path)
+      .filter((path) => targetExclusions.has(path) || descendantExclusions.has(path));
+    for (const path of overlappingPaths) {
+      conflicts.push({
+        kind: 'excluded-path-overlap',
+        path,
+        message: 'Checkpoint exclusion evidence overlaps a path the rewind would change.',
+      });
+    }
+    const inventoryIncomplete = target.exclusionsTruncated || descendant.exclusionsTruncated;
+    if (inventoryIncomplete) {
+      conflicts.push({
+        kind: 'inventory-incomplete',
+        message: 'Checkpoint exclusion inventory is truncated, so automatic rewind is unsafe.',
+      });
+    }
+
+    const descendantFiles = new Map(descendant.files.map((file) => [file.path, file]));
+    const currentFiles = new Map(current.files.map((file) => [file.path, file]));
+    const files = checkpointDiff.files.map((file) => {
+      const fileConflicts = inspectFileConflicts(
+        file.path,
+        descendantFiles.get(file.path),
+        currentFiles.get(file.path)
+      );
+      if (
+        !checkpointDiff.attribution?.evidenceComplete ||
+        file.attribution?.source !== 'agent-tool' ||
+        file.attribution.confidence !== 'high'
+      ) {
+        fileConflicts.push({
+          kind: 'attribution-ambiguous',
+          path: file.path,
+          message: 'The changed file is not proven to contain only agent-authored changes.',
+        });
+      }
+      conflicts.push(...fileConflicts);
+      const action = rewindAction(file.kind);
+      const estimatedDiscardedBytes =
+        action === 'restore-mode' ? 0 : (currentFiles.get(file.path)?.size ?? 0);
+      return {
+        path: file.path,
+        action,
+        estimatedDiscardedBytes,
+        ...(file.attribution ? { attribution: file.attribution } : {}),
+        conflicts: fileConflicts,
+      } satisfies WorkspaceCheckpointRewindFilePreview;
+    });
+
+    return {
+      schemaVersion: 'workspace-checkpoint-rewind-preview/v1',
+      ...scope,
+      targetCheckpointId: target.id,
+      descendantCheckpointId: descendant.id,
+      ownership: {
+        manifestId: secondAuthority.manifest.id,
+        leaseId: secondAuthority.manifest.lease.id,
+        ownerAttemptId: input.attemptId,
+        verifiedAt: this.now().toISOString(),
+      },
+      current,
+      checkpointDiff,
+      git: {
+        headWillChange: target.git.head !== descendant.git.head,
+        branchWillChange: target.git.branch !== descendant.git.branch,
+        indexWillChange: target.git.indexDigest !== descendant.git.indexDigest,
+      },
+      conversation: {
+        cursorWillChange: target.conversationCursor !== descendant.conversationCursor,
+        targetCursorAvailable: Boolean(target.conversationCursor),
+      },
+      files,
+      exclusions: {
+        targetCount: target.excludedCount,
+        descendantCount: descendant.excludedCount,
+        overlappingPaths,
+        inventoryIncomplete,
+      },
+      conflicts,
+      estimatedDataLossBytes: files.reduce(
+        (total, file) => total + file.estimatedDiscardedBytes,
+        0
+      ),
+      safeForAutomaticRewind: conflicts.length === 0,
+    };
+  }
+}
+
+function inspectFileConflicts(
+  path: string,
+  expected: WorkspaceCheckpointFile | undefined,
+  current: WorkspaceCheckpointCurrentFile | undefined
+): WorkspaceCheckpointRewindConflict[] {
+  const conflicts: WorkspaceCheckpointRewindConflict[] = [];
+  const expectedState = expected?.state ?? 'absent';
+  const currentState = current?.state ?? 'absent';
+  if (['symlink', 'unsupported', 'too-large', 'unreadable'].includes(currentState)) {
+    return [
+      {
+        kind: 'file-unreadable',
+        path,
+        message: 'Current file cannot be proven safe for automatic rewind.',
+        expected: expectedState,
+        actual: currentState,
+      },
+    ];
+  }
+  if (expectedState !== currentState) {
+    conflicts.push({
+      kind: 'file-diverged',
+      path,
+      message: 'Current file presence differs from the descendant checkpoint.',
+      expected: expectedState,
+      actual: currentState,
+    });
+    return conflicts;
+  }
+  if (
+    expectedState === 'present' &&
+    (expected?.contentDigest !== current?.contentDigest || expected?.mode !== current?.mode)
+  ) {
+    conflicts.push({
+      kind: 'file-diverged',
+      path,
+      message: 'Current file content or mode differs from the descendant checkpoint.',
+      expected: `${expected?.contentDigest ?? 'missing'}:${expected?.mode ?? 'missing'}`,
+      actual: `${current?.contentDigest ?? 'missing'}:${current?.mode ?? 'missing'}`,
+    });
+  }
+  return conflicts;
+}
+
+function rewindAction(kind: WorkspaceCheckpointFileChangeKind): WorkspaceCheckpointRewindAction {
+  if (kind === 'added') return 'delete';
+  if (kind === 'mode-changed') return 'restore-mode';
+  return 'restore';
+}
+
+function addGitConflict(
+  conflicts: WorkspaceCheckpointRewindConflict[],
+  kind: Extract<
+    WorkspaceCheckpointRewindConflict['kind'],
+    | 'worktree-root-changed'
+    | 'head-diverged'
+    | 'branch-diverged'
+    | 'index-diverged'
+    | 'status-diverged'
+  >,
+  message: string,
+  expected: string | null,
+  actual: string | null
+): void {
+  if (expected === actual) return;
+  conflicts.push({ kind, message, expected, actual });
+}

--- a/server/src/services/workspace-checkpoint-service.ts
+++ b/server/src/services/workspace-checkpoint-service.ts
@@ -2,20 +2,19 @@ import type {
   TaskEnvelope,
   WorkspaceCheckpoint,
   WorkspaceCheckpointBoundary,
-  WorktreeManifest,
 } from '@veritas-kanban/shared';
-import { ConflictError } from '../middleware/error-handler.js';
 import {
   FileWorkspaceCheckpointRepository,
   getWorkspaceCheckpointIdForOperation,
   type WorkspaceCheckpointRepository,
 } from '../storage/workspace-checkpoint-repository.js';
 import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
-import { WorktreeService } from './worktree-service.js';
+import {
+  WorkspaceCheckpointOwnershipService,
+  type WorkspaceCheckpointOwnershipSource,
+} from './workspace-checkpoint-ownership-service.js';
 
-export interface WorkspaceCheckpointOwnershipSource {
-  getManifest(taskId: string): Promise<WorktreeManifest | null>;
-}
+export type { WorkspaceCheckpointOwnershipSource } from './workspace-checkpoint-ownership-service.js';
 
 export interface WorkspaceCheckpointBoundaryInput {
   taskEnvelope: TaskEnvelope;
@@ -45,83 +44,22 @@ export interface WorkspaceCheckpointServiceOptions {
 
 export class WorkspaceCheckpointService {
   private readonly repository: WorkspaceCheckpointRepository;
-  private readonly ownership: WorkspaceCheckpointOwnershipSource;
-  private readonly now: () => Date;
+  private readonly authority: WorkspaceCheckpointOwnershipService;
   private readonly captureQueues = new Map<string, Promise<void>>();
 
   constructor(options: WorkspaceCheckpointServiceOptions = {}) {
     this.repository = options.repository ?? new FileWorkspaceCheckpointRepository();
-    this.ownership = options.ownership ?? new WorktreeService();
-    this.now = options.now ?? (() => new Date());
+    this.authority = new WorkspaceCheckpointOwnershipService(options);
   }
 
   async captureBoundary(
     input: WorkspaceCheckpointBoundaryInput
   ): Promise<WorkspaceCheckpointBoundaryResult> {
     const workspace = input.taskEnvelope.workspace;
-    if (!workspace.worktreeManifestId && !workspace.ownershipLeaseId) {
-      return { status: 'skipped', reason: 'unmanaged-worktree' };
-    }
-    if (!workspace.worktreeManifestId || !workspace.ownershipLeaseId) {
-      throw new ConflictError(
-        'Workspace checkpoint requires complete managed-worktree ownership evidence.',
-        {
-          taskId: input.taskId,
-          attemptId: input.attemptId,
-          hasManifestId: Boolean(workspace.worktreeManifestId),
-          hasLeaseId: Boolean(workspace.ownershipLeaseId),
-        }
-      );
-    }
-    if (
-      input.taskEnvelope.subject.id !== input.taskId ||
-      input.taskEnvelope.attempt.id !== input.attemptId ||
-      workspace.ownershipAttemptId !== input.attemptId
-    ) {
-      throw new ConflictError(
-        'Workspace checkpoint request does not match its task-envelope ownership.',
-        {
-          taskId: input.taskId,
-          attemptId: input.attemptId,
-          envelopeTaskId: input.taskEnvelope.subject.id,
-          envelopeAttemptId: input.taskEnvelope.attempt.id,
-          ownershipAttemptId: workspace.ownershipAttemptId,
-        }
-      );
-    }
-
     const scopeKey = digestRunLaunchValue([workspace.workspaceId, input.taskId, input.attemptId]);
     return this.serializeCapture(scopeKey, async () => {
-      const manifest = await this.ownership.getManifest(input.taskId);
-      if (
-        !manifest ||
-        manifest.id !== workspace.worktreeManifestId ||
-        manifest.taskId !== input.taskId ||
-        manifest.path !== workspace.worktreePath ||
-        manifest.branch !== workspace.branch ||
-        manifest.lease.id !== workspace.ownershipLeaseId ||
-        manifest.lease.ownerTaskId !== input.taskId ||
-        manifest.lease.ownerAttemptId !== input.attemptId ||
-        Date.parse(manifest.lease.expiresAt) <= this.now().getTime() ||
-        manifest.lifecycle.creation !== 'ready' ||
-        manifest.lifecycle.integration !== 'idle' ||
-        manifest.lifecycle.cleanup !== 'active' ||
-        manifest.rebase.state !== 'idle'
-      ) {
-        throw new ConflictError(
-          'Workspace checkpoint cannot prove current run-owned worktree authority.',
-          {
-            taskId: input.taskId,
-            attemptId: input.attemptId,
-            manifestId: workspace.worktreeManifestId,
-            activeManifestId: manifest?.id,
-            activeOwnerAttemptId: manifest?.lease.ownerAttemptId,
-            leaseExpiresAt: manifest?.lease.expiresAt,
-            lifecycle: manifest?.lifecycle,
-            rebaseState: manifest?.rebase.state,
-          }
-        );
-      }
+      const authority = await this.authority.verify(input);
+      if (authority.status === 'skipped') return authority;
 
       const operationIdDigest = digestRunLaunchValue(input.operationId);
       const checkpointId = getWorkspaceCheckpointIdForOperation({
@@ -153,7 +91,7 @@ export class WorkspaceCheckpointService {
         operationId: input.operationId,
         boundary: input.boundary,
         worktreePath: workspace.worktreePath,
-        worktreeManifestId: workspace.worktreeManifestId,
+        worktreeManifestId: authority.manifest.id,
         parentCheckpointId: existing?.parentCheckpointId ?? latest?.id,
         turnId: input.turnId,
         conversationCursor: input.conversationCursor,

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -56,6 +56,7 @@ export {
   type WorkspaceCheckpointCaptureInput,
   type WorkspaceCheckpointCommandResult,
   type WorkspaceCheckpointCommandRunner,
+  type WorkspaceCheckpointCurrentInspectionInput,
   type WorkspaceCheckpointListQuery,
   type WorkspaceCheckpointLookup,
   type WorkspaceCheckpointOperationLookup,

--- a/server/src/storage/workspace-checkpoint-repository.ts
+++ b/server/src/storage/workspace-checkpoint-repository.ts
@@ -7,6 +7,8 @@ import { nanoid } from 'nanoid';
 import type {
   WorkspaceCheckpoint,
   WorkspaceCheckpointBoundary,
+  WorkspaceCheckpointCurrentFile,
+  WorkspaceCheckpointCurrentState,
   WorkspaceCheckpointExclusion,
   WorkspaceCheckpointFile,
   WorkspaceCheckpointFileSource,
@@ -72,11 +74,21 @@ export interface WorkspaceCheckpointListQuery {
   limit?: number;
 }
 
+export interface WorkspaceCheckpointCurrentInspectionInput {
+  worktreePath: string;
+  paths: string[];
+  maxFileBytes: number;
+  maxBytes: number;
+}
+
 export interface WorkspaceCheckpointRepository {
   capture(input: WorkspaceCheckpointCaptureInput): Promise<WorkspaceCheckpoint>;
   get(lookup: WorkspaceCheckpointLookup): Promise<WorkspaceCheckpoint | null>;
   list(query: WorkspaceCheckpointListQuery): Promise<WorkspaceCheckpoint[]>;
   readBlob(digest: string): Promise<Buffer>;
+  inspectCurrent(
+    input: WorkspaceCheckpointCurrentInspectionInput
+  ): Promise<WorkspaceCheckpointCurrentState>;
 }
 
 export interface WorkspaceCheckpointCommandResult {
@@ -436,6 +448,75 @@ export class FileWorkspaceCheckpointRepository implements WorkspaceCheckpointRep
     return content;
   }
 
+  async inspectCurrent(
+    input: WorkspaceCheckpointCurrentInspectionInput
+  ): Promise<WorkspaceCheckpointCurrentState> {
+    if (
+      !Number.isInteger(input.maxFileBytes) ||
+      input.maxFileBytes < 1 ||
+      input.maxFileBytes > MAX_POLICY.maxFileBytes ||
+      !Number.isInteger(input.maxBytes) ||
+      input.maxBytes < input.maxFileBytes ||
+      input.maxBytes > MAX_POLICY.maxBytes
+    ) {
+      throw new Error('Workspace checkpoint current inspection limits are invalid.');
+    }
+    const paths = [...new Set(input.paths)].sort((left, right) => left.localeCompare(right));
+    if (paths.length > MAX_POLICY.maxFiles) {
+      throw new Error('Workspace checkpoint current inspection exceeds its file-count bound.');
+    }
+    for (const candidate of paths) validateCurrentInspectionPath(candidate);
+
+    const canonicalRoot = await realpath(path.resolve(input.worktreePath));
+    const gitRoot = (await this.git(canonicalRoot, ['rev-parse', '--show-toplevel']))
+      .toString('utf8')
+      .trim();
+    const canonicalGitRoot = await realpath(gitRoot);
+    if (canonicalGitRoot !== canonicalRoot) {
+      throw new ConflictError('Workspace checkpoint inspection root is not the exact Git root.');
+    }
+    const before = await this.captureGitState(canonicalRoot);
+    const files: WorkspaceCheckpointCurrentFile[] = [];
+    let inspectedBytes = 0;
+    for (const candidate of paths) {
+      const file = await this.inspectCurrentFile(
+        canonicalRoot,
+        candidate,
+        input.maxFileBytes,
+        Math.max(0, input.maxBytes - inspectedBytes)
+      );
+      files.push(file);
+      if (file.state === 'present') inspectedBytes += file.size ?? 0;
+    }
+    const after = await this.captureGitState(canonicalRoot);
+    if (
+      before.head !== after.head ||
+      before.branch !== after.branch ||
+      before.indexDigest !== after.indexDigest ||
+      before.statusDigest !== after.statusDigest
+    ) {
+      throw new ConflictError('Workspace Git state changed during checkpoint inspection.');
+    }
+    const inspectedAt = this.now().toISOString();
+    const payload = {
+      schemaVersion: 'workspace-checkpoint-current-state/v1' as const,
+      worktreeRootDigest: digestRunLaunchValue(canonicalRoot),
+      git: {
+        head: before.head,
+        branch: before.branch,
+        indexDigest: before.indexDigest,
+        statusDigest: before.statusDigest,
+        dirty: before.status.byteLength > 0,
+      },
+      files,
+      inspectedAt,
+    };
+    return {
+      ...payload,
+      digest: digestRunLaunchValue(payload),
+    };
+  }
+
   private async captureGitState(worktreeRoot: string): Promise<GitCaptureState> {
     const [headResult, branchResult, indexPathResult, status, tracked, untracked] =
       await Promise.all([
@@ -467,6 +548,79 @@ export class FileWorkspaceCheckpointRepository implements WorkspaceCheckpointRep
       tracked: parseNullList(tracked),
       untracked: parseNullList(untracked),
     };
+  }
+
+  private async inspectCurrentFile(
+    worktreeRoot: string,
+    relativePath: string,
+    maxFileBytes: number,
+    remainingBytes: number
+  ): Promise<WorkspaceCheckpointCurrentFile> {
+    const resolved = ensureWithinBase(worktreeRoot, path.resolve(worktreeRoot, relativePath));
+    let first: Awaited<ReturnType<typeof lstat>>;
+    try {
+      first = await lstat(resolved);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { path: relativePath, state: 'absent' };
+      }
+      return { path: relativePath, state: 'unreadable' };
+    }
+    if (first.isSymbolicLink()) {
+      return { path: relativePath, state: 'symlink', size: first.size };
+    }
+    if (!first.isFile()) {
+      return { path: relativePath, state: 'unsupported', size: first.size };
+    }
+    if (first.size > maxFileBytes || first.size > remainingBytes) {
+      return { path: relativePath, state: 'too-large', size: first.size };
+    }
+
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(resolved, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const opened = await handle.stat();
+      if (
+        !opened.isFile() ||
+        first.dev !== opened.dev ||
+        first.ino !== opened.ino ||
+        first.size !== opened.size ||
+        first.mtimeMs !== opened.mtimeMs
+      ) {
+        throw new ConflictError('Workspace file changed during checkpoint inspection.', {
+          path: relativePath,
+        });
+      }
+      const content = await handle.readFile();
+      const second = await handle.stat();
+      if (
+        !second.isFile() ||
+        opened.dev !== second.dev ||
+        opened.ino !== second.ino ||
+        opened.size !== second.size ||
+        opened.mtimeMs !== second.mtimeMs ||
+        content.byteLength !== second.size
+      ) {
+        throw new ConflictError('Workspace file changed during checkpoint inspection.', {
+          path: relativePath,
+        });
+      }
+      return {
+        path: relativePath,
+        state: 'present',
+        mode: second.mode & 0o7777,
+        size: content.byteLength,
+        contentDigest: sha256(content),
+      };
+    } catch (error) {
+      if (error instanceof ConflictError) throw error;
+      if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+        return { path: relativePath, state: 'symlink', size: first.size };
+      }
+      return { path: relativePath, state: 'unreadable', size: first.size };
+    } finally {
+      await handle?.close();
+    }
   }
 
   private async git(worktreeRoot: string, args: string[], allowFailure = false): Promise<Buffer> {
@@ -680,6 +834,20 @@ function validateScope(
   validateIdentifier(scope.workspaceId, 'workspaceId');
   validateIdentifier(scope.taskId, 'taskId');
   validateIdentifier(scope.attemptId, 'attemptId');
+}
+
+function validateCurrentInspectionPath(value: string): void {
+  if (
+    !value ||
+    value.length > 4_096 ||
+    value.includes('\0') ||
+    value.includes('\\') ||
+    value.startsWith('/') ||
+    /^[A-Za-z]:/.test(value) ||
+    value.split('/').some((segment) => segment === '..' || segment === '')
+  ) {
+    throw new Error('Workspace checkpoint inspection path is invalid.');
+  }
 }
 
 function validateIdentifier(value: string, label: string): void {

--- a/shared/src/types/workspace-checkpoint.types.ts
+++ b/shared/src/types/workspace-checkpoint.types.ts
@@ -1,5 +1,9 @@
 export const WORKSPACE_CHECKPOINT_SCHEMA_VERSION = 'workspace-checkpoint/v1' as const;
 export const WORKSPACE_CHECKPOINT_DIFF_SCHEMA_VERSION = 'workspace-checkpoint-diff/v1' as const;
+export const WORKSPACE_CHECKPOINT_CURRENT_STATE_SCHEMA_VERSION =
+  'workspace-checkpoint-current-state/v1' as const;
+export const WORKSPACE_CHECKPOINT_REWIND_PREVIEW_SCHEMA_VERSION =
+  'workspace-checkpoint-rewind-preview/v1' as const;
 
 export const WORKSPACE_CHECKPOINT_BOUNDARIES = [
   'before-user-turn',
@@ -174,4 +178,98 @@ export interface WorkspaceCheckpointDiff {
     eventsConsidered: number;
   };
   files: WorkspaceCheckpointFileDiff[];
+}
+
+export type WorkspaceCheckpointCurrentFileState =
+  'present' | 'absent' | 'symlink' | 'unsupported' | 'too-large' | 'unreadable';
+
+export interface WorkspaceCheckpointCurrentFile {
+  path: string;
+  state: WorkspaceCheckpointCurrentFileState;
+  mode?: number;
+  size?: number;
+  contentDigest?: string;
+}
+
+export interface WorkspaceCheckpointCurrentState {
+  schemaVersion: typeof WORKSPACE_CHECKPOINT_CURRENT_STATE_SCHEMA_VERSION;
+  worktreeRootDigest: string;
+  git: {
+    head: string | null;
+    branch: string | null;
+    indexDigest: string;
+    statusDigest: string;
+    dirty: boolean;
+  };
+  files: WorkspaceCheckpointCurrentFile[];
+  inspectedAt: string;
+  digest: string;
+}
+
+export type WorkspaceCheckpointRewindAction = 'delete' | 'restore' | 'restore-mode';
+export type WorkspaceCheckpointRewindConflictKind =
+  | 'worktree-root-changed'
+  | 'head-diverged'
+  | 'branch-diverged'
+  | 'index-diverged'
+  | 'status-diverged'
+  | 'git-history-change'
+  | 'index-posture-change'
+  | 'conversation-cursor-unavailable'
+  | 'file-diverged'
+  | 'file-unreadable'
+  | 'excluded-path-overlap'
+  | 'inventory-incomplete'
+  | 'attribution-ambiguous';
+
+export interface WorkspaceCheckpointRewindConflict {
+  kind: WorkspaceCheckpointRewindConflictKind;
+  message: string;
+  path?: string;
+  expected?: string | null;
+  actual?: string | null;
+}
+
+export interface WorkspaceCheckpointRewindFilePreview {
+  path: string;
+  action: WorkspaceCheckpointRewindAction;
+  estimatedDiscardedBytes: number;
+  attribution?: WorkspaceCheckpointHunkAttribution;
+  conflicts: WorkspaceCheckpointRewindConflict[];
+}
+
+export interface WorkspaceCheckpointRewindPreview {
+  schemaVersion: typeof WORKSPACE_CHECKPOINT_REWIND_PREVIEW_SCHEMA_VERSION;
+  workspaceId: string;
+  taskId: string;
+  attemptId: string;
+  targetCheckpointId: string;
+  descendantCheckpointId: string;
+  ownership: {
+    manifestId: string;
+    leaseId: string;
+    ownerAttemptId: string;
+    verifiedAt: string;
+  };
+  current: WorkspaceCheckpointCurrentState;
+  checkpointDiff: WorkspaceCheckpointDiff;
+  git: {
+    headWillChange: boolean;
+    branchWillChange: boolean;
+    indexWillChange: boolean;
+  };
+  conversation: {
+    cursorWillChange: boolean;
+    targetCursorAvailable: boolean;
+  };
+  files: WorkspaceCheckpointRewindFilePreview[];
+  exclusions: {
+    targetCount: number;
+    descendantCount: number;
+    overlappingPaths: string[];
+    inventoryIncomplete: boolean;
+  };
+  conflicts: WorkspaceCheckpointRewindConflict[];
+  estimatedDataLossBytes: number;
+  safeForAutomaticRewind: boolean;
 }


### PR DESCRIPTION
## Summary

- Add a no-follow current-state inspector for affected checkpoint paths plus exact HEAD, branch, index, and status evidence.
- Extract the durable worktree ownership guard so capture and rewind preview share one authority check.
- Build a read-only rewind preview with reverse file actions, exclusions, attribution, Git and conversation changes, estimated discarded bytes, and explicit blockers.
- Revalidate ownership after inspection and fail automatic rewind closed for divergence, incomplete inventories, excluded overlaps, non-agent changes, missing cursors, or unowned Git/index posture changes.

## Verification

- Shared and server TypeScript checks
- Targeted ESLint and Prettier checks
- 17 focused checkpoint capture, ownership, comparison, attribution, and rewind-preview tests
- Git diff integrity check

## Scope

This PR does not mutate a worktree. Selective conflict resolution, approval binding, recoverable restore execution, and retention remain follow-up slices.

Refs #872
