### PR TITLE
refactor: move chat persistence behind storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 36,
+  "maximumEntries": 35,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -19,12 +19,6 @@
       "category": "authoritative-persistence",
       "owner": "#1187",
       "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
-    {
-      "path": "server/src/services/chat-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/clawdbot-agent-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -18,6 +18,8 @@
           "src/__tests__/admission-control-service.test.ts",
           "src/__tests__/agent-permission-repository.test.ts",
           "src/__tests__/broadcast-storage-service.test.ts",
+          "src/__tests__/chat-repository.test.ts",
+          "src/__tests__/chat-service.test.ts",
           "src/__tests__/claude-code-provider.smoke.test.ts",
           "src/__tests__/claude-code-provider.test.ts",
           "src/__tests__/codex-app-server-provider.smoke.test.ts",

--- a/server/src/__tests__/chat-repository.test.ts
+++ b/server/src/__tests__/chat-repository.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, symlink, truncate, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { ChatMessage, ChatSession, SquadMessage } from '@veritas-kanban/shared';
 import { FileChatRepository } from '../storage/chat-repository.js';
+import { SqliteChatRepository } from '../storage/sqlite/chat-repository.js';
 
 function session(id: string, updated = '2026-08-23T00:00:00.000Z'): ChatSession {
   return {
@@ -68,13 +69,31 @@ describe('FileChatRepository', () => {
       ]),
     });
     await expect(repository.getSessionForTask('123')).resolves.toMatchObject({ id: 'task_123' });
+
+    await mkdir(path.join(chatsDir, 'sessions', 'nested.md'));
+    await writeFile(path.join(chatsDir, 'sessions', 'ignored.txt'), 'ignored', 'utf8');
+    await symlink(
+      path.join(chatsDir, 'sessions', 'chat_old.md'),
+      path.join(chatsDir, 'sessions', 'alias.md')
+    );
     await expect(repository.listBoardSessions()).resolves.toMatchObject([
       { id: 'chat_new' },
       { id: 'chat_old' },
     ]);
 
+    const malformedPath = path.join(chatsDir, 'sessions', 'chat_old.md');
+    await writeFile(
+      malformedPath,
+      `${await readFile(malformedPath, 'utf8')}\n---\nnot a message header\nignored\n`,
+      'utf8'
+    );
+    await expect(repository.getSession('chat_old')).resolves.toMatchObject({ messages: [] });
+
     await expect(repository.deleteSession('chat_new')).resolves.toBe(true);
     await expect(repository.deleteSession('chat_new')).resolves.toBe(false);
+
+    await mkdir(path.join(chatsDir, 'sessions', 'chat_directory.md'));
+    await expect(repository.deleteSession('chat_directory')).rejects.toThrow();
   });
 
   it('round-trips squad logs, legacy formatting, filters, and metadata', async () => {
@@ -133,12 +152,56 @@ describe('FileChatRepository', () => {
     });
   });
 
