### PR TITLE
ci: pin external actions to immutable revisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,23 +63,27 @@ jobs:
       diff_range: ${{ steps.scope.outputs.diff_range }}
       reason: ${{ steps.scope.outputs.reason }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Verify CI scope controls
         run: >-
           node --test
+          scripts/check-actions-pinned.test.mjs
           scripts/check-delivery-cadence.test.mjs
           scripts/select-ci-test-scope.test.mjs
           scripts/verify-full-suite-job-evidence.test.mjs
 
       - name: Guard delivery cadence
         run: node scripts/check-delivery-cadence.mjs
+
+      - name: Guard immutable GitHub Actions references
+        run: node scripts/check-actions-pinned.mjs
 
       - name: Find reviewed full-suite evidence
         id: reviewed_full
@@ -236,11 +240,11 @@ jobs:
       github.event.label.name == 'ci:full'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -298,15 +302,15 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: needs.select-tests.outputs.scope == 'focused'
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: needs.select-tests.outputs.scope == 'focused'
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         if: needs.select-tests.outputs.scope == 'focused'
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -426,13 +430,13 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: needs.select-tests.outputs.scope == 'full'
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: needs.select-tests.outputs.scope == 'full'
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         if: needs.select-tests.outputs.scope == 'full'
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -503,11 +507,11 @@ jobs:
       github.event.label.name == 'ci:full'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -561,11 +565,11 @@ jobs:
       github.event.label.name == 'ci:full'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -40,11 +40,11 @@ jobs:
     name: Unsigned macOS Artifact
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -65,7 +65,7 @@ jobs:
         run: node ./node_modules/electron-builder/cli.js --mac dmg zip --publish never --config.mac.identity=null --config.mac.notarize=false
 
       - name: Upload desktop artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: veritas-kanban-mac-unsigned
           path: |
@@ -80,11 +80,11 @@ jobs:
     name: Unsigned Linux Artifacts
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -108,7 +108,7 @@ jobs:
         run: node ./node_modules/electron-builder/cli.js --linux AppImage deb rpm --x64 --publish never
 
       - name: Upload Linux preview desktop artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: veritas-kanban-linux-unsigned
           path: |
@@ -124,11 +124,11 @@ jobs:
     name: Unsigned Windows Artifacts
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -149,7 +149,7 @@ jobs:
         run: node ./node_modules/electron-builder/cli.js --win nsis zip --x64 --publish never
 
       - name: Upload Windows preview desktop artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: veritas-kanban-windows-unsigned
           path: |

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -32,11 +32,11 @@ jobs:
     name: Signed and Notarized macOS Artifact
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/scheduled-qa.yml
+++ b/.github/workflows/scheduled-qa.yml
@@ -39,11 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-artifacts
           path: |
@@ -86,11 +86,11 @@ jobs:
     env:
       K6_PROFILE: ${{ github.event_name == 'workflow_dispatch' && inputs.load_profile || 'smoke' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload k6 artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: k6-artifacts
           path: |

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 pnpm check:security-artifacts
+pnpm check:actions-pinned
 node scripts/check-delivery-cadence.mjs
 npx lint-staged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ pnpm lint
 pnpm lint:fix
 
 # Smoke checks
+pnpm check:actions-pinned       # Rejects mutable external GitHub Action references
 pnpm check:pnpm-settings        # Validates package manager fields match this file
 pnpm check:delivery-cadence     # Prevents verification and review policy drift
 pnpm check:vite-native-config   # Loads web build and test configs with Vite's native loader

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,22 @@ GitHub secret scanning and push protection should remain enabled for the
 repository. The tracked-file guard complements those services because generic
 password and recovery-key hashes may not match provider-specific signatures.
 
+## CI Supply Chain Integrity
+
+Every external GitHub Action and reusable workflow reference must use a full
+40-character commit SHA followed by a readable release comment. Local actions
+under `./.github/actions/` are reviewed with the repository and do not need a
+remote revision. Docker actions must use a complete SHA-256 image digest.
+
+The same policy is enforced locally and in CI:
+
+```bash
+pnpm check:actions-pinned
+```
+
+Dependabot retains the `github-actions` ecosystem entry so reviewed updates can
+advance both the immutable commit and its release comment.
+
 ## Scope
 
 This policy applies to:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint:report": "node scripts/lint-warning-budget.mjs --all-rules",
     "lint:fix": "eslint . --fix",
     "check:delivery-cadence": "node --test scripts/check-delivery-cadence.test.mjs && node scripts/check-delivery-cadence.mjs",
+    "check:actions-pinned": "node --test scripts/check-actions-pinned.test.mjs && node scripts/check-actions-pinned.mjs",
     "check:vite-native-config": "pnpm --filter @veritas-kanban/web exec vite build --configLoader native && vitest run --configLoader native web/src/lib/__tests__/client-policy.test.ts",
     "check:pnpm-settings": "node scripts/check-pnpm-settings.mjs",
     "check:security-artifacts": "node scripts/check-security-artifacts.mjs",

--- a/scripts/check-actions-pinned.mjs
+++ b/scripts/check-actions-pinned.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FULL_COMMIT_SHA = /^[0-9a-f]{40}$/;
+const FULL_DOCKER_DIGEST = /^docker:\/\/[^@\s]+@sha256:[0-9a-f]{64}$/;
+const RELEASE_COMMENT = /^v?\d+(?:\.\d+){0,2}(?:[-+][0-9A-Za-z.-]+)?$/;
+
+function parseUsesLine(line) {
+  const match = line.match(/^\s*(?:-\s*)?uses:\s*(.+?)\s*$/);
+  if (!match) return null;
+
+  const declaration = match[1].trim();
+  let reference;
+  let comment = '';
+
+  if (declaration.startsWith("'") || declaration.startsWith('"')) {
+    const quote = declaration[0];
+    const closingQuote = declaration.indexOf(quote, 1);
+    if (closingQuote < 0) return { reference: declaration, comment };
+    reference = declaration.slice(1, closingQuote);
+    const remainder = declaration.slice(closingQuote + 1).trim();
+    if (remainder.startsWith('#')) comment = remainder.slice(1).trim();
+  } else {
+    const commentIndex = declaration.search(/\s+#/);
+    reference = (commentIndex >= 0 ? declaration.slice(0, commentIndex) : declaration).trim();
+    if (commentIndex >= 0)
+      comment = declaration
+        .slice(commentIndex)
+        .replace(/^\s+#\s*/, '')
+        .trim();
+  }
+
+  return { reference, comment };
+}
+
+function releaseCommentViolation(file, line, reference, comment) {
+  if (RELEASE_COMMENT.test(comment)) return null;
+  return {
+    file,
+    line,
+    reference,
+    message: 'immutable external action pin must include a trailing release comment',
+  };
+}
+
+export function findActionPinningViolations(files) {
+  const violations = [];
+
+  for (const [file, content] of Object.entries(files).sort(([a], [b]) => a.localeCompare(b))) {
+    for (const [index, sourceLine] of content.split(/\r?\n/).entries()) {
+      const parsed = parseUsesLine(sourceLine);
+      if (!parsed) continue;
+
+      const { reference, comment } = parsed;
+      const line = index + 1;
+
+      if (reference.startsWith('./')) continue;
+
+      if (reference.startsWith('docker://')) {
+        if (!FULL_DOCKER_DIGEST.test(reference)) {
+          violations.push({
+            file,
+            line,
+            reference,
+            message: 'Docker action must use a full sha256 digest',
+          });
+          continue;
+        }
+        const commentViolation = releaseCommentViolation(file, line, reference, comment);
+        if (commentViolation) violations.push(commentViolation);
+        continue;
+      }
+
+      const separator = reference.lastIndexOf('@');
+      const action = separator >= 0 ? reference.slice(0, separator) : reference;
+      const revision = separator >= 0 ? reference.slice(separator + 1) : '';
+      if (!action.includes('/') || !FULL_COMMIT_SHA.test(revision)) {
+        violations.push({
+          file,
+          line,
+          reference,
+          message: 'external action must use a full 40-character commit SHA',
+        });
+        continue;
+      }
+
+      const commentViolation = releaseCommentViolation(file, line, reference, comment);
+      if (commentViolation) violations.push(commentViolation);
+    }
+  }
+
+  return violations;
+}
+
+export function findDependabotConfigurationViolations(content) {
+  return /package-ecosystem:\s*['"]?github-actions['"]?(?:\s|$)/.test(content)
+    ? []
+    : ['Dependabot must retain a github-actions ecosystem entry'];
+}
+
+function collectYamlFiles(directory) {
+  if (!existsSync(directory)) return {};
+  const files = {};
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      Object.assign(files, collectYamlFiles(absolutePath));
+    } else if (/\.ya?ml$/i.test(entry.name)) {
+      const relativePath = path.relative(process.cwd(), absolutePath).replaceAll('\\', '/');
+      files[relativePath] = readFileSync(absolutePath, 'utf8');
+    }
+  }
+
+  return files;
+}
+
+export function runActionPinningCheck() {
+  const workflowFiles = {
+    ...collectYamlFiles(path.resolve('.github/workflows')),
+    ...collectYamlFiles(path.resolve('.github/actions')),
+  };
+  const violations = findActionPinningViolations(workflowFiles);
+  const dependabotPath = path.resolve('.github/dependabot.yml');
+  const dependabotViolations = existsSync(dependabotPath)
+    ? findDependabotConfigurationViolations(readFileSync(dependabotPath, 'utf8'))
+    : ['Dependabot configuration is missing'];
+
+  if (violations.length > 0 || dependabotViolations.length > 0) {
+    console.error('Immutable GitHub Actions check failed.');
+    for (const violation of violations) {
+      console.error(
+        `- ${violation.file}:${violation.line} ${violation.reference}: ${violation.message}`
+      );
+    }
+    for (const message of dependabotViolations)
+      console.error(`- .github/dependabot.yml: ${message}`);
+    process.exitCode = 1;
+    return false;
+  }
+
+  console.log(
+    `Immutable GitHub Actions check passed (${Object.keys(workflowFiles).length} YAML files scanned).`
+  );
+  return true;
+}
+
+function isDirectExecution() {
+  return process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isDirectExecution()) runActionPinningCheck();

--- a/scripts/check-actions-pinned.test.mjs
+++ b/scripts/check-actions-pinned.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  findActionPinningViolations,
+  findDependabotConfigurationViolations,
+} from './check-actions-pinned.mjs';
+
+const SHA = '3d3c42e5aac5ba805825da76410c181273ba90b1';
+const DIGEST = 'a'.repeat(64);
+
+test('accepts immutable external action pins with release comments', () => {
+  assert.deepEqual(
+    findActionPinningViolations({
+      '.github/workflows/ci.yml': `steps:\n  - uses: actions/checkout@${SHA} # v7.0.1\n`,
+    }),
+    []
+  );
+});
+
+test('rejects mutable tags, branches, short SHAs, and missing release comments', () => {
+  assert.deepEqual(
+    findActionPinningViolations({
+      '.github/workflows/ci.yml': [
+        'steps:',
+        '  - uses: actions/checkout@v7',
+        '  - uses: actions/setup-node@main',
+        '  - uses: actions/upload-artifact@043fb46',
+        `  - uses: pnpm/action-setup@${SHA}`,
+      ].join('\n'),
+    }),
+    [
+      {
+        file: '.github/workflows/ci.yml',
+        line: 2,
+        reference: 'actions/checkout@v7',
+        message: 'external action must use a full 40-character commit SHA',
+      },
+      {
+        file: '.github/workflows/ci.yml',
+        line: 3,
+        reference: 'actions/setup-node@main',
+        message: 'external action must use a full 40-character commit SHA',
+      },
+      {
+        file: '.github/workflows/ci.yml',
+        line: 4,
+        reference: 'actions/upload-artifact@043fb46',
+        message: 'external action must use a full 40-character commit SHA',
+      },
+      {
+        file: '.github/workflows/ci.yml',
+        line: 5,
+        reference: `pnpm/action-setup@${SHA}`,
+        message: 'immutable external action pin must include a trailing release comment',
+      },
+    ]
+  );
+});
+
+test('allows local actions without a commit pin', () => {
+  assert.deepEqual(
+    findActionPinningViolations({
+      '.github/workflows/ci.yml': 'steps:\n  - uses: ./.github/actions/setup\n',
+    }),
+    []
+  );
+});
+
+test('requires immutable digests for Docker actions', () => {
+  assert.deepEqual(
+    findActionPinningViolations({
+      '.github/actions/example/action.yml': [
+        'runs:',
+        '  using: docker',
+        '  image: docker://alpine:3.22',
+        '  - uses: docker://alpine:3.22',
+        `  - uses: docker://alpine@sha256:${DIGEST} # 3.22.1`,
+      ].join('\n'),
+    }),
+    [
+      {
+        file: '.github/actions/example/action.yml',
+        line: 4,
+        reference: 'docker://alpine:3.22',
+        message: 'Docker action must use a full sha256 digest',
+      },
+    ]
+  );
+});
+
+test('requires Dependabot maintenance for GitHub Actions', () => {
+  assert.deepEqual(
+    findDependabotConfigurationViolations("version: 2\nupdates:\n  - package-ecosystem: 'npm'\n"),
+    ['Dependabot must retain a github-actions ecosystem entry']
+  );
+  assert.deepEqual(
+    findDependabotConfigurationViolations(
+      "version: 2\nupdates:\n  - package-ecosystem: 'github-actions'\n    directory: '/'\n"
+    ),
+    []
+  );
+});


### PR DESCRIPTION
## Summary

- pin all 40 external action invocations across CI, scheduled QA, desktop artifacts, and desktop release workflows
- add a dependency-free guard that rejects tags, branches, short SHAs, missing release comments, and mutable Docker action references
- run the guard in CI and pre-commit, and retain Dependabot maintenance for the `github-actions` ecosystem
- document the repository supply-chain policy and verification command

## Verified upstream pins

- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1` (`v7.0.1`)
- `actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38` (`v6.5.0`)
- `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (`v7.0.1`)
- `pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86` (`v6.0.10`, peeled from its verified annotated tag)

Each commit was resolved from the named upstream release tag and has verified GitHub commit or tag provenance.

## Verification

- `pnpm check:actions-pinned` (5 guard tests; 4 workflow files and 40 references scanned)
- `pnpm test:ci-scope` (17/17)
- `pnpm check:delivery-cadence` (18/18 plus live guidance check)
- `pnpm check:security-artifacts`
- `pnpm check:pnpm-settings`
- `pnpm lint` (0 errors, 588 existing warnings)
- Prettier and `git diff --check`

Fixes #1167