### PR TITLE
refactor: move broadcasts behind storage repository

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 48,
+  "maximumEntries": 47,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -25,12 +25,6 @@
       "category": "authoritative-persistence",
       "owner": "#1187",
       "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
-    {
-      "path": "server/src/services/broadcast-storage-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/ceremony-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -16,6 +16,7 @@
         "testFiles": [
           "src/__tests__/acp-stdio-provider.test.ts",
           "src/__tests__/admission-control-service.test.ts",
+          "src/__tests__/broadcast-storage-service.test.ts",
           "src/__tests__/claude-code-provider.smoke.test.ts",
           "src/__tests__/claude-code-provider.test.ts",
           "src/__tests__/codex-app-server-provider.smoke.test.ts",

--- a/server/src/__tests__/broadcast-storage-service.test.ts
+++ b/server/src/__tests__/broadcast-storage-service.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { Broadcast } from '@veritas-kanban/shared';
+import { BroadcastStorageService } from '../services/broadcast-storage-service.js';
+import { FileBroadcastRepository } from '../storage/broadcast-repository.js';
+
+function broadcast(id: string, overrides: Partial<Broadcast> = {}): Broadcast {
+  return {
+    id,
+    message: `Message ${id}`,
+    priority: 'info',
+    tags: [],
+    createdAt: '2026-08-23T20:00:00.000Z',
+    readBy: [],
+    ...overrides,
+  };
+}
+
+describe('BroadcastStorageService', () => {
+  let root: string;
+  let broadcastsDir: string;
+  let repository: FileBroadcastRepository;
+  let service: BroadcastStorageService;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-broadcast-storage-'));
+    broadcastsDir = path.join(root, 'broadcasts');
+    repository = new FileBroadcastRepository(broadcastsDir);
+    service = new BroadcastStorageService({ repository });
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('creates and round-trips safe frontmatter without field injection', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-23T21:00:00.000Z'));
+
+    const created = await service.create({
+      message: 'Ship the release.',
+      from: 'agent\npriority: urgent',
+      tags: ['release'],
+    });
+    const loaded = await service.getById(created.id);
+
+    expect(loaded).toMatchObject({
+      id: created.id,
+      message: 'Ship the release.',
+      priority: 'info',
+      from: 'agent\npriority: urgent',
+      tags: ['release'],
+      createdAt: '2026-08-23T21:00:00.000Z',
+    });
+    expect(await readFile(path.join(broadcastsDir, `${created.id}.md`), 'utf8')).toContain(
+      'from: "agent\\npriority: urgent"'
+    );
+  });
+
+  it('filters, sorts, limits, and marks broadcasts read without duplicate receipts', async () => {
+    await repository.save(
+      broadcast('older', {
+        priority: 'urgent',
+        createdAt: '2026-08-23T20:00:00.000Z',
+      })
+    );
+    await repository.save(
+      broadcast('newer', {
+        priority: 'urgent',
+        createdAt: '2026-08-23T21:00:00.000Z',
+      })
+    );
+    await repository.save(
+      broadcast('informational', {
+        createdAt: '2026-08-23T22:00:00.000Z',
+      })
+    );
+
+    await expect(service.list({ priority: 'urgent', limit: 1 })).resolves.toMatchObject([
+      { id: 'newer' },
+    ]);
+    await expect(
+      service.list({ since: '2026-08-23T20:30:00.000Z', priority: 'urgent' })
+    ).resolves.toMatchObject([{ id: 'newer' }]);
+
+    await expect(service.markRead('newer', 'VERITAS')).resolves.toBe(true);
+    await expect(service.markRead('newer', 'VERITAS')).resolves.toBe(true);
+    await expect(service.list({ unread: true, agent: 'VERITAS' })).resolves.toMatchObject([
+      { id: 'informational' },
+      { id: 'older' },
+    ]);
+    expect((await service.getById('newer'))?.readBy).toHaveLength(1);
+    await expect(service.markRead('missing', 'VERITAS')).resolves.toBe(false);
+  });
+
+  it('serializes concurrent read receipts', async () => {
+    await repository.save(broadcast('shared'));
+    await Promise.all([service.markRead('shared', 'TARS'), service.markRead('shared', 'CASE')]);
+
+    const receipts = (await repository.get('shared'))?.readBy.map(({ agent }) => agent);
+    expect(receipts).toEqual(expect.arrayContaining(['TARS', 'CASE']));
+    expect(receipts).toHaveLength(2);
+  });
+
+  it('loads legacy frontmatter and skips malformed broadcasts when listing', async () => {
+    await mkdir(broadcastsDir, { recursive: true });
+    await writeFile(
+      path.join(broadcastsDir, 'legacy.md'),
+      ['---', 'from: legacy-agent', 'tags: invalid', 'readBy: {}', 'ignored', '---', 'Legacy'].join(
+        '\n'
+      ),
+      'utf8'
+    );
+    await writeFile(path.join(broadcastsDir, 'broken.md'), 'not frontmatter', 'utf8');
+
+    await expect(service.getById('legacy')).resolves.toMatchObject({
+      id: 'legacy',
+      message: 'Legacy',
+      priority: 'info',
+      from: 'legacy-agent',
+      tags: [],
+      readBy: [],
+    });
+    await expect(service.getById('broken')).resolves.toBeNull();
+    await expect(service.list()).resolves.toMatchObject([{ id: 'legacy' }]);
+  });
+
+  it('fails closed for unsafe, non-file, oversized, and linked storage paths', async () => {
+    await mkdir(broadcastsDir, { recursive: true });
+    const outside = path.join(root, 'outside.md');
+    await writeFile(outside, 'not a broadcast', 'utf8');
+    await symlink(outside, path.join(broadcastsDir, 'linked.md'));
+    await expect(service.getById('linked')).resolves.toBeNull();
+
+    await mkdir(path.join(broadcastsDir, 'directory.md'));
+    await expect(service.getById('directory')).resolves.toBeNull();
+    await expect(service.getById('../outside')).resolves.toBeNull();
+    await expect(service.markRead('../outside', 'VERITAS')).resolves.toBe(false);
+    await expect(service.create({ message: 'x'.repeat(1024 * 1024) })).rejects.toThrow(
+      /Failed to create broadcast/
+    );
+
+    const realDirectory = path.join(root, 'real-broadcasts');
+    const linkedDirectory = path.join(root, 'linked-broadcasts');
+    await mkdir(realDirectory);
+    await symlink(realDirectory, linkedDirectory, 'dir');
+    const linkedService = new BroadcastStorageService({ broadcastsDir: linkedDirectory });
+    await expect(linkedService.list()).rejects.toThrow(/Failed to list broadcasts/);
+  });
+});

--- a/server/src/services/broadcast-storage-service.ts
+++ b/server/src/services/broadcast-storage-service.ts
@@ -7,143 +7,34 @@
  */
 
 import { createLogger } from '../lib/logger.js';
-import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type {
   Broadcast,
   CreateBroadcastRequest,
   GetBroadcastsQuery,
   BroadcastReadReceipt,
-  BroadcastPriority,
 } from '@veritas-kanban/shared';
-import { fileExists } from '../storage/fs-helpers.js';
-import { validatePathSegment } from '../utils/sanitize.js';
-import { withFileLock } from './file-lock.js';
 import { getBroadcastsDir } from '../utils/paths.js';
+import { FileBroadcastRepository } from '../storage/broadcast-repository.js';
 
 const BROADCASTS_DIR = getBroadcastsDir();
 
 const log = createLogger('broadcast-storage');
 
-// ─── Frontmatter Parsing ─────────────────────────────────────
-
-interface BroadcastFrontmatter {
-  id: string;
-  priority: BroadcastPriority;
-  from?: string;
-  tags?: string[];
-  createdAt: string;
-  readBy?: BroadcastReadReceipt[];
-}
-
-/**
- * Parse a broadcast markdown file (frontmatter + content).
- */
-function parseBroadcastFile(content: string, id: string): Broadcast {
-  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-
-  if (!frontmatterMatch) {
-    throw new Error(`Invalid broadcast file format: ${id}`);
-  }
-
-  const frontmatterText = frontmatterMatch[1];
-  const message = frontmatterMatch[2].trim();
-
-  // Parse frontmatter manually (simple YAML subset)
-  const frontmatter: Partial<BroadcastFrontmatter> = {};
-  const lines = frontmatterText.split('\n');
-
-  for (const line of lines) {
-    const [key, ...valueParts] = line.split(':');
-    if (!key || valueParts.length === 0) continue;
-
-    const value = valueParts.join(':').trim();
-    const trimmedKey = key.trim();
-
-    if (trimmedKey === 'id') {
-      frontmatter.id = value;
-    } else if (trimmedKey === 'priority') {
-      frontmatter.priority = value as BroadcastPriority;
-    } else if (trimmedKey === 'from') {
-      frontmatter.from = value;
-    } else if (trimmedKey === 'tags') {
-      try {
-        frontmatter.tags = JSON.parse(value);
-      } catch {
-        frontmatter.tags = [];
-      }
-    } else if (trimmedKey === 'createdAt') {
-      frontmatter.createdAt = value;
-    } else if (trimmedKey === 'readBy') {
-      try {
-        frontmatter.readBy = JSON.parse(value);
-      } catch {
-        frontmatter.readBy = [];
-      }
-    }
-  }
-
-  return {
-    id: frontmatter.id || id,
-    message,
-    priority: frontmatter.priority || 'info',
-    from: frontmatter.from,
-    tags: frontmatter.tags || [],
-    createdAt: frontmatter.createdAt || new Date().toISOString(),
-    readBy: frontmatter.readBy || [],
-  };
-}
-
-/**
- * Serialize a broadcast to markdown with frontmatter.
- */
-function serializeBroadcast(broadcast: Broadcast): string {
-  const frontmatter = [
-    '---',
-    `id: ${broadcast.id}`,
-    `priority: ${broadcast.priority}`,
-    broadcast.from ? `from: ${broadcast.from}` : null,
-    broadcast.tags && broadcast.tags.length > 0 ? `tags: ${JSON.stringify(broadcast.tags)}` : null,
-    `createdAt: ${broadcast.createdAt}`,
-    broadcast.readBy.length > 0 ? `readBy: ${JSON.stringify(broadcast.readBy)}` : null,
-    '---',
-  ]
-    .filter((line) => line !== null)
-    .join('\n');
-
-  return `${frontmatter}\n${broadcast.message}\n`;
-}
-
 // ─── Service ─────────────────────────────────────────────────
 
 export class BroadcastStorageService {
-  /**
-   * Ensure the broadcasts directory exists.
-   */
-  private async ensureDir(): Promise<void> {
-    try {
-      await fs.mkdir(BROADCASTS_DIR, { recursive: true });
-    } catch (err) {
-      log.error({ err }, 'Failed to create broadcasts directory');
-      throw err;
-    }
-  }
+  private readonly repository: FileBroadcastRepository;
 
-  /**
-   * Get the file path for a broadcast ID.
-   */
-  private getBroadcastPath(id: string): string {
-    validatePathSegment(id);
-    return path.join(BROADCASTS_DIR, `${id}.md`);
+  constructor(options: BroadcastStorageServiceOptions = {}) {
+    this.repository =
+      options.repository ?? new FileBroadcastRepository(options.broadcastsDir ?? BROADCASTS_DIR);
   }
 
   /**
    * Create a new broadcast.
    */
   async create(data: CreateBroadcastRequest): Promise<Broadcast> {
-    await this.ensureDir();
-
     const id = randomUUID();
     const broadcast: Broadcast = {
       id,
@@ -155,13 +46,8 @@ export class BroadcastStorageService {
       readBy: [],
     };
 
-    const filePath = this.getBroadcastPath(id);
-    const content = serializeBroadcast(broadcast);
-
     try {
-      await withFileLock(filePath, async () => {
-        await fs.writeFile(filePath, content, 'utf-8');
-      });
+      await this.repository.save(broadcast);
       log.info({ id, priority: broadcast.priority }, 'Broadcast created');
       return broadcast;
     } catch (err) {
@@ -174,15 +60,8 @@ export class BroadcastStorageService {
    * Get a single broadcast by ID.
    */
   async getById(id: string): Promise<Broadcast | null> {
-    const filePath = this.getBroadcastPath(id);
-
-    if (!(await fileExists(filePath))) {
-      return null;
-    }
-
     try {
-      const content = await fs.readFile(filePath, 'utf-8');
-      return parseBroadcastFile(content, id);
+      return await this.repository.get(id);
     } catch (err) {
       log.error({ err, id }, 'Failed to read broadcast');
       return null;
@@ -193,16 +72,9 @@ export class BroadcastStorageService {
    * List broadcasts with optional filters.
    */
   async list(query: GetBroadcastsQuery = {}): Promise<Broadcast[]> {
-    await this.ensureDir();
-
     try {
-      const files = await fs.readdir(BROADCASTS_DIR);
-      const broadcastFiles = files.filter((f) => f.endsWith('.md'));
-
       const broadcasts: Broadcast[] = [];
-
-      for (const file of broadcastFiles) {
-        const id = path.basename(file, '.md');
+      for (const id of await this.repository.listIds()) {
         const broadcast = await this.getById(id);
 
         if (!broadcast) continue;
@@ -245,40 +117,31 @@ export class BroadcastStorageService {
    * Mark a broadcast as read by an agent.
    */
   async markRead(id: string, agent: string): Promise<boolean> {
-    const filePath = this.getBroadcastPath(id);
-
     try {
-      return await withFileLock(filePath, async () => {
-        // Read inside lock to prevent TOCTTOU race
-        const broadcast = await this.getById(id);
-
-        if (!broadcast) {
-          return false;
-        }
-
-        // Check if already marked as read
+      const updated = await this.repository.update(id, (broadcast) => {
         const alreadyRead = broadcast.readBy.some((r: BroadcastReadReceipt) => r.agent === agent);
         if (alreadyRead) {
-          return true;
+          return broadcast;
         }
-
-        // Add read receipt
         broadcast.readBy.push({
           agent,
           readAt: new Date().toISOString(),
         });
-
-        // Write back
-        const content = serializeBroadcast(broadcast);
-        await fs.writeFile(filePath, content, 'utf-8');
-        log.info({ id, agent }, 'Broadcast marked as read');
-        return true;
+        return broadcast;
       });
+      if (!updated) return false;
+      log.info({ id, agent }, 'Broadcast marked as read');
+      return true;
     } catch (err) {
       log.error({ err, id, agent }, 'Failed to mark broadcast as read');
       return false;
     }
   }
+}
+
+export interface BroadcastStorageServiceOptions {
+  broadcastsDir?: string;
+  repository?: FileBroadcastRepository;
 }
 
 // Singleton instance

--- a/server/src/storage/broadcast-repository.ts
+++ b/server/src/storage/broadcast-repository.ts
@@ -1,0 +1,180 @@
+import { constants } from 'node:fs';
+import { lstat, mkdir, open, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import type { Broadcast, BroadcastPriority, BroadcastReadReceipt } from '@veritas-kanban/shared';
+import { withFileLock } from '../services/file-lock.js';
+import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import { atomicWriteFile } from './fs-helpers.js';
+
+const MAX_BROADCAST_BYTES = 1024 * 1024;
+
+interface BroadcastFrontmatter {
+  id: string;
+  priority: BroadcastPriority;
+  from?: string;
+  tags?: string[];
+  createdAt: string;
+  readBy?: BroadcastReadReceipt[];
+}
+
+export class FileBroadcastRepository {
+  private readonly broadcastsDir: string;
+
+  constructor(broadcastsDir: string) {
+    this.broadcastsDir = path.resolve(broadcastsDir);
+    ensureWithinBase(path.dirname(this.broadcastsDir), this.broadcastsDir);
+  }
+
+  async get(id: string): Promise<Broadcast | null> {
+    const filePath = this.getBroadcastPath(id);
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const stats = await handle.stat();
+      if (!stats.isFile() || stats.size > MAX_BROADCAST_BYTES) {
+        throw new Error('Broadcast storage must use a bounded regular file');
+      }
+      return parseBroadcastFile(await handle.readFile({ encoding: 'utf8' }), id);
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOENT') return null;
+      if (errorCode === 'ELOOP') {
+        throw new Error('Broadcast storage must not use symbolic links', { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  async listIds(): Promise<string[]> {
+    await this.prepareDirectory();
+    return (await readdir(this.broadcastsDir))
+      .filter((file) => file.endsWith('.md'))
+      .map((file) => path.basename(file, '.md'));
+  }
+
+  async save(broadcast: Broadcast): Promise<void> {
+    const filePath = this.getBroadcastPath(broadcast.id);
+    const content = serializeBroadcast(broadcast);
+    this.assertBounded(content);
+    await this.prepareDirectory();
+    await withFileLock(filePath, () => atomicWriteFile(filePath, content, 'utf8'));
+  }
+
+  async update(
+    id: string,
+    updater: (broadcast: Broadcast) => Broadcast
+  ): Promise<Broadcast | null> {
+    const filePath = this.getBroadcastPath(id);
+    await this.prepareDirectory();
+    return withFileLock(filePath, async () => {
+      const broadcast = await this.get(id);
+      if (!broadcast) return null;
+      const updated = updater(broadcast);
+      const content = serializeBroadcast(updated);
+      this.assertBounded(content);
+      await atomicWriteFile(filePath, content, 'utf8');
+      return updated;
+    });
+  }
+
+  private getBroadcastPath(id: string): string {
+    const safeId = validatePathSegment(id);
+    return ensureWithinBase(this.broadcastsDir, path.join(this.broadcastsDir, `${safeId}.md`));
+  }
+
+  private async prepareDirectory(): Promise<void> {
+    await mkdir(this.broadcastsDir, { recursive: true, mode: 0o700 });
+    const stats = await lstat(this.broadcastsDir);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error('Broadcast storage path must use a regular directory');
+    }
+  }
+
+  private assertBounded(content: string): void {
+    if (Buffer.byteLength(content, 'utf8') > MAX_BROADCAST_BYTES) {
+      throw new Error('Broadcast exceeds the 1 MiB storage limit');
+    }
+  }
+}
+
+function parseBroadcastFile(content: string, id: string): Broadcast {
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!frontmatterMatch) {
+    throw new Error(`Invalid broadcast file format: ${id}`);
+  }
+
+  const frontmatter: Partial<BroadcastFrontmatter> = {};
+  for (const line of frontmatterMatch[1].split('\n')) {
+    const [key, ...valueParts] = line.split(':');
+    if (!key || valueParts.length === 0) continue;
+    const value = valueParts.join(':').trim();
+
+    switch (key.trim()) {
+      case 'id':
+        frontmatter.id = value;
+        break;
+      case 'priority':
+        frontmatter.priority = value as BroadcastPriority;
+        break;
+      case 'from':
+        frontmatter.from = parseJsonString(value);
+        break;
+      case 'tags':
+        frontmatter.tags = parseJsonArray<string>(value);
+        break;
+      case 'createdAt':
+        frontmatter.createdAt = value;
+        break;
+      case 'readBy':
+        frontmatter.readBy = parseJsonArray<BroadcastReadReceipt>(value);
+        break;
+    }
+  }
+
+  return {
+    id: frontmatter.id || id,
+    message: frontmatterMatch[2].trim(),
+    priority: frontmatter.priority || 'info',
+    from: frontmatter.from,
+    tags: frontmatter.tags || [],
+    createdAt: frontmatter.createdAt || new Date().toISOString(),
+    readBy: frontmatter.readBy || [],
+  };
+}
+
+function parseJsonString(value: string): string {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === 'string' ? parsed : value;
+  } catch {
+    return value;
+  }
+}
+
+function parseJsonArray<T>(value: string): T[] {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function serializeBroadcast(broadcast: Broadcast): string {
+  const frontmatter = [
+    '---',
+    `id: ${broadcast.id}`,
+    `priority: ${broadcast.priority}`,
+    broadcast.from ? `from: ${JSON.stringify(broadcast.from)}` : null,
+    broadcast.tags && broadcast.tags.length > 0 ? `tags: ${JSON.stringify(broadcast.tags)}` : null,
+    `createdAt: ${broadcast.createdAt}`,
+    broadcast.readBy.length > 0 ? `readBy: ${JSON.stringify(broadcast.readBy)}` : null,
+    '---',
+  ]
+    .filter((line) => line !== null)
+    .join('\n');
+
+  return `${frontmatter}\n${broadcast.message}\n`;
+}

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -42,6 +42,7 @@ export { LocalWorkspaceFileRepository } from './workspace-file-repository.js';
 export { FileProgressRepository, type ProgressRepository } from './progress-repository.js';
 export { FileStatusHistoryStore } from './status-history-repository.js';
 export { FileScheduledDeliverablesStore } from './scheduled-deliverables-repository.js';
+export { FileBroadcastRepository } from './broadcast-repository.js';
 export { FileWorkflowDefinitionRepository } from './workflow-definition-repository.js';
 export {
   FileWorkspaceExecutionTrustRepository,


### PR DESCRIPTION
## Summary

- move broadcast Markdown reads and writes into a dedicated file repository
- serialize read receipt updates under a lock with atomic replacement
- add bounded reads, path containment, symbolic-link rejection, and safe frontmatter string encoding
- ratchet the service filesystem boundary from 48 to 47

## Verification

- 5 focused broadcast storage tests
- server build
- service filesystem boundary check
- server critical-path coverage: 914 passed, 5 skipped
- focused lint and format checks

## Risk

Low. API filtering and response behavior remain in the service. Legacy unquoted frontmatter remains readable; new sender values are JSON-encoded to prevent frontmatter field injection.

Refs #1186