### PR TITLE
fix: restore flex on overlay Tabs root so drawer panels scroll

### DIFF
--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -98,6 +98,16 @@
   scrollbar-width: thin;
 }
 
+/* Mantine's Tabs root stylesheet (.m_* class) sets display: block and wins the
+   cascade over the Tailwind `flex flex-col` utilities on the same element,
+   which un-constrains the flex-1/min-h-0 overlay scroll panels (issue #935
+   regression after the Mantine migration). Two-class specificity restores the
+   flex column so drawer tab panels clamp and scroll again. */
+.veritas-overlay-surface .mantine-Tabs-root {
+  display: flex;
+  flex-direction: column;
+}
+
 .veritas-overlay-scroll::-webkit-scrollbar {
   width: 0.625rem;
 }


### PR DESCRIPTION
Fixes #1153 (regression of #935 after the Mantine migration; the original fix was #992).

## What

One CSS rule at the shared overlay level in `web/src/globals.css`:

```css
.veritas-overlay-surface .mantine-Tabs-root {
  display: flex;
  flex-direction: column;
}
```

## Why

Mantine's Tabs stylesheet sets `display: block` on the Tabs root and wins the cascade over the Tailwind `flex flex-col` utilities that `TaskDetailPanel.tsx` puts on the same element. That un-constrains the `flex-1 min-h-0 veritas-overlay-scroll` tab panels: they grow to full content height inside the `overflow: hidden` drawer, so long content is clipped with no scrollbar (details and runtime measurements in #1153).

Two-class specificity restores the flex column regardless of stylesheet order, and applies to every overlay drawer's Tabs, matching #935's request to fix this at the shared overlay-shell level rather than per panel.

## Verification

- Reproduced on a v6.1.0 production Docker build in Chrome: task drawer panel measured `scrollHeight` 1711 == `clientHeight` 1711 (unscrollable) inside a 730px `overflow: hidden` parent.
- With this rule, the same drawer clamps to the viewport (614px) and scrolls on the Work, Details, and Evidence tabs.
- CSS-only change; no component or test files touched. Behavior verified in the browser per the contributing guide's "test the behavior" guidance.
