### PR TITLE
refactor: move conflict files behind storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 47,
+  "maximumEntries": 46,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -55,12 +55,6 @@
       "category": "compatibility-debt",
       "owner": "#1188",
       "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
-    {
-      "path": "server/src/services/conflict-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/delegation-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -24,6 +24,7 @@
           "src/__tests__/codex-env.test.ts",
           "src/__tests__/codex-provider-service.test.ts",
           "src/__tests__/communication-adapter-schemas.test.ts",
+          "src/__tests__/conflict-workspace-repository.test.ts",
           "src/__tests__/context-provider-health-service.test.ts",
           "src/__tests__/credential-broker-service.test.ts",
           "src/__tests__/enforcement.test.ts",

--- a/server/src/__tests__/conflict-workspace-repository.test.ts
+++ b/server/src/__tests__/conflict-workspace-repository.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  truncate,
+  writeFile,
+} from 'node:fs/promises';
+import path from 'node:path';
+import { LocalConflictWorkspaceRepository } from '../storage/conflict-workspace-repository.js';
+
+describe('LocalConflictWorkspaceRepository', () => {
+  let root: string;
+  let outsideRoot: string;
+  const repository = new LocalConflictWorkspaceRepository();
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-conflict-workspace-'));
+    outsideRoot = await mkdtemp(path.join(process.cwd(), '.veritas-conflict-outside-'));
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      rm(root, { recursive: true, force: true }),
+      rm(outsideRoot, { recursive: true, force: true }),
+    ]);
+  });
+
+  it('inspects Git state paths and distinguishes missing entries', async () => {
+    await mkdir(path.join(root, '.git', 'rebase-merge'), { recursive: true });
+    await writeFile(path.join(root, '.git', 'MERGE_HEAD'), 'abc123\n', 'utf8');
+
+    await expect(repository.exists(root, '.git/rebase-merge')).resolves.toBe(true);
+    await expect(repository.exists(root, '.git/MERGE_HEAD')).resolves.toBe(true);
+    await expect(repository.exists(root, '.git/rebase-apply')).resolves.toBe(false);
+    await expect(repository.exists(root, '.git/MERGE_HEAD/child')).resolves.toBe(false);
+  });
+
+  it('reads and rewrites conflict content without changing file mode', async () => {
+    const conflictPath = path.join(root, 'script.sh');
+    await writeFile(conflictPath, '<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n', 'utf8');
+    await chmod(conflictPath, 0o755);
+
+    await expect(repository.readText(root, 'script.sh')).resolves.toContain('<<<<<<< HEAD');
+    await repository.writeText(root, 'script.sh', '#!/bin/sh\necho resolved\n');
+
+    await expect(readFile(conflictPath, 'utf8')).resolves.toBe('#!/bin/sh\necho resolved\n');
+    expect((await stat(conflictPath)).mode & 0o777).toBe(0o755);
+  });
+
+  it('allows internal symlinks and rejects traversal or external symlinks', async () => {
+    await writeFile(path.join(root, 'target.txt'), 'inside\n', 'utf8');
+    await symlink(path.join(root, 'target.txt'), path.join(root, 'inside-link.txt'));
+    await expect(repository.readText(root, 'inside-link.txt')).resolves.toBe('inside\n');
+
+    await writeFile(path.join(outsideRoot, 'outside.txt'), 'outside\n', 'utf8');
+    await symlink(path.join(outsideRoot, 'outside.txt'), path.join(root, 'outside-link.txt'));
+    await expect(repository.readText(root, 'outside-link.txt')).rejects.toThrow(
+      /outside the base directory/i
+    );
+    await expect(repository.exists(root, '../outside.txt')).rejects.toThrow(
+      /outside the base directory/i
+    );
+  });
+
+  it('rejects missing, non-file, and oversized conflict content', async () => {
+    await expect(repository.readText(root, 'missing.txt')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+
+    await mkdir(path.join(root, 'directory'));
+    await expect(repository.readText(root, 'directory')).rejects.toThrow(/bounded regular file/i);
+    await expect(repository.writeText(root, 'directory', 'content')).rejects.toThrow();
+
+    const oversizedPath = path.join(root, 'oversized.txt');
+    await writeFile(oversizedPath, '', 'utf8');
+    await truncate(oversizedPath, 16 * 1024 * 1024 + 1);
+    await expect(repository.readText(root, 'oversized.txt')).rejects.toThrow(
+      /bounded regular file/i
+    );
+    await expect(
+      repository.writeText(root, 'oversized.txt', 'x'.repeat(16 * 1024 * 1024 + 1))
+    ).rejects.toThrow(/16 MiB/i);
+  });
+});

