### PR TITLE
fix: scope QMD searches with supported flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,9 @@ change while retaining full release gates.
 
 ### Fixed
 
+- Updated QMD query scoping to pass one documented `-c` flag per collection.
+  Current QMD versions silently ignore the former unknown `--collections`
+  argument, which could broaden a supposedly scoped search (#867).
 - Replaced the desktop-only bottom Chat surface with a bounded dock that opens on
   the right by default and can switch between Right and Bottom without remounting
   the active conversation. Both dimensions are clamped against the live viewport,

--- a/server/src/__tests__/search-service.test.ts
+++ b/server/src/__tests__/search-service.test.ts
@@ -147,6 +147,12 @@ describe('SearchService', () => {
       score: 0.92,
       collection: 'tasks-active',
     });
+    expect(execFileMock).toHaveBeenCalledWith(
+      'qmd',
+      ['query', 'semantic search', '--json', '-n', '10', '-c', 'tasks-active'],
+      expect.objectContaining({ cwd: root }),
+      expect.any(Function)
+    );
   });
 
   it('searches telemetry events as agent run results with timeline targets', async () => {

--- a/server/src/services/search-service.ts
+++ b/server/src/services/search-service.ts
@@ -249,7 +249,9 @@ class SearchService {
       args.push('--min-score', String(options.minScore));
     }
 
-    args.push('--collections', qmdCollections.join(','));
+    for (const collection of qmdCollections) {
+      args.push('-c', collection);
+    }
 
     const stdout = await this.runQmdCommand(
       args,


### PR DESCRIPTION
## Summary

- replace the unsupported QMD `--collections` argument with one documented `-c` flag per collection
- add an exact invocation regression test
- document why the old flag could silently broaden scoped searches

## Verification

- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/search-service.test.ts --reporter=dot` (7 passed)
- `pnpm --filter @veritas-kanban/server typecheck`
- targeted Prettier and ESLint checks

## Scope

Advances #867 and is required before adding per-collection knowledge projections to QMD.
