### PR TITLE
refactor: move workflow execution files behind storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 38,
+  "maximumEntries": 37,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -220,12 +220,6 @@
     },
     {
       "path": "server/src/services/workflow-run-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
-    },
-    {
-      "path": "server/src/services/workflow-step-executor.ts",
       "category": "authoritative-persistence",
       "owner": "#1186",
       "rationale": "Coordination-state storage migration is tracked in issue #1186."

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -94,6 +94,7 @@
           "src/__tests__/work-product-run-launch-manifest.test.ts",
           "src/__tests__/work-product-schemas.test.ts",
           "src/__tests__/workflow-definition-repository.test.ts",
+          "src/__tests__/workflow-execution-file-repository.test.ts",
           "src/__tests__/workflow-run-service.test.ts",
           "src/__tests__/workflow-service.test.ts",
           "src/__tests__/workflow-step-executor-codex.test.ts",

--- a/server/src/__tests__/workflow-execution-file-repository.test.ts
+++ b/server/src/__tests__/workflow-execution-file-repository.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { FileWorkflowExecutionFileRepository } from '../storage/workflow-execution-file-repository.js';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, lstat: vi.fn(actual.lstat) };
+});
+
+describe('FileWorkflowExecutionFileRepository', () => {
+  let root: string;
+  let runsDir: string;
+  let repository: FileWorkflowExecutionFileRepository;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-workflow-files-'));
+    runsDir = path.join(root, 'runs');
+    repository = new FileWorkflowExecutionFileRepository(runsDir);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('atomically writes outputs and preserves concurrent progress appends', async () => {
+    const outputPath = await repository.writeStepOutput('run-1', 'result.md', 'complete');
+    await expect(readFile(outputPath, 'utf8')).resolves.toBe('complete');
+
+    await Promise.all([
+      repository.appendProgress('run-1', 'step one\n'),
+      repository.appendProgress('run-1', 'step two\n'),
+    ]);
+    const progress = await repository.readProgress('run-1');
+    expect(progress).toContain('step one');
+    expect(progress).toContain('step two');
+  });
+
+  it('rejects traversal, symbolic links, changed files, and non-files', async () => {
+    await expect(repository.readProgress('../outside')).rejects.toThrow(/traversal/i);
+    await mkdir(path.join(runsDir, 'run-1'), { recursive: true });
+    const progressPath = path.join(runsDir, 'run-1', 'progress.md');
+    const target = path.join(root, 'outside.md');
+    await writeFile(target, 'outside', 'utf8');
+    await symlink(target, progressPath);
+    await expect(repository.readProgress('run-1')).rejects.toThrow(/symbolic link/i);
+
+    await rm(progressPath);
+    await writeFile(progressPath, 'current', 'utf8');
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.mocked(lstat).mockImplementation(async (filePath) => {
+      const stats = await actual.lstat(filePath);
+      if (path.resolve(String(filePath)) !== progressPath) return stats;
+      return Object.assign(Object.create(Object.getPrototypeOf(stats)), stats, {
+        ino: stats.ino + 1,
+      });
+    });
+    await expect(repository.readProgress('run-1')).rejects.toThrow(/changed file/i);
+    vi.mocked(lstat).mockImplementation(actual.lstat);
+
+    await rm(progressPath);
+    await mkdir(progressPath);
+    await expect(repository.readProgress('run-1')).rejects.toThrow(/bounded regular file/i);
+  });
+
+  it('rejects symbolic-link directories and oversized content', async () => {
+    const realRuns = path.join(root, 'real-runs');
+    const linkedRuns = path.join(root, 'linked-runs');
+    await mkdir(realRuns);
+    await symlink(realRuns, linkedRuns, 'dir');
+    const linkedRepository = new FileWorkflowExecutionFileRepository(linkedRuns);
+    await expect(linkedRepository.appendProgress('run-1', 'entry')).rejects.toThrow(
+      /regular directory/i
+    );
+
+    await expect(
+      repository.writeStepOutput('run-1', 'large.md', 'x'.repeat(16 * 1024 * 1024 + 1))
+    ).rejects.toThrow(/16 MiB/i);
+    const oversizedProgress = await repository.appendProgress(
+      'run-1',
+      'x'.repeat(10 * 1024 * 1024 + 1)
+    );
+    expect(oversizedProgress).toEqual({ appended: false, size: 0 });
+  });
+});

