### PR TITLE
refactor: remove activity service filesystem fallback

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,13 +1,7 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 53,
+  "maximumEntries": 52,
   "entries": [
-    {
-      "path": "server/src/services/activity-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
-    },
     {
       "path": "server/src/services/agent-health-service.ts",
       "category": "authoritative-persistence",

--- a/server/src/services/activity-service.ts
+++ b/server/src/services/activity-service.ts
@@ -1,4 +1,3 @@
-import { mkdir } from 'fs/promises';
 import { join } from 'path';
 import { getDataDir } from '../utils/paths.js';
 import type { ActivityRepository } from '../storage/interfaces.js';
@@ -93,11 +92,6 @@ export class ActivityService {
         maxActivities: this.MAX_ACTIVITIES,
       });
     }
-  }
-
-  private async ensureDir() {
-    const dir = getDataDir();
-    await mkdir(dir, { recursive: true });
   }
 
   /**
@@ -250,7 +244,6 @@ export class ActivityService {
       return;
     }
 
-    await this.ensureDir();
     // Fallback: no-op
   }
 


### PR DESCRIPTION
## Summary

- remove the last service-layer filesystem call from `ActivityService`
- keep activity file operations inside `AppendActivityRepository`, where they already execute
- ratchet the classified service filesystem baseline from 53 to 52

This is the first bounded #1186 coordination-state migration. The parent stays open for the remaining domains.

## Verification

- `pnpm check:service-filesystem-boundary`
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/activity-service.test.ts` (6 passed)
- focused ESLint and Prettier checks

Refs #1186
