### PR TITLE
fix: support native Vite config loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,6 +518,9 @@ jobs:
       - name: Build shared (dependency for all builds)
         run: pnpm --filter @veritas-kanban/shared build
 
+      - name: Verify native Vite config loading
+        run: pnpm check:vite-native-config
+
       - name: Build all packages
         run: pnpm build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ pnpm lint:fix
 # Smoke checks
 pnpm check:pnpm-settings        # Validates package manager fields match this file
 pnpm check:delivery-cadence     # Prevents verification and review policy drift
+pnpm check:vite-native-config   # Loads web build and test configs with Vite's native loader
 pnpm test:ci-scope              # Validates path-aware CI test selection
 pnpm smoke:cli-mcp              # CLI ↔ MCP compatibility smoke test
 pnpm test:buzz:compatibility    # Credential-free composed Buzz release gate

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint:report": "node scripts/lint-warning-budget.mjs --all-rules",
     "lint:fix": "eslint . --fix",
     "check:delivery-cadence": "node --test scripts/check-delivery-cadence.test.mjs && node scripts/check-delivery-cadence.mjs",
+    "check:vite-native-config": "pnpm --filter @veritas-kanban/web exec vite build --configLoader native && vitest run --configLoader native web/src/lib/__tests__/client-policy.test.ts",
     "check:pnpm-settings": "node scripts/check-pnpm-settings.mjs",
     "check:security-artifacts": "node scripts/check-security-artifacts.mjs",
     "typecheck": "pnpm --filter @veritas-kanban/shared build && pnpm -r typecheck",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss() as any],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(import.meta.dirname, './src'),
     },
   },
   test: {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(import.meta.dirname, './src'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- replace CommonJS `__dirname` use in the web build and test configs with `import.meta.dirname`
- add an explicit native-loader smoke command for both config paths
- run that smoke in CI before the all-package build and document it in the repository command reference

## Verification

- `pnpm check:vite-native-config` (native production build plus alias-using Vitest smoke, no compatibility warning)
- `pnpm test:unit` (server 3,236; web 469; CLI 62; MCP 71; expected skips only)
- `pnpm test:e2e` (37/37 Chromium and WebKit)
- `pnpm typecheck`
- `pnpm build` including Electron artifact checks
- `pnpm lint` (0 errors, 588 existing warnings)
- `pnpm check:pnpm-settings`
- Prettier and `git diff --check`

Closes #1171