### PR TITLE
refactor: move lifecycle hooks behind storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 41,
+  "maximumEntries": 40,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -85,12 +85,6 @@
       "category": "authoritative-persistence",
       "owner": "#1187",
       "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
-    {
-      "path": "server/src/services/lifecycle-hooks-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/maintenance-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -35,6 +35,7 @@
           "src/__tests__/filesystem-sandbox-service.test.ts",
           "src/__tests__/harness-support-profile-schemas.test.ts",
           "src/__tests__/hermes-provider.test.ts",
+          "src/__tests__/lifecycle-hooks-repository.test.ts",
           "src/__tests__/log-redaction.test.ts",
           "src/__tests__/middleware/auth.test.ts",
           "src/__tests__/middleware/write-enforcement.integration.test.ts",

--- a/server/src/__tests__/lifecycle-hooks-repository.test.ts
+++ b/server/src/__tests__/lifecycle-hooks-repository.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { HookConfig, HookExecution } from '../services/lifecycle-hooks-service.js';
+import { FileLifecycleHooksRepository } from '../storage/lifecycle-hooks-repository.js';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, lstat: vi.fn(actual.lstat) };
+});
+
+function hook(id: string, name = id): HookConfig {
+  return {
+    id,
+    name,
+    event: 'task.created',
+    action: 'log_activity',
+    enabled: true,
+    builtIn: false,
+    order: 10,
+    createdAt: '2026-08-23T00:00:00.000Z',
+    updatedAt: '2026-08-23T00:00:00.000Z',
+  };
+}
+
+function execution(hookId: string): HookExecution {
+  return {
+    hookId,
+    hookName: hookId,
+    event: 'task.created',
+    taskId: 'task-1',
+    action: 'log_activity',
+    success: true,
+    durationMs: 1,
+    executedAt: '2026-08-23T00:00:00.000Z',
+  };
+}
+
+describe('FileLifecycleHooksRepository', () => {
+  let root: string;
+  let runtimeDir: string;
+  let repository: FileLifecycleHooksRepository;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-lifecycle-hooks-'));
+    runtimeDir = path.join(root, 'runtime');
+    repository = new FileLifecycleHooksRepository(runtimeDir);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('preserves concurrent hook and execution updates', async () => {
+    await expect(repository.readHooks()).resolves.toBeNull();
+    await Promise.all([
+      repository.updateHooks((hooks) => [...(hooks ?? []), hook('one')]),
+      repository.updateHooks((hooks) => [...(hooks ?? []), hook('two')]),
+    ]);
+    expect(new Set((await repository.readHooks())?.map(({ id }) => id))).toEqual(
+      new Set(['one', 'two'])
+    );
+
+    await Promise.all([
+      repository.updateExecutions((executions) => [...executions, execution('one')]),
+      repository.updateExecutions((executions) => [...executions, execution('two')]),
+    ]);
+    expect(new Set((await repository.readExecutions()).map(({ hookId }) => hookId))).toEqual(
+      new Set(['one', 'two'])
+    );
+  });
+
+  it('rejects symbolic links, changed files, and non-file paths', async () => {
+    await mkdir(runtimeDir, { recursive: true });
+    const hooksFile = path.join(runtimeDir, 'lifecycle-hooks.json');
+    const target = path.join(root, 'outside.json');
+    await writeFile(target, JSON.stringify([hook('outside')]), 'utf8');
+    await symlink(target, hooksFile);
+    await expect(repository.readHooks()).rejects.toThrow(/symbolic link/i);
+
+    await rm(hooksFile);
+    await writeFile(hooksFile, JSON.stringify([hook('changed')]), 'utf8');
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.mocked(lstat).mockImplementationOnce(async (filePath) => {
+      const stats = await actual.lstat(filePath);
+      return Object.assign(Object.create(Object.getPrototypeOf(stats)), stats, {
+        ino: stats.ino + 1,
+      });
+    });
+    await expect(repository.readHooks()).rejects.toThrow(/changed file/i);
+
+    await rm(hooksFile);
+    await mkdir(hooksFile);
+    await expect(repository.readHooks()).rejects.toThrow(/bounded regular file/i);
+  });
+
+  it('rejects symbolic-link directories and oversized state', async () => {
+    const realDirectory = path.join(root, 'real-runtime');
+    const linkedDirectory = path.join(root, 'linked-runtime');
+    await mkdir(realDirectory);
+    await symlink(realDirectory, linkedDirectory, 'dir');
+    const linkedRepository = new FileLifecycleHooksRepository(linkedDirectory);
+    await expect(linkedRepository.updateHooks(() => [hook('linked')])).rejects.toThrow(
+      /regular directory/i
+    );
+
+    await expect(
+      repository.updateHooks(() => [hook('large', 'x'.repeat(8 * 1024 * 1024))])
+    ).rejects.toThrow(/8 MiB/i);
+  });
+});

