### PR TITLE
refactor: move delegation state behind storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 46,
+  "maximumEntries": 45,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -55,12 +55,6 @@
       "category": "compatibility-debt",
       "owner": "#1188",
       "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
-    {
-      "path": "server/src/services/delegation-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/doc-freshness-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -27,6 +27,7 @@
           "src/__tests__/conflict-workspace-repository.test.ts",
           "src/__tests__/context-provider-health-service.test.ts",
           "src/__tests__/credential-broker-service.test.ts",
+          "src/__tests__/delegation-repository.test.ts",
           "src/__tests__/enforcement.test.ts",
           "src/__tests__/filesystem-sandbox-service.test.ts",
           "src/__tests__/harness-support-profile-schemas.test.ts",

--- a/server/src/__tests__/delegation-repository.test.ts
+++ b/server/src/__tests__/delegation-repository.test.ts
@@ -1,8 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { DelegationApproval, DelegationSettings } from '@veritas-kanban/shared';
 import { FileDelegationRepository } from '../storage/delegation-repository.js';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, lstat: vi.fn(actual.lstat) };
+});
 
 function settings(delegateAgent: string): DelegationSettings {
   return {
@@ -88,6 +93,19 @@ describe('FileDelegationRepository', () => {
 
     await mkdir(path.join(runtimeDir, 'delegation-log.json'));
     await expect(repository.readLog()).rejects.toThrow(/bounded regular file/i);
+  });
+
+  it('rejects state replaced after its file handle is opened', async () => {
+    await repository.writeSettings(settings('TARS'));
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.mocked(lstat).mockImplementationOnce(async (filePath) => {
+      const stats = await actual.lstat(filePath);
+      return Object.assign(Object.create(Object.getPrototypeOf(stats)), stats, {
+        ino: stats.ino + 1,
+      });
+    });
+
+    await expect(repository.readSettings()).rejects.toThrow(/changed file/i);
   });
 
   it('rejects symbolic-link directories and oversized state', async () => {

--- a/server/src/__tests__/delegation-repository.test.ts
+++ b/server/src/__tests__/delegation-repository.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { DelegationApproval, DelegationSettings } from '@veritas-kanban/shared';
+import { FileDelegationRepository } from '../storage/delegation-repository.js';
+
+function settings(delegateAgent: string): DelegationSettings {
+  return {
+    enabled: true,
+    delegateAgent,
+    expires: '2026-08-24T00:00:00.000Z',
+    scope: { type: 'all' },
+    createdAt: '2026-08-23T20:00:00.000Z',
+    createdBy: 'brad',
+  };
+}
+
+function approval(id: string): DelegationApproval {
+  return {
+    id,
+    taskId: `task-${id}`,
+    taskTitle: `Task ${id}`,
+    agent: 'TARS',
+    delegated: true,
+    timestamp: '2026-08-23T20:00:00.000Z',
+    originalDelegation: 'TARS_2026-08-23T20:00:00.000Z',
+  };
+}
+
+describe('FileDelegationRepository', () => {
+  let root: string;
+  let runtimeDir: string;
+  let repository: FileDelegationRepository;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-delegation-repository-'));
+    runtimeDir = path.join(root, 'runtime');
+    repository = new FileDelegationRepository(runtimeDir);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('reads defaults and persists settings and approvals', async () => {
+    await expect(repository.readSettings()).resolves.toBeNull();
+    await expect(repository.readLog()).resolves.toEqual({ approvals: [] });
+
+    await repository.writeSettings(settings('TARS'));
+    await repository.updateLog(() => ({ approvals: [approval('one')] }));
+
+    await expect(repository.readSettings()).resolves.toEqual(settings('TARS'));
+    await expect(repository.readLog()).resolves.toEqual({ approvals: [approval('one')] });
+    await expect(readFile(path.join(runtimeDir, 'delegation.json'), 'utf8')).resolves.toContain(
+      '"delegateAgent": "TARS"'
+    );
+  });
+
+  it('serializes concurrent settings and log updates', async () => {
+    await repository.writeSettings(settings('TARS'));
+    await Promise.all([
+      repository.updateSettings((current) =>
+        current ? { ...current, excludeTags: [...(current.excludeTags ?? []), 'private'] } : null
+      ),
+      repository.updateSettings((current) =>
+        current ? { ...current, excludeTags: [...(current.excludeTags ?? []), 'blocked'] } : null
+      ),
+    ]);
+    await Promise.all([
+      repository.updateLog((current) => ({ approvals: [...current.approvals, approval('one')] })),
+      repository.updateLog((current) => ({ approvals: [...current.approvals, approval('two')] })),
+    ]);
+
+    expect((await repository.readSettings())?.excludeTags).toEqual(
+      expect.arrayContaining(['private', 'blocked'])
+    );
+    expect((await repository.readLog()).approvals.map(({ id }) => id)).toEqual(
+      expect.arrayContaining(['one', 'two'])
+    );
+  });
+
+  it('rejects symbolic links and non-file state paths', async () => {
+    await mkdir(runtimeDir, { recursive: true });
+    const target = path.join(root, 'outside.json');
+    await writeFile(target, JSON.stringify(settings('CASE')), 'utf8');
+    await symlink(target, path.join(runtimeDir, 'delegation.json'));
+    await expect(repository.readSettings()).rejects.toThrow(/symbolic link/i);
+
+    await mkdir(path.join(runtimeDir, 'delegation-log.json'));
+    await expect(repository.readLog()).rejects.toThrow(/bounded regular file/i);
+  });
+
+  it('rejects symbolic-link directories and oversized state', async () => {
+    const realDirectory = path.join(root, 'real-runtime');
+    const linkedDirectory = path.join(root, 'linked-runtime');
+    await mkdir(realDirectory);
+    await symlink(realDirectory, linkedDirectory, 'dir');
+    const linkedRepository = new FileDelegationRepository(linkedDirectory);
+    await expect(linkedRepository.writeSettings(settings('TARS'))).rejects.toThrow(
+      /regular directory/i
+    );
+
+    await expect(
+      repository.writeSettings({ ...settings('TARS'), excludeTags: ['x'.repeat(4 * 1024 * 1024)] })
+    ).rejects.toThrow(/4 MiB/i);
+  });
+});

--- a/server/src/services/delegation-service.ts
+++ b/server/src/services/delegation-service.ts
@@ -5,115 +5,39 @@
  * delegate task approval authority to a designated agent.
  */
 
-import fs from 'fs/promises';
-import path from 'path';
 import { nanoid } from 'nanoid';
 import { createLogger } from '../lib/logger.js';
-import { withFileLock } from './file-lock.js';
 import type { DelegationSettings, DelegationScope, TaskPriority } from '@veritas-kanban/shared';
-import type { DelegationApproval, DelegationLog } from '@veritas-kanban/shared';
-import { getRuntimeDir } from '../utils/paths.js';
+import type { DelegationApproval } from '@veritas-kanban/shared';
+import {
+  FileDelegationRepository,
+  type DelegationRepository,
+} from '../storage/delegation-repository.js';
 
 const log = createLogger('delegation');
 
-// Storage paths
-const DELEGATION_DIR = getRuntimeDir();
-const SETTINGS_FILE = path.join(DELEGATION_DIR, 'delegation.json');
-const LOG_FILE = path.join(DELEGATION_DIR, 'delegation-log.json');
-
 export class DelegationService {
-  private settings: DelegationSettings | null = null;
-  private log: DelegationLog = { approvals: [] };
-  private settingsLoaded = false;
-  private logLoaded = false;
-
-  constructor() {
-    this.ensureDir();
-  }
-
-  private async ensureDir(): Promise<void> {
-    await fs.mkdir(DELEGATION_DIR, { recursive: true });
-  }
+  constructor(private readonly repository: DelegationRepository = new FileDelegationRepository()) {}
 
   /**
    * Load delegation settings from disk
    */
   private async loadSettings(): Promise<DelegationSettings | null> {
-    if (this.settingsLoaded && this.settings) {
-      // Check if delegation has expired
-      if (this.settings.enabled && new Date(this.settings.expires) < new Date()) {
-        log.info({ expires: this.settings.expires }, 'Delegation has expired, auto-disabling');
-        this.settings.enabled = false;
-        await this.saveSettings();
-        // Could emit WebSocket event here
-      }
-      return this.settings;
+    const settings = await this.repository.readSettings();
+    if (settings?.enabled && new Date(settings.expires) < new Date()) {
+      log.info({ expires: settings.expires }, 'Delegation expired on load, disabling');
+      return this.repository.updateSettings((current) => {
+        if (
+          current?.enabled &&
+          current.createdAt === settings.createdAt &&
+          current.expires === settings.expires
+        ) {
+          return { ...current, enabled: false };
+        }
+        return current;
+      });
     }
-
-    try {
-      const content = await fs.readFile(SETTINGS_FILE, 'utf-8');
-      this.settings = JSON.parse(content) as DelegationSettings;
-      this.settingsLoaded = true;
-
-      // Check expiry on load
-      if (this.settings.enabled && new Date(this.settings.expires) < new Date()) {
-        log.info({ expires: this.settings.expires }, 'Delegation expired on load, disabling');
-        this.settings.enabled = false;
-        await this.saveSettings();
-      }
-
-      return this.settings;
-    } catch (err: any) {
-      if (err.code === 'ENOENT') {
-        this.settingsLoaded = true;
-        return null;
-      }
-      throw err;
-    }
-  }
-
-  /**
-   * Save delegation settings to disk
-   */
-  private async saveSettings(): Promise<void> {
-    await this.ensureDir();
-    await withFileLock(SETTINGS_FILE, async () => {
-      const content = JSON.stringify(this.settings, null, 2);
-      await fs.writeFile(SETTINGS_FILE, content, 'utf-8');
-    });
-  }
-
-  /**
-   * Load delegation log from disk
-   */
-  private async loadLog(): Promise<DelegationLog> {
-    if (this.logLoaded) return this.log;
-
-    try {
-      const content = await fs.readFile(LOG_FILE, 'utf-8');
-      this.log = JSON.parse(content) as DelegationLog;
-      this.logLoaded = true;
-    } catch (err: any) {
-      if (err.code === 'ENOENT') {
-        this.log = { approvals: [] };
-        this.logLoaded = true;
-      } else {
-        throw err;
-      }
-    }
-
-    return this.log;
-  }
-
-  /**
-   * Save delegation log to disk
-   */
-  private async saveLog(): Promise<void> {
-    await this.ensureDir();
-    await withFileLock(LOG_FILE, async () => {
-      const content = JSON.stringify(this.log, null, 2);
-      await fs.writeFile(LOG_FILE, content, 'utf-8');
-    });
+    return settings;
   }
 
   /**
@@ -136,7 +60,7 @@ export class DelegationService {
   }): Promise<DelegationSettings> {
     const now = new Date().toISOString();
 
-    this.settings = {
+    const settings: DelegationSettings = {
       enabled: true,
       delegateAgent: params.delegateAgent,
       expires: params.expires,
@@ -147,29 +71,28 @@ export class DelegationService {
       createdBy: params.createdBy,
     };
 
-    await this.saveSettings();
+    await this.repository.writeSettings(settings);
 
     log.info(
       {
-        delegateAgent: this.settings.delegateAgent,
-        expires: this.settings.expires,
-        scope: this.settings.scope,
+        delegateAgent: settings.delegateAgent,
+        expires: settings.expires,
+        scope: settings.scope,
       },
       'Delegation enabled'
     );
 
-    return this.settings;
+    return settings;
   }
 
   /**
    * Revoke delegation immediately
    */
   async revokeDelegation(): Promise<boolean> {
-    const current = await this.loadSettings();
+    const current = await this.repository.updateSettings((settings) =>
+      settings ? { ...settings, enabled: false } : null
+    );
     if (!current) return false;
-
-    this.settings = { ...current, enabled: false };
-    await this.saveSettings();
 
     log.info({ delegateAgent: current.delegateAgent }, 'Delegation revoked');
     return true;
@@ -213,8 +136,9 @@ export class DelegationService {
       }
     }
 
-    if (delegation.excludeTags && task.tags) {
-      const excluded = task.tags.find((tag) => delegation.excludeTags!.includes(tag));
+    const excludedTags = delegation.excludeTags;
+    if (excludedTags && task.tags) {
+      const excluded = task.tags.find((tag) => excludedTags.includes(tag));
       if (excluded) {
         return { allowed: false, reason: `Task has excluded tag: ${excluded}` };
       }
@@ -256,8 +180,6 @@ export class DelegationService {
     taskTitle: string;
     agent: string;
   }): Promise<DelegationApproval> {
-    await this.loadLog();
-
     const delegation = await this.loadSettings();
     const delegationRef = delegation
       ? `${delegation.delegateAgent}_${delegation.createdAt}`
@@ -273,14 +195,9 @@ export class DelegationService {
       originalDelegation: delegationRef,
     };
 
-    this.log.approvals.push(approval);
-
-    // Keep only last 1000 approvals
-    if (this.log.approvals.length > 1000) {
-      this.log.approvals = this.log.approvals.slice(-1000);
-    }
-
-    await this.saveLog();
+    await this.repository.updateLog((delegationLog) => ({
+      approvals: [...delegationLog.approvals, approval].slice(-1000),
+    }));
 
     log.info(
       { taskId: params.taskId, agent: params.agent, delegationRef },
@@ -298,9 +215,8 @@ export class DelegationService {
     agent?: string;
     limit?: number;
   }): Promise<DelegationApproval[]> {
-    await this.loadLog();
-
-    let approvals = [...this.log.approvals];
+    const delegationLog = await this.repository.readLog();
+    let approvals = [...delegationLog.approvals];
 
     if (params?.taskId) {
       approvals = approvals.filter((a) => a.taskId === params.taskId);

--- a/server/src/storage/delegation-repository.ts
+++ b/server/src/storage/delegation-repository.ts
@@ -84,12 +84,15 @@ export class FileDelegationRepository implements DelegationRepository {
   private async readJson<T>(filePath: string, fallback: T, label: string): Promise<T> {
     let handle: Awaited<ReturnType<typeof open>> | undefined;
     try {
-      const pathStats = await lstat(filePath);
-      if (pathStats.isSymbolicLink()) {
-        throw new Error(`${label} must not use a symbolic link`);
-      }
       handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
-      const stats = await handle.stat();
+      const [pathStats, stats] = await Promise.all([lstat(filePath), handle.stat()]);
+      if (
+        pathStats.isSymbolicLink() ||
+        pathStats.dev !== stats.dev ||
+        pathStats.ino !== stats.ino
+      ) {
+        throw new Error(`${label} must not use a symbolic link or changed file`);
+      }
       if (!stats.isFile() || stats.size > MAX_DELEGATION_BYTES) {
         throw new Error(`${label} must use a bounded regular file`);
       }
@@ -97,6 +100,9 @@ export class FileDelegationRepository implements DelegationRepository {
     } catch (error) {
       const errorCode = (error as NodeJS.ErrnoException).code;
       if (errorCode === 'ENOENT') return fallback;
+      if (errorCode === 'ELOOP') {
+        throw new Error(`${label} must not use a symbolic link`, { cause: error });
+      }
       throw error;
     } finally {
       await handle?.close();

--- a/server/src/storage/delegation-repository.ts
+++ b/server/src/storage/delegation-repository.ts
@@ -97,9 +97,6 @@ export class FileDelegationRepository implements DelegationRepository {
     } catch (error) {
       const errorCode = (error as NodeJS.ErrnoException).code;
       if (errorCode === 'ENOENT') return fallback;
-      if (errorCode === 'ELOOP') {
-        throw new Error(`${label} must not use a symbolic link`, { cause: error });
-      }
       throw error;
     } finally {
       await handle?.close();

--- a/server/src/storage/delegation-repository.ts
+++ b/server/src/storage/delegation-repository.ts
@@ -84,15 +84,12 @@ export class FileDelegationRepository implements DelegationRepository {
   private async readJson<T>(filePath: string, fallback: T, label: string): Promise<T> {
     let handle: Awaited<ReturnType<typeof open>> | undefined;
     try {
-      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
-      const [pathStats, stats] = await Promise.all([lstat(filePath), handle.stat()]);
-      if (
-        pathStats.isSymbolicLink() ||
-        pathStats.dev !== stats.dev ||
-        pathStats.ino !== stats.ino
-      ) {
-        throw new Error(`${label} must not use a symbolic link or changed file`);
+      const pathStats = await lstat(filePath);
+      if (pathStats.isSymbolicLink()) {
+        throw new Error(`${label} must not use a symbolic link`);
       }
+      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const stats = await handle.stat();
       if (!stats.isFile() || stats.size > MAX_DELEGATION_BYTES) {
         throw new Error(`${label} must use a bounded regular file`);
       }

--- a/server/src/storage/delegation-repository.ts
+++ b/server/src/storage/delegation-repository.ts
@@ -1,0 +1,119 @@
+import { constants } from 'node:fs';
+import { lstat, mkdir, open } from 'node:fs/promises';
+import path from 'node:path';
+import type { DelegationLog, DelegationSettings } from '@veritas-kanban/shared';
+import { withFileLock } from '../services/file-lock.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import { atomicWriteFile } from './fs-helpers.js';
+
+const MAX_DELEGATION_BYTES = 4 * 1024 * 1024;
+
+export interface DelegationRepository {
+  readSettings(): Promise<DelegationSettings | null>;
+  writeSettings(settings: DelegationSettings): Promise<void>;
+  updateSettings(
+    updater: (settings: DelegationSettings | null) => DelegationSettings | null
+  ): Promise<DelegationSettings | null>;
+  readLog(): Promise<DelegationLog>;
+  updateLog(updater: (log: DelegationLog) => DelegationLog): Promise<DelegationLog>;
+}
+
+export class FileDelegationRepository implements DelegationRepository {
+  private readonly runtimeDir: string;
+  private readonly settingsFile: string;
+  private readonly logFile: string;
+
+  constructor(runtimeDir = getRuntimeDir()) {
+    this.runtimeDir = path.resolve(runtimeDir);
+    this.settingsFile = ensureWithinBase(
+      this.runtimeDir,
+      path.join(this.runtimeDir, 'delegation.json')
+    );
+    this.logFile = ensureWithinBase(
+      this.runtimeDir,
+      path.join(this.runtimeDir, 'delegation-log.json')
+    );
+  }
+
+  readSettings(): Promise<DelegationSettings | null> {
+    return this.readJson<DelegationSettings | null>(this.settingsFile, null, 'Delegation settings');
+  }
+
+  async writeSettings(settings: DelegationSettings): Promise<void> {
+    await this.prepareDirectory();
+    await withFileLock(this.settingsFile, () =>
+      this.writeJson(this.settingsFile, settings, 'Delegation settings')
+    );
+  }
+
+  async updateSettings(
+    updater: (settings: DelegationSettings | null) => DelegationSettings | null
+  ): Promise<DelegationSettings | null> {
+    await this.prepareDirectory();
+    return withFileLock(this.settingsFile, async () => {
+      const settings = updater(await this.readSettings());
+      if (settings) {
+        await this.writeJson(this.settingsFile, settings, 'Delegation settings');
+      }
+      return settings;
+    });
+  }
+
+  async readLog(): Promise<DelegationLog> {
+    return this.readJson<DelegationLog>(this.logFile, { approvals: [] }, 'Delegation log');
+  }
+
+  async updateLog(updater: (log: DelegationLog) => DelegationLog): Promise<DelegationLog> {
+    await this.prepareDirectory();
+    return withFileLock(this.logFile, async () => {
+      const delegationLog = updater(await this.readLog());
+      await this.writeJson(this.logFile, delegationLog, 'Delegation log');
+      return delegationLog;
+    });
+  }
+
+  private async prepareDirectory(): Promise<void> {
+    await mkdir(this.runtimeDir, { recursive: true, mode: 0o700 });
+    const stats = await lstat(this.runtimeDir);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error('Delegation storage path must use a regular directory');
+    }
+  }
+
+  private async readJson<T>(filePath: string, fallback: T, label: string): Promise<T> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const [pathStats, stats] = await Promise.all([lstat(filePath), handle.stat()]);
+      if (
+        pathStats.isSymbolicLink() ||
+        pathStats.dev !== stats.dev ||
+        pathStats.ino !== stats.ino
+      ) {
+        throw new Error(`${label} must not use a symbolic link or changed file`);
+      }
+      if (!stats.isFile() || stats.size > MAX_DELEGATION_BYTES) {
+        throw new Error(`${label} must use a bounded regular file`);
+      }
+      return JSON.parse(await handle.readFile({ encoding: 'utf8' })) as T;
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOENT') return fallback;
+      if (errorCode === 'ELOOP') {
+        throw new Error(`${label} must not use a symbolic link`, { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private async writeJson(filePath: string, value: unknown, label: string): Promise<void> {
+    const content = JSON.stringify(value, null, 2);
+    if (Buffer.byteLength(content, 'utf8') > MAX_DELEGATION_BYTES) {
+      throw new Error(`${label} exceeds the 4 MiB storage limit`);
+    }
+    await atomicWriteFile(filePath, content, 'utf8');
+  }
+}

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -43,6 +43,7 @@ export { FileProgressRepository, type ProgressRepository } from './progress-repo
 export { FileStatusHistoryStore } from './status-history-repository.js';
 export { FileScheduledDeliverablesStore } from './scheduled-deliverables-repository.js';
 export { FileBroadcastRepository } from './broadcast-repository.js';
+export { FileDelegationRepository, type DelegationRepository } from './delegation-repository.js';
 export {
   LocalConflictWorkspaceRepository,
   type ConflictWorkspaceRepository,


### PR DESCRIPTION
## Summary

- move delegation settings and approval-log persistence into a bounded file repository
- serialize settings and approval-log mutations under file locks with atomic writes
- reject symbolic links, non-files, and oversized state while preserving existing JSON formats
- remove stale service caches so concurrent instances observe current delegation state
- ratchet the service filesystem boundary from 46 to 45

## Verification

- 9 focused delegation service and repository tests
- server build
- service filesystem boundary check
- server critical-path coverage: 922 passed, 5 skipped
- all server critical-path coverage ratchets passed
- focused lint and format checks

## Risk

Low. API behavior and persisted JSON shapes are unchanged. Delegation reads now return current disk state instead of a process-local cached copy.

Refs #1186