### PR TITLE
refactor: move scheduler state behind storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 40,
+  "maximumEntries": 39,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -151,12 +151,6 @@
       "category": "authoritative-persistence",
       "owner": "#1187",
       "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
-    {
-      "path": "server/src/services/scheduler-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/search-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -51,6 +51,7 @@
           "src/__tests__/provider-task-envelope-renderer.test.ts",
           "src/__tests__/reflection-extraction-job-service.test.ts",
           "src/__tests__/runtime-paths.test.ts",
+          "src/__tests__/scheduler-state-repository.test.ts",
           "src/__tests__/scheduled-deliverables-repository.test.ts",
           "src/__tests__/routes/admin-governance-auth.test.ts",
           "src/__tests__/routes/auth.test.ts",

--- a/server/src/__tests__/scheduler-state-repository.test.ts
+++ b/server/src/__tests__/scheduler-state-repository.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { SchedulerEvent } from '@veritas-kanban/shared';
+import { FileSchedulerStateRepository } from '../storage/scheduler-state-repository.js';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, lstat: vi.fn(actual.lstat) };
+});
+
+function event(id: string): SchedulerEvent {
+  return {
+    id,
+    itemId: id,
+    sourceId: id,
+    kind: 'workflow',
+    type: 'manual-run',
+    status: 'success',
+    summary: id,
+    runAt: '2026-08-23T00:00:00.000Z',
+  };
+}
+
+describe('FileSchedulerStateRepository', () => {
+  let root: string;
+  let stateFile: string;
+  let repository: FileSchedulerStateRepository;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-scheduler-state-'));
+    stateFile = path.join(root, 'runtime', 'scheduler-state.json');
+    repository = new FileSchedulerStateRepository(stateFile);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('normalizes missing state and preserves concurrent mutations', async () => {
+    await expect(repository.read()).resolves.toEqual({ version: 1, items: {}, events: [] });
+    await Promise.all(
+      ['one', 'two'].map((id) =>
+        repository.update((state) => ({
+          ...state,
+          items: { ...state.items, [id]: { attempts: 1 } },
+          events: [...state.events, event(id)],
+        }))
+      )
+    );
+
+    const state = await repository.read();
+    expect(new Set(Object.keys(state.items))).toEqual(new Set(['one', 'two']));
+    expect(new Set(state.events.map(({ id }) => id))).toEqual(new Set(['one', 'two']));
+  });
+
+  it('rejects symbolic links, changed files, and non-file paths', async () => {
+    const runtimeDir = path.dirname(stateFile);
+    await mkdir(runtimeDir, { recursive: true });
+    const target = path.join(root, 'outside.json');
+    await writeFile(target, JSON.stringify({ version: 1, items: {}, events: [] }), 'utf8');
+    await symlink(target, stateFile);
+    await expect(repository.read()).rejects.toThrow(/symbolic link/i);
+
+    await rm(stateFile);
+    await writeFile(stateFile, JSON.stringify({ version: 1, items: {}, events: [] }), 'utf8');
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.mocked(lstat).mockImplementationOnce(async (filePath) => {
+      const stats = await actual.lstat(filePath);
+      return Object.assign(Object.create(Object.getPrototypeOf(stats)), stats, {
+        ino: stats.ino + 1,
+      });
+    });
+    await expect(repository.read()).rejects.toThrow(/changed file/i);
+
+    await rm(stateFile);
+    await mkdir(stateFile);
+    await expect(repository.read()).rejects.toThrow(/bounded regular file/i);
+  });
+
+  it('rejects symbolic-link directories and oversized state', async () => {
+    const realDirectory = path.join(root, 'real-runtime');
+    const linkedDirectory = path.join(root, 'linked-runtime');
+    await mkdir(realDirectory);
+    await symlink(realDirectory, linkedDirectory, 'dir');
+    const linkedRepository = new FileSchedulerStateRepository(
+      path.join(linkedDirectory, 'scheduler-state.json')
+    );
+    await expect(linkedRepository.update((state) => state)).rejects.toThrow(/regular directory/i);
+
+    await expect(
+      repository.update((state) => ({
+        ...state,
+        items: { large: { lastSummary: 'x'.repeat(8 * 1024 * 1024) } },
+      }))
+    ).rejects.toThrow(/8 MiB/i);
+  });
+});

