### PR TITLE
fix: clear v6.1.0 release gate failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,9 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
 - All routes go through centralized middleware in `server/src/middleware/`.
 - Auth: JWT + API keys. Dev bypass: `VERITAS_AUTH_LOCALHOST_BYPASS=true`.
 - Storage: always go through `storage/interfaces.ts`. Never import `fs` directly in service files.
+- Append-only durable records must complete the entire serialized write before
+  sync. Never assume one `FileHandle.write()` call wrote every byte or ignore
+  `bytesWritten`.
 - Error classes: `UnauthorizedError`, `ForbiddenError`, `BadRequestError`, `InternalError`.
 - Pagination: `sendPaginated(res, items, { page, limit, total })`.
 - Path traversal: always call `validatePathSegment()` on any user-supplied path component,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nested headings, bold-led prose items, and consecutive sentence-sized blocks
   in v6.0.2 and later release bodies (#1025).
 
+### Fixed
+
+- Completed append-only admission snapshot writes before sync so a short
+  `FileHandle.write()` cannot leave a truncated JSONL record that makes durable
+  reservation state unreadable (#1139).
+- Restored the complete `node:fs/promises` surface in filesystem test doubles
+  after centralized storage added `lstat`, clearing collateral concurrent-suite
+  failures without weakening production path checks (#1136).
+- Mapped the exact knowledge-collection router prefix to shared work-product
+  read/write permissions, restoring fail-closed client/server permission
+  coverage parity (#1141).
+
 ## [6.0.2] - 2026-07-24
 
 Veritas Kanban 6.0.2 is a desktop recovery and supportability hotfix. It keeps

--- a/server/src/__tests__/docker-paths.test.ts
+++ b/server/src/__tests__/docker-paths.test.ts
@@ -5,6 +5,7 @@ const createFsPromisesMock = vi.hoisted(() => () => {
     access: vi.fn().mockResolvedValue(undefined),
     appendFile: vi.fn().mockResolvedValue(undefined),
     copyFile: vi.fn().mockResolvedValue(undefined),
+    lstat: vi.fn().mockResolvedValue({ isSymbolicLink: () => false }),
     mkdir: vi.fn().mockResolvedValue(undefined),
     readFile: vi.fn().mockResolvedValue(''),
     writeFile: vi.fn().mockResolvedValue(undefined),

--- a/server/src/__tests__/jwt-rotation.test.ts
+++ b/server/src/__tests__/jwt-rotation.test.ts
@@ -7,6 +7,7 @@ const mockFs: Record<string, string> = vi.hoisted(() => ({}));
 
 vi.mock('node:fs/promises', () => {
   const access = vi.fn().mockResolvedValue(undefined);
+  const lstat = vi.fn().mockResolvedValue({ isSymbolicLink: () => false });
   const mkdir = vi.fn().mockResolvedValue(undefined);
   const readFile = vi.fn().mockResolvedValue('');
   const rename = vi.fn().mockResolvedValue(undefined);
@@ -16,6 +17,7 @@ vi.mock('node:fs/promises', () => {
   const rm = vi.fn().mockResolvedValue(undefined);
   return {
     access,
+    lstat,
     mkdir,
     readFile,
     rename,
@@ -23,7 +25,7 @@ vi.mock('node:fs/promises', () => {
     readdir,
     unlink,
     rm,
-    default: { access, mkdir, readFile, rename, writeFile, readdir, unlink, rm },
+    default: { access, lstat, mkdir, readFile, rename, writeFile, readdir, unlink, rm },
   };
 });
 

--- a/server/src/storage/admission-reservation-repository.ts
+++ b/server/src/storage/admission-reservation-repository.ts
@@ -597,7 +597,10 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
       0o600
     );
     try {
-      await handle.write(line, undefined, 'utf8');
+      // FileHandle.write() may complete with fewer bytes than requested. A
+      // partial JSONL record makes the entire durable admission log unreadable,
+      // so use writeFile() to complete the full append before syncing.
+      await handle.writeFile(line, 'utf8');
       await handle.sync();
     } finally {
       await handle.close();

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -204,7 +204,11 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     ],
   },
   { prefix: '/api/admission', read: 'agent:read', write: 'admin:manage' },
-  { prefix: '/api/knowledge', read: 'work_product:read', write: 'work_product:write' },
+  {
+    prefix: '/api/knowledge/collections',
+    read: 'work_product:read',
+    write: 'work_product:write',
+  },
   {
     prefix: '/api/diff',
     read: 'task:read',


### PR DESCRIPTION
## Summary

- maps the exact `/api/knowledge/collections` router mount to shared work-product permissions
- restores the current `node:fs/promises` contract in the two complete filesystem test doubles
- completes append-only admission snapshot writes before sync so short writes cannot corrupt durable JSONL state
- records the durability rule in canonical agent instructions and documents all three release-gate fixes

## Why one PR

The three fixes are independently small but CI-interdependent on current `main`: the permission-coverage failure blocks the mock and storage PRs, while the shared permission change selects the full suite that needs the mock and storage fixes. Combining the reviewed commits gives CI one coherent release-gate candidate instead of three branches that cannot independently turn green.

## Verification

- permission coverage: 219 classified surfaces and 200 discovered surfaces plus REST route-map parity
- shared API permissions: 17 tests passed
- filesystem and automation regression slice: 3 files and 29 tests passed
- complete server suite after the mock fix: 285 files passed, 2 skipped; 3,234 tests passed, 5 skipped
- exact concurrent admission fan-out stress: 5 consecutive runs passed after the storage fix
- admission-control test file: 48 tests passed
- delivery-cadence guard: 18 tests passed
- focused ESLint and security artifact pre-commit gates
- `git diff --check`

Closes #1136.
Closes #1139.
Closes #1141.
