### PR TITLE
test: bound workflow draft interaction cost

### DIFF
--- a/web/src/__tests__/workflow-browser-actions.test.tsx
+++ b/web/src/__tests__/workflow-browser-actions.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { WorkflowDefinition } from '@veritas-kanban/shared';
 
@@ -250,8 +250,7 @@ describe('workflow browser view and edit actions', () => {
       .find((input) => (input as HTMLInputElement).value === 'Owned workflow');
     expect(nameInput).toBeDefined();
     if (!nameInput) throw new Error('Workflow name input was not rendered');
-    await user.clear(nameInput);
-    await user.type(nameInput, 'Owned workflow revised!');
+    fireEvent.change(nameInput, { target: { value: 'Owned workflow revised!' } });
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => expect(updateAttempts).toBe(1));
@@ -263,8 +262,7 @@ describe('workflow browser view and edit actions', () => {
       })
     );
 
-    await user.clear(nameInput);
-    await user.type(nameInput, 'Owned workflow revised');
+    fireEvent.change(nameInput, { target: { value: 'Owned workflow revised' } });
     expect((nameInput as HTMLInputElement).value).toBe('Owned workflow revised');
 
     await user.click(screen.getByRole('button', { name: 'Save changes' }));


### PR DESCRIPTION
## Summary

- replace two long per-character name edits with direct change events in the workflow draft persistence test
- preserve the user-driven save actions and every assertion covering validation failure, retained draft state, loaded revision, and successful retry
- remove the CI-only timeout path observed after the original deterministic-suite fix merged

## Evidence

The first CI attempt on PR #1180 timed out this test at 15 seconds after all server tests had passed. Rerunning the same commit passed, while the exact test also passed locally. That combination identifies a cost-sensitive test interaction rather than a product regression.

## Verification

- affected test: 10 consecutive passes before commit
- full web suite: 469/469 after rebasing onto current `main`
- full canonical workspace unit gate: server 3,236 plus 5 skipped; web 469; CLI 62; MCP 71 plus 19 skipped
- `pnpm check:security-gates`
- `pnpm check:gitleaks`
- focused ESLint, Prettier, web typecheck, and `git diff --check`

Fixes #1172
