### PR TITLE
refactor: move ceremony state behind storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 45,
+  "maximumEntries": 44,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -25,12 +25,6 @@
       "category": "authoritative-persistence",
       "owner": "#1187",
       "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
-    {
-      "path": "server/src/services/ceremony-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/chat-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -23,6 +23,7 @@
           "src/__tests__/codex-app-server-provider.test.ts",
           "src/__tests__/codex-env.test.ts",
           "src/__tests__/codex-provider-service.test.ts",
+          "src/__tests__/ceremony-state-repository.test.ts",
           "src/__tests__/communication-adapter-schemas.test.ts",
           "src/__tests__/conflict-workspace-repository.test.ts",
           "src/__tests__/context-provider-health-service.test.ts",

--- a/server/src/__tests__/ceremony-state-repository.test.ts
+++ b/server/src/__tests__/ceremony-state-repository.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { CeremonyRequirement } from '@veritas-kanban/shared';
+import { CeremonyService } from '../services/ceremony-service.js';
+import { FileCeremonyStateRepository } from '../storage/ceremony-state-repository.js';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, lstat: vi.fn(actual.lstat) };
+});
+
+function requirement(id: string): CeremonyRequirement {
+  return {
+    id,
+    kind: 'design_review',
+    status: 'pending',
+    enforcementMode: 'warn',
+    title: `Review ${id}`,
+    reason: 'Test requirement',
+    target: { taskId: `task-${id}` },
+    trigger: 'task.completion',
+    participants: [],
+    requiredArtifacts: [],
+    artifacts: [],
+    actionItems: [],
+    createdAt: '2026-08-23T20:00:00.000Z',
+    updatedAt: '2026-08-23T20:00:00.000Z',
+  };
+}
+
+describe('FileCeremonyStateRepository', () => {
+  let root: string;
+  let storageDir: string;
+  let repository: FileCeremonyStateRepository;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-ceremony-state-'));
+    storageDir = path.join(root, 'ceremonies');
+    repository = new FileCeremonyStateRepository(storageDir);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('reads defaults and persists normalized state', async () => {
+    await expect(repository.read()).resolves.toMatchObject({ version: 1, requirements: [] });
+    await repository.update((state) => ({
+      ...state,
+      requirements: [requirement('one')],
+    }));
+    await expect(repository.read()).resolves.toMatchObject({
+      version: 1,
+      requirements: [requirement('one')],
+    });
+
+    await writeFile(
+      path.join(storageDir, 'requirements.json'),
+      JSON.stringify({ version: 99, requirements: 'legacy' }),
+      'utf8'
+    );
+    await expect(repository.read()).resolves.toMatchObject({ version: 1, requirements: [] });
+  });
+
+  it('serializes concurrent read-modify-write updates', async () => {
+    await Promise.all([
+      repository.update((state) => ({
+        ...state,
+        requirements: [...state.requirements, requirement('one')],
+      })),
+      repository.update((state) => ({
+        ...state,
+        requirements: [...state.requirements, requirement('two')],
+      })),
+    ]);
+
+    expect((await repository.read()).requirements.map(({ id }) => id)).toEqual(
+      expect.arrayContaining(['one', 'two'])
+    );
+  });
+
+  it('prevents duplicate requirements across concurrent service instances', async () => {
+    const serviceOptions = {
+      storageDir,
+      persist: true,
+      audit: vi.fn().mockResolvedValue(undefined),
+      governanceTraceService: { record: vi.fn().mockResolvedValue({ id: 'trace-one' }) } as never,
+    };
+    const first = new CeremonyService(serviceOptions);
+    const second = new CeremonyService(serviceOptions);
+    const input = {
+      kind: 'design_review' as const,
+      enforcementMode: 'warn' as const,
+      reason: 'Concurrent creation test',
+      target: { taskId: 'task-concurrent' },
+      trigger: 'task.completion' as const,
+    };
+
+    const [firstResult, secondResult] = await Promise.all([
+      first.create(input),
+      second.create(input),
+    ]);
+
+    expect(firstResult.id).toBe(secondResult.id);
+    await expect(repository.read()).resolves.toMatchObject({
+      requirements: [{ id: firstResult.id }],
+    });
+  });
+
+  it('rejects symbolic links and non-file state paths', async () => {
+    await mkdir(storageDir, { recursive: true });
+    const target = path.join(root, 'outside.json');
+    await writeFile(target, JSON.stringify({ version: 1, requirements: [] }), 'utf8');
+    await symlink(target, path.join(storageDir, 'requirements.json'));
+    await expect(repository.read()).rejects.toThrow(/symbolic link/i);
+
+    await rm(path.join(storageDir, 'requirements.json'));
+    await mkdir(path.join(storageDir, 'requirements.json'));
+    await expect(repository.read()).rejects.toThrow(/bounded regular file/i);
+  });
+
+  it('rejects state replaced after its file handle is opened', async () => {
+    await repository.update((state) => ({ ...state, requirements: [requirement('one')] }));
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.mocked(lstat).mockImplementationOnce(async (filePath) => {
+      const stats = await actual.lstat(filePath);
+      return Object.assign(Object.create(Object.getPrototypeOf(stats)), stats, {
+        ino: stats.ino + 1,
+      });
+    });
+
+    await expect(repository.read()).rejects.toThrow(/changed file/i);
+  });
+
+  it('rejects symbolic-link directories and oversized state', async () => {
+    const realDirectory = path.join(root, 'real-ceremonies');
+    const linkedDirectory = path.join(root, 'linked-ceremonies');
+    await mkdir(realDirectory);
+    await symlink(realDirectory, linkedDirectory, 'dir');
+    const linkedRepository = new FileCeremonyStateRepository(linkedDirectory);
+    await expect(
+      linkedRepository.update((state) => ({ ...state, requirements: [requirement('unsafe')] }))
+    ).rejects.toThrow(/regular directory/i);
+
+    await expect(
+      repository.update((state) => ({
+        ...state,
+        requirements: [{ ...requirement('large'), reason: 'x'.repeat(16 * 1024 * 1024) }],
+      }))
+    ).rejects.toThrow(/16 MiB/i);
+  });
+});