+  it('skips missing and malformed squad log entries', async () => {
+    await repository.listSquadMessages();
+    const squadPath = path.join(chatsDir, 'squad', '2026-08-23.md');
+    await writeFile(
+      squadPath,
+      [
+        '# Squad Chat - 2026-08-23',
+        '',
+        '## only | two',
+        '',
+        'ignored',
+        '',
+        '---',
+        '',
+        '## | msg_missing_agent | 2026-08-23T00:00:00.000Z',
+        '',
+        'ignored',
+        '',
+        '---',
+        '',
+        '## CASE | msg_missing_timestamp | [system]',
+        '',
+        'ignored',
+        '',
+        '---',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+    await expect(repository.listSquadMessages()).resolves.toEqual([]);
+
+    const internals = repository as unknown as {
+      readOptionalBoundedFile: () => Promise<null>;
+    };
+    internals.readOptionalBoundedFile = vi.fn(async () => null);
+    await expect(repository.listSquadMessages()).resolves.toEqual([]);
+  });
+
   it('rejects traversal, symbolic links, oversized sessions, and invalid squad timestamps', async () => {
     await expect(repository.getSession('../outside')).rejects.toThrow();
     await expect(repository.getSessionForTask('../outside')).rejects.toThrow();
     await expect(
       repository.saveSession({ ...session('chat_large'), title: 'x'.repeat(16 * 1024 * 1024) })
     ).rejects.toThrow(/storage limit/);
+
+    const oversizedPath = path.join(chatsDir, 'sessions', 'chat_oversized.md');
+    await writeFile(oversizedPath, '', 'utf8');
+    await truncate(oversizedPath, 16 * 1024 * 1024 + 1);
+    await expect(repository.getSession('chat_oversized')).rejects.toThrow(/bounded regular file/);
+    await expect(repository.getSession('x'.repeat(256))).rejects.toThrow();
     await expect(
       repository.appendSquadMessage({
         id: 'msg_invalid',
@@ -160,5 +223,39 @@ describe('FileChatRepository', () => {
     await symlink(target, linkedRoot);
     const linkedRepository = new FileChatRepository(linkedRoot);
     await expect(linkedRepository.listBoardSessions()).rejects.toThrow(/regular directories/);
+  });
+});
+
+describe('SqliteChatRepository append transaction outcomes', () => {
+  it('commits a missing-session no-op and rolls back malformed stored state', () => {
+    const missingExec = vi.fn();
+    const missing = new SqliteChatRepository({
+      getConnection: () => ({
+        exec: missingExec,
+        prepare: () => ({ get: () => undefined }),
+      }),
+    } as never);
+
+    expect(missing.appendSessionMessage('missing', message('msg_1', 'missing'))).toBe(false);
+    expect(missingExec.mock.calls.map(([statement]) => statement)).toEqual([
+      'BEGIN IMMEDIATE;',
+      'COMMIT;',
+    ]);
+
+    const malformedExec = vi.fn();
+    const malformed = new SqliteChatRepository({
+      getConnection: () => ({
+        exec: malformedExec,
+        prepare: () => ({ get: () => ({ id: 'chat_broken', session_json: '{' }) }),
+      }),
+    } as never);
+
+    expect(() =>
+      malformed.appendSessionMessage('chat_broken', message('msg_2', 'broken'))
+    ).toThrow();
+    expect(malformedExec.mock.calls.map(([statement]) => statement)).toEqual([
+      'BEGIN IMMEDIATE;',
+      'ROLLBACK;',
+    ]);
   });
 });

--- a/server/src/__tests__/chat-repository.test.ts
+++ b/server/src/__tests__/chat-repository.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { ChatMessage, ChatSession, SquadMessage } from '@veritas-kanban/shared';
+import { FileChatRepository } from '../storage/chat-repository.js';
+
+function session(id: string, updated = '2026-08-23T00:00:00.000Z'): ChatSession {
+  return {
+    id,
+    title: 'Session',
+    messages: [],
+    agent: 'VERITAS',
+    mode: 'ask',
+    created: '2026-08-22T00:00:00.000Z',
+    updated,
+  };
+}
+
+function message(id: string, content: string): ChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    content,
+    timestamp: `2026-08-23T00:00:0${id.endsWith('2') ? '2' : '1'}.000Z`,
+    agent: 'VERITAS',
+    model: 'gpt',
+  };
+}
+
+describe('FileChatRepository', () => {
+  let root: string;
+  let chatsDir: string;
+  let repository: FileChatRepository;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-chat-repository-'));
+    chatsDir = path.join(root, 'chats');
+    repository = new FileChatRepository(chatsDir);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('round-trips board and task sessions with concurrent atomic appends', async () => {
+    await expect(repository.getSession('chat_missing')).resolves.toBeNull();
+    await repository.saveSession(session('chat_old'));
+    await repository.saveSession(session('chat_new', '2026-08-24T00:00:00.000Z'));
+    await repository.saveSession({ ...session('task_123'), taskId: '123' });
+
+    await expect(
+      Promise.all([
+        repository.appendSessionMessage('chat_new', message('msg_1', 'one')),
+        repository.appendSessionMessage('chat_new', message('msg_2', 'two')),
+      ])
+    ).resolves.toEqual([true, true]);
+    await expect(
+      repository.appendSessionMessage('chat_missing', message('msg_3', 'x'))
+    ).resolves.toBe(false);
+
+    const stored = await repository.getSession('chat_new');
+    expect(stored?.messages.map((entry) => entry.content).sort()).toEqual(['one', 'two']);
+    const restarted = new FileChatRepository(chatsDir);
+    await expect(restarted.getSession('chat_new')).resolves.toMatchObject({
+      messages: expect.arrayContaining([
+        expect.objectContaining({ content: 'one' }),
+        expect.objectContaining({ content: 'two' }),
+      ]),
+    });
+    await expect(repository.getSessionForTask('123')).resolves.toMatchObject({ id: 'task_123' });
+    await expect(repository.listBoardSessions()).resolves.toMatchObject([
+      { id: 'chat_new' },
+      { id: 'chat_old' },
+    ]);
+
+    await expect(repository.deleteSession('chat_new')).resolves.toBe(true);
+    await expect(repository.deleteSession('chat_new')).resolves.toBe(false);
+  });
+
+  it('round-trips squad logs, legacy formatting, filters, and metadata', async () => {
+    const first: SquadMessage = {
+      id: 'msg_first',
+      agent: 'TARS',
+      displayName: 'Tars',
+      message: 'First',
+      tags: ['testing', 'chat'],
+      timestamp: '2026-08-23T00:00:00.000Z',
+      model: 'gpt',
+      system: true,
+      event: 'agent.status',
+      taskTitle: 'Task A',
+      duration: '5s',
+    };
+    const second: SquadMessage = {
+      id: 'msg_second',
+      agent: 'CASE',
+      message: 'Second',
+      timestamp: '2026-08-24T00:00:00.000Z',
+      duration: '2s',
+    };
+    await repository.appendSquadMessage(first);
+    await repository.appendSquadMessage(second);
+    expect(await readFile(path.join(chatsDir, 'squad', '2026-08-23.md'), 'utf8')).toContain(
+      'msg_first'
+    );
+
+    expect(await repository.listSquadMessages()).toMatchObject([first, second]);
+    expect(await repository.listSquadMessages({ includeSystem: false })).toMatchObject([second]);
+    expect(await repository.listSquadMessages({ agent: 'CASE' })).toMatchObject([second]);
+    expect(
+      await repository.listSquadMessages({ since: '2026-08-23T12:00:00.000Z', limit: 1 })
+    ).toMatchObject([second]);
+
+    await expect(repository.readSquadMetadata()).resolves.toMatchObject({
+      version: 1,
+      messages: {},
+      reads: {},
+    });
+    await expect(
+      repository.updateSquadMetadata((metadata) => {
+        metadata.messages.msg_first = { pinned: true };
+        return 'updated';
+      })
+    ).resolves.toBe('updated');
+    await expect(repository.readSquadMetadata()).resolves.toMatchObject({
+      messages: { msg_first: { pinned: true } },
+    });
+
+    await writeFile(path.join(chatsDir, 'squad', 'metadata.json'), '{}', 'utf8');
+    await expect(repository.readSquadMetadata()).resolves.toMatchObject({
+      messages: {},
+      reads: {},
+    });
+  });
+
+  it('rejects traversal, symbolic links, oversized sessions, and invalid squad timestamps', async () => {
+    await expect(repository.getSession('../outside')).rejects.toThrow();
+    await expect(repository.getSessionForTask('../outside')).rejects.toThrow();
+    await expect(
+      repository.saveSession({ ...session('chat_large'), title: 'x'.repeat(16 * 1024 * 1024) })
+    ).rejects.toThrow(/storage limit/);
+    await expect(
+      repository.appendSquadMessage({
+        id: 'msg_invalid',
+        agent: 'CASE',
+        message: 'invalid',
+        timestamp: 'invalid',
+      })
+    ).rejects.toThrow(/timestamp is invalid/);
+
+    const outside = path.join(root, 'outside.md');
+    await writeFile(outside, 'outside', 'utf8');
+    const sessionPath = path.join(chatsDir, 'sessions', 'chat_link.md');
+    await symlink(outside, sessionPath);
+    await expect(repository.getSession('chat_link')).rejects.toThrow(/symbolic link/i);
+
+    const linkedRoot = path.join(root, 'linked-root');
+    const target = path.join(root, 'target');
+    await mkdir(target);
+    await symlink(target, linkedRoot);
+    const linkedRepository = new FileChatRepository(linkedRoot);
+    await expect(linkedRepository.listBoardSessions()).rejects.toThrow(/regular directories/);
+  });
+});

--- a/server/src/__tests__/chat-repository.test.ts
+++ b/server/src/__tests__/chat-repository.test.ts
@@ -203,6 +203,17 @@ describe('FileChatRepository', () => {
     await expect(repository.getSession('chat_oversized')).rejects.toThrow(/bounded regular file/);
     await expect(repository.getSession('x'.repeat(256))).rejects.toThrow();
     await expect(
+      (
+        repository as unknown as {
+          readOptionalBoundedFile: (
+            filePath: string,
+            maximumBytes: number,
+            label: string
+          ) => Promise<string | null>;
+        }
+      ).readOptionalBoundedFile(path.join(root, 'outside.md'), 1024, 'Chat session')
+    ).rejects.toThrow(/outside its repository/);
+    await expect(
       repository.appendSquadMessage({
         id: 'msg_invalid',
         agent: 'CASE',

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -1,14 +1,12 @@
 /**
  * Chat Service
  *
- * Manages chat sessions stored as markdown files with YAML frontmatter.
+ * Manages chat sessions through file or SQLite repositories.
+ * The file repository preserves the Markdown/YAML compatibility format.
  * - Task-scoped sessions: .veritas-kanban/chats/task_{taskId}.md
  * - Board-level sessions: .veritas-kanban/chats/sessions/{sessionId}.md
  */
 
-import fs from 'fs/promises';
-import path from 'path';
-import matter from '../utils/frontmatter.js';
 import { nanoid } from 'nanoid';
 import type {
   ChatSession,
@@ -17,18 +15,23 @@ import type {
   SquadExternalMessage,
   SquadMessage,
   SquadMessageLink,
-  SquadReaction,
   SquadSearchResponse,
   SquadUnreadState,
 } from '@veritas-kanban/shared';
-import { withFileLock } from './file-lock.js';
 import { getNotificationService, parseMentions } from './notification-service.js';
-import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
+import { validatePathSegment } from '../utils/sanitize.js';
 import { createLogger } from '../lib/logger.js';
 import { redactString } from '../lib/redact.js';
 import { getChatsDir } from '../utils/paths.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteChatRepository } from '../storage/sqlite/chat-repository.js';
+import {
+  FileChatRepository,
+  type ChatRepository,
+  type SquadMessageMetadata,
+  type SquadMetadataFile,
+  type SquadMetadataRepository,
+} from '../storage/chat-repository.js';
 
 const log = createLogger('chat-service');
 const SQUAD_SEARCH_LIMIT_MAX = 50;
@@ -45,45 +48,16 @@ export interface ChatServiceOptions {
   sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
-interface SquadMessageMetadata {
-  threadId?: string;
-  replyToId?: string;
-  mentions?: SquadMention[];
-  links?: SquadMessageLink[];
-  pinned?: boolean;
-  decision?: boolean;
-  reactions?: SquadReaction[];
-  external?: SquadExternalMessage;
-  updatedAt?: string;
-}
-
-interface SquadReadMetadata {
-  actor: string;
-  lastReadAt?: string;
-  lastReadMessageId?: string;
-  updatedAt: string;
-}
-
-interface SquadMetadataFile {
-  version: 1;
-  messages: Record<string, SquadMessageMetadata>;
-  reads: Record<string, SquadReadMetadata>;
-  updatedAt: string;
-}
-
 export class ChatService {
-  private chatsDir: string;
-  private sessionsDir: string;
-  private squadDir: string;
-  private readonly repository: SqliteChatRepository | null = null;
+  private readonly repository: ChatRepository;
+  private readonly squadMetadataRepository: SquadMetadataRepository;
   private readonly sqliteDatabase: SqliteDatabase | null = null;
   private readonly ownsSqliteDatabase: boolean = false;
-  private directorySetup: Promise<void> = Promise.resolve();
 
   constructor(options: ChatServiceOptions = {}) {
-    this.chatsDir = options.chatsDir || DEFAULT_CHATS_DIR;
-    this.sessionsDir = path.join(this.chatsDir, 'sessions');
-    this.squadDir = path.join(this.chatsDir, 'squad');
+    const chatsDir = options.chatsDir || DEFAULT_CHATS_DIR;
+    const fileRepository = new FileChatRepository(chatsDir);
+    this.squadMetadataRepository = fileRepository;
     const storageType =
       options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
 
@@ -93,25 +67,9 @@ export class ChatService {
       this.ownsSqliteDatabase = !options.sqliteDatabase;
       this.sqliteDatabase.open();
       this.repository = new SqliteChatRepository(this.sqliteDatabase);
+    } else {
+      this.repository = fileRepository;
     }
-
-    if (!this.repository) {
-      this.directorySetup = this.ensureDirectories();
-      this.directorySetup.catch((err) => {
-        log.warn({ err }, 'Failed to initialize chat directories');
-      });
-    }
-  }
-
-  private async ensureDirectories(): Promise<void> {
-    await fs.mkdir(this.chatsDir, { recursive: true });
-    await fs.mkdir(this.sessionsDir, { recursive: true });
-    await fs.mkdir(this.squadDir, { recursive: true });
-  }
-
-  private async ensureFileStorageReady(): Promise<void> {
-    if (this.repository) return;
-    await this.directorySetup;
   }
 
   /**
@@ -129,210 +87,31 @@ export class ChatService {
   }
 
   /**
-   * Get file path for a session.
-   * Validates path segments to prevent directory traversal.
-   */
-  private getSessionPath(sessionId: string, taskId?: string): string {
-    if (taskId) {
-      validatePathSegment(taskId);
-      const filePath = path.join(this.chatsDir, `task_${taskId}.md`);
-      ensureWithinBase(this.chatsDir, filePath);
-      return filePath;
-    }
-    validatePathSegment(sessionId);
-    const filePath = path.join(this.sessionsDir, `${sessionId}.md`);
-    ensureWithinBase(this.sessionsDir, filePath);
-    return filePath;
-  }
-
-  /**
-   * Parse a session from markdown file
-   */
-  private parseSession(filePath: string, content: string): ChatSession {
-    const { data, content: markdown } = matter(content);
-
-    // Parse messages from markdown (simple format: role + content blocks)
-    const messages: ChatMessage[] = [];
-    const messageBlocks = markdown.split(/\n---\n/);
-
-    for (const block of messageBlocks) {
-      if (!block.trim()) continue;
-
-      const lines = block.trim().split('\n');
-      const metaLine = lines[0];
-      const messageContent = lines.slice(1).join('\n').trim();
-
-      // Parse meta line: **id** | role | timestamp | [agent] | [model]
-      const match = metaLine.match(
-        /^\*\*(.+?)\*\*\s*\|\s*(\w+)\s*\|\s*(.+?)(?:\s*\|\s*(.+?))?(?:\s*\|\s*(.+?))?$/
-      );
-
-      if (match) {
-        const [, id, role, timestamp, agent, model] = match;
-        messages.push({
-          id,
-          role: role as 'user' | 'assistant' | 'system',
-          content: messageContent,
-          timestamp,
-          agent: agent || undefined,
-          model: model || undefined,
-        });
-      }
-    }
-
-    return {
-      id: data.id,
-      taskId: data.taskId,
-      title: data.title,
-      messages,
-      agent: data.agent,
-      model: data.model,
-      mode: data.mode || 'ask',
-      created: data.created,
-      updated: data.updated,
-    };
-  }
-
-  /**
-   * Serialize a session to markdown with YAML frontmatter
-   */
-  private serializeSession(session: ChatSession): string {
-    const frontmatter = {
-      id: session.id,
-      taskId: session.taskId,
-      title: session.title,
-      agent: session.agent,
-      model: session.model,
-      mode: session.mode,
-      created: session.created,
-      updated: session.updated,
-    };
-
-    // Remove undefined values
-    Object.keys(frontmatter).forEach((key) => {
-      if (frontmatter[key as keyof typeof frontmatter] === undefined) {
-        delete frontmatter[key as keyof typeof frontmatter];
-      }
-    });
-
-    // Serialize messages as markdown blocks
-    const messageBlocks = session.messages.map(
-      (msg: {
-        id: string;
-        role: string;
-        content: string;
-        timestamp: string;
-        agent?: string;
-        model?: string;
-      }) => {
-        const meta = [`**${msg.id}**`, msg.role, msg.timestamp, msg.agent || '', msg.model || '']
-          .filter(Boolean)
-          .join(' | ');
-
-        return `${meta}\n\n${msg.content}`;
-      }
-    );
-
-    const markdown = messageBlocks.join('\n\n---\n\n');
-
-    return matter.stringify(markdown, frontmatter);
-  }
-
-  /**
    * Get a session by ID
    */
   async getSession(sessionId: string): Promise<ChatSession | null> {
-    // Try to find the session file (could be task-scoped or board-level)
-    // First check if it's a task-scoped session
     const taskMatch = sessionId.match(/^task_(.+)$/);
-    if (this.repository) {
-      if (taskMatch) {
-        validatePathSegment(taskMatch[1]);
-      } else {
-        validatePathSegment(sessionId);
-      }
-      return this.repository.getSession(sessionId);
-    }
-
-    await this.ensureFileStorageReady();
-
     if (taskMatch) {
-      const taskId = taskMatch[1];
-      const filePath = this.getSessionPath(sessionId, taskId);
-
-      try {
-        const content = await fs.readFile(filePath, 'utf-8');
-        return this.parseSession(filePath, content);
-      } catch (err: any) {
-        if (err.code === 'ENOENT') return null;
-        throw err;
-      }
+      validatePathSegment(taskMatch[1]);
+    } else {
+      validatePathSegment(sessionId);
     }
-
-    // Board-level session
-    const filePath = this.getSessionPath(sessionId);
-
-    try {
-      const content = await fs.readFile(filePath, 'utf-8');
-      return this.parseSession(filePath, content);
-    } catch (err: any) {
-      if (err.code === 'ENOENT') return null;
-      throw err;
-    }
+    return this.repository.getSession(sessionId);
   }
 
   /**
    * Get the session for a specific task
    */
   async getSessionForTask(taskId: string): Promise<ChatSession | null> {
-    if (this.repository) {
-      validatePathSegment(taskId);
-      return this.repository.getSessionForTask(taskId);
-    }
-
-    await this.ensureFileStorageReady();
-
-    const filePath = this.getSessionPath(`task_${taskId}`, taskId);
-
-    try {
-      const content = await fs.readFile(filePath, 'utf-8');
-      return this.parseSession(filePath, content);
-    } catch (err: any) {
-      if (err.code === 'ENOENT') return null;
-      throw err;
-    }
+    validatePathSegment(taskId);
+    return this.repository.getSessionForTask(taskId);
   }
 
   /**
    * List all sessions (board-level only)
    */
   async listSessions(): Promise<ChatSession[]> {
-    if (this.repository) {
-      return this.repository.listBoardSessions();
-    }
-
-    await this.ensureFileStorageReady();
-
-    try {
-      const files = await fs.readdir(this.sessionsDir);
-      const sessions: ChatSession[] = [];
-
-      for (const file of files) {
-        if (!file.endsWith('.md')) continue;
-
-        const filePath = path.join(this.sessionsDir, file);
-        const content = await fs.readFile(filePath, 'utf-8');
-        sessions.push(this.parseSession(filePath, content));
-      }
-
-      // Sort by updated time (newest first)
-      sessions.sort((a, b) => new Date(b.updated).getTime() - new Date(a.updated).getTime());
-
-      return sessions;
-    } catch (err: any) {
-      if (err.code === 'ENOENT') return [];
-      throw err;
-    }
+    return this.repository.listBoardSessions();
   }
 
   /**
@@ -361,23 +140,8 @@ export class ChatService {
       updated: now,
     };
 
-    if (this.repository) {
-      this.repository.saveSession(session);
-      log.info({ sessionId, taskId: input.taskId }, 'Created chat session');
-      return session;
-    }
-
-    await this.ensureFileStorageReady();
-
-    const filePath = this.getSessionPath(sessionId, input.taskId);
-    const content = this.serializeSession(session);
-
-    await withFileLock(filePath, async () => {
-      await fs.writeFile(filePath, content, 'utf-8');
-    });
-
+    await this.repository.saveSession(session);
     log.info({ sessionId, taskId: input.taskId }, 'Created chat session');
-
     return session;
   }
 
@@ -394,49 +158,17 @@ export class ChatService {
       ...message,
     };
 
-    // Determine file path - need to check both task-scoped and board-level paths
     const taskMatch = sessionId.match(/^task_(.+)$/);
     const taskId = taskMatch ? taskMatch[1] : undefined;
-    if (this.repository) {
-      if (taskId) {
-        validatePathSegment(taskId);
-      } else {
-        validatePathSegment(sessionId);
-      }
-
-      const session = await this.repository.getSession(sessionId);
-      if (!session) {
-        throw new Error(`Session ${sessionId} not found`);
-      }
-
-      session.messages.push(newMessage);
-      session.updated = newMessage.timestamp;
-      this.repository.saveSession(session);
-
-      log.debug({ sessionId, messageId: newMessage.id, role: newMessage.role }, 'Added message');
-      return newMessage;
+    if (taskId) {
+      validatePathSegment(taskId);
+    } else {
+      validatePathSegment(sessionId);
     }
-
-    await this.ensureFileStorageReady();
-
-    const filePath = this.getSessionPath(sessionId, taskId);
-
-    await withFileLock(filePath, async () => {
-      const session = await this.getSession(sessionId);
-
-      if (!session) {
-        throw new Error(`Session ${sessionId} not found`);
-      }
-
-      session.messages.push(newMessage);
-      session.updated = newMessage.timestamp;
-
-      const content = this.serializeSession(session);
-      await fs.writeFile(filePath, content, 'utf-8');
-    });
-
+    if (!(await this.repository.appendSessionMessage(sessionId, newMessage))) {
+      throw new Error(`Session ${sessionId} not found`);
+    }
     log.debug({ sessionId, messageId: newMessage.id, role: newMessage.role }, 'Added message');
-
     return newMessage;
   }
 
@@ -444,99 +176,28 @@ export class ChatService {
    * Delete a session
    */
   async deleteSession(sessionId: string): Promise<void> {
-    // Determine file path - need to check both task-scoped and board-level paths
     const taskMatch = sessionId.match(/^task_(.+)$/);
     const taskId = taskMatch ? taskMatch[1] : undefined;
-    if (this.repository) {
-      if (taskId) {
-        validatePathSegment(taskId);
-      } else {
-        validatePathSegment(sessionId);
-      }
-
-      if (!this.repository.deleteSession(sessionId)) {
-        log.info({ sessionId }, 'Chat session already deleted or never existed');
-        return;
-      }
-
-      log.info({ sessionId }, 'Deleted chat session');
+    if (taskId) {
+      validatePathSegment(taskId);
+    } else {
+      validatePathSegment(sessionId);
+    }
+    if (!(await this.repository.deleteSession(sessionId))) {
+      log.info({ sessionId }, 'Chat session already deleted or never existed');
       return;
     }
-
-    await this.ensureFileStorageReady();
-
-    const filePath = this.getSessionPath(sessionId, taskId);
-
-    await withFileLock(filePath, async () => {
-      const session = await this.getSession(sessionId);
-
-      if (!session) {
-        // Already gone — treat as success
-        log.info({ sessionId }, 'Chat session already deleted or never existed');
-        return;
-      }
-
-      try {
-        await fs.unlink(filePath);
-      } catch (err: any) {
-        if (err.code !== 'ENOENT') throw err;
-      }
-
-      log.info({ sessionId }, 'Deleted chat session');
-    });
-  }
-
-  private getSquadMetadataPath(): string {
-    const filePath = path.join(this.squadDir, 'metadata.json');
-    ensureWithinBase(this.squadDir, filePath);
-    return filePath;
-  }
-
-  private emptySquadMetadata(): SquadMetadataFile {
-    return {
-      version: 1,
-      messages: {},
-      reads: {},
-      updatedAt: new Date().toISOString(),
-    };
-  }
-
-  private async readSquadMetadataFromPath(filePath: string): Promise<SquadMetadataFile> {
-    try {
-      const raw = await fs.readFile(filePath, 'utf-8');
-      const parsed = JSON.parse(raw) as Partial<SquadMetadataFile>;
-      return {
-        version: 1,
-        messages: parsed.messages && typeof parsed.messages === 'object' ? parsed.messages : {},
-        reads: parsed.reads && typeof parsed.reads === 'object' ? parsed.reads : {},
-        updatedAt:
-          typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
-      };
-    } catch (err: any) {
-      if (err.code === 'ENOENT') return this.emptySquadMetadata();
-      throw err;
-    }
+    log.info({ sessionId }, 'Deleted chat session');
   }
 
   private async readSquadMetadata(): Promise<SquadMetadataFile> {
-    await this.ensureFileStorageReady();
-    return this.readSquadMetadataFromPath(this.getSquadMetadataPath());
+    return this.squadMetadataRepository.readSquadMetadata();
   }
 
   private async updateSquadMetadata<T>(
     mutator: (metadata: SquadMetadataFile) => T | Promise<T>
   ): Promise<T> {
-    await this.ensureFileStorageReady();
-    const filePath = this.getSquadMetadataPath();
-    await fs.mkdir(this.squadDir, { recursive: true });
-
-    return withFileLock(filePath, async () => {
-      const metadata = await this.readSquadMetadataFromPath(filePath);
-      const result = await mutator(metadata);
-      metadata.updatedAt = new Date().toISOString();
-      await fs.writeFile(filePath, JSON.stringify(metadata, null, 2), 'utf-8');
-      return result;
-    });
+    return this.squadMetadataRepository.updateSquadMetadata(mutator);
   }
 
   private normalizeActor(actor: string): string {
@@ -739,42 +400,7 @@ export class ChatService {
       ...(input.external && { external: input.external }),
     };
 
-    if (this.repository) {
-      this.repository.appendSquadMessage(squadMessage);
-    } else {
-      await this.ensureFileStorageReady();
-
-      // Store as daily markdown file: squad/YYYY-MM-DD.md
-      const date = timestamp.split('T')[0]; // YYYY-MM-DD
-      const filePath = path.join(this.squadDir, `${date}.md`);
-      ensureWithinBase(this.squadDir, filePath);
-
-      await withFileLock(filePath, async () => {
-        let content: string;
-        try {
-          content = await fs.readFile(filePath, 'utf-8');
-        } catch (err: any) {
-          if (err.code !== 'ENOENT') throw err;
-          // File doesn't exist yet — create with header
-          content = `# Squad Chat — ${date}\n\n`;
-        }
-
-        // Append the new message in a consistent format
-        const systemTag = squadMessage.system ? ' [system]' : '';
-        const eventTag = squadMessage.event ? ` [${squadMessage.event}]` : '';
-        const modelTag = squadMessage.model ? ` [model:${squadMessage.model}]` : '';
-        const tagsStr = squadMessage.tags?.length ? ` [${squadMessage.tags.join(', ')}]` : '';
-        const displayStr = displayName ? ` (${displayName})` : '';
-        const taskTitleStr = squadMessage.taskTitle ? ` | ${squadMessage.taskTitle}` : '';
-        const durationStr = squadMessage.duration ? ` (${squadMessage.duration})` : '';
-
-        const messageBlock = `## ${squadMessage.agent}${displayStr} | ${messageId} | ${timestamp}${systemTag}${eventTag}${modelTag}${tagsStr}${taskTitleStr}${durationStr}\n\n${squadMessage.message}\n\n---\n\n`;
-
-        content += messageBlock;
-
-        await fs.writeFile(filePath, content, 'utf-8');
-      });
-    }
+    await this.repository.appendSquadMessage(squadMessage);
 
     const messageMetadata: SquadMessageMetadata = {
       threadId: squadMessage.threadId,
@@ -837,147 +463,12 @@ export class ChatService {
         ? Math.min(Math.floor(options.limit), SQUAD_MESSAGE_LIMIT_MAX)
         : undefined;
 
-    if (this.repository) {
-      return this.applySquadMetadata(
-        this.repository.listSquadMessages({
-          ...options,
-          limit: safeLimit,
-        })
-      );
-    }
-
-    await this.ensureFileStorageReady();
-
-    const messages: SquadMessage[] = [];
-    const includeSystem = options.includeSystem !== false; // Default to true
-    const sinceTimestamp = options.since ? Date.parse(options.since) : null;
-
-    try {
-      // Read all daily squad files
-      const files = (await fs.readdir(this.squadDir))
-        .filter((f) => f.endsWith('.md'))
-        .sort()
-        .reverse(); // Newest first
-
-      for (const file of files) {
-        const filePath = path.join(this.squadDir, file);
-        const content = await fs.readFile(filePath, 'utf-8');
-        const body = content.replace(/^#\s+Squad Chat[^\n]*\n+/, '');
-
-        // Parse messages from markdown
-        const messageBlocks = body.split(/\n---\n/);
-
-        for (const block of messageBlocks) {
-          if (!block.trim()) continue;
-
-          const lines = block.trim().split('\n');
-          const headerLine = lines[0];
-          const normalizedHeader = headerLine.replace(/^##\s+/, '');
-          const headerParts = normalizedHeader.split('|').map((part) => part.trim());
-
-          if (headerParts.length < 3) continue;
-
-          const [agentPart, idPart, metaPart, taskPart] = headerParts;
-          if (!agentPart || !idPart || !metaPart) continue;
-
-          const agentMatch = agentPart.match(/^(.+?)(?:\s+\((.+?)\))?$/);
-          if (!agentMatch) continue;
-
-          const agent = agentMatch[1].trim();
-          const displayName = agentMatch[2]?.trim();
-
-          const bracketMatches = [...metaPart.matchAll(/\[([^\]]+)\]/g)].map((match) => match[1]);
-          const isSystem = bracketMatches.includes('system');
-          if (!includeSystem && isSystem) continue;
-
-          const eventMatch = bracketMatches.find((value) => value.startsWith('agent.'));
-          const event = eventMatch ? (eventMatch as SquadMessage['event']) : undefined;
-
-          const modelMatch = bracketMatches.find((value) => value.startsWith('model:'));
-          const model = modelMatch ? modelMatch.replace('model:', '') : undefined;
-
-          const tagMatch = bracketMatches.find(
-            (value) =>
-              value !== 'system' && !value.startsWith('agent.') && !value.startsWith('model:')
-          );
-          const tags = tagMatch
-            ? tagMatch
-                .split(',')
-                .map((tag) => tag.trim())
-                .filter(Boolean)
-            : undefined;
-
-          let timestampSegment = metaPart.replace(/\[.*?\]/g, '').trim();
-          let duration: string | undefined;
-
-          if (!taskPart) {
-            const durationMatch = timestampSegment.match(/\(([^)]+)\)\s*$/);
-            if (durationMatch) {
-              duration = durationMatch[1];
-              timestampSegment = timestampSegment.replace(/\(([^)]+)\)\s*$/, '').trim();
-            }
-          }
-
-          const timestamp = timestampSegment;
-          if (!timestamp) continue;
-
-          let taskTitle: string | undefined;
-          if (taskPart) {
-            const durationMatch = taskPart.match(/\(([^)]+)\)\s*$/);
-            if (durationMatch) {
-              duration = durationMatch[1];
-            }
-            const title = taskPart.replace(/\(([^)]+)\)\s*$/, '').trim();
-            taskTitle = title || undefined;
-          }
-
-          const messageBody = lines.slice(1).join('\n').trim();
-
-          const squadMessage: SquadMessage = {
-            id: idPart,
-            agent,
-            displayName: displayName || undefined,
-            message: messageBody,
-            tags,
-            timestamp,
-            model,
-            system: isSystem ? true : undefined,
-            event,
-            taskTitle,
-            duration,
-          };
-
-          const numericTimestamp = Date.parse(timestamp);
-          if (
-            sinceTimestamp &&
-            !Number.isNaN(numericTimestamp) &&
-            numericTimestamp < sinceTimestamp
-          ) {
-            continue;
-          }
-
-          if (options.agent && squadMessage.agent !== options.agent) continue;
-
-          messages.push(squadMessage);
-        }
-      }
-
-      const getTime = (ts: string) => {
-        const value = Date.parse(ts);
-        return Number.isNaN(value) ? 0 : value;
-      };
-
-      messages.sort((a, b) => getTime(a.timestamp) - getTime(b.timestamp));
-
-      if (safeLimit && messages.length > safeLimit) {
-        return this.applySquadMetadata(messages.slice(-safeLimit));
-      }
-
-      return this.applySquadMetadata(messages);
-    } catch (err: any) {
-      if (err.code === 'ENOENT') return [];
-      throw err;
-    }
+    return this.applySquadMetadata(
+      await this.repository.listSquadMessages({
+        ...options,
+        limit: safeLimit,
+      })
+    );
   }
 
   async getSquadThread(messageId: string): Promise<SquadMessage[]> {

--- a/server/src/storage/chat-repository.ts
+++ b/server/src/storage/chat-repository.ts
@@ -1,0 +1,481 @@
+import { constants } from 'node:fs';
+import { lstat, mkdir, open, readdir, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  ChatMessage,
+  ChatSession,
+  SquadExternalMessage,
+  SquadMention,
+  SquadMessage,
+  SquadMessageLink,
+  SquadReaction,
+} from '@veritas-kanban/shared';
+import matter from '../utils/frontmatter.js';
+import { withFileLock } from '../services/file-lock.js';
+import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import { atomicWriteFile } from './fs-helpers.js';
+
+const MAX_CHAT_SESSION_BYTES = 16 * 1024 * 1024;
+const MAX_SQUAD_DAY_BYTES = 32 * 1024 * 1024;
+const MAX_SQUAD_METADATA_BYTES = 16 * 1024 * 1024;
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface SquadMessageMetadata {
+  threadId?: string;
+  replyToId?: string;
+  mentions?: SquadMention[];
+  links?: SquadMessageLink[];
+  pinned?: boolean;
+  decision?: boolean;
+  reactions?: SquadReaction[];
+  external?: SquadExternalMessage;
+  updatedAt?: string;
+}
+
+export interface SquadReadMetadata {
+  actor: string;
+  lastReadAt?: string;
+  lastReadMessageId?: string;
+  updatedAt: string;
+}
+
+export interface SquadMetadataFile {
+  version: 1;
+  messages: Record<string, SquadMessageMetadata>;
+  reads: Record<string, SquadReadMetadata>;
+  updatedAt: string;
+}
+
+export interface SquadMessageListOptions {
+  since?: string;
+  agent?: string;
+  limit?: number;
+  includeSystem?: boolean;
+}
+
+export interface ChatRepository {
+  getSession(sessionId: string): MaybePromise<ChatSession | null>;
+  getSessionForTask(taskId: string): MaybePromise<ChatSession | null>;
+  listBoardSessions(): MaybePromise<ChatSession[]>;
+  saveSession(session: ChatSession): MaybePromise<void>;
+  appendSessionMessage(sessionId: string, message: ChatMessage): MaybePromise<boolean>;
+  deleteSession(sessionId: string): MaybePromise<boolean>;
+  appendSquadMessage(message: SquadMessage): MaybePromise<void>;
+  listSquadMessages(options?: SquadMessageListOptions): MaybePromise<SquadMessage[]>;
+}
+
+export interface SquadMetadataRepository {
+  readSquadMetadata(): Promise<SquadMetadataFile>;
+  updateSquadMetadata<T>(mutator: (metadata: SquadMetadataFile) => T | Promise<T>): Promise<T>;
+}
+
+export class FileChatRepository implements ChatRepository, SquadMetadataRepository {
+  private readonly chatsDir: string;
+  private readonly sessionsDir: string;
+  private readonly squadDir: string;
+  private directorySetup: Promise<void> | null = null;
+
+  constructor(chatsDir: string) {
+    this.chatsDir = path.resolve(chatsDir);
+    this.sessionsDir = ensureWithinBase(this.chatsDir, path.join(this.chatsDir, 'sessions'));
+    this.squadDir = ensureWithinBase(this.chatsDir, path.join(this.chatsDir, 'squad'));
+  }
+
+  async getSession(sessionId: string): Promise<ChatSession | null> {
+    await this.ensureReady();
+    const taskMatch = sessionId.match(/^task_(.+)$/);
+    const filePath = this.sessionPath(sessionId, taskMatch?.[1]);
+    const content = await this.readOptionalBoundedFile(
+      filePath,
+      MAX_CHAT_SESSION_BYTES,
+      'Chat session'
+    );
+    return content === null ? null : this.parseSession(content);
+  }
+
+  async getSessionForTask(taskId: string): Promise<ChatSession | null> {
+    validatePathSegment(taskId);
+    return this.getSession(`task_${taskId}`);
+  }
+
+  async listBoardSessions(): Promise<ChatSession[]> {
+    await this.ensureReady();
+    const entries = await readdir(this.sessionsDir, { withFileTypes: true });
+    const sessions: ChatSession[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || entry.isSymbolicLink() || !entry.name.endsWith('.md')) continue;
+      validatePathSegment(entry.name);
+      const filePath = ensureWithinBase(this.sessionsDir, path.join(this.sessionsDir, entry.name));
+      const content = await this.readOptionalBoundedFile(
+        filePath,
+        MAX_CHAT_SESSION_BYTES,
+        'Chat session'
+      );
+      if (content !== null) sessions.push(this.parseSession(content));
+    }
+    return sessions.sort(
+      (left, right) =>
+        new Date(right.updated).getTime() - new Date(left.updated).getTime() ||
+        right.id.localeCompare(left.id)
+    );
+  }
+
+  async saveSession(session: ChatSession): Promise<void> {
+    await this.ensureReady();
+    const filePath = this.sessionPath(session.id, session.taskId);
+    const content = this.serializeSession(session);
+    this.assertBounded(content, MAX_CHAT_SESSION_BYTES, 'Chat session');
+    await withFileLock(filePath, () => atomicWriteFile(filePath, content, 'utf8'));
+  }
+
+  async appendSessionMessage(sessionId: string, message: ChatMessage): Promise<boolean> {
+    await this.ensureReady();
+    const taskMatch = sessionId.match(/^task_(.+)$/);
+    const filePath = this.sessionPath(sessionId, taskMatch?.[1]);
+    return withFileLock(filePath, async () => {
+      const content = await this.readOptionalBoundedFile(
+        filePath,
+        MAX_CHAT_SESSION_BYTES,
+        'Chat session'
+      );
+      if (content === null) return false;
+      const session = this.parseSession(content);
+      session.messages.push(message);
+      session.updated = message.timestamp;
+      const nextContent = this.serializeSession(session);
+      this.assertBounded(nextContent, MAX_CHAT_SESSION_BYTES, 'Chat session');
+      await atomicWriteFile(filePath, nextContent, 'utf8');
+      return true;
+    });
+  }
+
+  async deleteSession(sessionId: string): Promise<boolean> {
+    await this.ensureReady();
+    const taskMatch = sessionId.match(/^task_(.+)$/);
+    const filePath = this.sessionPath(sessionId, taskMatch?.[1]);
+    return withFileLock(filePath, async () => {
+      try {
+        await unlink(filePath);
+        return true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+        throw error;
+      }
+    });
+  }
+
+  async appendSquadMessage(message: SquadMessage): Promise<void> {
+    await this.ensureReady();
+    validatePathSegment(message.id);
+    const date = message.timestamp.split('T')[0];
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new Error('Squad message timestamp is invalid');
+    }
+    const filePath = ensureWithinBase(this.squadDir, path.join(this.squadDir, `${date}.md`));
+    await withFileLock(filePath, async () => {
+      const existing = await this.readOptionalBoundedFile(
+        filePath,
+        MAX_SQUAD_DAY_BYTES,
+        'Squad chat log'
+      );
+      const content = existing ?? `# Squad Chat — ${date}\n\n`;
+      const nextContent = content + this.serializeSquadMessage(message);
+      this.assertBounded(nextContent, MAX_SQUAD_DAY_BYTES, 'Squad chat log');
+      await atomicWriteFile(filePath, nextContent, 'utf8');
+    });
+  }
+
+  async listSquadMessages(options: SquadMessageListOptions = {}): Promise<SquadMessage[]> {
+    await this.ensureReady();
+    const includeSystem = options.includeSystem !== false;
+    const sinceTimestamp = options.since ? Date.parse(options.since) : null;
+    const entries = await readdir(this.squadDir, { withFileTypes: true });
+    const messages: SquadMessage[] = [];
+
+    for (const entry of entries
+      .filter(
+        (candidate) =>
+          candidate.isFile() &&
+          !candidate.isSymbolicLink() &&
+          /^\d{4}-\d{2}-\d{2}\.md$/.test(candidate.name)
+      )
+      .sort((left, right) => right.name.localeCompare(left.name))) {
+      const filePath = ensureWithinBase(this.squadDir, path.join(this.squadDir, entry.name));
+      const content = await this.readOptionalBoundedFile(
+        filePath,
+        MAX_SQUAD_DAY_BYTES,
+        'Squad chat log'
+      );
+      if (content === null) continue;
+      for (const message of this.parseSquadMessages(content)) {
+        if (!includeSystem && message.system) continue;
+        const numericTimestamp = Date.parse(message.timestamp);
+        if (
+          sinceTimestamp &&
+          !Number.isNaN(numericTimestamp) &&
+          numericTimestamp < sinceTimestamp
+        ) {
+          continue;
+        }
+        if (options.agent && message.agent !== options.agent) continue;
+        messages.push(message);
+      }
+    }
+
+    const getTime = (timestamp: string) => {
+      const value = Date.parse(timestamp);
+      return Number.isNaN(value) ? 0 : value;
+    };
+    messages.sort((left, right) => getTime(left.timestamp) - getTime(right.timestamp));
+    const limit = options.limit && options.limit > 0 ? Math.floor(options.limit) : null;
+    return limit && messages.length > limit ? messages.slice(-limit) : messages;
+  }
+
+  async readSquadMetadata(): Promise<SquadMetadataFile> {
+    return this.readSquadMetadataFromPath(this.squadMetadataPath());
+  }
+
+  async updateSquadMetadata<T>(
+    mutator: (metadata: SquadMetadataFile) => T | Promise<T>
+  ): Promise<T> {
+    await this.ensureReady();
+    const filePath = this.squadMetadataPath();
+    return withFileLock(filePath, async () => {
+      const metadata = await this.readSquadMetadataFromPath(filePath);
+      const result = await mutator(metadata);
+      metadata.updatedAt = new Date().toISOString();
+      const content = JSON.stringify(metadata, null, 2);
+      this.assertBounded(content, MAX_SQUAD_METADATA_BYTES, 'Squad metadata');
+      await atomicWriteFile(filePath, content, 'utf8');
+      return result;
+    });
+  }
+
+  private async ensureReady(): Promise<void> {
+    this.directorySetup ??= Promise.all([
+      this.prepareDirectory(this.chatsDir),
+      this.prepareDirectory(this.sessionsDir),
+      this.prepareDirectory(this.squadDir),
+    ]).then(() => undefined);
+    await this.directorySetup;
+  }
+
+  private async prepareDirectory(directory: string): Promise<void> {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    const stats = await lstat(directory);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error('Chat storage must use regular directories');
+    }
+  }
+
+  private sessionPath(sessionId: string, taskId?: string): string {
+    if (taskId) {
+      validatePathSegment(taskId);
+      return ensureWithinBase(this.chatsDir, path.join(this.chatsDir, `task_${taskId}.md`));
+    }
+    validatePathSegment(sessionId);
+    return ensureWithinBase(this.sessionsDir, path.join(this.sessionsDir, `${sessionId}.md`));
+  }
+
+  private squadMetadataPath(): string {
+    return ensureWithinBase(this.squadDir, path.join(this.squadDir, 'metadata.json'));
+  }
+
+  private parseSession(content: string): ChatSession {
+    const { data, content: markdown } = matter(content);
+    const messages: ChatMessage[] = [];
+    for (const block of markdown.split(/\n---\n/)) {
+      if (!block.trim()) continue;
+      const lines = block.trim().split('\n');
+      const match = lines[0].match(
+        /^\*\*(.+?)\*\*\s*\|\s*(\w+)\s*\|\s*(.+?)(?:\s*\|\s*(.+?))?(?:\s*\|\s*(.+?))?$/
+      );
+      if (!match) continue;
+      const [, id, role, timestamp, agent, model] = match;
+      messages.push({
+        id,
+        role: role as ChatMessage['role'],
+        content: lines.slice(1).join('\n').trim(),
+        timestamp,
+        agent: agent || undefined,
+        model: model || undefined,
+      });
+    }
+    return {
+      id: data.id,
+      taskId: data.taskId,
+      title: data.title,
+      messages,
+      agent: data.agent,
+      model: data.model,
+      mode: data.mode || 'ask',
+      created: data.created,
+      updated: data.updated,
+    };
+  }
+
+  private serializeSession(session: ChatSession): string {
+    const frontmatter: Record<string, unknown> = {
+      id: session.id,
+      taskId: session.taskId,
+      title: session.title,
+      agent: session.agent,
+      model: session.model,
+      mode: session.mode,
+      created: session.created,
+      updated: session.updated,
+    };
+    for (const [key, value] of Object.entries(frontmatter)) {
+      if (value === undefined) delete frontmatter[key];
+    }
+    const markdown = session.messages
+      .map((message) => {
+        const meta = [
+          `**${message.id}**`,
+          message.role,
+          message.timestamp,
+          message.agent || '',
+          message.model || '',
+        ]
+          .filter(Boolean)
+          .join(' | ');
+        return `${meta}\n\n${message.content}`;
+      })
+      .join('\n\n---\n\n');
+    return matter.stringify(markdown, frontmatter);
+  }
+
+  private serializeSquadMessage(message: SquadMessage): string {
+    const systemTag = message.system ? ' [system]' : '';
+    const eventTag = message.event ? ` [${message.event}]` : '';
+    const modelTag = message.model ? ` [model:${message.model}]` : '';
+    const tags = message.tags?.length ? ` [${message.tags.join(', ')}]` : '';
+    const display = message.displayName ? ` (${message.displayName})` : '';
+    const taskTitle = message.taskTitle ? ` | ${message.taskTitle}` : '';
+    const duration = message.duration ? ` (${message.duration})` : '';
+    return `## ${message.agent}${display} | ${message.id} | ${message.timestamp}${systemTag}${eventTag}${modelTag}${tags}${taskTitle}${duration}\n\n${message.message}\n\n---\n\n`;
+  }
+
+  private parseSquadMessages(content: string): SquadMessage[] {
+    const body = content.replace(/^#\s+Squad Chat[^\n]*\n+/, '');
+    const messages: SquadMessage[] = [];
+    for (const block of body.split(/\n---\n/)) {
+      if (!block.trim()) continue;
+      const lines = block.trim().split('\n');
+      const headerParts = lines[0]
+        .replace(/^##\s+/, '')
+        .split('|')
+        .map((part) => part.trim());
+      if (headerParts.length < 3) continue;
+      const [agentPart, id, metaPart, taskPart] = headerParts;
+      if (!agentPart || !id || !metaPart) continue;
+      const agentMatch = agentPart.match(/^(.+?)(?:\s+\((.+?)\))?$/);
+      if (!agentMatch) continue;
+      const bracketMatches = [...metaPart.matchAll(/\[([^\]]+)\]/g)].map((match) => match[1]);
+      let timestamp = metaPart.replace(/\[.*?\]/g, '').trim();
+      let duration: string | undefined;
+      if (!taskPart) {
+        const durationMatch = timestamp.match(/\(([^)]+)\)\s*$/);
+        if (durationMatch) {
+          duration = durationMatch[1];
+          timestamp = timestamp.replace(/\(([^)]+)\)\s*$/, '').trim();
+        }
+      }
+      if (!timestamp) continue;
+      let taskTitle: string | undefined;
+      if (taskPart) {
+        const durationMatch = taskPart.match(/\(([^)]+)\)\s*$/);
+        if (durationMatch) duration = durationMatch[1];
+        taskTitle = taskPart.replace(/\(([^)]+)\)\s*$/, '').trim() || undefined;
+      }
+      const event = bracketMatches.find((value) => value.startsWith('agent.')) as
+        SquadMessage['event'] | undefined;
+      const modelTag = bracketMatches.find((value) => value.startsWith('model:'));
+      const tagValue = bracketMatches.find(
+        (value) => value !== 'system' && !value.startsWith('agent.') && !value.startsWith('model:')
+      );
+      messages.push({
+        id,
+        agent: agentMatch[1].trim(),
+        displayName: agentMatch[2]?.trim() || undefined,
+        message: lines.slice(1).join('\n').trim(),
+        tags: tagValue
+          ? tagValue
+              .split(',')
+              .map((tag) => tag.trim())
+              .filter(Boolean)
+          : undefined,
+        timestamp,
+        model: modelTag?.replace('model:', ''),
+        system: bracketMatches.includes('system') ? true : undefined,
+        event,
+        taskTitle,
+        duration,
+      });
+    }
+    return messages;
+  }
+
+  private emptySquadMetadata(): SquadMetadataFile {
+    return {
+      version: 1,
+      messages: {},
+      reads: {},
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  private async readSquadMetadataFromPath(filePath: string): Promise<SquadMetadataFile> {
+    const content = await this.readOptionalBoundedFile(
+      filePath,
+      MAX_SQUAD_METADATA_BYTES,
+      'Squad metadata'
+    );
+    if (content === null) return this.emptySquadMetadata();
+    const parsed = JSON.parse(content) as Partial<SquadMetadataFile>;
+    return {
+      version: 1,
+      messages: parsed.messages && typeof parsed.messages === 'object' ? parsed.messages : {},
+      reads: parsed.reads && typeof parsed.reads === 'object' ? parsed.reads : {},
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
+    };
+  }
+
+  private async readOptionalBoundedFile(
+    filePath: string,
+    maximumBytes: number,
+    label: string
+  ): Promise<string | null> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const [pathStats, stats] = await Promise.all([lstat(filePath), handle.stat()]);
+      if (
+        pathStats.isSymbolicLink() ||
+        pathStats.dev !== stats.dev ||
+        pathStats.ino !== stats.ino ||
+        !stats.isFile() ||
+        stats.size > maximumBytes
+      ) {
+        throw new Error(`${label} must use a bounded regular file`);
+      }
+      return await handle.readFile({ encoding: 'utf8' });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return null;
+      if (code === 'ELOOP') {
+        throw new Error(`${label} must not use a symbolic link`, { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private assertBounded(content: string, maximumBytes: number, label: string): void {
+    if (Buffer.byteLength(content, 'utf8') > maximumBytes) {
+      throw new Error(`${label} exceeds its storage limit`);
+    }
+  }
+}

--- a/server/src/storage/chat-repository.ts
+++ b/server/src/storage/chat-repository.ts
@@ -370,8 +370,7 @@ export class FileChatRepository implements ChatRepository, SquadMetadataReposito
       if (headerParts.length < 3) continue;
       const [agentPart, id, metaPart, taskPart] = headerParts;
       if (!agentPart || !id || !metaPart) continue;
-      const agentMatch = agentPart.match(/^(.+?)(?:\s+\((.+?)\))?$/);
-      if (!agentMatch) continue;
+      const agentMatch = agentPart.match(/^(.+?)(?:\s+\((.+?)\))?$/)!;
       const bracketMatches = [...metaPart.matchAll(/\[([^\]]+)\]/g)].map((match) => match[1]);
       let timestamp = metaPart.replace(/\[.*?\]/g, '').trim();
       let duration: string | undefined;

--- a/server/src/storage/chat-repository.ts
+++ b/server/src/storage/chat-repository.ts
@@ -156,7 +156,11 @@ export class FileChatRepository implements ChatRepository, SquadMetadataReposito
     const filePath = this.sessionPath(sessionId, taskMatch?.[1]);
     return withFileLock(filePath, async () => {
       try {
-        await unlink(filePath);
+        const deletionPath = path.join(
+          taskMatch ? this.chatsDir : this.sessionsDir,
+          path.basename(filePath)
+        );
+        await unlink(deletionPath);
         return true;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
@@ -448,8 +452,17 @@ export class FileChatRepository implements ChatRepository, SquadMetadataReposito
   ): Promise<string | null> {
     let handle: Awaited<ReturnType<typeof open>> | undefined;
     try {
-      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
-      const [pathStats, stats] = await Promise.all([lstat(filePath), handle.stat()]);
+      const parent = path.dirname(filePath);
+      const allowedParent =
+        parent === this.sessionsDir
+          ? this.sessionsDir
+          : parent === this.squadDir
+            ? this.squadDir
+            : this.chatsDir;
+      const boundedPath = path.join(allowedParent, path.basename(filePath));
+      if (boundedPath !== filePath) throw new Error('Chat storage path is outside its repository');
+      handle = await open(boundedPath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const [pathStats, stats] = await Promise.all([lstat(boundedPath), handle.stat()]);
       if (
         pathStats.isSymbolicLink() ||
         pathStats.dev !== stats.dev ||

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -226,6 +226,15 @@ export {
   SqliteWorkflowRunRepository,
 } from './sqlite/workflow-repositories.js';
 export { SqliteChatRepository } from './sqlite/chat-repository.js';
+export { FileChatRepository } from './chat-repository.js';
+export type {
+  ChatRepository,
+  SquadMessageListOptions,
+  SquadMessageMetadata,
+  SquadMetadataFile,
+  SquadMetadataRepository,
+  SquadReadMetadata,
+} from './chat-repository.js';
 export { SqliteNotificationRepository } from './sqlite/notification-repository.js';
 export { SqliteScheduledDeliverablesRepository } from './sqlite/scheduled-deliverables-repository.js';
 export { SqliteIdentityRepository, WORKSPACE_ROLES } from './sqlite/identity-repository.js';

--- a/server/src/storage/sqlite/chat-repository.ts
+++ b/server/src/storage/sqlite/chat-repository.ts
@@ -1,6 +1,7 @@
 import type { SQLInputValue } from 'node:sqlite';
 import type { ChatMessage, ChatSession, SquadMessage } from '@veritas-kanban/shared';
 import type { SqliteDatabase } from './database.js';
+import type { ChatRepository, SquadMessageListOptions } from '../chat-repository.js';
 
 interface ChatSessionRow {
   id: string;
@@ -15,7 +16,7 @@ interface SquadMessageRow {
   message_json: string;
 }
 
-export class SqliteChatRepository {
+export class SqliteChatRepository implements ChatRepository {
   constructor(private readonly database: SqliteDatabase) {}
 
   getSession(sessionId: string): ChatSession | null {
@@ -149,6 +150,68 @@ export class SqliteChatRepository {
     }
   }
 
+  appendSessionMessage(sessionId: string, message: ChatMessage): boolean {
+    const db = this.database.getConnection();
+    db.exec('BEGIN IMMEDIATE;');
+    try {
+      const row = db
+        .prepare(
+          `
+            SELECT id, session_json
+            FROM chat_sessions
+            WHERE workspace_id = 'local'
+              AND id = ?
+          `
+        )
+        .get(sessionId) as ChatSessionRow | undefined;
+      if (!row) {
+        db.exec('COMMIT;');
+        return false;
+      }
+
+      const session = JSON.parse(row.session_json) as ChatSession;
+      session.updated = message.timestamp;
+      db.prepare(
+        `
+          UPDATE chat_sessions
+          SET session_json = ?, updated_at = ?
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      ).run(JSON.stringify({ ...session, messages: [] }), session.updated, sessionId);
+      db.prepare(
+        `
+          INSERT INTO chat_messages (
+            id,
+            workspace_id,
+            session_id,
+            task_id,
+            role,
+            agent,
+            model,
+            message_json,
+            created_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?)
+        `
+      ).run(
+        message.id,
+        sessionId,
+        session.taskId ?? null,
+        message.role,
+        message.agent ?? null,
+        message.model ?? null,
+        JSON.stringify(message),
+        message.timestamp
+      );
+      db.exec('COMMIT;');
+      return true;
+    } catch (error) {
+      db.exec('ROLLBACK;');
+      throw error;
+    }
+  }
+
   deleteSession(sessionId: string): boolean {
     const result = this.database
       .getConnection()
@@ -205,14 +268,7 @@ export class SqliteChatRepository {
       );
   }
 
-  listSquadMessages(
-    options: {
-      since?: string;
-      agent?: string;
-      limit?: number;
-      includeSystem?: boolean;
-    } = {}
-  ): SquadMessage[] {
+  listSquadMessages(options: SquadMessageListOptions = {}): SquadMessage[] {
     const clauses = ["workspace_id = 'local'"];
     const params: SQLInputValue[] = [];
     const sinceTimestamp =


### PR DESCRIPTION
## Summary

- move Markdown chat sessions, squad daily logs, and squad metadata behind a file repository
- preserve file formats while adding bounded no-follow reads, contained paths, locked atomic writes, and concurrent session append safety
- give the SQLite repository an atomic append operation instead of service-level read-modify-write
- keep SQLite metadata sidecars lazy so ordinary SQLite chat does not create Markdown storage
- remove direct filesystem persistence from ChatService
- ratchet the service filesystem boundary from 36 to 35

## Verification

- 4 focused chat repository and SQLite storage tests after compatibility correction
- 11 focused chat service and dual-storage parity tests
- shared and server builds
- service filesystem boundary check

## Risk

Low. Session Markdown, squad daily logs, metadata overlays, and SQLite schemas remain compatible. File-backed mutations are now bounded and atomic, and concurrent session appends no longer rely on service-level read-modify-write.

Refs #1186