### PR TITLE
fix: complete admission snapshot writes

### DIFF
--- a/server/src/storage/admission-reservation-repository.ts
+++ b/server/src/storage/admission-reservation-repository.ts
@@ -597,7 +597,10 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
       0o600
     );
     try {
-      await handle.write(line, undefined, 'utf8');
+      // FileHandle.write() may complete with fewer bytes than requested. A
+      // partial JSONL record makes the entire durable admission log unreadable,
+      // so use writeFile() to complete the full append before syncing.
+      await handle.writeFile(line, 'utf8');
       await handle.sync();
     } finally {
       await handle.close();


### PR DESCRIPTION
## Summary

- completes each append-only admission snapshot write before syncing
- prevents a short `FileHandle.write()` result from leaving a truncated JSONL record
- preserves no-follow open flags, the process/host file lock, size bounds, sync, and fail-closed parsing

## Root cause

`FileHandle.write()` may write fewer bytes than requested. The repository ignored `bytesWritten`, synced the partial result, and later failed closed with `SyntaxError: Unterminated string in JSON` while materializing reservations. Whole-suite I/O pressure reproduced the defect in GitHub Actions.

## Verification

- exact concurrent fan-out stress test passed five consecutive runs
- `admission-control-service.test.ts`: 48 tests passed
- focused ESLint
- security artifact pre-commit gate
- `git diff --check`

Closes #1139.
