### PR TITLE
refactor: move agent permissions behind storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,18 +1,12 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 43,
+  "maximumEntries": 42,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
       "category": "authoritative-persistence",
       "owner": "#1187",
       "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
-    {
-      "path": "server/src/services/agent-permission-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/attachment-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -16,6 +16,7 @@
         "testFiles": [
           "src/__tests__/acp-stdio-provider.test.ts",
           "src/__tests__/admission-control-service.test.ts",
+          "src/__tests__/agent-permission-repository.test.ts",
           "src/__tests__/broadcast-storage-service.test.ts",
           "src/__tests__/claude-code-provider.smoke.test.ts",
           "src/__tests__/claude-code-provider.test.ts",

--- a/server/src/__tests__/agent-permission-repository.test.ts
+++ b/server/src/__tests__/agent-permission-repository.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  AgentPermissionService,
+  type AgentPermissionConfig,
+  type ApprovalRequest,
+} from '../services/agent-permission-service.js';
+import {
+  FileAgentPermissionRepository,
+  InMemoryAgentPermissionRepository,
+} from '../storage/agent-permission-repository.js';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, lstat: vi.fn(actual.lstat) };
+});
+
+function permission(agentId: string): AgentPermissionConfig {
+  return {
+    agentId,
+    level: 'specialist',
+    canCreateTasks: true,
+    canDelegate: false,
+    canApprove: false,
+    autoComplete: true,
+    updatedAt: '2026-08-23T20:00:00.000Z',
+  };
+}
+
+function approval(id: string): ApprovalRequest {
+  return {
+    id,
+    agentId: 'tars',
+    action: 'create_task',
+    status: 'pending',
+    createdAt: '2026-08-23T20:00:00.000Z',
+  };
+}
+
+describe('FileAgentPermissionRepository', () => {
+  let root: string;
+  let runtimeDir: string;
+  let repository: FileAgentPermissionRepository;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-agent-permission-'));
+    runtimeDir = path.join(root, 'runtime');
+    repository = new FileAgentPermissionRepository(runtimeDir, []);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('serializes concurrent permission and approval mutations', async () => {
+    await expect(repository.readPermissions()).resolves.toEqual([]);
+    await expect(repository.readApprovals()).resolves.toEqual([]);
+    await Promise.all([
+      repository.mutatePermissions((values) => ({
+        values: [...values, permission('tars')],
+        result: undefined,
+      })),
+      repository.mutatePermissions((values) => ({
+        values: [...values, permission('case')],
+        result: undefined,
+      })),
+      repository.mutateApprovals((values) => ({
+        values: [...values, approval('one')],
+        result: undefined,
+      })),
+      repository.mutateApprovals((values) => ({
+        values: [...values, approval('two')],
+        result: undefined,
+      })),
+    ]);
+    expect((await repository.readPermissions()).map(({ agentId }) => agentId)).toEqual(
+      expect.arrayContaining(['tars', 'case'])
+    );
+    expect((await repository.readApprovals()).map(({ id }) => id)).toEqual(
+      expect.arrayContaining(['one', 'two'])
+    );
+  });
+
+  it('migrates legacy state and tolerates malformed or non-array JSON', async () => {
+    const legacyDir = path.join(root, 'legacy');
+    await mkdir(legacyDir);
+    await writeFile(
+      path.join(legacyDir, 'agent-permissions.json'),
+      JSON.stringify([permission('legacy')]),
+      'utf8'
+    );
+    await writeFile(
+      path.join(legacyDir, 'approval-requests.json'),
+      JSON.stringify([approval('legacy')]),
+      'utf8'
+    );
+    const migratingRepository = new FileAgentPermissionRepository(runtimeDir, [legacyDir]);
+    await expect(migratingRepository.readPermissions()).resolves.toEqual([permission('legacy')]);
+    await expect(migratingRepository.readApprovals()).resolves.toEqual([approval('legacy')]);
+
+    await writeFile(path.join(runtimeDir, 'agent-permissions.json'), '{broken', 'utf8');
+    await expect(repository.readPermissions()).resolves.toEqual([]);
+    await writeFile(path.join(runtimeDir, 'agent-permissions.json'), '{}', 'utf8');
+    await expect(repository.readPermissions()).resolves.toEqual([]);
+  });
+
+  it('rejects symbolic links, changed files, and non-file paths', async () => {
+    await mkdir(runtimeDir, { recursive: true });
+    const stateFile = path.join(runtimeDir, 'agent-permissions.json');
+    const target = path.join(root, 'outside.json');
+    await writeFile(target, '[]', 'utf8');
+    await symlink(target, stateFile);
+    await expect(repository.readPermissions()).rejects.toThrow(/symbolic link/i);
+
+    await rm(stateFile);
+    await writeFile(stateFile, '[]', 'utf8');
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.mocked(lstat).mockImplementationOnce(async (filePath) => {
+      const stats = await actual.lstat(filePath);
+      return Object.assign(Object.create(Object.getPrototypeOf(stats)), stats, {
+        ino: stats.ino + 1,
+      });
+    });
+    await expect(repository.readPermissions()).rejects.toThrow(/changed file/i);
+
+    await rm(stateFile);
+    await mkdir(stateFile);
+    await expect(repository.readPermissions()).rejects.toThrow(/bounded regular file/i);
+  });
+
+  it('rejects symbolic-link directories and oversized state', async () => {
+    const realDirectory = path.join(root, 'real-runtime');
+    const linkedDirectory = path.join(root, 'linked-runtime');
+    await mkdir(realDirectory);
+    await symlink(realDirectory, linkedDirectory, 'dir');
+    const linkedRepository = new FileAgentPermissionRepository(linkedDirectory, []);
+    await expect(
+      linkedRepository.mutatePermissions(() => ({ values: [permission('unsafe')], result: null }))
+    ).rejects.toThrow(/regular directory/i);
+
+    await expect(
+      repository.mutatePermissions(() => ({
+        values: [{ ...permission('large'), restrictions: ['x'.repeat(16 * 1024 * 1024)] }],
+        result: null,
+      }))
+    ).rejects.toThrow(/16 MiB/i);
+  });
+});
+
+describe('AgentPermissionService storage integration', () => {
+  it('manages levels, restrictions, and approval requests through the repository', async () => {
+    const repository = new InMemoryAgentPermissionRepository();
+    const service = new AgentPermissionService(repository);
+    await expect(service.getPermissions('TARS')).resolves.toMatchObject({
+      agentId: 'tars',
+      level: 'specialist',
+    });
+
+    await service.setLevel('TARS', 'intern');
+    await service.updatePermissions('TARS', { restrictions: ['deploy'] });
+    await expect(service.checkPermission('TARS', 'deploy_production')).resolves.toMatchObject({
+      allowed: false,
+    });
+    await expect(service.listPermissions()).resolves.toHaveLength(1);
+
+    const request = await service.requestApproval({ agentId: 'TARS', action: 'create_task' });
+    await expect(service.getPendingApprovals({ agentId: 'TARS' })).resolves.toHaveLength(1);
+    await expect(service.reviewApproval(request.id, 'approved', 'brad')).resolves.toMatchObject({
+      status: 'approved',
+      reviewedBy: 'brad',
+    });
+    await expect(service.getPendingApprovals()).resolves.toEqual([]);
+  });
+});

