### PR TITLE
feat: enforce workspace checkpoint retention

### DIFF
--- a/docs/architecture/WORKSPACE-CHECKPOINTS-V1.md
+++ b/docs/architecture/WORKSPACE-CHECKPOINTS-V1.md
@@ -39,7 +39,9 @@ Provider event mappers normalize bounded relative file paths and tool names into
 
 Rewind preview revalidates the durable worktree lease before and after a no-follow current-state inspection. It compares the current worktree root, HEAD, branch, index, status, affected file hashes, modes, exclusions, and attribution against the expected descendant checkpoint. The result lists reverse file actions, Git and conversation-cursor changes, estimated discarded bytes, and explicit blockers. Automatic rewind is safe only when every current-state and ownership check matches and every changed file is exclusively supported by high-confidence agent evidence.
 
-This foundation does not yet claim exact overlapping-hunk attribution, selective conflict resolution, restore, recoverable transaction execution, or retention cleanup. Those layers must consume the immutable repository and remain preview-first. A later rewind write must revalidate the same evidence plus exact approval immediately before mutation.
+Retention pruning accepts explicit checkpoint-count, logical-byte, age, and protected-checkpoint limits. An active run always preserves every discovered complete chain tip even when configured limits are zero, including conservative preservation of concurrent branches. Cleanup reports the exact metadata bytes removed and logical content bytes dereferenced. Content-addressed blob garbage collection is deliberately deferred until it can coordinate safely with concurrent captures, so retention never claims those shared blob bytes as reclaimed.
+
+This foundation does not yet claim exact overlapping-hunk attribution, selective conflict resolution, restore, recoverable transaction execution, or shared blob garbage collection. Those layers must consume the immutable repository and remain preview-first. A later rewind write must revalidate the same evidence plus exact approval immediately before mutation.
 
 ## Code
 

--- a/server/src/__tests__/workspace-checkpoint-repository.test.ts
+++ b/server/src/__tests__/workspace-checkpoint-repository.test.ts
@@ -308,4 +308,66 @@ describe('FileWorkspaceCheckpointRepository', () => {
       })
     ).rejects.toThrow('inspection path is invalid');
   });