--- a/server/src/services/conflict-service.ts
+++ b/server/src/services/conflict-service.ts
@@ -1,9 +1,10 @@
 import { simpleGit, SimpleGit } from 'simple-git';
-import fs from 'fs/promises';
-import path from 'path';
 import { ConfigService } from './config-service.js';
 import { TaskService } from './task-service.js';
-import { ensureWithinBase } from '../utils/sanitize.js';
+import {
+  LocalConflictWorkspaceRepository,
+  type ConflictWorkspaceRepository,
+} from '../storage/conflict-workspace-repository.js';
 
 export interface ConflictFile {
   path: string;
@@ -37,10 +38,14 @@ export interface ResolveResult {
 export class ConflictService {
   private configService: ConfigService;
   private taskService: TaskService;
+  private workspaceFiles: ConflictWorkspaceRepository;
 
-  constructor() {
+  constructor(
+    workspaceFiles: ConflictWorkspaceRepository = new LocalConflictWorkspaceRepository()
+  ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
+    this.workspaceFiles = workspaceFiles;
   }
 
   private expandPath(p: string): string {
@@ -78,25 +83,12 @@ export class ConflictService {
     const { git, workDir } = await this.getWorkingDir(taskId);
 
     // Check for rebase in progress
-    const rebaseDir = path.join(workDir, '.git', 'rebase-merge');
-    const rebaseApplyDir = path.join(workDir, '.git', 'rebase-apply');
-    // Intentionally silent catches: fs.access throws if path doesn't exist — false means not present
+    // A missing path means the corresponding Git operation is not in progress.
     const rebaseInProgress =
-      (await fs
-        .access(rebaseDir)
-        .then(() => true)
-        .catch(() => false)) ||
-      (await fs
-        .access(rebaseApplyDir)
-        .then(() => true)
-        .catch(() => false));
+      (await this.workspaceFiles.exists(workDir, '.git/rebase-merge')) ||
+      (await this.workspaceFiles.exists(workDir, '.git/rebase-apply'));
 
-    // Check for merge in progress (intentionally silent: false means no MERGE_HEAD)
-    const mergeHead = path.join(workDir, '.git', 'MERGE_HEAD');
-    const mergeInProgress = await fs
-      .access(mergeHead)
-      .then(() => true)
-      .catch(() => false);
+    const mergeInProgress = await this.workspaceFiles.exists(workDir, '.git/MERGE_HEAD');
 
     // Get status to find conflicted files
     const status = await git.status();
@@ -116,8 +108,7 @@ export class ConflictService {
   async getFileConflict(taskId: string, filePath: string): Promise<ConflictFile> {
     const { git, workDir } = await this.getWorkingDir(taskId);
 
-    const fullPath = ensureWithinBase(workDir, path.join(workDir, filePath));
-    const content = await fs.readFile(fullPath, 'utf-8');
+    const content = await this.workspaceFiles.readText(workDir, filePath);
 
     // Parse conflict markers
     const markers = this.parseConflictMarkers(content);
@@ -214,13 +205,11 @@ export class ConflictService {
     manualContent?: string
   ): Promise<ResolveResult> {
     const { git, workDir } = await this.getWorkingDir(taskId);
-    const fullPath = ensureWithinBase(workDir, path.join(workDir, filePath));
-
     if (resolution === 'manual') {
       if (!manualContent) {
         throw new Error('Manual content required for manual resolution');
       }
-      await fs.writeFile(fullPath, manualContent, 'utf-8');
+      await this.workspaceFiles.writeText(workDir, filePath, manualContent);
     } else if (resolution === 'ours') {
       // Checkout our version
       await git.checkout(['--ours', filePath]);

--- a/server/src/storage/conflict-workspace-repository.ts
+++ b/server/src/storage/conflict-workspace-repository.ts
@@ -1,0 +1,73 @@
+import { constants } from 'node:fs';
+import { open, realpath } from 'node:fs/promises';
+import path from 'node:path';
+import { withFileLock } from '../services/file-lock.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+
+const MAX_CONFLICT_FILE_BYTES = 16 * 1024 * 1024;
+
+export interface ConflictWorkspaceRepository {
+  exists(workspaceRoot: string, relativePath: string): Promise<boolean>;
+  readText(workspaceRoot: string, relativePath: string): Promise<string>;
+  writeText(workspaceRoot: string, relativePath: string, content: string): Promise<void>;
+}
+
+export class LocalConflictWorkspaceRepository implements ConflictWorkspaceRepository {
+  async exists(workspaceRoot: string, relativePath: string): Promise<boolean> {
+    try {
+      await this.resolveCanonicalPath(workspaceRoot, relativePath);
+      return true;
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOENT' || errorCode === 'ENOTDIR') return false;
+      throw error;
+    }
+  }
+
+  async readText(workspaceRoot: string, relativePath: string): Promise<string> {
+    const filePath = await this.resolveCanonicalPath(workspaceRoot, relativePath);
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const stats = await handle.stat();
+      if (!stats.isFile() || stats.size > MAX_CONFLICT_FILE_BYTES) {
+        throw new Error('Conflict content must use a bounded regular file');
+      }
+      return await handle.readFile({ encoding: 'utf8' });
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  async writeText(workspaceRoot: string, relativePath: string, content: string): Promise<void> {
+    if (Buffer.byteLength(content, 'utf8') > MAX_CONFLICT_FILE_BYTES) {
+      throw new Error('Conflict content exceeds the 16 MiB storage limit');
+    }
+
+    const filePath = await this.resolveCanonicalPath(workspaceRoot, relativePath);
+    await withFileLock(filePath, async () => {
+      let handle: Awaited<ReturnType<typeof open>> | undefined;
+      try {
+        handle = await open(filePath, constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0));
+        const stats = await handle.stat();
+        if (!stats.isFile()) {
+          throw new Error('Conflict content must use a regular file');
+        }
+        await handle.truncate(0);
+        await handle.writeFile(content, { encoding: 'utf8' });
+      } finally {
+        await handle?.close();
+      }
+    });
+  }
+
+  private async resolveCanonicalPath(workspaceRoot: string, relativePath: string): Promise<string> {
+    const resolvedRoot = path.resolve(workspaceRoot);
+    const resolvedPath = ensureWithinBase(resolvedRoot, path.resolve(resolvedRoot, relativePath));
+    const [canonicalRoot, canonicalPath] = await Promise.all([
+      realpath(resolvedRoot),
+      realpath(resolvedPath),
+    ]);
+    return ensureWithinBase(canonicalRoot, canonicalPath);
+  }
+}

--- a/server/src/storage/conflict-workspace-repository.ts
+++ b/server/src/storage/conflict-workspace-repository.ts
@@ -46,13 +46,25 @@ export class LocalConflictWorkspaceRepository implements ConflictWorkspaceReposi
 
     const filePath = await this.resolveCanonicalPath(workspaceRoot, relativePath);
     await withFileLock(filePath, async () => {
-      let handle: Awaited<ReturnType<typeof open>> | undefined;
+      let inspectionHandle: Awaited<ReturnType<typeof open>> | undefined;
       try {
-        handle = await open(filePath, constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0));
-        const stats = await handle.stat();
-        if (!stats.isFile()) {
+        inspectionHandle = await open(
+          filePath,
+          constants.O_RDONLY | constants.O_NONBLOCK | (constants.O_NOFOLLOW ?? 0)
+        );
+        if (!(await inspectionHandle.stat()).isFile()) {
           throw new Error('Conflict content must use a regular file');
         }
+      } finally {
+        await inspectionHandle?.close();
+      }
+
+      let handle: Awaited<ReturnType<typeof open>> | undefined;
+      try {
+        handle = await open(
+          filePath,
+          constants.O_WRONLY | constants.O_NONBLOCK | (constants.O_NOFOLLOW ?? 0)
+        );
         await handle.truncate(0);
         await handle.writeFile(content, { encoding: 'utf8' });
       } finally {

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -43,6 +43,10 @@ export { FileProgressRepository, type ProgressRepository } from './progress-repo
 export { FileStatusHistoryStore } from './status-history-repository.js';
 export { FileScheduledDeliverablesStore } from './scheduled-deliverables-repository.js';
 export { FileBroadcastRepository } from './broadcast-repository.js';
+export {
+  LocalConflictWorkspaceRepository,
+  type ConflictWorkspaceRepository,
+} from './conflict-workspace-repository.js';
 export { FileWorkflowDefinitionRepository } from './workflow-definition-repository.js';
 export {
   FileWorkspaceExecutionTrustRepository,


### PR DESCRIPTION
## Summary

- move conflict file existence checks, reads, and manual writes into a contained workspace repository
- preserve file modes during manual conflict resolution
- reject traversal, external symlinks, non-files, and oversized conflict content
- ratchet the service filesystem boundary from 47 to 46

## Verification

- 11 focused conflict repository and marker tests
- server build
- service filesystem boundary check
- server critical-path coverage: 918 passed, 5 skipped
- focused lint and format checks

## Risk

Low. Git commands and conflict parsing are unchanged. Manual resolution still updates the existing file before staging it, now through a bounded contained repository.

Refs #1186