### PR TITLE
refactor: move scheduled deliverables file I/O behind storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 50,
+  "maximumEntries": 49,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -193,12 +193,6 @@
       "category": "authoritative-persistence",
       "owner": "#1187",
       "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
-    {
-      "path": "server/src/services/scheduled-deliverables-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/scheduler-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -44,6 +44,7 @@
           "src/__tests__/provider-task-envelope-renderer.test.ts",
           "src/__tests__/reflection-extraction-job-service.test.ts",
           "src/__tests__/runtime-paths.test.ts",
+          "src/__tests__/scheduled-deliverables-repository.test.ts",
           "src/__tests__/routes/admin-governance-auth.test.ts",
           "src/__tests__/routes/auth.test.ts",
           "src/__tests__/routes/credential-broker.test.ts",

--- a/server/src/__tests__/scheduled-deliverables-repository.test.ts
+++ b/server/src/__tests__/scheduled-deliverables-repository.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { Deliverable, DeliverableRun } from '../services/scheduled-deliverables-service.js';
+import { FileScheduledDeliverablesStore } from '../storage/scheduled-deliverables-repository.js';
+
+const deliverable: Deliverable = {
+  id: 'del_1',
+  name: 'Daily pulse',
+  description: 'Produce the daily pulse.',
+  schedule: 'daily',
+  scheduleDescription: 'Every day',
+  enabled: true,
+  tags: ['operations'],
+  createdAt: '2026-08-23T20:00:00.000Z',
+  totalRuns: 0,
+};
+
+const run: DeliverableRun = {
+  id: 'run_1',
+  deliverableId: deliverable.id,
+  status: 'success',
+  runAt: '2026-08-23T21:00:00.000Z',
+};
+
+describe('FileScheduledDeliverablesStore', () => {
+  let root: string;
+  let deliverablesFile: string;
+  let runsFile: string;
+  let store: FileScheduledDeliverablesStore;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-deliverables-store-'));
+    deliverablesFile = path.join(root, 'state', 'deliverables.json');
+    runsFile = path.join(root, 'state', 'runs.json');
+    store = new FileScheduledDeliverablesStore(deliverablesFile, runsFile);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('loads missing files and atomically persists both collections', async () => {
+    await expect(store.loadDeliverables()).resolves.toEqual([]);
+    await expect(store.loadRuns()).resolves.toEqual([]);
+
+    await store.saveDeliverables([deliverable]);
+    await store.saveRuns([run]);
+
+    await expect(store.loadDeliverables()).resolves.toEqual([deliverable]);
+    await expect(store.loadRuns()).resolves.toEqual([run]);
+  });
+
+  it('treats malformed and non-array legacy content as empty state', async () => {
+    await mkdir(path.dirname(deliverablesFile), { recursive: true });
+    await writeFile(deliverablesFile, '{broken', 'utf8');
+    await expect(store.loadDeliverables()).resolves.toEqual([]);
+
+    await writeFile(deliverablesFile, '{}', 'utf8');
+    await expect(store.loadDeliverables()).resolves.toEqual([]);
+  });
+
+  it('rejects symbolic links and non-file state paths', async () => {
+    await mkdir(path.dirname(deliverablesFile), { recursive: true });
+    const target = path.join(root, 'outside.json');
+    await writeFile(target, '[]', 'utf8');
+    await symlink(target, deliverablesFile);
+    await expect(store.loadDeliverables()).rejects.toThrow(/symbolic link/i);
+
+    await rm(deliverablesFile);
+    await mkdir(deliverablesFile);
+    await expect(store.loadDeliverables()).rejects.toThrow(/bounded regular file/i);
+  });
+
+  it('rejects symbolic-link parent directories and oversized state', async () => {
+    const realDirectory = path.join(root, 'real-state');
+    const linkedDirectory = path.join(root, 'linked-state');
+    await mkdir(realDirectory);
+    await symlink(realDirectory, linkedDirectory, 'dir');
+    const linkedStore = new FileScheduledDeliverablesStore(
+      path.join(linkedDirectory, 'deliverables.json'),
+      path.join(linkedDirectory, 'runs.json')
+    );
+    await expect(linkedStore.saveDeliverables([deliverable])).rejects.toThrow(/regular directory/i);
+
+    await expect(
+      store.saveDeliverables([
+        {
+          ...deliverable,
+          description: 'x'.repeat(16 * 1024 * 1024),
+        },
+      ])
+    ).rejects.toThrow(/16 MiB/i);
+  });
+});

--- a/server/src/services/scheduled-deliverables-service.ts
+++ b/server/src/services/scheduled-deliverables-service.ts
@@ -6,8 +6,8 @@
  */
 
 import { createLogger } from '../lib/logger.js';
-import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { FileScheduledDeliverablesStore } from '../storage/scheduled-deliverables-repository.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteScheduledDeliverablesRepository } from '../storage/sqlite/scheduled-deliverables-repository.js';
 import { getRuntimeDir } from '../utils/paths.js';
@@ -100,8 +100,7 @@ export class ScheduledDeliverablesService {
   private deliverables: Deliverable[] = [];
   private runs: DeliverableRun[] = [];
   private loaded = false;
-  private readonly deliverablesFile: string;
-  private readonly runsFile: string;
+  private readonly fileStore: FileScheduledDeliverablesStore | null;
   private readonly runRetentionLimit: number;
   private readonly repository: SqliteScheduledDeliverablesRepository | null = null;
   private readonly sqliteDatabase: SqliteDatabase | null = null;
@@ -109,9 +108,9 @@ export class ScheduledDeliverablesService {
 
   constructor(options: ScheduledDeliverablesServiceOptions = {}) {
     const dataDir = options.dataDir ?? DATA_DIR;
-    this.deliverablesFile =
+    const deliverablesFile =
       options.deliverablesFile ?? path.join(dataDir, 'scheduled-deliverables.json');
-    this.runsFile = options.runsFile ?? path.join(dataDir, 'deliverable-runs.json');
+    const runsFile = options.runsFile ?? path.join(dataDir, 'deliverable-runs.json');
     this.runRetentionLimit = options.runRetentionLimit ?? 500;
     const storageType =
       options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
@@ -122,6 +121,9 @@ export class ScheduledDeliverablesService {
       this.ownsSqliteDatabase = !options.sqliteDatabase;
       this.sqliteDatabase.open();
       this.repository = new SqliteScheduledDeliverablesRepository(this.sqliteDatabase);
+      this.fileStore = null;
+    } else {
+      this.fileStore = new FileScheduledDeliverablesStore(deliverablesFile, runsFile);
     }
   }
 
@@ -138,21 +140,10 @@ export class ScheduledDeliverablesService {
       return;
     }
 
-    try {
-      const data = await fs.readFile(this.deliverablesFile, 'utf-8');
-      this.deliverables = JSON.parse(data);
-    } catch {
-      this.deliverables = [];
-    }
-    try {
-      const data = await fs.readFile(this.runsFile, 'utf-8');
-      this.runs = JSON.parse(data);
-      // Keep only last 500 runs
-      if (this.runs.length > this.runRetentionLimit) {
-        this.runs = this.runs.slice(-this.runRetentionLimit);
-      }
-    } catch {
-      this.runs = [];
+    this.deliverables = await this.getFileStore().loadDeliverables();
+    this.runs = await this.getFileStore().loadRuns();
+    if (this.runs.length > this.runRetentionLimit) {
+      this.runs = this.runs.slice(-this.runRetentionLimit);
     }
     this.loaded = true;
   }
@@ -163,8 +154,7 @@ export class ScheduledDeliverablesService {
       return;
     }
 
-    await fs.mkdir(path.dirname(this.deliverablesFile), { recursive: true });
-    await fs.writeFile(this.deliverablesFile, JSON.stringify(this.deliverables, null, 2));
+    await this.getFileStore().saveDeliverables(this.deliverables);
   }
 
   private async saveRuns(): Promise<void> {
@@ -173,8 +163,7 @@ export class ScheduledDeliverablesService {
       return;
     }
 
-    await fs.mkdir(path.dirname(this.runsFile), { recursive: true });
-    await fs.writeFile(this.runsFile, JSON.stringify(this.runs, null, 2));
+    await this.getFileStore().saveRuns(this.runs);
   }
 
   /**
@@ -403,6 +392,11 @@ export class ScheduledDeliverablesService {
   }
 
   // ─── Private ─────────────────────────────────────────────────
+
+  private getFileStore(): FileScheduledDeliverablesStore {
+    if (!this.fileStore) throw new Error('File scheduled deliverables store is unavailable');
+    return this.fileStore;
+  }
 
   private describeSchedule(schedule: DeliverableSchedule, cronExpr?: string): string {
     switch (schedule) {

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -41,6 +41,7 @@ export type {
 export { LocalWorkspaceFileRepository } from './workspace-file-repository.js';
 export { FileProgressRepository, type ProgressRepository } from './progress-repository.js';
 export { FileStatusHistoryStore } from './status-history-repository.js';
+export { FileScheduledDeliverablesStore } from './scheduled-deliverables-repository.js';
 export {
   FileWorkspaceExecutionTrustRepository,
   InMemoryWorkspaceExecutionTrustRepository,

--- a/server/src/storage/scheduled-deliverables-repository.ts
+++ b/server/src/storage/scheduled-deliverables-repository.ts
@@ -1,0 +1,80 @@
+import { lstat, mkdir, open } from 'node:fs/promises';
+import path from 'node:path';
+import type { Deliverable, DeliverableRun } from '../services/scheduled-deliverables-service.js';
+import { withFileLock } from '../services/file-lock.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import { atomicWriteFile } from './fs-helpers.js';
+
+const MAX_STATE_BYTES = 16 * 1024 * 1024;
+
+export class FileScheduledDeliverablesStore {
+  private readonly deliverablesFile: string;
+  private readonly runsFile: string;
+
+  constructor(deliverablesFile: string, runsFile: string) {
+    this.deliverablesFile = this.resolveFile(deliverablesFile);
+    this.runsFile = this.resolveFile(runsFile);
+  }
+
+  loadDeliverables(): Promise<Deliverable[]> {
+    return this.readArray<Deliverable>(this.deliverablesFile, 'Scheduled deliverables');
+  }
+
+  loadRuns(): Promise<DeliverableRun[]> {
+    return this.readArray<DeliverableRun>(this.runsFile, 'Scheduled deliverable runs');
+  }
+
+  saveDeliverables(deliverables: Deliverable[]): Promise<void> {
+    return this.writeArray(this.deliverablesFile, deliverables, 'Scheduled deliverables');
+  }
+
+  saveRuns(runs: DeliverableRun[]): Promise<void> {
+    return this.writeArray(this.runsFile, runs, 'Scheduled deliverable runs');
+  }
+
+  private resolveFile(filePath: string): string {
+    const resolved = path.resolve(filePath);
+    return ensureWithinBase(path.dirname(resolved), resolved);
+  }
+
+  private async readArray<T>(filePath: string, label: string): Promise<T[]> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, 'r');
+      const [pathStats, stats] = await Promise.all([lstat(filePath), handle.stat()]);
+      if (
+        pathStats.isSymbolicLink() ||
+        pathStats.dev !== stats.dev ||
+        pathStats.ino !== stats.ino
+      ) {
+        throw new Error(`${label} must not use a symbolic link or changed file`);
+      }
+      if (!stats.isFile() || stats.size > MAX_STATE_BYTES) {
+        throw new Error(`${label} must use a bounded regular file`);
+      }
+      const parsed: unknown = JSON.parse(await handle.readFile({ encoding: 'utf8' }));
+      return Array.isArray(parsed) ? (parsed as T[]) : [];
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOENT' || error instanceof SyntaxError) return [];
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private async writeArray<T>(filePath: string, entries: T[], label: string): Promise<void> {
+    const parent = path.dirname(filePath);
+    await mkdir(parent, { recursive: true, mode: 0o700 });
+    const parentStats = await lstat(parent);
+    if (!parentStats.isDirectory() || parentStats.isSymbolicLink()) {
+      throw new Error(`${label} path must use a regular directory`);
+    }
+
+    const content = JSON.stringify(entries, null, 2);
+    if (Buffer.byteLength(content, 'utf8') > MAX_STATE_BYTES) {
+      throw new Error(`${label} exceeds the 16 MiB storage limit`);
+    }
+    await withFileLock(filePath, () => atomicWriteFile(filePath, content, 'utf8'));
+  }
+}


### PR DESCRIPTION
## Summary

- move scheduled-deliverables file reads and writes from the service into a dedicated storage module
- preserve the existing SQLite repository path and service interface
- replace direct file writes with locked atomic replacement
- reject symlink, non-file, and oversized state while preserving missing and malformed legacy-file handling
- ratchet the classified service filesystem baseline from 50 to 49

This is a bounded #1186 coordination-state migration. The parent stays open for the remaining domains.

## Verification

- focused file, SQLite, runner, and scheduler tests (16 passed)
- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm check:service-filesystem-boundary` (49 classified exceptions)
- `pnpm test:coverage --packages server` (897 passed; all critical-path ratchets passed)

Refs #1186