--- a/server/src/__tests__/ceremony-state-repository.test.ts
+++ b/server/src/__tests__/ceremony-state-repository.test.ts
@@ -3,7 +3,10 @@ import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import path from 'node:path';
 import type { CeremonyRequirement } from '@veritas-kanban/shared';
 import { CeremonyService } from '../services/ceremony-service.js';
-import { FileCeremonyStateRepository } from '../storage/ceremony-state-repository.js';
+import {
+  FileCeremonyStateRepository,
+  InMemoryCeremonyStateRepository,
+} from '../storage/ceremony-state-repository.js';
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>();
@@ -149,5 +152,20 @@ describe('FileCeremonyStateRepository', () => {
         requirements: [{ ...requirement('large'), reason: 'x'.repeat(16 * 1024 * 1024) }],
       }))
     ).rejects.toThrow(/16 MiB/i);
+  });
+});
+
+describe('InMemoryCeremonyStateRepository', () => {
+  it('reads and updates transient ceremony state', async () => {
+    const repository = new InMemoryCeremonyStateRepository();
+    await repository.update((state) => ({
+      ...state,
+      requirements: [requirement('memory')],
+    }));
+
+    await expect(repository.read()).resolves.toMatchObject({
+      version: 1,
+      requirements: [requirement('memory')],
+    });
   });
 });

