### PR TITLE
refactor: move progress persistence behind repository

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 52,
+  "maximumEntries": 51,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -169,12 +169,6 @@
       "category": "transient-process-io",
       "owner": "#1189",
       "rationale": "Remaining process I/O migration is tracked in issue #1189."
-    },
-    {
-      "path": "server/src/services/progress-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/prompt-registry-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -34,6 +34,7 @@
           "src/__tests__/middleware/write-enforcement.integration.test.ts",
           "src/__tests__/openclaw-provider.test.ts",
           "src/__tests__/path-audit.test.ts",
+          "src/__tests__/progress-service.test.ts",
           "src/__tests__/provider-completion-service.test.ts",
           "src/__tests__/provider-launch-credential-plan-service.test.ts",
           "src/__tests__/provider-runtime-adapters.test.ts",

--- a/server/src/__tests__/progress-service.test.ts
+++ b/server/src/__tests__/progress-service.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { ProgressService } from '../services/progress-service.js';
+
+const unlinkFailure = vi.hoisted(() => ({
+  error: undefined as NodeJS.ErrnoException | undefined,
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    unlink: async (filePath: Parameters<typeof actual.unlink>[0]) => {
+      if (unlinkFailure.error) throw unlinkFailure.error;
+      return actual.unlink(filePath);
+    },
+  };
+});
+
+describe('ProgressService file repository', () => {
+  let root: string;
+  let progressDir: string;
+  let service: ProgressService;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(os.tmpdir(), 'veritas-progress-service-'));
+    progressDir = path.join(root, 'progress');
+    service = new ProgressService(progressDir);
+  });
+
+  afterEach(async () => {
+    unlinkFailure.error = undefined;
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('rejects task IDs that escape the progress directory', async () => {
+    await expect(service.updateProgress('../escape', 'outside')).rejects.toThrow(/path segment/i);
+    await expect(readFile(path.join(root, 'escape.md'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('persists, appends, and deletes progress through the repository', async () => {
+    await service.updateProgress('task-1', '# Progress\n');
+    await service.appendProgress('task-1', 'Done', 'first item');
+    await service.appendProgress('task-1', 'Done', 'second item');
+
+    const progress = await service.getProgress('task-1');
+    expect(progress).toContain('# Progress');
+    expect(progress).toContain('## Done');
+    expect(progress).toContain('first item');
+    expect(progress).toContain('second item');
+
+    await service.deleteProgress('task-1');
+    await expect(service.getProgress('task-1')).resolves.toBeNull();
+    await expect(service.deleteProgress('task-1')).resolves.toBeUndefined();
+  });
+
+  it('preserves concurrent appends with a repository lock', async () => {
+    await Promise.all([
+      service.appendProgress('task-2', 'Notes', 'alpha'),
+      service.appendProgress('task-2', 'Notes', 'beta'),
+    ]);
+
+    const progress = await service.getProgress('task-2');
+    expect(progress).toContain('alpha');
+    expect(progress).toContain('beta');
+  });
+
+  it('refuses to read progress through a symbolic link', async () => {
+    const target = path.join(root, 'target.md');
+    await mkdir(progressDir, { recursive: true });
+    await writeFile(target, 'outside');
+    await symlink(target, path.join(progressDir, 'task-3.md'));
+
+    await expect(service.getProgress('task-3')).rejects.toThrow(/symbolic link/i);
+  });
+
+  it('rejects oversized progress content and non-file entries', async () => {
+    await expect(service.updateProgress('task-4', 'x'.repeat(2 * 1024 * 1024 + 1))).rejects.toThrow(
+      /2 MiB/i
+    );
+
+    await mkdir(path.join(progressDir, 'task-4.md'), { recursive: true });
+    await expect(service.getProgress('task-4')).rejects.toThrow(/bounded regular file/i);
+  });
+
+  it('keeps concurrent deletes idempotent', async () => {
+    await service.updateProgress('task-5', 'temporary');
+
+    await expect(
+      Promise.all([service.deleteProgress('task-5'), service.deleteProgress('task-5')])
+    ).resolves.toEqual([undefined, undefined]);
+  });
+
+  it('propagates repository delete failures', async () => {
+    await service.updateProgress('task-6', 'temporary');
+    unlinkFailure.error = Object.assign(new Error('delete denied'), { code: 'EACCES' });
+
+    await expect(service.deleteProgress('task-6')).rejects.toThrow('delete denied');
+  });
+
+  it('rejects a symbolic-link progress directory', async () => {
+    const realDirectory = path.join(root, 'real-progress');
+    await mkdir(realDirectory);
+    await symlink(realDirectory, progressDir, 'dir');
+
+    await expect(service.updateProgress('task-7', 'unsafe')).rejects.toThrow(/regular directory/i);
+  });
+});

--- a/server/src/services/progress-service.ts
+++ b/server/src/services/progress-service.ts
@@ -1,7 +1,5 @@
-import fs from 'fs/promises';
-import path from 'path';
 import { createLogger } from '../lib/logger.js';
-import { getRuntimeDir } from '../utils/paths.js';
+import { FileProgressRepository, type ProgressRepository } from '../storage/progress-repository.js';
 
 const log = createLogger('progress-service');
 
@@ -10,24 +8,10 @@ const log = createLogger('progress-service');
  * Stores markdown files in .veritas-kanban/progress/<task-id>.md
  */
 export class ProgressService {
-  private progressDir: string;
+  private readonly repository: ProgressRepository;
 
-  constructor(progressDir?: string) {
-    this.progressDir = progressDir || path.join(getRuntimeDir(), 'progress');
-  }
-
-  /**
-   * Ensure the progress directory exists
-   */
-  private async ensureDirectory(): Promise<void> {
-    await fs.mkdir(this.progressDir, { recursive: true });
-  }
-
-  /**
-   * Get the file path for a task's progress file
-   */
-  private getProgressPath(taskId: string): string {
-    return path.join(this.progressDir, `${taskId}.md`);
+  constructor(progressDir?: string, repository?: ProgressRepository) {
+    this.repository = repository ?? new FileProgressRepository(progressDir || undefined);
   }
 
   /**
@@ -36,15 +20,10 @@ export class ProgressService {
    */
   async getProgress(taskId: string): Promise<string | null> {
     try {
-      const filepath = this.getProgressPath(taskId);
-      const content = await fs.readFile(filepath, 'utf-8');
-      log.debug({ taskId }, 'Progress file read');
+      const content = await this.repository.get(taskId);
+      if (content !== null) log.debug({ taskId }, 'Progress file read');
       return content;
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        // No progress file exists yet — that's fine
-        return null;
-      }
       log.error({ err: error, taskId }, 'Failed to read progress file');
       throw error;
     }
@@ -54,11 +33,8 @@ export class ProgressService {
    * Update (overwrite) progress content for a task
    */
   async updateProgress(taskId: string, content: string): Promise<void> {
-    await this.ensureDirectory();
-    const filepath = this.getProgressPath(taskId);
-
     try {
-      await fs.writeFile(filepath, content, 'utf-8');
+      await this.repository.set(taskId, content);
       log.debug({ taskId }, 'Progress file updated');
     } catch (error) {
       log.error({ err: error, taskId }, 'Failed to update progress file');
@@ -72,45 +48,15 @@ export class ProgressService {
    * Section format: ## Section Name
    */
   async appendProgress(taskId: string, section: string, content: string): Promise<void> {
-    await this.ensureDirectory();
-
-    const existingContent = (await this.getProgress(taskId)) || '';
-    const sectionHeader = `## ${section}`;
-    const appendText = `\n${content.trim()}\n`;
-
-    let updatedContent: string;
-
-    if (existingContent.includes(sectionHeader)) {
-      // Section exists — find it and append after the header
-      const lines = existingContent.split('\n');
-      const sectionIndex = lines.findIndex((line) => line.trim() === sectionHeader);
-
-      if (sectionIndex !== -1) {
-        // Find the next section header or end of file
-        let endIndex = lines.length;
-        for (let i = sectionIndex + 1; i < lines.length; i++) {
-          if (lines[i].startsWith('## ')) {
-            endIndex = i;
-            break;
-          }
-        }
-
-        // Insert content before the next section
-        lines.splice(endIndex, 0, appendText.trim());
-        updatedContent = lines.join('\n');
-      } else {
-        // Shouldn't happen, but fallback to appending at end
-        updatedContent = `${existingContent}\n${sectionHeader}${appendText}`;
-      }
-    } else {
-      // Section doesn't exist — create it at the end
-      updatedContent = existingContent
-        ? `${existingContent.trim()}\n\n${sectionHeader}${appendText}`
-        : `${sectionHeader}${appendText}`;
+    try {
+      await this.repository.update(taskId, (existingContent) =>
+        this.appendToSection(existingContent ?? '', section, content)
+      );
+      log.debug({ taskId, section }, 'Progress appended to section');
+    } catch (error) {
+      log.error({ err: error, taskId, section }, 'Failed to append progress');
+      throw error;
     }
-
-    await this.updateProgress(taskId, updatedContent);
-    log.debug({ taskId, section }, 'Progress appended to section');
   }
 
   /**
@@ -118,17 +64,37 @@ export class ProgressService {
    */
   async deleteProgress(taskId: string): Promise<void> {
     try {
-      const filepath = this.getProgressPath(taskId);
-      await fs.unlink(filepath);
+      await this.repository.delete(taskId);
       log.debug({ taskId }, 'Progress file deleted');
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        // File doesn't exist — that's fine
-        return;
-      }
       log.error({ err: error, taskId }, 'Failed to delete progress file');
       throw error;
     }
+  }
+
+  private appendToSection(existingContent: string, section: string, content: string): string {
+    const sectionHeader = `## ${section}`;
+    const appendText = `\n${content.trim()}\n`;
+
+    if (!existingContent.includes(sectionHeader)) {
+      return existingContent
+        ? `${existingContent.trim()}\n\n${sectionHeader}${appendText}`
+        : `${sectionHeader}${appendText}`;
+    }
+
+    const lines = existingContent.split('\n');
+    const sectionIndex = lines.findIndex((line) => line.trim() === sectionHeader);
+    if (sectionIndex === -1) return `${existingContent}\n${sectionHeader}${appendText}`;
+
+    let endIndex = lines.length;
+    for (let index = sectionIndex + 1; index < lines.length; index += 1) {
+      if (lines[index].startsWith('## ')) {
+        endIndex = index;
+        break;
+      }
+    }
+    lines.splice(endIndex, 0, appendText.trim());
+    return lines.join('\n');
   }
 }
 

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -39,6 +39,7 @@ export type {
   StorageProvider,
 } from './interfaces.js';
 export { LocalWorkspaceFileRepository } from './workspace-file-repository.js';
+export { FileProgressRepository, type ProgressRepository } from './progress-repository.js';
 export {
   FileWorkspaceExecutionTrustRepository,
   InMemoryWorkspaceExecutionTrustRepository,

--- a/server/src/storage/progress-repository.ts
+++ b/server/src/storage/progress-repository.ts
@@ -1,0 +1,96 @@
+import { constants } from 'node:fs';
+import { lstat, mkdir, open, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { withFileLock } from '../services/file-lock.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import { atomicWriteFile } from './fs-helpers.js';
+
+const MAX_PROGRESS_BYTES = 2 * 1024 * 1024;
+
+export interface ProgressRepository {
+  get(taskId: string): Promise<string | null>;
+  set(taskId: string, content: string): Promise<void>;
+  update(taskId: string, updater: (content: string | null) => string): Promise<void>;
+  delete(taskId: string): Promise<void>;
+}
+
+export class FileProgressRepository implements ProgressRepository {
+  private readonly progressDir: string;
+
+  constructor(progressDir = path.join(getRuntimeDir(), 'progress')) {
+    this.progressDir = path.resolve(progressDir);
+    ensureWithinBase(path.dirname(this.progressDir), this.progressDir);
+  }
+
+  async get(taskId: string): Promise<string | null> {
+    return this.read(this.getProgressPath(taskId));
+  }
+
+  async set(taskId: string, content: string): Promise<void> {
+    const progressPath = this.getProgressPath(taskId);
+    await this.prepareDirectory();
+    await withFileLock(progressPath, () => this.write(progressPath, content));
+  }
+
+  async update(taskId: string, updater: (content: string | null) => string): Promise<void> {
+    const progressPath = this.getProgressPath(taskId);
+    await this.prepareDirectory();
+    await withFileLock(progressPath, async () => {
+      const current = await this.read(progressPath);
+      await this.write(progressPath, updater(current));
+    });
+  }
+
+  async delete(taskId: string): Promise<void> {
+    const progressPath = this.getProgressPath(taskId);
+    if ((await this.read(progressPath)) === null) return;
+    await this.prepareDirectory();
+    await withFileLock(progressPath, async () => {
+      await unlink(progressPath).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== 'ENOENT') throw error;
+      });
+    });
+  }
+
+  private getProgressPath(taskId: string): string {
+    const safeTaskId = validatePathSegment(taskId);
+    return ensureWithinBase(this.progressDir, path.join(this.progressDir, `${safeTaskId}.md`));
+  }
+
+  private async prepareDirectory(): Promise<void> {
+    await mkdir(this.progressDir, { recursive: true, mode: 0o700 });
+    const stats = await lstat(this.progressDir);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error('Progress storage path must be a regular directory');
+    }
+  }
+
+  private async read(progressPath: string): Promise<string | null> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(progressPath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const stats = await handle.stat();
+      if (!stats.isFile() || stats.size > MAX_PROGRESS_BYTES) {
+        throw new Error('Progress file must be a bounded regular file');
+      }
+      return await handle.readFile({ encoding: 'utf8' });
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOENT') return null;
+      if (errorCode === 'ELOOP') {
+        throw new Error('Progress file must not be a symbolic link', { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private async write(progressPath: string, content: string): Promise<void> {
+    if (Buffer.byteLength(content, 'utf8') > MAX_PROGRESS_BYTES) {
+      throw new Error('Progress content exceeds the 2 MiB storage limit');
+    }
+    await atomicWriteFile(progressPath, content, 'utf8');
+  }
+}


### PR DESCRIPTION
## Summary

- move progress file I/O out of `ProgressService` and into a dedicated `FileProgressRepository`
- validate task IDs and enforce path containment before resolving progress files
- reject symlink and oversized-file reads, use atomic writes, and serialize read-modify-write appends
- ratchet the classified service filesystem baseline from 52 to 51

This is a bounded #1186 coordination-state migration. The parent stays open for the remaining domains.

## Verification

- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm check:service-filesystem-boundary`
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/progress-service.test.ts` (8 passed)
- `pnpm test:coverage --packages server` (887 passed; all critical-path ratchets passed)
- focused ESLint and Prettier checks

Refs #1186