--- a/server/src/__tests__/workflow-step-executor-openclaw.test.ts
+++ b/server/src/__tests__/workflow-step-executor-openclaw.test.ts
@@ -200,6 +200,30 @@ describe('WorkflowStepExecutor OpenClaw integration', () => {
     expect(output).not.toContain('Implement OpenClaw adapter');
   });
 
+  it('continues when the bounded progress file rejects an append', async () => {
+    adapter.spawn.mockResolvedValue({
+      sessionKey: 'oc_session_progress_limit',
+      runId: 'oc_run_progress_limit',
+      status: 'completed',
+      output: 'STATUS: done\nOUTPUT: Completed without progress append',
+    });
+    const executionFiles = {
+      writeStepOutput: vi.fn().mockResolvedValue(path.join(tmpDir, 'implement.md')),
+      readProgress: vi.fn().mockResolvedValue(null),
+      appendProgress: vi.fn().mockResolvedValue({ appended: false, size: 10 * 1024 * 1024 }),
+    };
+    const executor = new WorkflowStepExecutor(tmpDir, {
+      openClawAdapter: adapter,
+      runtimeManifestResolver,
+      executionFiles,
+    });
+
+    await expect(executor.executeStep(createStep(), createRun())).resolves.toMatchObject({
+      output: expect.stringContaining('Completed without progress append'),
+    });
+    expect(executionFiles.appendProgress).toHaveBeenCalledOnce();
+  });
+
   it('does not require token telemetry for runtime-only workflow budgets', async () => {
     adapter.spawn.mockResolvedValue({
       sessionKey: 'oc_session_runtime_budget',

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -3,7 +3,6 @@
  * Executes workflow steps through provider-specific agent adapters.
  */
 
-import fs from 'fs/promises';
 import path from 'path';
 import sanitizeFilename from 'sanitize-filename';
 import yaml from 'yaml';
@@ -66,6 +65,10 @@ import {
   type PhaseLaunchParentSnapshot,
 } from './phase-launch-authority-service.js';
 import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
+import {
+  FileWorkflowExecutionFileRepository,
+  type WorkflowExecutionFileRepository,
+} from '../storage/workflow-execution-file-repository.js';
 
 const log = createLogger('workflow-step-executor');
 
@@ -96,6 +99,7 @@ interface WorkflowStepExecutorOptions {
   phaseAuthority?: PhaseLaunchAuthorityService;
   runEgressGateway?: Pick<RunEgressGatewayService, 'start'>;
   approvalBroker?: Pick<RunApprovalBrokerService, 'request' | 'awaitDecision' | 'cancelAttempt'>;
+  executionFiles?: WorkflowExecutionFileRepository;
 }
 
 type WorkflowExecutableProvider = Extract<ExecutableAgentProvider, 'codex-sdk' | 'openclaw'>;
@@ -143,7 +147,7 @@ export class WorkflowStepExecutor {
     RunApprovalBrokerService,
     'request' | 'awaitDecision' | 'cancelAttempt'
   >;
-  private appendCountCache?: Map<string, number>; // Performance: Track append counts to reduce stat() calls
+  private executionFiles: WorkflowExecutionFileRepository;
 
   constructor(runsDir?: string, options: WorkflowStepExecutorOptions = {}) {
     this.runsDir = runsDir || getWorkflowRunsDir();
@@ -158,6 +162,8 @@ export class WorkflowStepExecutor {
     this.phaseAuthority = options.phaseAuthority ?? new PhaseLaunchAuthorityService();
     this.runEgressGateway = options.runEgressGateway ?? getRunEgressGatewayService();
     this.approvalBroker = options.approvalBroker ?? getRunApprovalBrokerService();
+    this.executionFiles =
+      options.executionFiles ?? new FileWorkflowExecutionFileRepository(this.runsDir);
   }
 
   /**
@@ -1345,15 +1351,10 @@ export class WorkflowStepExecutor {
       throw new Error(`Invalid run ID: ${runId}`);
     }
 
-    const outputDir = path.join(this.runsDir, safeRunId, 'step-outputs');
-    await fs.mkdir(outputDir, { recursive: true });
-
     const candidate = filename || `${stepId}.md`;
     const safeName = sanitizeFilename(candidate) || `${stepId}.md`;
-    const outputPath = path.join(outputDir, safeName);
-
     const content = typeof output === 'string' ? output : JSON.stringify(output, null, 2);
-    await fs.writeFile(outputPath, content, 'utf-8');
+    const outputPath = await this.executionFiles.writeStepOutput(safeRunId, safeName, content);
 
     log.info({ runId, stepId, outputPath }, 'Step output saved');
     return outputPath;
@@ -2021,17 +2022,7 @@ export class WorkflowStepExecutor {
       throw new Error(`Invalid run ID: ${runId}`);
     }
 
-    const progressPath = path.join(this.runsDir, safeRunId, 'progress.md');
-
-    try {
-      const content = await fs.readFile(progressPath, 'utf-8');
-      return content;
-    } catch (err: unknown) {
-      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
-        return null; // File doesn't exist yet
-      }
-      throw err;
-    }
+    return this.executionFiles.readProgress(safeRunId);
   }
 
   /**
@@ -2044,44 +2035,17 @@ export class WorkflowStepExecutor {
       throw new Error(`Invalid run ID: ${runId}`);
     }
 
-    const progressPath = path.join(this.runsDir, safeRunId, 'progress.md');
     const timestamp = new Date().toISOString();
 
-    // Performance: Check progress file size before appending (cap at 10MB)
-    // Only check size periodically to avoid repeated stat() calls
-    const MAX_PROGRESS_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-    const SIZE_CHECK_INTERVAL = 5; // Check every 5 appends
-
-    // Use a cache to track append count per run (avoids repeated stat calls)
-    if (!this.appendCountCache) {
-      this.appendCountCache = new Map<string, number>();
-    }
-
-    const appendCount = (this.appendCountCache.get(runId) || 0) + 1;
-    this.appendCountCache.set(runId, appendCount);
-
-    // Only check file size periodically
-    if (appendCount % SIZE_CHECK_INTERVAL === 0) {
-      try {
-        const stats = await fs.stat(progressPath);
-        if (stats.size > MAX_PROGRESS_FILE_SIZE) {
-          log.warn(
-            { runId, fileSize: stats.size, appends: appendCount },
-            'Progress file exceeds size limit — skipping append'
-          );
-          return; // Skip appending if file is too large
-        }
-      } catch (err: unknown) {
-        // File doesn't exist yet — that's fine
-        if (!(err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT')) {
-          throw err;
-        }
-      }
-    }
-
     const entry = `## Step: ${stepId} (${timestamp})\n\n${typeof output === 'string' ? output : JSON.stringify(output, null, 2)}\n\n---\n\n`;
-
-    await fs.appendFile(progressPath, entry, 'utf-8');
+    const result = await this.executionFiles.appendProgress(safeRunId, entry);
+    if (!result.appended) {
+      log.warn(
+        { runId, fileSize: result.size },
+        'Progress file exceeds size limit — skipping append'
+      );
+      return;
+    }
 
     log.info({ runId, stepId }, 'Progress file updated');
   }

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -60,6 +60,10 @@ export {
   type ReflectionState,
   type ReflectionStateRepository,
 } from './reflection-state-repository.js';
+export {
+  FileWorkflowExecutionFileRepository,
+  type WorkflowExecutionFileRepository,
+} from './workflow-execution-file-repository.js';
 export { FileScheduledDeliverablesStore } from './scheduled-deliverables-repository.js';
 export { FileBroadcastRepository } from './broadcast-repository.js';
 export {

--- a/server/src/storage/workflow-execution-file-repository.ts
+++ b/server/src/storage/workflow-execution-file-repository.ts
@@ -1,0 +1,113 @@
+import { constants } from 'node:fs';
+import { lstat, mkdir, open } from 'node:fs/promises';
+import path from 'node:path';
+import { withFileLock } from '../services/file-lock.js';
+import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import { atomicWriteFile } from './fs-helpers.js';
+
+const MAX_STEP_OUTPUT_BYTES = 16 * 1024 * 1024;
+const MAX_PROGRESS_BYTES = 10 * 1024 * 1024;
+
+export interface WorkflowExecutionFileRepository {
+  writeStepOutput(runId: string, filename: string, content: string): Promise<string>;
+  readProgress(runId: string): Promise<string | null>;
+  appendProgress(runId: string, entry: string): Promise<{ appended: boolean; size: number }>;
+}
+
+export class FileWorkflowExecutionFileRepository implements WorkflowExecutionFileRepository {
+  private readonly runsDir: string;
+
+  constructor(runsDir: string) {
+    this.runsDir = path.resolve(runsDir);
+  }
+
+  async writeStepOutput(runId: string, filename: string, content: string): Promise<string> {
+    const runDir = this.runDir(runId);
+    const outputDir = ensureWithinBase(runDir, path.join(runDir, 'step-outputs'));
+    await this.prepareDirectory(this.runsDir);
+    await this.prepareDirectory(runDir);
+    await this.prepareDirectory(outputDir);
+    const outputPath = ensureWithinBase(
+      outputDir,
+      path.join(outputDir, validatePathSegment(filename))
+    );
+    if (Buffer.byteLength(content, 'utf8') > MAX_STEP_OUTPUT_BYTES) {
+      throw new Error('Workflow step output exceeds the 16 MiB storage limit');
+    }
+    await withFileLock(outputPath, () => atomicWriteFile(outputPath, content, 'utf8'));
+    return outputPath;
+  }
+
+  async readProgress(runId: string): Promise<string | null> {
+    const runDir = this.runDir(runId);
+    await this.prepareDirectory(this.runsDir);
+    await this.prepareDirectory(runDir);
+    return this.readBounded(this.progressPath(runId), MAX_PROGRESS_BYTES, 'Workflow progress');
+  }
+
+  async appendProgress(runId: string, entry: string): Promise<{ appended: boolean; size: number }> {
+    const runDir = this.runDir(runId);
+    const progressPath = this.progressPath(runId);
+    await this.prepareDirectory(this.runsDir);
+    await this.prepareDirectory(runDir);
+    return withFileLock(progressPath, async () => {
+      const current = (await this.readProgress(runId)) ?? '';
+      const next = `${current}${entry}`;
+      const size = Buffer.byteLength(next, 'utf8');
+      if (size > MAX_PROGRESS_BYTES) {
+        return { appended: false, size: Buffer.byteLength(current, 'utf8') };
+      }
+      await atomicWriteFile(progressPath, next, 'utf8');
+      return { appended: true, size };
+    });
+  }
+
+  private runDir(runId: string): string {
+    return ensureWithinBase(this.runsDir, path.join(this.runsDir, validatePathSegment(runId)));
+  }
+
+  private progressPath(runId: string): string {
+    const runDir = this.runDir(runId);
+    return ensureWithinBase(runDir, path.join(runDir, 'progress.md'));
+  }
+
+  private async prepareDirectory(directory: string): Promise<void> {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    const stats = await lstat(directory);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error('Workflow execution path must use a regular directory');
+    }
+  }
+
+  private async readBounded(
+    filePath: string,
+    maximumBytes: number,
+    label: string
+  ): Promise<string | null> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const [pathStats, stats] = await Promise.all([lstat(filePath), handle.stat()]);
+      if (
+        pathStats.isSymbolicLink() ||
+        pathStats.dev !== stats.dev ||
+        pathStats.ino !== stats.ino
+      ) {
+        throw new Error(`${label} must not use a symbolic link or changed file`);
+      }
+      if (!stats.isFile() || stats.size > maximumBytes) {
+        throw new Error(`${label} must use a bounded regular file`);
+      }
+      return await handle.readFile({ encoding: 'utf8' });
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOENT') return null;
+      if (errorCode === 'ELOOP') {
+        throw new Error(`${label} must not use a symbolic link`, { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- move workflow step outputs and progress files into a bounded repository
- use locked atomic writes for outputs and concurrent progress appends
- reject traversal, symbolic links, changed files, non-files, unsafe directories, and oversized content
- enforce the 10 MiB progress limit on every append instead of periodic checks
- remove the process-local append counter
- ratchet the service filesystem boundary from 38 to 37

## Verification

- 3 focused workflow execution repository tests
- 9 focused OpenClaw executor tests
- shared and server builds
- service filesystem boundary check

## Risk

Low. Output paths and progress Markdown remain compatible. Progress appends now stop before crossing 10 MiB rather than checking only every fifth append.

Refs #1186