+
+  it('prunes bounded metadata while preserving the newest active-run checkpoint', async () => {
+    const { worktreePath, storePath } = await fixture();
+    let now = new Date('2026-07-26T06:00:00.000Z');
+    const repository = new FileWorkspaceCheckpointRepository({
+      baseDir: storePath,
+      now: () => now,
+    });
+    const scope = {
+      workspaceId: 'workspace-retention',
+      taskId: 'task-retention',
+      attemptId: 'attempt-retention',
+      boundary: 'manual' as const,
+      worktreePath,
+    };
+    const first = await repository.capture({ ...scope, operationId: 'capture-1' });
+    now = new Date('2026-07-26T06:01:00.000Z');
+    await fs.writeFile(path.join(worktreePath, 'tracked.txt'), 'second checkpoint\n');
+    const second = await repository.capture({
+      ...scope,
+      operationId: 'capture-2',
+      parentCheckpointId: first.id,
+    });
+    now = new Date('2026-07-26T06:02:00.000Z');
+    await fs.writeFile(path.join(worktreePath, 'tracked.txt'), 'third checkpoint\n');
+    const third = await repository.capture({
+      ...scope,
+      operationId: 'capture-3',
+      parentCheckpointId: second.id,
+    });
+    now = new Date('2026-07-26T06:03:00.000Z');
+    await fs.writeFile(path.join(worktreePath, 'tracked.txt'), 'branch checkpoint\n');
+    const branch = await repository.capture({
+      ...scope,
+      operationId: 'capture-branch',
+      parentCheckpointId: first.id,
+    });
+
+    const result = await repository.prune({
+      ...scope,
+      activeRun: true,
+      maxCheckpoints: 0,
+      maxLogicalBytes: 0,
+      maxAgeSeconds: 1,
+    });
+
+    expect(result).toMatchObject({
+      schemaVersion: 'workspace-checkpoint-retention-result/v1',
+      activeRun: true,
+      preservedCheckpointIds: [branch.id, third.id],
+      removedCheckpointIds: [second.id, first.id],
+      reclaimedMetadataBytes: expect.any(Number),
+      logicalContentBytesDereferenced: first.storedBytes + second.storedBytes,
+      contentBlobGcDeferred: true,
+    });
+    expect(result.reclaimedMetadataBytes).toBeGreaterThan(0);
+    await expect(repository.list(scope)).resolves.toEqual([branch, third]);
+    const firstTracked = first.files.find((file) => file.path === 'tracked.txt');
+    await expect(repository.readBlob(firstTracked?.blobDigest ?? '')).resolves.toEqual(
+      Buffer.from('tracked worktree\n')
+    );
+  });
 });

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -60,6 +60,7 @@ export {
   type WorkspaceCheckpointListQuery,
   type WorkspaceCheckpointLookup,
   type WorkspaceCheckpointOperationLookup,
+  type WorkspaceCheckpointRetentionInput,
   type WorkspaceCheckpointRepository,
 } from './workspace-checkpoint-repository.js';
 export {

--- a/server/src/storage/workspace-checkpoint-repository.ts
+++ b/server/src/storage/workspace-checkpoint-repository.ts
@@ -13,6 +13,7 @@ import type {
   WorkspaceCheckpointFile,
   WorkspaceCheckpointFileSource,
   WorkspaceCheckpointPolicy,
+  WorkspaceCheckpointRetentionResult,
 } from '@veritas-kanban/shared';
 import { parseWorkspaceCheckpoint } from '../schemas/workspace-checkpoint-schemas.js';
 import { ConflictError } from '../middleware/error-handler.js';
@@ -81,6 +82,14 @@ export interface WorkspaceCheckpointCurrentInspectionInput {
   maxBytes: number;
 }
 
+export interface WorkspaceCheckpointRetentionInput extends WorkspaceCheckpointListQuery {
+  activeRun: boolean;
+  maxCheckpoints: number;
+  maxLogicalBytes: number;
+  maxAgeSeconds: number;
+  protectedCheckpointIds?: string[];
+}
+
 export interface WorkspaceCheckpointRepository {
   capture(input: WorkspaceCheckpointCaptureInput): Promise<WorkspaceCheckpoint>;
   get(lookup: WorkspaceCheckpointLookup): Promise<WorkspaceCheckpoint | null>;
@@ -89,6 +98,7 @@ export interface WorkspaceCheckpointRepository {
   inspectCurrent(
     input: WorkspaceCheckpointCurrentInspectionInput
   ): Promise<WorkspaceCheckpointCurrentState>;
+  prune(input: WorkspaceCheckpointRetentionInput): Promise<WorkspaceCheckpointRetentionResult>;
 }
 
 export interface WorkspaceCheckpointCommandResult {
@@ -514,6 +524,118 @@ export class FileWorkspaceCheckpointRepository implements WorkspaceCheckpointRep
     return {
       ...payload,
       digest: digestRunLaunchValue(payload),
+    };
+  }
+
+  async prune(
+    input: WorkspaceCheckpointRetentionInput
+  ): Promise<WorkspaceCheckpointRetentionResult> {
+    validateScope(input);
+    if (
+      !Number.isInteger(input.maxCheckpoints) ||
+      input.maxCheckpoints < 0 ||
+      input.maxCheckpoints > 100_000 ||
+      !Number.isInteger(input.maxLogicalBytes) ||
+      input.maxLogicalBytes < 0 ||
+      input.maxLogicalBytes > MAX_POLICY.maxBytes * 100_000 ||
+      !Number.isInteger(input.maxAgeSeconds) ||
+      input.maxAgeSeconds < 1
+    ) {
+      throw new Error('Workspace checkpoint retention policy is invalid.');
+    }
+    const protectedIds = new Set(input.protectedCheckpointIds ?? []);
+    for (const checkpointId of protectedIds) validateIdentifier(checkpointId, 'checkpointId');
+    const parent = this.attemptPath(input);
+    if (!(await this.assertPrivateDirectoryPath(parent, true))) {
+      return {
+        schemaVersion: 'workspace-checkpoint-retention-result/v1',
+        workspaceId: input.workspaceId,
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        activeRun: input.activeRun,
+        preservedCheckpointIds: [],
+        removedCheckpointIds: [],
+        reclaimedMetadataBytes: 0,
+        logicalContentBytesDereferenced: 0,
+        contentBlobGcDeferred: true,
+        completedAt: this.now().toISOString(),
+      };
+    }
+    const entries = (await readdir(parent, { withFileTypes: true }))
+      .filter(
+        (entry) =>
+          entry.isDirectory() && !entry.isSymbolicLink() && entry.name.startsWith('checkpoint_')
+      )
+      .sort((left, right) => left.name.localeCompare(right.name));
+    const checkpoints: WorkspaceCheckpoint[] = [];
+    for (const entry of entries) {
+      const checkpoint = await this.get({
+        workspaceId: input.workspaceId,
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        checkpointId: entry.name,
+      });
+      if (checkpoint) checkpoints.push(checkpoint);
+    }
+    checkpoints.sort(
+      (left, right) =>
+        Date.parse(right.createdAt) - Date.parse(left.createdAt) || left.id.localeCompare(right.id)
+    );
+    if (input.activeRun) {
+      const parentIds = new Set(
+        checkpoints
+          .map((checkpoint) => checkpoint.parentCheckpointId)
+          .filter((checkpointId): checkpointId is string => Boolean(checkpointId))
+      );
+      const tips = checkpoints.filter((checkpoint) => !parentIds.has(checkpoint.id));
+      for (const checkpoint of tips.length > 0 ? tips : checkpoints.slice(0, 1)) {
+        protectedIds.add(checkpoint.id);
+      }
+    }
+
+    const preserved: WorkspaceCheckpoint[] = [];
+    const removed: WorkspaceCheckpoint[] = [];
+    let retainedLogicalBytes = 0;
+    const cutoff = this.now().getTime() - input.maxAgeSeconds * 1_000;
+    for (const checkpoint of checkpoints) {
+      const required = protectedIds.has(checkpoint.id);
+      const withinAge = Date.parse(checkpoint.createdAt) >= cutoff;
+      const withinCount = preserved.length < input.maxCheckpoints;
+      const withinBytes = retainedLogicalBytes + checkpoint.storedBytes <= input.maxLogicalBytes;
+      if (required || (withinAge && withinCount && withinBytes)) {
+        preserved.push(checkpoint);
+        retainedLogicalBytes += checkpoint.storedBytes;
+      } else {
+        removed.push(checkpoint);
+      }
+    }
+
+    let reclaimedMetadataBytes = 0;
+    for (const checkpoint of removed) {
+      const checkpointPath = this.checkpointPath({ ...checkpoint, checkpointId: checkpoint.id });
+      await this.assertPrivateDirectoryPath(checkpointPath);
+      const metadata = await lstat(path.join(checkpointPath, 'metadata.json'));
+      if (!metadata.isFile() || metadata.isSymbolicLink()) {
+        throw new ConflictError('Workspace checkpoint retention found invalid metadata.');
+      }
+      await rm(checkpointPath, { recursive: true, force: false });
+      reclaimedMetadataBytes += metadata.size;
+    }
+    return {
+      schemaVersion: 'workspace-checkpoint-retention-result/v1',
+      workspaceId: input.workspaceId,
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+      activeRun: input.activeRun,
+      preservedCheckpointIds: preserved.map((checkpoint) => checkpoint.id),
+      removedCheckpointIds: removed.map((checkpoint) => checkpoint.id),
+      reclaimedMetadataBytes,
+      logicalContentBytesDereferenced: removed.reduce(
+        (total, checkpoint) => total + checkpoint.storedBytes,
+        0
+      ),
+      contentBlobGcDeferred: true,
+      completedAt: this.now().toISOString(),
     };
   }
 

--- a/shared/src/types/workspace-checkpoint.types.ts
+++ b/shared/src/types/workspace-checkpoint.types.ts
@@ -4,6 +4,8 @@ export const WORKSPACE_CHECKPOINT_CURRENT_STATE_SCHEMA_VERSION =
   'workspace-checkpoint-current-state/v1' as const;
 export const WORKSPACE_CHECKPOINT_REWIND_PREVIEW_SCHEMA_VERSION =
   'workspace-checkpoint-rewind-preview/v1' as const;
+export const WORKSPACE_CHECKPOINT_RETENTION_RESULT_SCHEMA_VERSION =
+  'workspace-checkpoint-retention-result/v1' as const;
 
 export const WORKSPACE_CHECKPOINT_BOUNDARIES = [
   'before-user-turn',
@@ -272,4 +274,18 @@ export interface WorkspaceCheckpointRewindPreview {
   conflicts: WorkspaceCheckpointRewindConflict[];
   estimatedDataLossBytes: number;
   safeForAutomaticRewind: boolean;
+}
+
+export interface WorkspaceCheckpointRetentionResult {
+  schemaVersion: typeof WORKSPACE_CHECKPOINT_RETENTION_RESULT_SCHEMA_VERSION;
+  workspaceId: string;
+  taskId: string;
+  attemptId: string;
+  activeRun: boolean;
+  preservedCheckpointIds: string[];
+  removedCheckpointIds: string[];
+  reclaimedMetadataBytes: number;
+  logicalContentBytesDereferenced: number;
+  contentBlobGcDeferred: true;
+  completedAt: string;
 }


### PR DESCRIPTION
## Summary

- Add configurable per-attempt checkpoint retention across count, logical-byte, age, and protected-checkpoint limits.
- Preserve every complete chain tip while a run is active, including concurrent checkpoint branches.
- Report exact checkpoint metadata bytes removed and logical bytes dereferenced while explicitly deferring shared content-blob garbage collection.
- Document the retention boundary and remaining restore, selective resolution, and safe blob-GC work.

## Verification

- `VERITAS_DISABLE_WATCHERS=1 ../node_modules/.bin/vitest run src/__tests__/workspace-checkpoint-repository.test.ts` (7 tests)
- `./node_modules/.bin/tsc -p shared/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p server/tsconfig.json --noEmit`
- Focused ESLint and Prettier checks
- `git diff --check`

## Scope

Content blobs remain available until garbage collection can coordinate safely with concurrent captures. This advances #872 without claiming the full rewind workflow is complete.