--- a/server/src/services/scheduler-service.ts
+++ b/server/src/services/scheduler-service.ts
@@ -1,5 +1,3 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import { nanoid } from 'nanoid';
 import type {
   SchedulerDueRunResult,
@@ -20,7 +18,12 @@ import type {
 import type { RunTelemetryEvent } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
-import { getRuntimeDir } from '../utils/paths.js';
+import {
+  FileSchedulerStateRepository,
+  type SchedulerItemState,
+  type SchedulerState,
+  type SchedulerStateRepository,
+} from '../storage/scheduler-state-repository.js';
 import {
   getScheduledDeliverablesService,
   type Deliverable,
@@ -41,32 +44,15 @@ import {
 } from './queue-intake-monitor-service.js';
 
 const log = createLogger('scheduler');
-const STATE_VERSION = 1;
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_BACKOFF_MINUTES = 5;
 const MAX_EVENTS = 200;
 const SCHEDULER_PROJECT = 'operations';
 const SCHEDULER_AGENT = 'scheduler';
 
-interface SchedulerItemState {
-  attempts?: number;
-  nextAttemptAt?: string;
-  lastRunAt?: string;
-  nextRunAt?: string;
-  lastStatus?: SchedulerRunStatus;
-  lastSummary?: string;
-  lastError?: string;
-  sourceRunId?: string;
-}
-
-interface SchedulerStateFile {
-  version: typeof STATE_VERSION;
-  items: Record<string, SchedulerItemState>;
-  events: SchedulerEvent[];
-}
-
 interface SchedulerServiceOptions {
   stateFile?: string;
+  stateRepository?: SchedulerStateRepository;
   deliverablesService?: ScheduledDeliverablesService;
   workflowService?: WorkflowService;
   workflowRunService?: WorkflowRunService;
@@ -76,19 +62,20 @@ interface SchedulerServiceOptions {
 }
 
 export class SchedulerService {
-  private readonly stateFile: string;
+  private readonly stateRepository: SchedulerStateRepository;
   private readonly deliverablesService: ScheduledDeliverablesService;
   private readonly workflowService: WorkflowService;
   private readonly workflowRunService: WorkflowRunService;
   private readonly workflowAuthoringService: WorkflowAuthoringService;
   private readonly queueMonitorService: QueueIntakeMonitorService;
   private readonly telemetryService: TelemetryService;
-  private state: SchedulerStateFile | null = null;
+  private state: SchedulerState | null = null;
   private runningDue = false;
   private readonly runningItems = new Set<string>();
 
   constructor(options: SchedulerServiceOptions = {}) {
-    this.stateFile = options.stateFile ?? path.join(getRuntimeDir(), 'scheduler-state.json');
+    this.stateRepository =
+      options.stateRepository ?? new FileSchedulerStateRepository(options.stateFile);
     this.deliverablesService = options.deliverablesService ?? getScheduledDeliverablesService();
     this.workflowService = options.workflowService ?? getWorkflowService();
     this.workflowRunService = options.workflowRunService ?? getWorkflowRunService();
@@ -166,12 +153,6 @@ export class SchedulerService {
       await this.updateWorkflowSchedule(item.sourceId, { enabled: false });
     }
 
-    const state = this.currentState();
-    state.items[itemId] = {
-      ...state.items[itemId],
-      attempts: 0,
-      nextAttemptAt: undefined,
-    };
     const event = await this.recordEvent({
       item: { ...item, enabled: false },
       type: 'pause',
@@ -179,7 +160,6 @@ export class SchedulerService {
       summary: 'Scheduler item paused.',
       now,
     });
-    await this.saveState();
     return { item: await this.getItem(itemId, now), event };
   }
 
@@ -197,12 +177,6 @@ export class SchedulerService {
       await this.updateWorkflowSchedule(item.sourceId, { enabled: true });
     }
 
-    const state = this.currentState();
-    state.items[itemId] = {
-      ...state.items[itemId],
-      attempts: 0,
-      nextAttemptAt: undefined,
-    };
     const event = await this.recordEvent({
       item: { ...item, enabled: true },
       type: 'resume',
@@ -210,7 +184,6 @@ export class SchedulerService {
       summary: 'Scheduler item resumed.',
       now,
     });
-    await this.saveState();
     return { item: await this.getItem(itemId, now), event };
   }
 
@@ -254,7 +227,6 @@ export class SchedulerService {
           : item.kind === 'queue-monitor'
             ? await this.runQueueMonitor(item, trigger, now, startedAt)
             : await this.runWorkflow(item, trigger, now, startedAt);
-      await this.saveState();
       return result;
     } finally {
       this.runningItems.delete(itemId);
@@ -654,27 +626,28 @@ export class SchedulerService {
       nextRunAt: params.nextRunAt,
     };
 
-    const state = this.currentState();
-    const previous = state.items[params.item.id] ?? {};
-    const failed = params.status === 'failed';
-    const attempts = failed ? (previous.attempts ?? 0) + 1 : 0;
-    state.items[params.item.id] = {
-      ...previous,
-      attempts,
-      nextAttemptAt:
-        failed && attempts < DEFAULT_MAX_ATTEMPTS
-          ? retryAttemptAt(params.now, attempts)
-          : undefined,
-      lastRunAt: params.now.toISOString(),
-      nextRunAt: params.nextRunAt ?? previous.nextRunAt,
-      lastStatus: params.status,
-      lastSummary: params.summary,
-      lastError: params.error,
-      sourceRunId: params.sourceRunId,
-    };
-    state.events.push(event);
-    state.events = state.events.slice(-MAX_EVENTS);
-    await this.saveState();
+    this.state = await this.stateRepository.update((state) => {
+      const previous = state.items[params.item.id] ?? {};
+      const failed = params.status === 'failed';
+      const attempts = failed ? (previous.attempts ?? 0) + 1 : 0;
+      state.items[params.item.id] = {
+        ...previous,
+        attempts,
+        nextAttemptAt:
+          failed && attempts < DEFAULT_MAX_ATTEMPTS
+            ? retryAttemptAt(params.now, attempts)
+            : undefined,
+        lastRunAt: params.now.toISOString(),
+        nextRunAt: params.nextRunAt ?? previous.nextRunAt,
+        lastStatus: params.status,
+        lastSummary: params.summary,
+        lastError: params.error,
+        sourceRunId: params.sourceRunId,
+      };
+      state.events.push(event);
+      state.events = state.events.slice(-MAX_EVENTS);
+      return state;
+    });
     await this.emitTelemetry(event);
     log.info(
       { eventId: event.id, itemId: event.itemId, status: event.status },
@@ -708,30 +681,14 @@ export class SchedulerService {
   }
 
   private async ensureLoaded(): Promise<void> {
-    if (this.state) return;
-    try {
-      const data = await fs.readFile(this.stateFile, 'utf-8');
-      const parsed = JSON.parse(data) as SchedulerStateFile;
-      this.state = {
-        version: STATE_VERSION,
-        items: parsed.items ?? {},
-        events: Array.isArray(parsed.events) ? parsed.events.slice(-MAX_EVENTS) : [],
-      };
-    } catch {
-      this.state = { version: STATE_VERSION, items: {}, events: [] };
-    }
+    this.state = await this.stateRepository.read();
   }
 
-  private currentState(): SchedulerStateFile {
+  private currentState(): SchedulerState {
     if (!this.state) {
       throw new Error('Scheduler state has not been loaded');
     }
     return this.state;
-  }
-
-  private async saveState(): Promise<void> {
-    await fs.mkdir(path.dirname(this.stateFile), { recursive: true });
-    await fs.writeFile(this.stateFile, JSON.stringify(this.state, null, 2));
   }
 }
 

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -49,6 +49,12 @@ export {
   FileLifecycleHooksRepository,
   type LifecycleHooksRepository,
 } from './lifecycle-hooks-repository.js';
+export {
+  FileSchedulerStateRepository,
+  type SchedulerItemState,
+  type SchedulerState,
+  type SchedulerStateRepository,
+} from './scheduler-state-repository.js';
 export { FileScheduledDeliverablesStore } from './scheduled-deliverables-repository.js';
 export { FileBroadcastRepository } from './broadcast-repository.js';
 export {

--- a/server/src/storage/scheduler-state-repository.ts
+++ b/server/src/storage/scheduler-state-repository.ts
@@ -1,0 +1,104 @@
+import { constants } from 'node:fs';
+import { lstat, mkdir, open } from 'node:fs/promises';
+import path from 'node:path';
+import type { SchedulerEvent, SchedulerRunStatus } from '@veritas-kanban/shared';
+import { withFileLock } from '../services/file-lock.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import { atomicWriteFile } from './fs-helpers.js';
+
+const MAX_SCHEDULER_STATE_BYTES = 8 * 1024 * 1024;
+const MAX_EVENTS = 200;
+
+export interface SchedulerItemState {
+  attempts?: number;
+  nextAttemptAt?: string;
+  lastRunAt?: string;
+  nextRunAt?: string;
+  lastStatus?: SchedulerRunStatus;
+  lastSummary?: string;
+  lastError?: string;
+  sourceRunId?: string;
+}
+
+export interface SchedulerState {
+  version: 1;
+  items: Record<string, SchedulerItemState>;
+  events: SchedulerEvent[];
+}
+
+export interface SchedulerStateRepository {
+  read(): Promise<SchedulerState>;
+  update(updater: (state: SchedulerState) => SchedulerState): Promise<SchedulerState>;
+}
+
+function emptyState(): SchedulerState {
+  return { version: 1, items: {}, events: [] };
+}
+
+function normalizeState(parsed: Partial<SchedulerState>): SchedulerState {
+  return {
+    version: 1,
+    items: parsed.items && typeof parsed.items === 'object' ? parsed.items : {},
+    events: Array.isArray(parsed.events) ? parsed.events.slice(-MAX_EVENTS) : [],
+  };
+}
+
+export class FileSchedulerStateRepository implements SchedulerStateRepository {
+  private readonly storageDir: string;
+  private readonly stateFile: string;
+
+  constructor(stateFile = path.join(getRuntimeDir(), 'scheduler-state.json')) {
+    this.storageDir = path.resolve(path.dirname(stateFile));
+    this.stateFile = ensureWithinBase(this.storageDir, path.resolve(stateFile));
+  }
+
+  async read(): Promise<SchedulerState> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(this.stateFile, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const [pathStats, stats] = await Promise.all([lstat(this.stateFile), handle.stat()]);
+      if (
+        pathStats.isSymbolicLink() ||
+        pathStats.dev !== stats.dev ||
+        pathStats.ino !== stats.ino
+      ) {
+        throw new Error('Scheduler state must not use a symbolic link or changed file');
+      }
+      if (!stats.isFile() || stats.size > MAX_SCHEDULER_STATE_BYTES) {
+        throw new Error('Scheduler state must use a bounded regular file');
+      }
+      return normalizeState(JSON.parse(await handle.readFile({ encoding: 'utf8' })));
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOENT') return emptyState();
+      if (errorCode === 'ELOOP') {
+        throw new Error('Scheduler state must not use a symbolic link', { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  async update(updater: (state: SchedulerState) => SchedulerState): Promise<SchedulerState> {
+    await this.prepareDirectory();
+    return withFileLock(this.stateFile, async () => {
+      const state = normalizeState(updater(await this.read()));
+      const content = JSON.stringify(state, null, 2);
+      if (Buffer.byteLength(content, 'utf8') > MAX_SCHEDULER_STATE_BYTES) {
+        throw new Error('Scheduler state exceeds the 8 MiB storage limit');
+      }
+      await atomicWriteFile(this.stateFile, content, 'utf8');
+      return state;
+    });
+  }
+
+  private async prepareDirectory(): Promise<void> {
+    await mkdir(this.storageDir, { recursive: true, mode: 0o700 });
+    const stats = await lstat(this.storageDir);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error('Scheduler state path must use a regular directory');
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- move scheduler event and retry state behind a bounded repository
- serialize event mutations with file locks and atomic writes
- reject symbolic links, changed files, non-files, corrupt JSON, and oversized state
- preserve concurrent scheduler updates and the 200-event retention limit
- remove redundant pause, resume, and post-run state writes
- ratchet the service filesystem boundary from 40 to 39

## Verification

- 3 focused scheduler repository tests
- 5 focused scheduler service tests
- shared and server builds
- service filesystem boundary check

## Risk

Low. Scheduler APIs and persisted JSON remain compatible. Corrupt or unsafe state now fails closed instead of being silently replaced with empty state.

Refs #1186