--- a/server/src/services/lifecycle-hooks-service.ts
+++ b/server/src/services/lifecycle-hooks-service.ts
@@ -15,14 +15,16 @@
  */
 
 import { createLogger } from '../lib/logger.js';
-import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
+import {
+  FileLifecycleHooksRepository,
+  type LifecycleHooksRepository,
+} from '../storage/lifecycle-hooks-repository.js';
 import { getLegacyRuntimeDirs, getRuntimeDir } from '../utils/paths.js';
 import { migrateLegacyFiles } from '../utils/migrate-legacy-files.js';
 import { getOutboundIntegrationService } from './outbound-integration-service.js';
 const DATA_DIR = getRuntimeDir();
 const LEGACY_DATA_DIRS = getLegacyRuntimeDirs();
-let migrationChecked = false;
+let migrationPromise: Promise<void> | null = null;
 
 const log = createLogger('lifecycle-hooks');
 
@@ -163,17 +165,17 @@ const BUILT_IN_HOOKS: Omit<HookConfig, 'id' | 'createdAt' | 'updatedAt'>[] = [
 // ─── Service ─────────────────────────────────────────────────────
 
 class LifecycleHooksService {
-  private hooks: HookConfig[] = [];
-  private executions: HookExecution[] = [];
-  private loaded = false;
-
   // Hook handlers — extensible
   private handlers = new Map<
     HookAction,
     (hook: HookConfig, context: HookContext) => Promise<void>
   >();
 
-  constructor() {
+  constructor(
+    private readonly repository: LifecycleHooksRepository = new FileLifecycleHooksRepository(
+      DATA_DIR
+    )
+  ) {
     // Register built-in handlers
     this.handlers.set('log_activity', async (_hook, ctx) => {
       log.info({ taskId: ctx.taskId, event: ctx.newStatus }, 'Activity logged');
@@ -238,71 +240,42 @@ class LifecycleHooksService {
     });
   }
 
-  private get storagePath(): string {
-    return path.join(DATA_DIR, 'lifecycle-hooks.json');
-  }
+  private async ensureReady(): Promise<void> {
+    migrationPromise ??= migrateLegacyFiles(
+      LEGACY_DATA_DIRS,
+      DATA_DIR,
+      ['lifecycle-hooks.json', 'hook-executions.json'],
+      'lifecycle hook'
+    );
+    try {
+      await migrationPromise;
+    } catch (error) {
+      migrationPromise = null;
+      throw error;
+    }
 
-  private get executionsPath(): string {
-    return path.join(DATA_DIR, 'hook-executions.json');
-  }
-
-  private async ensureLoaded(): Promise<void> {
-    if (!migrationChecked) {
-      migrationChecked = true;
-      await migrateLegacyFiles(
-        LEGACY_DATA_DIRS,
-        DATA_DIR,
-        ['lifecycle-hooks.json', 'hook-executions.json'],
-        'lifecycle hook'
+    if ((await this.repository.readHooks()) === null) {
+      const now = new Date().toISOString();
+      await this.repository.updateHooks(
+        (hooks) =>
+          hooks ??
+          BUILT_IN_HOOKS.map((hook, index) => ({
+            ...hook,
+            id: `hook_builtin_${index}`,
+            createdAt: now,
+            updatedAt: now,
+          }))
       );
     }
-
-    if (this.loaded) return;
-
-    try {
-      const data = await fs.readFile(this.storagePath, 'utf-8');
-      this.hooks = JSON.parse(data);
-    } catch {
-      // Initialize with built-in hooks
-      const now = new Date().toISOString();
-      this.hooks = BUILT_IN_HOOKS.map((h, i) => ({
-        ...h,
-        id: `hook_builtin_${i}`,
-        createdAt: now,
-        updatedAt: now,
-      }));
-      await this.saveHooks();
-    }
-
-    try {
-      const data = await fs.readFile(this.executionsPath, 'utf-8');
-      this.executions = JSON.parse(data);
-      // Keep only last 500 executions
-      if (this.executions.length > 500) {
-        this.executions = this.executions.slice(-500);
-      }
-    } catch {
-      this.executions = [];
-    }
-
-    this.loaded = true;
-  }
-
-  private async saveHooks(): Promise<void> {
-    await fs.writeFile(this.storagePath, JSON.stringify(this.hooks, null, 2));
-  }
-
-  private async saveExecutions(): Promise<void> {
-    await fs.writeFile(this.executionsPath, JSON.stringify(this.executions, null, 2));
   }
 
   /**
    * Fire hooks for a lifecycle event.
    */
   async fireEvent(event: LifecycleEvent, context: HookContext): Promise<HookExecution[]> {
-    await this.ensureLoaded();
+    await this.ensureReady();
 
-    const matchingHooks = this.hooks
+    const matchingHooks = ((await this.repository.readHooks()) ?? [])
       .filter((h) => h.enabled && h.event === event)
       .filter((h) => {
         if (
@@ -356,12 +329,13 @@ class LifecycleHooksService {
       }
 
       execution.durationMs = Date.now() - start;
-      this.executions.push(execution);
       results.push(execution);
     }
 
     if (results.length > 0) {
-      await this.saveExecutions();
+      await this.repository.updateExecutions((executions) =>
+        [...executions, ...results].slice(-500)
+      );
       log.info(
         { event, taskId: context.taskId, hooksRun: results.length },
         'Lifecycle event fired'
@@ -378,9 +352,9 @@ class LifecycleHooksService {
     event?: LifecycleEvent;
     enabledOnly?: boolean;
   }): Promise<HookConfig[]> {
-    await this.ensureLoaded();
+    await this.ensureReady();
 
-    let results = [...this.hooks];
+    let results = [...((await this.repository.readHooks()) ?? [])];
     if (options?.event) results = results.filter((h) => h.event === options.event);
     if (options?.enabledOnly) results = results.filter((h) => h.enabled);
 
@@ -401,7 +375,7 @@ class LifecycleHooksService {
     config?: Record<string, unknown>;
     order?: number;
   }): Promise<HookConfig> {
-    await this.ensureLoaded();
+    await this.ensureReady();
 
     const hook: HookConfig = {
       id: `hook_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
@@ -419,8 +393,7 @@ class LifecycleHooksService {
       updatedAt: new Date().toISOString(),
     };
 
-    this.hooks.push(hook);
-    await this.saveHooks();
+    await this.repository.updateHooks((hooks) => [...(hooks ?? []), hook]);
     return hook;
   }
 
@@ -442,35 +415,36 @@ class LifecycleHooksService {
       >
     >
   ): Promise<HookConfig | null> {
-    await this.ensureLoaded();
+    await this.ensureReady();
 
-    const hook = this.hooks.find((h) => h.id === id);
-    if (!hook) return null;
-
-    Object.assign(hook, update, { updatedAt: new Date().toISOString() });
-    await this.saveHooks();
-    return hook;
+    let updatedHook: HookConfig | null = null;
+    await this.repository.updateHooks((hooks) =>
+      (hooks ?? []).map((hook) => {
+        if (hook.id !== id) return hook;
+        updatedHook = { ...hook, ...update, updatedAt: new Date().toISOString() };
+        return updatedHook;
+      })
+    );
+    return updatedHook;
   }
 
   /**
    * Delete a custom hook (built-in hooks can only be disabled).
    */
   async deleteHook(id: string): Promise<boolean> {
-    await this.ensureLoaded();
+    await this.ensureReady();
 
-    const hook = this.hooks.find((h) => h.id === id);
-    if (!hook) return false;
-    if (hook.builtIn) {
-      // Just disable it
-      hook.enabled = false;
-      hook.updatedAt = new Date().toISOString();
-      await this.saveHooks();
-      return true;
-    }
-
-    this.hooks = this.hooks.filter((h) => h.id !== id);
-    await this.saveHooks();
-    return true;
+    let deleted = false;
+    await this.repository.updateHooks((hooks) =>
+      (hooks ?? []).flatMap((hook) => {
+        if (hook.id !== id) return [hook];
+        deleted = true;
+        return hook.builtIn
+          ? [{ ...hook, enabled: false, updatedAt: new Date().toISOString() }]
+          : [];
+      })
+    );
+    return deleted;
   }
 
   /**
@@ -481,9 +455,9 @@ class LifecycleHooksService {
     taskId?: string;
     limit?: number;
   }): Promise<HookExecution[]> {
-    await this.ensureLoaded();
+    await this.ensureReady();
 
-    let results = [...this.executions];
+    let results = (await this.repository.readExecutions()).slice(-500);
     if (filters?.hookId) results = results.filter((e) => e.hookId === filters.hookId);
     if (filters?.taskId) results = results.filter((e) => e.taskId === filters.taskId);
 

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -45,6 +45,10 @@ export {
   FileTransitionHooksConfigRepository,
   type TransitionHooksConfigRepository,
 } from './transition-hooks-config-repository.js';
+export {
+  FileLifecycleHooksRepository,
+  type LifecycleHooksRepository,
+} from './lifecycle-hooks-repository.js';
 export { FileScheduledDeliverablesStore } from './scheduled-deliverables-repository.js';
 export { FileBroadcastRepository } from './broadcast-repository.js';
 export {

--- a/server/src/storage/lifecycle-hooks-repository.ts
+++ b/server/src/storage/lifecycle-hooks-repository.ts
@@ -1,0 +1,109 @@
+import { constants } from 'node:fs';
+import { lstat, mkdir, open } from 'node:fs/promises';
+import path from 'node:path';
+import type { HookConfig, HookExecution } from '../services/lifecycle-hooks-service.js';
+import { withFileLock } from '../services/file-lock.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import { atomicWriteFile } from './fs-helpers.js';
+
+const MAX_LIFECYCLE_HOOKS_BYTES = 8 * 1024 * 1024;
+
+export interface LifecycleHooksRepository {
+  readHooks(): Promise<HookConfig[] | null>;
+  updateHooks(updater: (hooks: HookConfig[] | null) => HookConfig[]): Promise<HookConfig[]>;
+  readExecutions(): Promise<HookExecution[]>;
+  updateExecutions(
+    updater: (executions: HookExecution[]) => HookExecution[]
+  ): Promise<HookExecution[]>;
+}
+
+export class FileLifecycleHooksRepository implements LifecycleHooksRepository {
+  private readonly runtimeDir: string;
+  private readonly hooksFile: string;
+  private readonly executionsFile: string;
+
+  constructor(runtimeDir = getRuntimeDir()) {
+    this.runtimeDir = path.resolve(runtimeDir);
+    this.hooksFile = ensureWithinBase(
+      this.runtimeDir,
+      path.join(this.runtimeDir, 'lifecycle-hooks.json')
+    );
+    this.executionsFile = ensureWithinBase(
+      this.runtimeDir,
+      path.join(this.runtimeDir, 'hook-executions.json')
+    );
+  }
+
+  readHooks(): Promise<HookConfig[] | null> {
+    return this.readJson<HookConfig[] | null>(this.hooksFile, null, 'Lifecycle hooks');
+  }
+
+  async updateHooks(updater: (hooks: HookConfig[] | null) => HookConfig[]): Promise<HookConfig[]> {
+    await this.prepareDirectory();
+    return withFileLock(this.hooksFile, async () => {
+      const hooks = updater(await this.readHooks());
+      await this.writeJson(this.hooksFile, hooks, 'Lifecycle hooks');
+      return hooks;
+    });
+  }
+
+  readExecutions(): Promise<HookExecution[]> {
+    return this.readJson<HookExecution[]>(this.executionsFile, [], 'Lifecycle hook executions');
+  }
+
+  async updateExecutions(
+    updater: (executions: HookExecution[]) => HookExecution[]
+  ): Promise<HookExecution[]> {
+    await this.prepareDirectory();
+    return withFileLock(this.executionsFile, async () => {
+      const executions = updater(await this.readExecutions());
+      await this.writeJson(this.executionsFile, executions, 'Lifecycle hook executions');
+      return executions;
+    });
+  }
+
+  private async prepareDirectory(): Promise<void> {
+    await mkdir(this.runtimeDir, { recursive: true, mode: 0o700 });
+    const stats = await lstat(this.runtimeDir);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error('Lifecycle hooks path must use a regular directory');
+    }
+  }
+
+  private async readJson<T>(filePath: string, fallback: T, label: string): Promise<T> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const [pathStats, stats] = await Promise.all([lstat(filePath), handle.stat()]);
+      if (
+        pathStats.isSymbolicLink() ||
+        pathStats.dev !== stats.dev ||
+        pathStats.ino !== stats.ino
+      ) {
+        throw new Error(`${label} must not use a symbolic link or changed file`);
+      }
+      if (!stats.isFile() || stats.size > MAX_LIFECYCLE_HOOKS_BYTES) {
+        throw new Error(`${label} must use a bounded regular file`);
+      }
+      return JSON.parse(await handle.readFile({ encoding: 'utf8' })) as T;
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOENT') return fallback;
+      if (errorCode === 'ELOOP') {
+        throw new Error(`${label} must not use a symbolic link`, { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private async writeJson(filePath: string, value: unknown, label: string): Promise<void> {
+    const content = JSON.stringify(value, null, 2);
+    if (Buffer.byteLength(content, 'utf8') > MAX_LIFECYCLE_HOOKS_BYTES) {
+      throw new Error(`${label} exceeds the 8 MiB storage limit`);
+    }
+    await atomicWriteFile(filePath, content, 'utf8');
+  }
+}


### PR DESCRIPTION
## Summary

- move lifecycle-hook configuration and execution persistence into a bounded file repository
- serialize concurrent mutations with file locks and atomic writes
- reject symbolic links, changed files, non-files, and oversized state
- remove stale process-local caches and preserve the latest 500 executions
- make concurrent legacy migration callers share one retryable migration
- ratchet the service filesystem boundary from 41 to 40

## Verification

- 3 focused lifecycle-hook repository tests
- shared and server builds
- service filesystem boundary check

## Risk

Low. Public lifecycle-hook APIs and JSON formats are unchanged. Reads now observe current persisted state, and concurrent writers no longer replace each other through stale caches.

Refs #1186