--- a/server/src/services/agent-permission-service.ts
+++ b/server/src/services/agent-permission-service.ts
@@ -11,14 +11,11 @@
  */
 
 import { createLogger } from '../lib/logger.js';
-import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
 import type { CreateGovernanceTraceInput } from '@veritas-kanban/shared';
-import { getLegacyRuntimeDirs, getRuntimeDir } from '../utils/paths.js';
-import { migrateLegacyFiles } from '../utils/migrate-legacy-files.js';
-const DATA_DIR = getRuntimeDir();
-const LEGACY_DATA_DIRS = getLegacyRuntimeDirs();
-let migrationChecked = false;
+import {
+  FileAgentPermissionRepository,
+  type AgentPermissionRepository,
+} from '../storage/agent-permission-repository.js';
 
 const log = createLogger('agent-permissions');
 
@@ -93,69 +90,20 @@ const DEFAULT_PERMISSIONS: Record<
 
 // ─── Service ─────────────────────────────────────────────────────
 
-class AgentPermissionService {
-  private permissions = new Map<string, AgentPermissionConfig>();
-  private approvals: ApprovalRequest[] = [];
-  private loaded = false;
-
-  private get permissionsPath(): string {
-    return path.join(DATA_DIR, 'agent-permissions.json');
-  }
-
-  private get approvalsPath(): string {
-    return path.join(DATA_DIR, 'approval-requests.json');
-  }
-
-  private async ensureLoaded(): Promise<void> {
-    if (!migrationChecked) {
-      migrationChecked = true;
-      await migrateLegacyFiles(
-        LEGACY_DATA_DIRS,
-        DATA_DIR,
-        ['agent-permissions.json', 'approval-requests.json'],
-        'agent permission'
-      );
-    }
-
-    if (this.loaded) return;
-    try {
-      const data = await fs.readFile(this.permissionsPath, 'utf-8');
-      const arr: AgentPermissionConfig[] = JSON.parse(data);
-      for (const p of arr) {
-        this.permissions.set(p.agentId, p);
-      }
-    } catch {
-      // No saved permissions
-    }
-    try {
-      const data = await fs.readFile(this.approvalsPath, 'utf-8');
-      this.approvals = JSON.parse(data);
-    } catch {
-      this.approvals = [];
-    }
-    this.loaded = true;
-  }
-
-  private async savePermissions(): Promise<void> {
-    const arr = Array.from(this.permissions.values());
-    await fs.writeFile(this.permissionsPath, JSON.stringify(arr, null, 2));
-  }
-
-  private async saveApprovals(): Promise<void> {
-    await fs.writeFile(this.approvalsPath, JSON.stringify(this.approvals, null, 2));
-  }
+export class AgentPermissionService {
+  constructor(
+    private readonly repository: AgentPermissionRepository = new FileAgentPermissionRepository()
+  ) {}
 
   /**
    * Get permission config for an agent. Returns default specialist if not configured.
    */
   async getPermissions(agentId: string): Promise<AgentPermissionConfig> {
-    await this.ensureLoaded();
+    const normalizedAgentId = agentId.toLowerCase();
+    const permissions = await this.repository.readPermissions();
     return (
-      this.permissions.get(agentId.toLowerCase()) || {
-        agentId: agentId.toLowerCase(),
-        ...DEFAULT_PERMISSIONS.specialist,
-        updatedAt: new Date().toISOString(),
-      }
+      permissions.find((config) => config.agentId === normalizedAgentId) ??
+      this.defaultPermissions(normalizedAgentId)
     );
   }
 
@@ -163,20 +111,23 @@ class AgentPermissionService {
    * Set permission level for an agent.
    */
   async setLevel(agentId: string, level: PermissionLevel): Promise<AgentPermissionConfig> {
-    await this.ensureLoaded();
-
-    const existing = this.permissions.get(agentId.toLowerCase());
-    const config: AgentPermissionConfig = {
-      ...(existing || { agentId: agentId.toLowerCase() }),
-      ...DEFAULT_PERMISSIONS[level],
-      agentId: agentId.toLowerCase(),
-      trustedDomains: existing?.trustedDomains,
-      restrictions: existing?.restrictions,
-      updatedAt: new Date().toISOString(),
-    };
-
-    this.permissions.set(agentId.toLowerCase(), config);
-    await this.savePermissions();
+    const normalizedAgentId = agentId.toLowerCase();
+    const config = await this.repository.mutatePermissions((permissions) => {
+      const index = permissions.findIndex((candidate) => candidate.agentId === normalizedAgentId);
+      const existing = index >= 0 ? permissions[index] : undefined;
+      const updated: AgentPermissionConfig = {
+        ...(existing || { agentId: normalizedAgentId }),
+        ...DEFAULT_PERMISSIONS[level],
+        agentId: normalizedAgentId,
+        trustedDomains: existing?.trustedDomains,
+        restrictions: existing?.restrictions,
+        updatedAt: new Date().toISOString(),
+      };
+      const next = [...permissions];
+      if (index >= 0) next[index] = updated;
+      else next.push(updated);
+      return { values: next, result: updated };
+    });
 
     log.info({ agentId, level }, 'Agent permission level updated');
     return config;
@@ -199,26 +150,27 @@ class AgentPermissionService {
       >
     >
   ): Promise<AgentPermissionConfig> {
-    await this.ensureLoaded();
-
-    const current = await this.getPermissions(agentId);
-    const updated: AgentPermissionConfig = {
-      ...current,
-      ...update,
-      updatedAt: new Date().toISOString(),
-    };
-
-    this.permissions.set(agentId.toLowerCase(), updated);
-    await this.savePermissions();
-    return updated;
+    const normalizedAgentId = agentId.toLowerCase();
+    return this.repository.mutatePermissions((permissions) => {
+      const index = permissions.findIndex((candidate) => candidate.agentId === normalizedAgentId);
+      const current = index >= 0 ? permissions[index] : this.defaultPermissions(normalizedAgentId);
+      const updated: AgentPermissionConfig = {
+        ...current,
+        ...update,
+        updatedAt: new Date().toISOString(),
+      };
+      const next = [...permissions];
+      if (index >= 0) next[index] = updated;
+      else next.push(updated);
+      return { values: next, result: updated };
+    });
   }
 
   /**
    * List all configured agent permissions.
    */
   async listPermissions(): Promise<AgentPermissionConfig[]> {
-    await this.ensureLoaded();
-    return Array.from(this.permissions.values());
+    return this.repository.readPermissions();
   }
 
   /**
@@ -319,8 +271,6 @@ class AgentPermissionService {
     taskId?: string;
     details?: string;
   }): Promise<ApprovalRequest> {
-    await this.ensureLoaded();
-
     const request: ApprovalRequest = {
       id: `approval_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
       agentId: params.agentId.toLowerCase(),
@@ -331,8 +281,10 @@ class AgentPermissionService {
       createdAt: new Date().toISOString(),
     };
 
-    this.approvals.push(request);
-    await this.saveApprovals();
+    await this.repository.mutateApprovals((approvals) => ({
+      values: [...approvals, request],
+      result: request,
+    }));
 
     log.info(
       { requestId: request.id, agentId: params.agentId, action: params.action },
@@ -349,16 +301,22 @@ class AgentPermissionService {
     decision: 'approved' | 'rejected',
     reviewedBy: string
   ): Promise<ApprovalRequest | null> {
-    await this.ensureLoaded();
-
-    const request = this.approvals.find((a) => a.id === requestId);
+    const request = await this.repository.mutateApprovals((approvals) => {
+      const index = approvals.findIndex((candidate) => candidate.id === requestId);
+      if (index === -1) {
+        return { values: approvals, result: null as ApprovalRequest | null };
+      }
+      const updated: ApprovalRequest = {
+        ...approvals[index],
+        status: decision,
+        reviewedBy,
+        reviewedAt: new Date().toISOString(),
+      };
+      const next = [...approvals];
+      next[index] = updated;
+      return { values: next, result: updated as ApprovalRequest | null };
+    });
     if (!request) return null;
-
-    request.status = decision;
-    request.reviewedBy = reviewedBy;
-    request.reviewedAt = new Date().toISOString();
-
-    await this.saveApprovals();
     log.info({ requestId, decision, reviewedBy }, 'Approval reviewed');
     return request;
   }
@@ -367,15 +325,24 @@ class AgentPermissionService {
    * Get pending approval requests.
    */
   async getPendingApprovals(filters?: { agentId?: string }): Promise<ApprovalRequest[]> {
-    await this.ensureLoaded();
-
-    let results = this.approvals.filter((a) => a.status === 'pending');
+    let results = (await this.repository.readApprovals()).filter(
+      (approval) => approval.status === 'pending'
+    );
     if (filters?.agentId) {
-      results = results.filter((a) => a.agentId === filters.agentId!.toLowerCase());
+      const agentId = filters.agentId.toLowerCase();
+      results = results.filter((approval) => approval.agentId === agentId);
     }
     return results.sort(
       (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
     );
+  }
+
+  private defaultPermissions(agentId: string): AgentPermissionConfig {
+    return {
+      agentId,
+      ...DEFAULT_PERMISSIONS.specialist,
+      updatedAt: new Date().toISOString(),
+    };
   }
 
   private buildPermissionTrace(

--- a/server/src/storage/agent-permission-repository.ts
+++ b/server/src/storage/agent-permission-repository.ts
@@ -1,0 +1,169 @@
+import { constants } from 'node:fs';
+import { lstat, mkdir, open } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  AgentPermissionConfig,
+  ApprovalRequest,
+} from '../services/agent-permission-service.js';
+import { withFileLock } from '../services/file-lock.js';
+import { migrateLegacyFiles } from '../utils/migrate-legacy-files.js';
+import { getLegacyRuntimeDirs, getRuntimeDir } from '../utils/paths.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import { atomicWriteFile } from './fs-helpers.js';
+
+const MAX_PERMISSION_STATE_BYTES = 16 * 1024 * 1024;
+
+interface RepositoryMutation<T, R> {
+  values: T[];
+  result: R;
+}
+
+export interface AgentPermissionRepository {
+  readPermissions(): Promise<AgentPermissionConfig[]>;
+  mutatePermissions<T>(
+    updater: (permissions: AgentPermissionConfig[]) => RepositoryMutation<AgentPermissionConfig, T>
+  ): Promise<T>;
+  readApprovals(): Promise<ApprovalRequest[]>;
+  mutateApprovals<T>(
+    updater: (approvals: ApprovalRequest[]) => RepositoryMutation<ApprovalRequest, T>
+  ): Promise<T>;
+}
+
+export class FileAgentPermissionRepository implements AgentPermissionRepository {
+  private readonly runtimeDir: string;
+  private readonly permissionsFile: string;
+  private readonly approvalsFile: string;
+  private migrationChecked = false;
+
+  constructor(
+    runtimeDir = getRuntimeDir(),
+    private readonly legacyRuntimeDirs: readonly string[] = getLegacyRuntimeDirs()
+  ) {
+    this.runtimeDir = path.resolve(runtimeDir);
+    this.permissionsFile = ensureWithinBase(
+      this.runtimeDir,
+      path.join(this.runtimeDir, 'agent-permissions.json')
+    );
+    this.approvalsFile = ensureWithinBase(
+      this.runtimeDir,
+      path.join(this.runtimeDir, 'approval-requests.json')
+    );
+  }
+
+  async readPermissions(): Promise<AgentPermissionConfig[]> {
+    await this.ensureMigrated();
+    return this.readArray<AgentPermissionConfig>(this.permissionsFile, 'Agent permissions');
+  }
+
+  mutatePermissions<T>(
+    updater: (permissions: AgentPermissionConfig[]) => RepositoryMutation<AgentPermissionConfig, T>
+  ): Promise<T> {
+    return this.mutateArray(this.permissionsFile, 'Agent permissions', updater);
+  }
+
+  async readApprovals(): Promise<ApprovalRequest[]> {
+    await this.ensureMigrated();
+    return this.readArray<ApprovalRequest>(this.approvalsFile, 'Approval requests');
+  }
+
+  mutateApprovals<T>(
+    updater: (approvals: ApprovalRequest[]) => RepositoryMutation<ApprovalRequest, T>
+  ): Promise<T> {
+    return this.mutateArray(this.approvalsFile, 'Approval requests', updater);
+  }
+
+  private async mutateArray<T, R>(
+    filePath: string,
+    label: string,
+    updater: (values: T[]) => RepositoryMutation<T, R>
+  ): Promise<R> {
+    await this.ensureMigrated();
+    await this.prepareDirectory();
+    return withFileLock(filePath, async () => {
+      const { values, result } = updater(await this.readArray<T>(filePath, label));
+      const content = JSON.stringify(values, null, 2);
+      if (Buffer.byteLength(content, 'utf8') > MAX_PERMISSION_STATE_BYTES) {
+        throw new Error(`${label} exceed the 16 MiB storage limit`);
+      }
+      await atomicWriteFile(filePath, content, 'utf8');
+      return result;
+    });
+  }
+
+  private async ensureMigrated(): Promise<void> {
+    if (this.migrationChecked) return;
+    this.migrationChecked = true;
+    await migrateLegacyFiles(
+      this.legacyRuntimeDirs,
+      this.runtimeDir,
+      ['agent-permissions.json', 'approval-requests.json'],
+      'agent permission'
+    );
+  }
+
+  private async prepareDirectory(): Promise<void> {
+    await mkdir(this.runtimeDir, { recursive: true, mode: 0o700 });
+    const stats = await lstat(this.runtimeDir);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error('Agent permission storage path must use a regular directory');
+    }
+  }
+
+  private async readArray<T>(filePath: string, label: string): Promise<T[]> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const [pathStats, stats] = await Promise.all([lstat(filePath), handle.stat()]);
+      if (
+        pathStats.isSymbolicLink() ||
+        pathStats.dev !== stats.dev ||
+        pathStats.ino !== stats.ino
+      ) {
+        throw new Error(`${label} must not use a symbolic link or changed file`);
+      }
+      if (!stats.isFile() || stats.size > MAX_PERMISSION_STATE_BYTES) {
+        throw new Error(`${label} must use a bounded regular file`);
+      }
+      const parsed: unknown = JSON.parse(await handle.readFile({ encoding: 'utf8' }));
+      return Array.isArray(parsed) ? (parsed as T[]) : [];
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOENT' || error instanceof SyntaxError) return [];
+      if (errorCode === 'ELOOP') {
+        throw new Error(`${label} must not use a symbolic link`, { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+}
+
+export class InMemoryAgentPermissionRepository implements AgentPermissionRepository {
+  private permissions: AgentPermissionConfig[] = [];
+  private approvals: ApprovalRequest[] = [];
+
+  async readPermissions(): Promise<AgentPermissionConfig[]> {
+    return this.permissions;
+  }
+
+  async mutatePermissions<T>(
+    updater: (permissions: AgentPermissionConfig[]) => RepositoryMutation<AgentPermissionConfig, T>
+  ): Promise<T> {
+    const mutation = updater(this.permissions);
+    this.permissions = mutation.values;
+    return mutation.result;
+  }
+
+  async readApprovals(): Promise<ApprovalRequest[]> {
+    return this.approvals;
+  }
+
+  async mutateApprovals<T>(
+    updater: (approvals: ApprovalRequest[]) => RepositoryMutation<ApprovalRequest, T>
+  ): Promise<T> {
+    const mutation = updater(this.approvals);
+    this.approvals = mutation.values;
+    return mutation.result;
+  }
+}

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -44,6 +44,11 @@ export { FileStatusHistoryStore } from './status-history-repository.js';
 export { FileScheduledDeliverablesStore } from './scheduled-deliverables-repository.js';
 export { FileBroadcastRepository } from './broadcast-repository.js';
 export {
+  FileAgentPermissionRepository,
+  InMemoryAgentPermissionRepository,
+  type AgentPermissionRepository,
+} from './agent-permission-repository.js';
+export {
   FileCeremonyStateRepository,
   InMemoryCeremonyStateRepository,
   type CeremonyState,


### PR DESCRIPTION
## Summary

- move agent permission and approval-request persistence into file and in-memory repositories
- serialize concurrent mutations for both state files under locks with atomic writes
- preserve legacy migration and configured permission ordering
- reject symbolic links, changed files, non-files, and oversized state
- ratchet the service filesystem boundary from 43 to 42

## Verification

- 5 focused repository and service integration tests
- concurrent dual-file mutation and legacy migration coverage
- server build
- service filesystem boundary check
- focused lint and format checks

## Risk

Low. Public permission checks, approval workflows, and persisted JSON arrays are unchanged. Reads now observe current persisted state, and concurrent writers no longer replace each other through stale process-local caches.

Refs #1186