--- a/server/src/services/ceremony-service.ts
+++ b/server/src/services/ceremony-service.ts
@@ -1,4 +1,3 @@
-import fs from 'fs/promises';
 import path from 'path';
 import { nanoid } from 'nanoid';
 import type {
@@ -21,24 +20,24 @@ import {
   getGovernanceTraceService,
   type GovernanceTraceService,
 } from './governance-trace-service.js';
-import { withFileLock } from './file-lock.js';
 import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
-import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import { validatePathSegment } from '../utils/sanitize.js';
 import { getRuntimeDir } from '../utils/paths.js';
+import {
+  FileCeremonyStateRepository,
+  InMemoryCeremonyStateRepository,
+  type CeremonyState,
+  type CeremonyStateRepository,
+} from '../storage/ceremony-state-repository.js';
 
 const MAX_REQUIREMENTS = 1000;
-
-interface CeremonyState {
-  version: 1;
-  requirements: CeremonyRequirement[];
-  updatedAt: string;
-}
 
 export interface CeremonyServiceOptions {
   storageDir?: string;
   persist?: boolean;
   audit?: (event: AuditEvent) => Promise<void>;
   governanceTraceService?: GovernanceTraceService;
+  repository?: CeremonyStateRepository;
 }
 
 export interface CeremonyListFilters {
@@ -83,24 +82,27 @@ function dueInHours(hours: number): string {
 }
 
 export class CeremonyService {
-  private readonly storageDir: string;
-  private readonly persist: boolean;
   private readonly audit: (event: AuditEvent) => Promise<void>;
   private readonly governanceTraceService: GovernanceTraceService;
-  private loaded = false;
-  private state: CeremonyState = this.emptyState();
+  private readonly repository: CeremonyStateRepository;
 
   constructor(options: CeremonyServiceOptions = {}) {
-    this.storageDir = options.storageDir ?? path.join(getRuntimeDir(), 'ceremonies');
-    this.persist = options.persist ?? process.env.VITEST !== 'true';
     this.audit = options.audit ?? auditLog;
     this.governanceTraceService = options.governanceTraceService ?? getGovernanceTraceService();
+    const persist = options.persist ?? process.env.VITEST !== 'true';
+    this.repository =
+      options.repository ??
+      (persist
+        ? new FileCeremonyStateRepository(
+            options.storageDir ?? path.join(getRuntimeDir(), 'ceremonies')
+          )
+        : new InMemoryCeremonyStateRepository());
   }
 
   async list(filters: CeremonyListFilters = {}): Promise<CeremonyRequirement[]> {
-    await this.ensureLoaded();
+    const state = await this.repository.read();
     const limit = Math.max(1, Math.min(Math.floor(filters.limit ?? 100), MAX_REQUIREMENTS));
-    return this.state.requirements
+    return state.requirements
       .filter((requirement) => !filters.status || requirement.status === filters.status)
       .filter((requirement) => !filters.kind || requirement.kind === filters.kind)
       .filter((requirement) => !filters.taskId || requirement.target.taskId === filters.taskId)
@@ -109,10 +111,6 @@ export class CeremonyService {
   }
 
   async create(input: CreateCeremonyRequirementInput): Promise<CeremonyRequirement> {
-    await this.ensureLoaded();
-    const existing = this.findOpenRequirement(input.kind, input.target.taskId, input.target.runId);
-    if (existing) return existing;
-
     const timestamp = nowIso();
     const requirement: CeremonyRequirement = {
       id: `ceremony_${Date.now()}_${nanoid(6)}`,
@@ -131,12 +129,24 @@ export class CeremonyService {
       createdAt: timestamp,
       updatedAt: timestamp,
     };
-
-    this.state.requirements.push(requirement);
-    if (this.state.requirements.length > MAX_REQUIREMENTS) {
-      this.state.requirements = this.state.requirements.slice(-MAX_REQUIREMENTS);
-    }
-    await this.saveState();
+    let selected = requirement;
+    await this.repository.update((state) => {
+      const existing = this.findOpenRequirement(
+        state,
+        input.kind,
+        input.target.taskId,
+        input.target.runId
+      );
+      if (existing) {
+        selected = existing;
+        return state;
+      }
+      return {
+        ...state,
+        requirements: [...state.requirements, requirement].slice(-MAX_REQUIREMENTS),
+      };
+    });
+    if (selected !== requirement) return selected;
     await this.auditChange('ceremony.created', requirement);
     return requirement;
   }
@@ -146,50 +156,60 @@ export class CeremonyService {
     input: CompleteCeremonyRequirementInput
   ): Promise<CeremonyRequirement> {
     validatePathSegment(id);
-    await this.ensureLoaded();
-    const requirement = this.findById(id);
-    if (!requirement) throw new NotFoundError('Ceremony requirement not found');
-    if (requirement.status !== 'pending') {
-      throw new ConflictError('Ceremony requirement is not pending');
-    }
-
     const timestamp = nowIso();
-    requirement.status = 'completed';
-    requirement.completedAt = timestamp;
-    requirement.completedBy = input.completedBy;
-    requirement.updatedAt = timestamp;
-    requirement.artifacts = [
-      ...requirement.artifacts,
-      ...(input.artifacts ?? []).map<CeremonyArtifact>((artifact) => ({
-        ...artifact,
-        createdAt: artifact.createdAt ?? timestamp,
-      })),
-    ];
-    requirement.actionItems = [
-      ...requirement.actionItems,
-      ...(input.actionItems ?? []).map<CeremonyActionItem>((item) => ({
-        ...item,
-        createdAt: item.createdAt ?? timestamp,
-      })),
-    ];
-
-    await this.saveState();
-    await this.auditChange('ceremony.completed', requirement);
-    return requirement;
+    let completed: CeremonyRequirement | undefined;
+    await this.repository.update((state) => {
+      const requirement = this.findById(state, id);
+      if (!requirement) throw new NotFoundError('Ceremony requirement not found');
+      if (requirement.status !== 'pending') {
+        throw new ConflictError('Ceremony requirement is not pending');
+      }
+      const completedRequirement: CeremonyRequirement = {
+        ...requirement,
+        status: 'completed',
+        completedAt: timestamp,
+        completedBy: input.completedBy,
+        updatedAt: timestamp,
+        artifacts: [
+          ...requirement.artifacts,
+          ...(input.artifacts ?? []).map<CeremonyArtifact>((artifact) => ({
+            ...artifact,
+            createdAt: artifact.createdAt ?? timestamp,
+          })),
+        ],
+        actionItems: [
+          ...requirement.actionItems,
+          ...(input.actionItems ?? []).map<CeremonyActionItem>((item) => ({
+            ...item,
+            createdAt: item.createdAt ?? timestamp,
+          })),
+        ],
+      };
+      completed = completedRequirement;
+      return {
+        ...state,
+        requirements: state.requirements.map((candidate) =>
+          candidate.id === id ? completedRequirement : candidate
+        ),
+      };
+    });
+    if (!completed) throw new NotFoundError('Ceremony requirement not found');
+    await this.auditChange('ceremony.completed', completed);
+    return completed;
   }
 
   async evaluateTaskCompletion(
     task: Task,
     enforcement?: Partial<EnforcementSettings>
   ): Promise<CeremonyEvaluationResult> {
-    await this.ensureLoaded();
+    const state = await this.repository.read();
     const required: CeremonyRequirement[] = [];
 
     const designMode = enforcement?.ceremonyDesignReview ?? 'off';
     if (
       designMode !== 'off' &&
       this.taskNeedsDesignReview(task) &&
-      !this.hasCompletedRequirement('design_review', task.id)
+      !this.hasCompletedRequirement(state, 'design_review', task.id)
     ) {
       required.push(
         await this.create({
@@ -208,7 +228,7 @@ export class CeremonyService {
     if (
       retroMode !== 'off' &&
       this.taskNeedsFailureRetrospective(task) &&
-      !this.hasCompletedRequirement('failure_retrospective', task.id)
+      !this.hasCompletedRequirement(state, 'failure_retrospective', task.id)
     ) {
       required.push(
         await this.create({
@@ -309,11 +329,12 @@ export class CeremonyService {
   }
 
   private findOpenRequirement(
+    state: CeremonyState,
     kind: CeremonyKind,
     taskId?: string,
     runId?: string
   ): CeremonyRequirement | undefined {
-    return this.state.requirements.find(
+    return state.requirements.find(
       (requirement) =>
         requirement.kind === kind &&
         requirement.status === 'pending' &&
@@ -322,8 +343,13 @@ export class CeremonyService {
     );
   }
 
-  private hasCompletedRequirement(kind: CeremonyKind, taskId?: string, runId?: string): boolean {
-    return this.state.requirements.some(
+  private hasCompletedRequirement(
+    state: CeremonyState,
+    kind: CeremonyKind,
+    taskId?: string,
+    runId?: string
+  ): boolean {
+    return state.requirements.some(
       (requirement) =>
         requirement.kind === kind &&
         requirement.status === 'completed' &&
@@ -332,52 +358,8 @@ export class CeremonyService {
     );
   }
 
-  private findById(id: string): CeremonyRequirement | undefined {
-    return this.state.requirements.find((requirement) => requirement.id === id);
-  }
-
-  private async ensureLoaded(): Promise<void> {
-    if (this.loaded) return;
-    if (!this.persist) {
-      this.loaded = true;
-      return;
-    }
-
-    await fs.mkdir(this.storageDir, { recursive: true });
-    try {
-      const raw = await fs.readFile(this.statePath, 'utf-8');
-      const parsed = JSON.parse(raw) as Partial<CeremonyState>;
-      this.state = {
-        version: 1,
-        requirements: Array.isArray(parsed.requirements)
-          ? (parsed.requirements as CeremonyRequirement[])
-          : [],
-        updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : nowIso(),
-      };
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-      this.state = this.emptyState();
-    }
-    this.loaded = true;
-  }
-
-  private async saveState(): Promise<void> {
-    this.state.updatedAt = nowIso();
-    if (!this.persist) return;
-    await fs.mkdir(this.storageDir, { recursive: true });
-    await withFileLock(this.statePath, async () => {
-      await fs.writeFile(this.statePath, JSON.stringify(this.state, null, 2), 'utf-8');
-    });
-  }
-
-  private get statePath(): string {
-    const filePath = path.join(this.storageDir, 'requirements.json');
-    ensureWithinBase(this.storageDir, filePath);
-    return filePath;
-  }
-
-  private emptyState(): CeremonyState {
-    return { version: 1, requirements: [], updatedAt: nowIso() };
+  private findById(state: CeremonyState, id: string): CeremonyRequirement | undefined {
+    return state.requirements.find((requirement) => requirement.id === id);
   }
 
   private async auditChange(action: string, requirement: CeremonyRequirement): Promise<void> {

--- a/server/src/storage/ceremony-state-repository.ts
+++ b/server/src/storage/ceremony-state-repository.ts
@@ -1,0 +1,117 @@
+import { constants } from 'node:fs';
+import { lstat, mkdir, open } from 'node:fs/promises';
+import path from 'node:path';
+import type { CeremonyRequirement } from '@veritas-kanban/shared';
+import { withFileLock } from '../services/file-lock.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import { atomicWriteFile } from './fs-helpers.js';
+
+const MAX_CEREMONY_STATE_BYTES = 16 * 1024 * 1024;
+
+export interface CeremonyState {
+  version: 1;
+  requirements: CeremonyRequirement[];
+  updatedAt: string;
+}
+
+export interface CeremonyStateRepository {
+  read(): Promise<CeremonyState>;
+  update(updater: (state: CeremonyState) => CeremonyState): Promise<CeremonyState>;
+}
+
+function emptyState(): CeremonyState {
+  return { version: 1, requirements: [], updatedAt: new Date().toISOString() };
+}
+
+function normalizeState(parsed: Partial<CeremonyState>): CeremonyState {
+  return {
+    version: 1,
+    requirements: Array.isArray(parsed.requirements)
+      ? (parsed.requirements as CeremonyRequirement[])
+      : [],
+    updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
+  };
+}
+
+export class FileCeremonyStateRepository implements CeremonyStateRepository {
+  private readonly storageDir: string;
+  private readonly stateFile: string;
+
+  constructor(storageDir: string) {
+    this.storageDir = path.resolve(storageDir);
+    this.stateFile = ensureWithinBase(
+      this.storageDir,
+      path.join(this.storageDir, 'requirements.json')
+    );
+  }
+
+  async read(): Promise<CeremonyState> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(this.stateFile, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const [pathStats, stats] = await Promise.all([lstat(this.stateFile), handle.stat()]);
+      if (
+        pathStats.isSymbolicLink() ||
+        pathStats.dev !== stats.dev ||
+        pathStats.ino !== stats.ino
+      ) {
+        throw new Error('Ceremony state must not use a symbolic link or changed file');
+      }
+      if (!stats.isFile() || stats.size > MAX_CEREMONY_STATE_BYTES) {
+        throw new Error('Ceremony state must use a bounded regular file');
+      }
+      return normalizeState(JSON.parse(await handle.readFile({ encoding: 'utf8' })));
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOENT') return emptyState();
+      if (errorCode === 'ELOOP') {
+        throw new Error('Ceremony state must not use a symbolic link', { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  async update(updater: (state: CeremonyState) => CeremonyState): Promise<CeremonyState> {
+    await this.prepareDirectory();
+    return withFileLock(this.stateFile, async () => {
+      const state = {
+        ...updater(await this.read()),
+        version: 1 as const,
+        updatedAt: new Date().toISOString(),
+      };
+      const content = JSON.stringify(state, null, 2);
+      if (Buffer.byteLength(content, 'utf8') > MAX_CEREMONY_STATE_BYTES) {
+        throw new Error('Ceremony state exceeds the 16 MiB storage limit');
+      }
+      await atomicWriteFile(this.stateFile, content, 'utf8');
+      return state;
+    });
+  }
+
+  private async prepareDirectory(): Promise<void> {
+    await mkdir(this.storageDir, { recursive: true, mode: 0o700 });
+    const stats = await lstat(this.storageDir);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error('Ceremony storage path must use a regular directory');
+    }
+  }
+}
+
+export class InMemoryCeremonyStateRepository implements CeremonyStateRepository {
+  private state = emptyState();
+
+  async read(): Promise<CeremonyState> {
+    return this.state;
+  }
+
+  async update(updater: (state: CeremonyState) => CeremonyState): Promise<CeremonyState> {
+    this.state = {
+      ...updater(this.state),
+      version: 1,
+      updatedAt: new Date().toISOString(),
+    };
+    return this.state;
+  }
+}

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -43,6 +43,12 @@ export { FileProgressRepository, type ProgressRepository } from './progress-repo
 export { FileStatusHistoryStore } from './status-history-repository.js';
 export { FileScheduledDeliverablesStore } from './scheduled-deliverables-repository.js';
 export { FileBroadcastRepository } from './broadcast-repository.js';
+export {
+  FileCeremonyStateRepository,
+  InMemoryCeremonyStateRepository,
+  type CeremonyState,
+  type CeremonyStateRepository,
+} from './ceremony-state-repository.js';
 export { FileDelegationRepository, type DelegationRepository } from './delegation-repository.js';
 export {
   LocalConflictWorkspaceRepository,


### PR DESCRIPTION
## Summary

- move ceremony requirement persistence into file and in-memory storage repositories
- serialize file-backed ceremony mutations under a lock with atomic writes
- prevent duplicate requirements across concurrent service instances
- reject symbolic links, changed files, non-files, and oversized state while preserving the existing JSON format
- ratchet the service filesystem boundary from 45 to 44

## Verification

- 9 focused ceremony service and repository tests
- concurrent two-instance requirement creation test
- server build
- service filesystem boundary check
- focused lint and format checks

## Risk

Low. Public service methods and persisted state shape are unchanged. Mutations now reload state under the repository lock, so concurrent processes no longer overwrite each other through stale service caches.

Refs #1186