### PR TITLE
test: restore filesystem mock contract

### DIFF
--- a/server/src/__tests__/docker-paths.test.ts
+++ b/server/src/__tests__/docker-paths.test.ts
@@ -5,6 +5,7 @@ const createFsPromisesMock = vi.hoisted(() => () => {
     access: vi.fn().mockResolvedValue(undefined),
     appendFile: vi.fn().mockResolvedValue(undefined),
     copyFile: vi.fn().mockResolvedValue(undefined),
+    lstat: vi.fn().mockResolvedValue({ isSymbolicLink: () => false }),
     mkdir: vi.fn().mockResolvedValue(undefined),
     readFile: vi.fn().mockResolvedValue(''),
     writeFile: vi.fn().mockResolvedValue(undefined),

--- a/server/src/__tests__/jwt-rotation.test.ts
+++ b/server/src/__tests__/jwt-rotation.test.ts
@@ -7,6 +7,7 @@ const mockFs: Record<string, string> = vi.hoisted(() => ({}));
 
 vi.mock('node:fs/promises', () => {
   const access = vi.fn().mockResolvedValue(undefined);
+  const lstat = vi.fn().mockResolvedValue({ isSymbolicLink: () => false });
   const mkdir = vi.fn().mockResolvedValue(undefined);
   const readFile = vi.fn().mockResolvedValue('');
   const rename = vi.fn().mockResolvedValue(undefined);
@@ -16,6 +17,7 @@ vi.mock('node:fs/promises', () => {
   const rm = vi.fn().mockResolvedValue(undefined);
   return {
     access,
+    lstat,
     mkdir,
     readFile,
     rename,
@@ -23,7 +25,7 @@ vi.mock('node:fs/promises', () => {
     readdir,
     unlink,
     rm,
-    default: { access, mkdir, readFile, rename, writeFile, readdir, unlink, rm },
+    default: { access, lstat, mkdir, readFile, rename, writeFile, readdir, unlink, rm },
   };
 });
 


### PR DESCRIPTION
## Summary

- restores the `lstat` export in the two complete `node:fs/promises` test doubles
- prevents `fs-helpers.ts` import failures after the centralized filesystem contract added `lstat`
- clears the collateral automation-route failure observed during the broken concurrent suite

## Root cause

The JWT rotation and Docker path tests fully replaced `node:fs/promises` but did not track its current imported surface. Their load failures destabilized the concurrent server run; the automation route passes without a production change once the mock contract is complete.

## Verification

- focused three-file loop: 3 files passed, 29 tests passed
- complete server suite: 285 files passed, 2 skipped; 3,234 tests passed, 5 skipped
- focused ESLint: zero errors; existing warnings unchanged
- security artifact pre-commit gate
- `git diff --check`

Closes #1136.
