### PR TITLE
refactor: move task persistence behind storage

### DIFF
--- a/docs/architecture/SERVICE-FILESYSTEM-BOUNDARY.md
+++ b/docs/architecture/SERVICE-FILESYSTEM-BOUNDARY.md
@@ -23,8 +23,7 @@ ignored. The command exits nonzero and names the file when it finds:
 
 `maximumEntries` must equal the number of classified exceptions. Any increase
 therefore requires a visible inventory and ratchet change in the same review.
-The remaining #1163 child issues own the reductions: #1186 covers coordination
-state, #1187 operational evidence, #1188 managed content, and #1189 final
-process I/O plus removal of the last compatibility exceptions. Each migration
-must delete its stale inventory entries and lower `maximumEntries` in the same
-change.
+The remaining #1163 child issues own the reductions: #1187 covers operational
+evidence, #1188 managed content, and #1189 final process I/O plus removal of the
+last compatibility exceptions. Each migration must delete its stale inventory
+entries and lower `maximumEntries` in the same change.

--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 35,
+  "maximumEntries": 34,
   "entries": [
     {
       "path": "server/src/services/agent-health-service.ts",
@@ -169,12 +169,6 @@
       "category": "authoritative-persistence",
       "owner": "#1187",
       "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
-    {
-      "path": "server/src/services/task-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1186",
-      "rationale": "Coordination-state storage migration is tracked in issue #1186."
     },
     {
       "path": "server/src/services/telemetry-service.ts",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -20,6 +20,7 @@
           "src/__tests__/broadcast-storage-service.test.ts",
           "src/__tests__/chat-repository.test.ts",
           "src/__tests__/chat-service.test.ts",
+          "src/__tests__/task-file-repository.test.ts",
           "src/__tests__/claude-code-provider.smoke.test.ts",
           "src/__tests__/claude-code-provider.test.ts",
           "src/__tests__/codex-app-server-provider.smoke.test.ts",

--- a/server/src/__tests__/task-file-repository.test.ts
+++ b/server/src/__tests__/task-file-repository.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, symlink, truncate, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { Task } from '@veritas-kanban/shared';
+import { FileTaskRepository } from '../storage/task-file-repository.js';
+
+function task(id = 'task_20260823_repo01', title = 'Repository task'): Task {
+  return {
+    id,
+    title,
+    description: 'initial',
+    type: 'code',
+    status: 'todo',
+    priority: 'medium',
+    created: '2026-08-23T00:00:00.000Z',
+    updated: '2026-08-23T00:00:00.000Z',
+    revision: 1,
+  };
+}
+
+describe('FileTaskRepository', () => {
+  let root: string;
+  let activeDir: string;
+  let archiveDir: string;
+  let repository: FileTaskRepository;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-task-repository-'));
+    activeDir = path.join(root, 'active');
+    archiveDir = path.join(root, 'archive');
+    repository = new FileTaskRepository({ activeDir, archiveDir });
+  });
+
+  afterEach(async () => {
+    repository.dispose();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('loads legacy Markdown and preserves tasks across repository restart', async () => {
+    await repository.ensureReady();
+    await writeFile(
+      path.join(activeDir, 'task_legacy-legacy-title.md'),
+      `---
+id: task_legacy
+title: Legacy Title
+type: code
+status: todo
+priority: high
+created: '2026-01-01T00:00:00.000Z'
+updated: '2026-01-02T00:00:00.000Z'
+---
+Legacy description.
+`,
+      'utf8'
+    );
+
+    await expect(repository.listActive()).resolves.toMatchObject([
+      { id: 'task_legacy', title: 'Legacy Title', description: 'Legacy description.' },
+    ]);
+
+    const created = task();
+    await repository.createActive(created);
+    const restarted = new FileTaskRepository({ activeDir, archiveDir });
+    await expect(restarted.findActiveById(created.id)).resolves.toMatchObject(created);
+    restarted.dispose();
+  });
+
+  it('serializes concurrent mutations and archive restoration without lost updates', async () => {
+    const original = task();
+    await repository.createActive(original);
+
+    const append = (value: string) =>
+      repository.withActiveMutation(original.id, async (current, persist) => {
+        const updated = {
+          ...current,
+          description: `${current.description}:${value}`,
+          revision: (current.revision ?? 1) + 1,
+          updated: `2026-08-23T00:00:0${value}.000Z`,
+        };
+        await persist(updated);
+        return updated;
+      });
+
+    await expect(Promise.all([append('1'), append('2')])).resolves.toHaveLength(2);
+    const mutated = await repository.findActiveById(original.id);
+    expect(mutated?.description).toBe('initial:1:2');
+
+    const archived = { ...mutated!, deletedBy: 'operator' };
+    await expect(repository.archiveActive(original.id, archived)).resolves.toBe(true);
+    await expect(repository.findActiveById(original.id)).resolves.toBeNull();
+    await expect(repository.findArchivedById(original.id)).resolves.toMatchObject({
+      deletedBy: 'operator',
+    });
+
+    const restored = {
+      ...archived,
+      status: 'done' as const,
+      deletedBy: undefined,
+      updated: '2026-08-23T00:00:03.000Z',
+    };
+    await expect(repository.restoreArchived(original.id, restored)).resolves.toBe(true);
+    await expect(repository.findActiveById(original.id)).resolves.toMatchObject(restored);
+    await expect(repository.findArchivedById(original.id)).resolves.toBeNull();
+  });
+
+  it('fails closed for unsafe state and treats absent tasks as normal misses', async () => {
+    await repository.ensureReady();
+    await expect(repository.findActiveById('../outside')).rejects.toThrow(/lookup ID/);
+    await expect(repository.deleteActive('missing')).resolves.toBe(false);
+    await expect(
+      repository.withActiveMutation('missing', async () => 'unexpected')
+    ).resolves.toBeNull();
+    await expect(repository.restoreArchived('missing', task('task_missing'))).resolves.toBe(false);
+
+    const outside = path.join(root, 'outside.md');
+    await writeFile(outside, 'outside', 'utf8');
+    await symlink(outside, path.join(activeDir, 'task_symlink-linked.md'));
+    await expect(repository.findActiveById('task_symlink')).resolves.toBeNull();
+
+    const oversized = path.join(activeDir, 'task_oversized-large.md');
+    await writeFile(oversized, '', 'utf8');
+    await truncate(oversized, 16 * 1024 * 1024 + 1);
+    await expect(repository.findActiveById('task_oversized')).rejects.toThrow(
+      /bounded regular file/
+    );
+    await expect(repository.listActive()).resolves.toEqual([]);
+  });
+});

--- a/server/src/__tests__/task-file-repository.test.ts
+++ b/server/src/__tests__/task-file-repository.test.ts
@@ -246,6 +246,7 @@ Legacy description.
       reviewComments: [{ file: 'server/src/file.ts', line: 12, content: 'Keep this.' }],
     };
     const descriptor = repository.describeActiveTask(reviewed);
+    expect(descriptor.filename).toBe('task_reviewed-reviewed-task.md');
     await repository.createActive(reviewed);
     await expect(readFile(descriptor.path, 'utf8')).resolves.toContain(
       '**server/src/file.ts:12** - Keep this.'

--- a/server/src/__tests__/task-file-repository.test.ts
+++ b/server/src/__tests__/task-file-repository.test.ts
@@ -1,8 +1,24 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, symlink, truncate, writeFile } from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  truncate,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
 import path from 'node:path';
 import type { Task } from '@veritas-kanban/shared';
 import { FileTaskRepository } from '../storage/task-file-repository.js';
+
+const { watchMock } = vi.hoisted(() => ({ watchMock: vi.fn() }));
+
+vi.mock('../storage/fs-helpers.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../storage/fs-helpers.js')>();
+  return { ...actual, watch: watchMock };
+});
 
 function task(id = 'task_20260823_repo01', title = 'Repository task'): Task {
   return {
@@ -25,6 +41,8 @@ describe('FileTaskRepository', () => {
   let repository: FileTaskRepository;
 
   beforeEach(async () => {
+    watchMock.mockReset();
+    watchMock.mockReturnValue({ close: vi.fn() });
     root = await mkdtemp(path.join(process.cwd(), '.veritas-task-repository-'));
     activeDir = path.join(root, 'active');
     archiveDir = path.join(root, 'archive');
@@ -124,5 +142,230 @@ Legacy description.
       /bounded regular file/
     );
     await expect(repository.listActive()).resolves.toEqual([]);
+  });
+
+  it('seeds examples once and reports unexpected seed storage errors', async () => {
+    const examplesDir = path.join(root, 'examples');
+    await mkdir(examplesDir);
+    await writeFile(
+      path.join(examplesDir, 'task_example-one.md'),
+      `---\nid: task_example\ntitle: Example\nupdated: '2026-08-23T00:00:00.000Z'\n---\nExample`,
+      'utf8'
+    );
+    await writeFile(path.join(examplesDir, 'ignored.txt'), 'ignored', 'utf8');
+
+    await expect(repository.seedExamplesIfEmpty()).resolves.toBe(1);
+    await expect(repository.findActiveById('task_example')).resolves.toMatchObject({
+      title: 'Example',
+    });
+    await expect(repository.seedExamplesIfEmpty()).resolves.toBe(0);
+
+    const brokenRoot = path.join(root, 'broken');
+    await mkdir(brokenRoot);
+    await writeFile(path.join(brokenRoot, 'examples'), 'not a directory', 'utf8');
+    const broken = new FileTaskRepository({
+      activeDir: path.join(brokenRoot, 'active'),
+      archiveDir: path.join(brokenRoot, 'archive'),
+    });
+    await expect(broken.seedExamplesIfEmpty()).rejects.toMatchObject({ code: 'ENOTDIR' });
+    broken.dispose();
+  });
+
+  it('rejects invalid identities and invalid mutation outcomes', async () => {
+    await expect(repository.createActive(task('invalid id'))).rejects.toThrow(/task ID format/);
+
+    const original = task('task_mutation', 'Original');
+    await repository.createActive(original);
+    await expect(
+      repository.withActiveMutation(original.id, async (current, persist) => {
+        await persist({ ...current, title: 'First' });
+        await persist({ ...current, title: 'Second' });
+      })
+    ).rejects.toThrow(/more than one persistence write/);
+    await expect(
+      repository.withActiveMutation(original.id, async (current, persist) => {
+        await persist({ ...current, id: 'task_changed' });
+      })
+    ).rejects.toThrow(/cannot change task identity/);
+
+    await writeFile(
+      path.join(activeDir, 'task_unreadable-bad.md'),
+      `---\nid: invalid.id\n---\ninvalid`,
+      'utf8'
+    );
+    await expect(
+      repository.withActiveMutation('task_unreadable', async () => 'unexpected')
+    ).resolves.toBeNull();
+  });
+
+  it('handles missing, unreadable, and identity-changing archive operations', async () => {
+    await repository.ensureReady();
+    await expect(repository.archiveActive('task_missing', task('task_missing'))).resolves.toBe(
+      false
+    );
+    await writeFile(
+      path.join(activeDir, 'task_badarchive-bad.md'),
+      `---\nid: invalid.id\n---\ninvalid`,
+      'utf8'
+    );
+    await expect(
+      repository.archiveActive('task_badarchive', task('task_badarchive'))
+    ).resolves.toBe(false);
+
+    const active = task('task_archiveidentity');
+    await repository.createActive(active);
+    await expect(repository.archiveActive(active.id, task('task_different'))).rejects.toThrow(
+      /Archived task identity/
+    );
+
+    await writeFile(
+      path.join(archiveDir, 'task_badrestore-bad.md'),
+      `---\nid: invalid.id\n---\ninvalid`,
+      'utf8'
+    );
+    await expect(
+      repository.restoreArchived('task_badrestore', task('task_badrestore'))
+    ).resolves.toBe(false);
+
+    const archived = task('task_restore');
+    await writeFile(
+      path.join(archiveDir, 'task_restore-restorable.md'),
+      `---\nid: task_restore\ntitle: Restorable\nupdated: '2026-08-23T00:00:00.000Z'\n---\nrestore`,
+      'utf8'
+    );
+    await expect(repository.restoreArchived(archived.id, () => null)).resolves.toBe(false);
+    await expect(repository.restoreArchived(archived.id, task('task_different'))).rejects.toThrow(
+      /Restored task identity/
+    );
+  });
+
+  it('exposes bounded diagnostics and preserves review comment serialization', async () => {
+    const reviewed = {
+      ...task('task_reviewed', '  Reviewed --- Task  '),
+      description: 'Description',
+      reviewComments: [{ file: 'server/src/file.ts', line: 12, content: 'Keep this.' }],
+    };
+    const descriptor = repository.describeActiveTask(reviewed);
+    await repository.createActive(reviewed);
+    await expect(readFile(descriptor.path, 'utf8')).resolves.toContain(
+      '**server/src/file.ts:12** - Keep this.'
+    );
+    await expect(repository.readActiveFile(descriptor.filename)).resolves.toMatchObject({
+      description: 'Description',
+    });
+    await expect(repository.readActiveFile('missing.md')).resolves.toBeNull();
+    await expect(repository.readActiveFile('../outside.md')).rejects.toThrow(/single path segment/);
+
+    expect(repository.getActiveDirectory()).toBe(activeDir);
+    expect(repository.getActiveDestinationPath()).toBe('active');
+    expect(repository.getIdentityScanSources(null)).toHaveLength(2);
+    expect(repository.getIdentityScanSources(path.join(root, 'backlog'))).toHaveLength(3);
+    expect(repository.describeIdentityCandidate(reviewed, 'active')).toMatchObject({
+      location: 'active',
+      taskId: reviewed.id,
+    });
+    expect(repository.describeIdentityCandidate(reviewed, 'archive')).toMatchObject({
+      location: 'archive',
+      taskId: reviewed.id,
+    });
+  });
+
+  it('tolerates malformed task files and strips legacy review sections', async () => {
+    await repository.ensureReady();
+    await writeFile(
+      path.join(activeDir, 'task_reviewsection-legacy.md'),
+      `---\nid: task_reviewsection\ntitle: Legacy\nupdated: '2026-08-23T00:00:00.000Z'\n---\nDescription\n\n## Review Comments\n\n- old`,
+      'utf8'
+    );
+    await writeFile(
+      path.join(activeDir, 'task_invalidid-invalid.md'),
+      `---\nid: invalid.id\n---\ninvalid`,
+      'utf8'
+    );
+    await writeFile(
+      path.join(activeDir, 'task_badyaml-invalid.md'),
+      `---\ninvalid: [\n---\ninvalid`,
+      'utf8'
+    );
+
+    await expect(repository.findActiveById('task_reviewsection')).resolves.toMatchObject({
+      description: 'Description',
+    });
+    await expect(repository.listActive()).resolves.toHaveLength(1);
+  });
+
+  it('handles watcher filtering, reloads, removal errors, and startup failure', async () => {
+    await repository.ensureReady();
+    await writeFile(
+      path.join(activeDir, 'task_watched-file.md'),
+      `---\nid: task_watched\ntitle: Watched\nupdated: '2026-08-23T00:00:00.000Z'\n---\nwatched`,
+      'utf8'
+    );
+    const listener = vi.fn();
+    repository.watchActive(listener);
+    repository.watchActive(listener);
+    expect(watchMock).toHaveBeenCalledTimes(1);
+    const callback = watchMock.mock.calls[0]?.[1] as (
+      eventType: string,
+      filename: string | null
+    ) => void;
+    callback('change', null);
+    callback('change', 'ignored.txt');
+    callback('change', 'task_watched-file.md');
+    await vi.waitFor(() =>
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filename: 'task_watched-file.md',
+          task: expect.objectContaining({ id: 'task_watched' }),
+        })
+      )
+    );
+
+    const readSpy = vi.spyOn(repository, 'readActiveFile');
+    readSpy.mockRejectedValueOnce(Object.assign(new Error('removed'), { code: 'ENOENT' }));
+    callback('rename', 'task_removed-file.md');
+    await vi.waitFor(() =>
+      expect(listener).toHaveBeenCalledWith({ filename: 'task_removed-file.md', task: null })
+    );
+    readSpy.mockRejectedValueOnce(new Error('reload failed'));
+    callback('change', 'task_failed-file.md');
+    await vi.waitFor(() => expect(readSpy).toHaveBeenCalledTimes(2));
+
+    const debounced = task('task_debounced');
+    await repository.createActive(debounced);
+    callback('change', repository.describeActiveTask(debounced).filename);
+
+    const failed = new FileTaskRepository({
+      activeDir: path.join(root, 'missing', 'active'),
+      archiveDir: path.join(root, 'missing', 'archive'),
+    });
+    watchMock.mockImplementationOnce(() => {
+      throw new Error('watch unavailable');
+    });
+    expect(() => failed.watchActive(vi.fn())).not.toThrow();
+    failed.dispose();
+  });
+
+  it('tolerates vanished rename sources but surfaces non-file unlink failures', async () => {
+    const vanished = task('task_vanished', 'Old');
+    await repository.createActive(vanished);
+    const vanishedPath = repository.describeActiveTask(vanished).path;
+    await expect(
+      repository.withActiveMutation(vanished.id, async (current, persist) => {
+        await unlink(vanishedPath);
+        await persist({ ...current, title: 'New' });
+      })
+    ).resolves.not.toBeNull();
+
+    const blocked = task('task_blockedunlink', 'Old');
+    await repository.createActive(blocked);
+    const blockedPath = repository.describeActiveTask(blocked).path;
+    await expect(
+      repository.withActiveMutation(blocked.id, async (current, persist) => {
+        await unlink(blockedPath);
+        await mkdir(blockedPath);
+        await persist({ ...current, title: 'New' });
+      })
+    ).rejects.toThrow();
   });
 });

--- a/server/src/services/backlog-service.ts
+++ b/server/src/services/backlog-service.ts
@@ -281,9 +281,9 @@ export class BacklogService {
     // Move file to active tasks directory
     await this.backlogRepo.moveToActive(id, activeTasksDir);
 
-    // Invalidate task service cache and reload to pick up the new task
+    // Reload the active repository cache to pick up the promoted task.
     this.invalidateIdentityCache();
-    await this.taskService['initCache'](); // Force cache reload
+    await this.taskService.reloadTaskCache();
 
     // Log activity
     await activityService.logActivity(
@@ -321,11 +321,11 @@ export class BacklogService {
     }
 
     // Move file to backlog directory
-    const activeTasksDir = this.taskService['tasksDir']; // Access private field
+    const activeTasksDir = this.taskService.getActiveTasksDir();
     await this.backlogRepo.moveFromActive(task, activeTasksDir);
 
     // Invalidate task from active cache
-    this.taskService['cacheInvalidate'](id); // Access private method
+    this.taskService.invalidateTaskCache(id);
     this.invalidateIdentityCache();
 
     // Log activity

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -1,13 +1,8 @@
-import fs from 'fs/promises';
-import { watch, batchedMap, atomicWriteFile, type FSWatcher } from '../storage/fs-helpers.js';
-import path from 'path';
-import matter from '../utils/frontmatter.js';
 import { nanoid } from 'nanoid';
 import type {
   Task,
   CreateTaskInput,
   UpdateTaskInput,
-  ReviewComment,
   TaskTelemetryEvent,
   TimeTracking,
   RunStartedEvent,
@@ -19,7 +14,6 @@ import type {
 import { normalizeBoardColumns, normalizeBoardDefaultStatus } from '@veritas-kanban/shared';
 import { getTelemetryService, type TelemetryService } from './telemetry-service.js';
 import { ConfigService } from './config-service.js';
-import { withFileLock } from './file-lock.js';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { fireHook, getHookEventForStatusChange } from './hook-service.js';
@@ -37,13 +31,13 @@ import { getWorkProductService } from './work-product-service.js';
 import { getTasksActiveDir, getTasksArchiveDir, getTasksBacklogDir } from '../utils/paths.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteTaskRepository } from '../storage/sqlite/task-repository.js';
+import { FileTaskRepository } from '../storage/task-file-repository.js';
 import {
   buildTaskIdentityConflictDetails,
   filterTaskIdentityDiagnostics,
   scanTaskIdentityDiagnostics,
   type TaskIdentityCandidate,
   type TaskIdentityDiagnostics,
-  type TaskIdentityLocation,
   type TaskIdentityScanSource,
 } from './task-identity-diagnostics.js';
 import { getCeremonyService, type CeremonyService } from './ceremony-service.js';
@@ -53,21 +47,9 @@ const TASK_SYNC_CONTEXT: TaskSyncContext = createTaskSyncToken('task-service');
 const TASK_RECONCILE_CONTEXT: TaskSyncContext = createTaskSyncToken('task-reconciler');
 
 /**
- * Task ID format validation
- * Production format: task_YYYYMMDD_XXXXXX (date + 6-char nanoid)
- * Legacy/test formats also accepted: task_YYYYMMDD_X{1,20} or task_WORD
- */
-const TASK_ID_REGEX = /^task_(\d{8}_[a-zA-Z0-9_-]{1,20}|[a-zA-Z0-9_-]+)$/;
-
-/**
  * Task types that require 4x10 review gate (when enforcement is enabled)
  */
 const CODE_TASK_TYPES = ['code', 'bug', 'feature', 'automation', 'system'];
-
-/** Validate task ID format */
-function isValidTaskId(id: string): boolean {
-  return TASK_ID_REGEX.test(id);
-}
 
 function normalizedTaskRevision(task: Pick<Task, 'revision'>): number {
   return typeof task.revision === 'number' && Number.isInteger(task.revision) && task.revision >= 0
@@ -84,15 +66,6 @@ interface BoardStatusConfig {
 type TaskMutationInput = UpdateTaskInput & {
   attemptPatch?: Pick<TaskAttempt, 'id'> & Partial<Omit<TaskAttempt, 'id'>>;
 };
-
-// Simple slug function to avoid CJS/ESM issues with slugify
-function makeSlug(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 50);
-}
 
 // Default paths are resolved via the shared paths utility so Docker, tests,
 // and local dev all agree on where tasks live.
@@ -121,6 +94,7 @@ export class TaskService {
   private telemetry: TelemetryService;
   private sqliteDatabase: SqliteDatabase | null = null;
   private sqliteTasks: SqliteTaskRepository | null = null;
+  private fileTasks: FileTaskRepository | null = null;
   private sqliteMutationQueue: Promise<unknown> = Promise.resolve();
   private configService: Pick<ConfigService, 'getFeatureSettings'>;
   private ceremonyService: Pick<CeremonyService, 'evaluateTaskCompletion'>;
@@ -129,20 +103,13 @@ export class TaskService {
   private cache: Map<string, Task> = new Map();
   private cacheInitialized = false;
   private cacheLoading: Promise<void> | null = null;
-  private watcher: FSWatcher | null = null;
-  private lastWriteTime = 0;
   private cacheStats = { hits: 0, misses: 0 };
   private taskSyncReconcileInterval: ReturnType<typeof setInterval> | null = null;
   private reconcileRunning = false;
 
-  // ============ Per-Task Mutex ============
-  // Keyed on task ID — not filepath — so all in-process mutations for the
-  // same task serialize even when the slug/filename changes between writes.
-  private taskMutexes = new Map<string, Promise<void>>();
-
   // ============ Identity Diagnostics Cache ============
   // Cached to avoid a full filesystem scan on every list request (#784).
-  // Invalidated by any mutation (markWrite path) and by external file changes.
+  // Invalidated by repository mutations and external file changes.
   private identityDiagnosticsCache: TaskIdentityDiagnostics | null = null;
 
   constructor(options: TaskServiceOptions = {}) {
@@ -161,6 +128,11 @@ export class TaskService {
         options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
       this.sqliteDatabase.open();
       this.sqliteTasks = new SqliteTaskRepository(this.sqliteDatabase);
+    } else {
+      this.fileTasks = new FileTaskRepository({
+        activeDir: this.tasksDir,
+        archiveDir: this.archiveDir,
+      });
     }
 
     this.startTaskSyncReconciler();
@@ -193,70 +165,12 @@ export class TaskService {
 
   /** Read every .md file in tasksDir and populate the cache */
   private async loadCacheFromDisk(): Promise<void> {
-    await this.ensureDirectories();
-    await this.seedIfEmpty();
-    const files = await fs.readdir(this.tasksDir);
-    const mdFiles = files.filter((f) => f.endsWith('.md'));
-
+    const fileTasks = this.requireFileTasks();
+    await fileTasks.ensureReady();
+    const seeded = await fileTasks.seedExamplesIfEmpty();
+    if (seeded > 0) log.info({ count: seeded }, 'Seeded example tasks for first run');
     this.cache.clear();
-
-    // Bounded-concurrency batch read — 10 files at a time.
-    // Individual read failures produce null (logged but don't abort the load).
-    const tasks = await batchedMap(mdFiles, async (filename) => {
-      const filepath = path.join(this.tasksDir, filename);
-      const content = await fs.readFile(filepath, 'utf-8');
-      return this.parseTaskFile(content, filename);
-    });
-
-    for (const task of tasks) {
-      if (task) {
-        this.cache.set(task.id, task);
-      }
-    }
-  }
-
-  /**
-   * First-run seed: if tasks/active/ is empty, copy example tasks from
-   * tasks/examples/ so new users see a populated board out of the box.
-   */
-  private async seedIfEmpty(): Promise<void> {
-    const files = await fs.readdir(this.tasksDir);
-    const hasTasks = files.some((f) => f.endsWith('.md'));
-    if (hasTasks) return;
-
-    const examplesDir = path.join(this.tasksDir, '..', 'examples');
-    try {
-      const examples = await fs.readdir(examplesDir);
-      const mdExamples = examples.filter((f) => f.endsWith('.md'));
-      if (mdExamples.length === 0) return;
-
-      await Promise.all(
-        mdExamples.map((filename) =>
-          fs.copyFile(path.join(examplesDir, filename), path.join(this.tasksDir, filename))
-        )
-      );
-      log.info({ count: mdExamples.length }, 'Seeded example tasks for first run');
-    } catch {
-      // examples/ doesn't exist — that's fine, skip silently
-    }
-  }
-
-  /** Reload a single file from disk into the cache */
-  private async reloadFile(filename: string): Promise<void> {
-    const filepath = path.join(this.tasksDir, filename);
-    // External file change also invalidates diagnostics cache (#784)
-    this.identityDiagnosticsCache = null;
-    try {
-      const content = await fs.readFile(filepath, 'utf-8');
-      const task = this.parseTaskFile(content, filename);
-      if (task) {
-        log.debug({ taskId: task.id }, 'Reloaded from disk');
-        this.cache.set(task.id, task);
-      }
-    } catch {
-      // File was deleted — find and remove matching cache entry
-      this.invalidateByFilename(filename);
-    }
+    for (const task of await fileTasks.listActive()) this.cache.set(task.id, task);
   }
 
   /** Remove a cache entry whose filename matches (used when a file is deleted externally) */
@@ -271,13 +185,20 @@ export class TaskService {
     }
   }
 
-  /** Invalidate a specific task by ID */
-  private cacheInvalidate(id: string): boolean {
+  /** Invalidate a specific task by ID. */
+  invalidateTaskCache(id: string): boolean {
     const deleted = this.cache.delete(id);
     if (deleted) {
       log.debug({ taskId: id }, 'Invalidated');
     }
     return deleted;
+  }
+
+  async reloadTaskCache(): Promise<void> {
+    if (this.sqliteTasks) return;
+    this.cacheInitialized = false;
+    this.cacheLoading = null;
+    await this.initCache();
   }
 
   private runSqliteMutation<T>(callback: () => Promise<T>): Promise<T> {
@@ -289,29 +210,9 @@ export class TaskService {
     return run;
   }
 
-  /**
-   * Serialize all in-process mutations for the given task ID.
-   *
-   * Uses the task ID as the queue key (not a filepath) so concurrent updates
-   * to the same task always serialize regardless of title / slug changes.
-   * The file lock inside still provides cross-process protection.
-   */
-  private withTaskMutex<T>(id: string, fn: () => Promise<T>): Promise<T> {
-    const previous = this.taskMutexes.get(id) ?? Promise.resolve();
-    let release!: () => void;
-    const myTurn = new Promise<void>((r) => {
-      release = r;
-    });
-    this.taskMutexes.set(id, myTurn);
-
-    return previous
-      .then(() => fn())
-      .finally(() => {
-        release();
-        if (this.taskMutexes.get(id) === myTurn) {
-          this.taskMutexes.delete(id);
-        }
-      });
+  private withTaskMutex<T>(id: string, callback: () => Promise<T>): Promise<T> {
+    if (this.fileTasks) return this.fileTasks.withTaskLock(id, callback);
+    return this.runSqliteMutation(callback);
   }
 
   /** Get a task from the cache */
@@ -333,40 +234,22 @@ export class TaskService {
     return tasks.sort((a, b) => new Date(b.updated).getTime() - new Date(a.updated).getTime());
   }
 
-  /** Record that we are about to write — suppresses watcher for WRITE_DEBOUNCE_MS */
-  private markWrite(): void {
-    this.lastWriteTime = Date.now();
-    // Invalidate diagnostics cache on any mutation (#784)
-    this.identityDiagnosticsCache = null;
-  }
-
   /** Start watching tasksDir for external file changes */
   private startWatcher(): void {
-    try {
-      this.watcher = watch(this.tasksDir, (eventType, filename) => {
-        if (!filename || !filename.endsWith('.md')) return;
-
-        // Ignore events caused by our own writes
-        if (Date.now() - this.lastWriteTime < WRITE_DEBOUNCE_MS) return;
-
-        log.debug({ eventType, filename }, 'File change detected');
-        // Re-read the changed file (or remove from cache if deleted)
-        this.reloadFile(filename).catch((err) =>
-          log.error({ err, filename }, 'Error reloading file')
-        );
-      });
-    } catch (err) {
-      // fs.watch can fail on some platforms or when dir doesn't exist yet
-      log.warn({ err }, 'Could not start file watcher');
-    }
+    this.fileTasks?.watchActive(({ filename, task }) => {
+      this.identityDiagnosticsCache = null;
+      if (!task) {
+        this.invalidateByFilename(filename);
+        return;
+      }
+      log.debug({ taskId: task.id }, 'Reloaded from disk');
+      this.cache.set(task.id, task);
+    });
   }
 
   /** Clean up watchers and cache. Call on server shutdown. */
   dispose(): void {
-    if (this.watcher) {
-      this.watcher.close();
-      this.watcher = null;
-    }
+    this.fileTasks?.dispose();
     if (this.taskSyncReconcileInterval) {
       clearInterval(this.taskSyncReconcileInterval);
       this.taskSyncReconcileInterval = null;
@@ -374,7 +257,7 @@ export class TaskService {
     this.sqliteDatabase?.close();
     this.sqliteDatabase = null;
     this.sqliteTasks = null;
-    this.taskMutexes.clear();
+    this.fileTasks = null;
     this.cache.clear();
     this.cacheInitialized = false;
     this.cacheLoading = null;
@@ -438,36 +321,24 @@ export class TaskService {
     return { cleaned, errors };
   }
 
-  private async ensureDirectories(): Promise<void> {
-    await fs.mkdir(this.tasksDir, { recursive: true });
-    await fs.mkdir(this.archiveDir, { recursive: true });
-  }
-
   getIdentityScanSources(): TaskIdentityScanSource[] {
     if (this.sqliteTasks) return [];
-    const sources: TaskIdentityScanSource[] = [
-      { location: 'active', dir: this.tasksDir },
-      { location: 'archive', dir: this.archiveDir },
-    ];
-    if (this.backlogDir) {
-      sources.push({ location: 'backlog', dir: this.backlogDir });
-    }
-    return sources;
+    return this.requireFileTasks().getIdentityScanSources(this.backlogDir);
   }
 
   getActiveTasksDir(): string {
-    return this.tasksDir;
+    return this.fileTasks?.getActiveDirectory() ?? this.tasksDir;
   }
 
   getActiveTasksDestinationPath(): string {
-    return this.diagnosticPath(this.tasksDir);
+    return this.fileTasks?.getActiveDestinationPath() ?? 'active';
   }
 
   async getTaskIdentityDiagnostics(
     extraSources: TaskIdentityScanSource[] = []
   ): Promise<TaskIdentityDiagnostics> {
     // Use cached result when no extra sources are requested (#784).
-    // The cache is invalidated by markWrite() and by external file changes.
+    // The cache is invalidated by repository mutations and external file changes.
     if (extraSources.length === 0) {
       if (!this.identityDiagnosticsCache) {
         this.identityDiagnosticsCache = await scanTaskIdentityDiagnostics(
@@ -531,175 +402,14 @@ export class TaskService {
     );
   }
 
-  private taskIdentityCandidate(
-    task: Task,
-    location: TaskIdentityLocation,
-    filepath: string
-  ): TaskIdentityCandidate {
-    return {
-      location,
-      path: filepath,
-      filename: path.basename(filepath),
-      taskId: task.id,
-      title: task.title,
-      git: task.git,
-      github: task.github,
-    };
-  }
-
-  private diagnosticPath(filepath: string): string {
-    return path.relative(path.dirname(this.tasksDir), filepath);
-  }
-
   private generateId(): string {
     const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     return `task_${date}_${nanoid(6)}`;
   }
 
-  private taskToFilename(task: Task): string {
-    const slug = makeSlug(task.title);
-    return `${task.id}-${slug}.md`;
-  }
-
-  /**
-   * Find the actual filename on disk for a task ID.
-   * Files are named `{id}-{slug}.md` but the slug may have changed since creation.
-   * Falls back to computed filename if no match found.
-   */
-  private async findTaskFile(dir: string, taskId: string): Promise<string | null> {
-    const files = await fs.readdir(dir);
-    // Files always start with `{taskId}-` prefix
-    const prefix = `${taskId}-`;
-    const match = files.find((f) => f.startsWith(prefix) && f.endsWith('.md'));
-    return match ?? null;
-  }
-
-  /**
-   * Find ALL files on disk for a task ID (handles stale files from title changes).
-   * Files are named `{id}-{slug}.md` but the slug changes when title is updated,
-   * leaving orphaned files behind. This method returns all matching files so they
-   * can be cleaned up together.
-   */
-  private async findAllTaskFiles(dir: string, taskId: string): Promise<string[]> {
-    const files = await fs.readdir(dir);
-    const prefix = `${taskId}-`;
-    return files.filter((f) => f.startsWith(prefix) && f.endsWith('.md'));
-  }
-
-  /** Recursively strip undefined values from an object (YAML can't serialize them) */
-  private deepCleanUndefined(obj: Record<string, any>): Record<string, any> {
-    const clean: Record<string, any> = {};
-    for (const [key, value] of Object.entries(obj)) {
-      if (value === undefined) continue;
-      if (Array.isArray(value)) {
-        clean[key] = value.map((item) =>
-          item && typeof item === 'object' && !Array.isArray(item)
-            ? this.deepCleanUndefined(item)
-            : item
-        );
-      } else if (value && typeof value === 'object') {
-        clean[key] = this.deepCleanUndefined(value);
-      } else {
-        clean[key] = value;
-      }
-    }
-    return clean;
-  }
-
-  private taskToMarkdown(task: Task): string {
-    const { description, reviewComments, ...rest } = task;
-
-    // Filter out undefined values (YAML can't serialize them)
-    const frontmatter = this.deepCleanUndefined(rest);
-
-    const content = matter.stringify(description || '', frontmatter);
-
-    // Add review comments section if present
-    if (reviewComments && reviewComments.length > 0) {
-      const commentsSection = reviewComments
-        .map((c: ReviewComment) => `- **${c.file}:${c.line}** - ${c.content}`)
-        .join('\n');
-      return content + '\n\n## Review Comments\n\n' + commentsSection;
-    }
-
-    return content;
-  }
-
-  private parseTaskFile(content: string, filename: string): Task | null {
-    try {
-      const { data, content: description } = matter(content);
-
-      // Extract review comments from description if present
-      let cleanDescription = description;
-      const reviewComments: Task['reviewComments'] = [];
-
-      const reviewSection = description.indexOf('## Review Comments');
-      if (reviewSection !== -1) {
-        cleanDescription = description.slice(0, reviewSection).trim();
-      }
-
-      // Validate required fields
-      const id = data.id || filename.split('-')[0];
-      if (!isValidTaskId(id)) {
-        log.warn({ filename, id }, 'Invalid task ID format');
-        return null;
-      }
-
-      return {
-        id,
-        title: data.title || 'Untitled',
-        description: cleanDescription.trim(),
-        type: data.type || 'code',
-        status: data.status || 'todo',
-        priority: data.priority || 'medium',
-        project: data.project,
-        sprint: data.sprint,
-        agent: data.agent,
-        agents: data.agents,
-        executionPolicy: data.executionPolicy,
-        created: data.created || new Date().toISOString(),
-        updated: data.updated || new Date().toISOString(),
-        git: data.git,
-        github: data.github,
-        delegatedWork: data.delegatedWork,
-        externalWorkItems: data.externalWorkItems,
-        attempt: data.attempt,
-        attempts: data.attempts,
-        reviewComments,
-        reviewScores: data.reviewScores,
-        review: data.review,
-        subtasks: data.subtasks,
-        autoCompleteOnSubtasks: data.autoCompleteOnSubtasks,
-        blockedBy: data.blockedBy,
-        blockedReason: data.blockedReason,
-        automation: data.automation,
-        timeTracking: data.timeTracking,
-        comments: data.comments,
-        observations: data.observations,
-        attachments: data.attachments,
-        position: data.position,
-        costPrediction: data.costPrediction,
-        actualCost: data.actualCost,
-        lessonsLearned: data.lessonsLearned,
-        lessonTags: data.lessonTags,
-        checkpoint: data.checkpoint,
-        verificationSteps: data.verificationSteps,
-        deliverables: data.deliverables,
-        dependencies: data.dependencies,
-        runMode: data.runMode,
-        qaGate: data.qaGate,
-        deletedAt: data.deletedAt,
-        deletedBy: data.deletedBy,
-        purgeAfter: data.purgeAfter,
-        revision:
-          typeof data.revision === 'number' && Number.isInteger(data.revision) && data.revision >= 0
-            ? data.revision
-            : undefined,
-      };
-    } catch (error) {
-      log.error({ err: error, filename }, 'Failed to parse task file');
-      return null;
-    }
+  private requireFileTasks(): FileTaskRepository {
+    if (!this.fileTasks) throw new Error('File task repository is not configured');
+    return this.fileTasks;
   }
 
   private syncAgentRegistryForStatusTransition(task: Task): void {
@@ -867,21 +577,16 @@ export class TaskService {
       const sqliteTasks = this.sqliteTasks;
       await this.runSqliteMutation(() => sqliteTasks.create(task));
     } else {
-      const filename = this.taskToFilename(task);
-      const filepath = path.join(this.tasksDir, filename);
-      const content = this.taskToMarkdown(task);
+      const fileTasks = this.requireFileTasks();
+      const descriptor = fileTasks.describeActiveTask(task);
 
       await this.assertTaskIdentityIntegrity('task.create', task.id, {
-        candidates: [this.taskIdentityCandidate(task, 'active', filepath)],
-        destinationPath: this.diagnosticPath(filepath),
+        candidates: [fileTasks.describeIdentityCandidate(task, 'active')],
+        destinationPath: descriptor.diagnosticPath,
       });
 
-      await withFileLock(filepath, async () => {
-        this.markWrite();
-        await atomicWriteFile(filepath, content, 'utf-8');
-      });
-
-      // Write-through: update cache immediately
+      await fileTasks.createActive(task);
+      this.identityDiagnosticsCache = null;
       this.cache.set(task.id, task);
     }
 
@@ -902,10 +607,7 @@ export class TaskService {
   }
 
   async updateTask(id: string, input: UpdateTaskInput): Promise<Task | null> {
-    if (this.sqliteTasks) {
-      return this.updateTaskMutation(id, input);
-    }
-    return this.withTaskMutex(id, () => this.updateTaskMutation(id, input));
+    return this.updateTaskMutation(id, input);
   }
 
   async patchTaskAttempt(
@@ -916,10 +618,7 @@ export class TaskService {
     const input: TaskMutationInput = {
       attemptPatch: { id: attemptId, ...patch },
     };
-    if (this.sqliteTasks) {
-      return this.updateTaskMutation(id, input);
-    }
-    return this.withTaskMutex(id, () => this.updateTaskMutation(id, input));
+    return this.updateTaskMutation(id, input);
   }
 
   private async updateTaskMutation(id: string, input: TaskMutationInput): Promise<Task | null> {
@@ -941,25 +640,28 @@ export class TaskService {
       ...restInput
     } = input;
 
-    // Compute the current file path for locking. We lock on the CURRENT filepath
-    // so the file lock provides cross-process protection. Additionally, we wrap
-    // the entire mutation in withTaskMutex (keyed on task ID) to ensure all
-    // in-process updates for the same task serialize even when the slug changes.
-    const oldFilename = this.taskToFilename(task);
-    const lockPath = path.join(this.tasksDir, oldFilename);
-
     let updatedTask!: Task;
     let shouldGenerateCompletionPacket = false;
     let attemptPatchApplied = attemptPatch === undefined;
+    let fileMutationTask: Task | null = null;
+    let persistFileTask: ((updated: Task) => Promise<void>) | null = null;
+    let mutationFound = true;
     const runMutation = async (callback: () => Promise<void>): Promise<void> => {
       if (this.sqliteTasks) {
         await this.runSqliteMutation(callback);
         return;
       }
 
-      // File lock provides cross-process protection.
-      // updateTask provides in-process serialization by task ID.
-      await withFileLock(lockPath, callback);
+      const result = await this.requireFileTasks().withActiveMutation(
+        id,
+        async (current, persist) => {
+          fileMutationTask = current;
+          persistFileTask = persist;
+          await callback();
+          return true;
+        }
+      );
+      mutationFound = result !== null;
     };
 
     await runMutation(async () => {
@@ -968,7 +670,7 @@ export class TaskService {
       // timer start) from overwriting each other's changes.
       const freshTask = this.sqliteTasks
         ? ((await this.sqliteTasks.findById(id)) ?? task)
-        : (this.cacheGet(id) ?? task);
+        : (fileMutationTask ?? task);
 
       if (attemptPatch && freshTask.attempt?.id !== attemptPatch.id) {
         updatedTask = freshTask;
@@ -1203,35 +905,19 @@ export class TaskService {
       if (this.sqliteTasks) {
         await this.sqliteTasks.replaceActive(updatedTask);
       } else {
-        // Compute destination filepath inside the lock from the fresh task state.
-        // The new filename may differ from lockPath when the title changed.
-        const freshOldFilename = this.taskToFilename(freshTask);
-        const newFilename = this.taskToFilename(updatedTask);
-        const filepath = path.join(this.tasksDir, newFilename);
+        const fileTasks = this.requireFileTasks();
+        const descriptor = fileTasks.describeActiveTask(updatedTask);
 
         await this.assertTaskIdentityIntegrity('task.update', id, {
-          candidates: [this.taskIdentityCandidate(updatedTask, 'active', filepath)],
-          destinationPath: this.diagnosticPath(filepath),
+          candidates: [fileTasks.describeIdentityCandidate(updatedTask, 'active')],
+          destinationPath: descriptor.diagnosticPath,
           excludeTaskIds: [id],
         });
 
-        const content = this.taskToMarkdown(updatedTask);
-        this.markWrite();
-
-        // Write new content atomically first; only then remove the old slug file.
-        // This ensures the task is never unrecoverable: if the write fails,
-        // the old file is still present under its original name.
-        await atomicWriteFile(filepath, content, 'utf-8');
-
-        if (freshOldFilename !== newFilename) {
-          // Remove the old slug only after the replacement file is installed.
-          await fs.unlink(path.join(this.tasksDir, freshOldFilename)).catch((err) => {
-            if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
-            throw err;
-          });
-        }
-
-        // Write-through: update cache immediately (inside lock for consistency)
+        const persist = persistFileTask;
+        if (!persist) throw new Error('File task mutation persistence is unavailable');
+        await persist(updatedTask);
+        this.identityDiagnosticsCache = null;
         this.cache.set(updatedTask.id, updatedTask);
       }
 
@@ -1350,6 +1036,7 @@ export class TaskService {
       }
     });
 
+    if (!mutationFound) return null;
     if (!attemptPatchApplied) {
       return null;
     }
@@ -1377,42 +1064,20 @@ export class TaskService {
       return this.runSqliteMutation(() => sqliteTasks.deleteActive(id));
     }
 
-    return this.withTaskMutex(id, async () => {
-      await this.assertTaskIdentityIntegrity('task.delete', id, {
-        allowSameLocationTaskIdDuplicates: true,
-      });
-      const task = await this.getTaskWithoutIdentityCheck(id);
-      if (!task) return false;
-
-      // Find ALL files on disk with this task ID (handles orphaned slug variations)
-      const allFilenames = await this.findAllTaskFiles(this.tasksDir, id);
-      if (allFilenames.length === 0) {
-        log.warn({ taskId: id }, 'No task files found on disk for deletion');
-        return false;
-      }
-
-      // Delete ALL matching files (cleanup orphaned files from title changes)
-      await Promise.all(
-        allFilenames.map(async (filename) => {
-          const filepath = path.join(this.tasksDir, filename);
-          await withFileLock(filepath, async () => {
-            this.markWrite();
-            await fs.unlink(filepath);
-          });
-          log.debug({ taskId: id, filename }, 'Deleted task file');
-        })
-      );
-
-      // Remove from cache
-      this.cacheInvalidate(id);
-
-      // Delete attachments
-      const { getAttachmentService } = await import('./attachment-service.js');
-      const attachmentService = getAttachmentService();
-      await attachmentService.deleteAllAttachments(id);
-
-      return true;
+    await this.assertTaskIdentityIntegrity('task.delete', id, {
+      allowSameLocationTaskIdDuplicates: true,
     });
+    const task = await this.getTaskWithoutIdentityCheck(id);
+    if (!task) return false;
+
+    const deleted = await this.requireFileTasks().deleteActive(id);
+    if (!deleted) return false;
+    this.identityDiagnosticsCache = null;
+    this.invalidateTaskCache(id);
+
+    const { getAttachmentService } = await import('./attachment-service.js');
+    await getAttachmentService().deleteAllAttachments(id);
+    return true;
   }
 
   async archiveTask(
@@ -1451,72 +1116,43 @@ export class TaskService {
       return true;
     }
 
-    return this.withTaskMutex(id, async () => {
-      await this.assertTaskIdentityIntegrity('task.archive', id, {
-        allowSameLocationTaskIdDuplicates: true,
-      });
-      const freshTask = await this.getTaskWithoutIdentityCheck(id);
-      if (!freshTask) return false;
-
-      const freshArchivedTask: Task = {
+    await this.assertTaskIdentityIntegrity('task.archive', id, {
+      allowSameLocationTaskIdDuplicates: true,
+    });
+    const archiveResult: { task?: Task } = {};
+    const archived = await this.requireFileTasks().archiveActive(id, (freshTask) => {
+      archiveResult.task = {
         ...freshTask,
         updated: new Date().toISOString(),
         deletedAt: options?.deletedAt ?? freshTask.deletedAt,
         deletedBy: options?.deletedBy ?? freshTask.deletedBy,
         purgeAfter: options?.purgeAfter ?? freshTask.purgeAfter,
       };
-      const archivedContent = this.taskToMarkdown(freshArchivedTask);
-
-      // Find ALL files on disk with this task ID (handles orphaned slug variations)
-      const allFilenames = await this.findAllTaskFiles(this.tasksDir, id);
-      if (allFilenames.length === 0) {
-        log.warn({ taskId: id }, 'No task files found on disk for archiving');
-        return false;
-      }
-
-      // Archive ALL matching files (cleanup orphaned files from title changes)
-      await Promise.all(
-        allFilenames.map(async (filename) => {
-          const sourcePath = path.join(this.tasksDir, filename);
-          const destPath = path.join(this.archiveDir, filename);
-          await withFileLock(sourcePath, async () => {
-            this.markWrite();
-            // Install the archive copy before removing the active source.
-            await atomicWriteFile(destPath, archivedContent, 'utf-8');
-            await fs.unlink(sourcePath);
-          });
-          log.debug({ taskId: id, filename }, 'Archived task file');
-        })
-      );
-
-      // Remove from active cache (archived tasks are not cached)
-      this.cacheInvalidate(id);
-
-      // Move attachments to archive
-      const { getAttachmentService } = await import('./attachment-service.js');
-      const attachmentService = getAttachmentService();
-      await attachmentService.archiveAttachments(id);
-
-      // Delete progress file (cleanup when archived)
-      const { getProgressService } = await import('./progress-service.js');
-      const progressService = getProgressService();
-      await progressService.deleteProgress(id);
-
-      // Emit telemetry event
-      await this.telemetry.emit<TaskTelemetryEvent>({
-        type: 'task.archived',
-        taskId: freshArchivedTask.id,
-        project: freshArchivedTask.project,
-        status: freshArchivedTask.status,
-      });
-
-      // Fire onArchived hook
-      fireHook('onArchived', freshArchivedTask).catch((err) => {
-        log.warn({ taskId: freshArchivedTask.id }, 'onArchived hook failed: %s', err);
-      });
-
-      return true;
+      return archiveResult.task;
     });
+    const freshArchivedTask = archiveResult.task;
+    if (!archived || !freshArchivedTask) return false;
+    this.identityDiagnosticsCache = null;
+    this.invalidateTaskCache(id);
+
+    const { getAttachmentService } = await import('./attachment-service.js');
+    await getAttachmentService().archiveAttachments(id);
+
+    const { getProgressService } = await import('./progress-service.js');
+    await getProgressService().deleteProgress(id);
+
+    await this.telemetry.emit<TaskTelemetryEvent>({
+      type: 'task.archived',
+      taskId: freshArchivedTask.id,
+      project: freshArchivedTask.project,
+      status: freshArchivedTask.status,
+    });
+
+    fireHook('onArchived', freshArchivedTask).catch((err) => {
+      log.warn({ taskId: freshArchivedTask!.id }, 'onArchived hook failed: %s', err);
+    });
+
+    return true;
   }
 
   async listArchivedTasks(): Promise<Task[]> {
@@ -1524,36 +1160,14 @@ export class TaskService {
       return this.sqliteTasks.listArchived();
     }
 
-    await this.ensureDirectories();
-
-    const files = await fs.readdir(this.archiveDir);
-    const mdFiles = files.filter((f) => f.endsWith('.md'));
-
-    // Bounded-concurrency batch read — 10 files at a time.
-    // Individual read/parse failures produce null and are filtered out;
-    // one bad archive file never aborts the entire listing.
-    const results = await batchedMap(mdFiles, async (filename) => {
-      const filepath = path.join(this.archiveDir, filename);
-      const content = await fs.readFile(filepath, 'utf-8');
-      return this.parseTaskFile(content, filename);
-    });
-
-    // Filter out nulls (failed reads or invalid task files)
-    const tasks = results.filter((t): t is Task => t !== null);
-
-    // Sort by updated date, newest first
-    return tasks.sort(
-      (a: Task, b: Task) => new Date(b.updated).getTime() - new Date(a.updated).getTime()
-    );
+    return this.requireFileTasks().listArchived();
   }
 
   async getArchivedTask(id: string): Promise<Task | null> {
     if (this.sqliteTasks) {
       return this.sqliteTasks.findArchivedById(id);
     }
-
-    const tasks = await this.listArchivedTasks();
-    return tasks.find((t) => t.id === id) || null;
+    return this.requireFileTasks().findArchivedById(id);
   }
 
   private isRestoreWindowExpired(task: Task): boolean {
@@ -1593,23 +1207,11 @@ export class TaskService {
       return restoredTask;
     }
 
-    return this.withTaskMutex(id, async () => {
-      await this.assertTaskIdentityIntegrity('task.restore', id);
-      const freshTask = await this.getArchivedTask(id);
-      if (!freshTask || this.isRestoreWindowExpired(freshTask)) return null;
-
-      // Find actual file on disk (slug may differ from current title)
-      const actualFilename = await this.findTaskFile(this.archiveDir, id);
-      if (!actualFilename) {
-        log.warn({ taskId: id }, 'Archived task file not found on disk for restoration');
-        return null;
-      }
-
-      const sourcePath = path.join(this.archiveDir, actualFilename);
-      const destPath = path.join(this.tasksDir, actualFilename);
-
-      // Update status to done
-      const restoredTask: Task = {
+    await this.assertTaskIdentityIntegrity('task.restore', id);
+    const restoreResult: { task?: Task } = {};
+    const restored = await this.requireFileTasks().restoreArchived(id, (freshTask) => {
+      if (this.isRestoreWindowExpired(freshTask)) return null;
+      restoreResult.task = {
         ...freshTask,
         status: 'done',
         updated: new Date().toISOString(),
@@ -1617,34 +1219,25 @@ export class TaskService {
         deletedBy: undefined,
         purgeAfter: undefined,
       };
-
-      const content = this.taskToMarkdown(restoredTask);
-
-      await withFileLock(destPath, async () => {
-        // Install the active copy before removing the archive source.
-        this.markWrite();
-        await atomicWriteFile(destPath, content, 'utf-8');
-        await fs.unlink(sourcePath);
-      });
-
-      // Restore attachments from archive
-      const { getAttachmentService } = await import('./attachment-service.js');
-      const attachmentService = getAttachmentService();
-      await attachmentService.restoreAttachments(id);
-
-      // Write-through: add restored task to active cache
-      this.cache.set(restoredTask.id, restoredTask);
-
-      // Emit telemetry event
-      await this.telemetry.emit<TaskTelemetryEvent>({
-        type: 'task.restored',
-        taskId: restoredTask.id,
-        project: restoredTask.project,
-        status: restoredTask.status,
-      });
-
-      return restoredTask;
+      return restoreResult.task;
     });
+    const restoredTask = restoreResult.task;
+    if (!restored || !restoredTask) return null;
+    this.identityDiagnosticsCache = null;
+
+    const { getAttachmentService } = await import('./attachment-service.js');
+    await getAttachmentService().restoreAttachments(id);
+
+    this.cache.set(restoredTask.id, restoredTask);
+
+    await this.telemetry.emit<TaskTelemetryEvent>({
+      type: 'task.restored',
+      taskId: restoredTask.id,
+      project: restoredTask.project,
+      status: restoredTask.status,
+    });
+
+    return restoredTask;
   }
 
   /**

--- a/server/src/storage/task-file-repository.ts
+++ b/server/src/storage/task-file-repository.ts
@@ -1,0 +1,529 @@
+import { constants } from 'node:fs';
+import { copyFile, lstat, mkdir, open, readdir, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import type { ReviewComment, Task } from '@veritas-kanban/shared';
+import matter from '../utils/frontmatter.js';
+import { createLogger } from '../lib/logger.js';
+import { withFileLock } from '../services/file-lock.js';
+import type {
+  TaskIdentityCandidate,
+  TaskIdentityLocation,
+  TaskIdentityScanSource,
+} from '../services/task-identity-diagnostics.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import { atomicWriteFile, batchedMap, watch, type FSWatcher } from './fs-helpers.js';
+
+const log = createLogger('task-file-repository');
+const MAX_TASK_FILE_BYTES = 16 * 1024 * 1024;
+const WRITE_DEBOUNCE_MS = 200;
+const TASK_ID_REGEX = /^task_(\d{8}_[a-zA-Z0-9_-]{1,20}|[a-zA-Z0-9_-]+)$/;
+
+export interface FileTaskRepositoryOptions {
+  activeDir: string;
+  archiveDir: string;
+}
+
+export interface TaskFileDescriptor {
+  path: string;
+  filename: string;
+  diagnosticPath: string;
+}
+
+export interface TaskFileChange {
+  filename: string;
+  task: Task | null;
+}
+
+type ActiveMutation<T> = (current: Task, persist: (updated: Task) => Promise<void>) => Promise<T>;
+
+function makeSlug(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+function assertTaskId(id: string): void {
+  if (!TASK_ID_REGEX.test(id)) {
+    throw new Error('Invalid task ID format');
+  }
+}
+
+function assertLookupId(id: string): void {
+  if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) {
+    throw new Error('Invalid task lookup ID');
+  }
+}
+
+export class FileTaskRepository {
+  private readonly activeDir: string;
+  private readonly archiveDir: string;
+  private readonly taskRoot: string;
+  private ready: Promise<void> | null = null;
+  private watcher: FSWatcher | null = null;
+  private lastWriteTime = 0;
+  private readonly taskMutexes = new Map<string, Promise<void>>();
+
+  constructor(options: FileTaskRepositoryOptions) {
+    this.activeDir = path.resolve(options.activeDir);
+    this.archiveDir = path.resolve(options.archiveDir);
+    this.taskRoot = path.dirname(this.activeDir);
+  }
+
+  ensureReady(): Promise<void> {
+    if (!this.ready) {
+      this.ready = Promise.all([
+        mkdir(this.activeDir, { recursive: true }),
+        mkdir(this.archiveDir, { recursive: true }),
+      ]).then(() => undefined);
+    }
+    return this.ready;
+  }
+
+  async seedExamplesIfEmpty(): Promise<number> {
+    await this.ensureReady();
+    const activeEntries = await readdir(this.activeDir, { withFileTypes: true });
+    if (activeEntries.some((entry) => entry.isFile() && entry.name.endsWith('.md'))) return 0;
+
+    const examplesDir = ensureWithinBase(this.taskRoot, path.join(this.taskRoot, 'examples'));
+    try {
+      const examples = await readdir(examplesDir, { withFileTypes: true });
+      const markdownExamples = examples.filter(
+        (entry) => entry.isFile() && !entry.isSymbolicLink() && entry.name.endsWith('.md')
+      );
+      await Promise.all(
+        markdownExamples.map((entry) =>
+          copyFile(
+            this.containedFile(examplesDir, entry.name),
+            this.containedFile(this.activeDir, entry.name)
+          )
+        )
+      );
+      return markdownExamples.length;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0;
+      throw error;
+    }
+  }
+
+  async listActive(): Promise<Task[]> {
+    await this.ensureReady();
+    const tasks = await this.listTasksIn(this.activeDir);
+    return this.sortNewestFirst(tasks);
+  }
+
+  async findActiveById(id: string): Promise<Task | null> {
+    assertLookupId(id);
+    await this.ensureReady();
+    return this.findTaskIn(this.activeDir, id);
+  }
+
+  async createActive(task: Task): Promise<void> {
+    assertTaskId(task.id);
+    await this.ensureReady();
+    await this.withTaskLock(task.id, async () => {
+      await withFileLock(this.taskLockPath(task.id), async () => {
+        const descriptor = this.describeActive(task);
+        this.markWrite();
+        await atomicWriteFile(descriptor.path, this.taskToMarkdown(task), 'utf8');
+      });
+    });
+  }
+
+  async withActiveMutation<T>(id: string, mutation: ActiveMutation<T>): Promise<T | null> {
+    assertLookupId(id);
+    await this.ensureReady();
+    return this.withTaskLock(id, () =>
+      withFileLock(this.taskLockPath(id), async () => {
+        const currentFile = await this.findTaskFilename(this.activeDir, id);
+        if (!currentFile) return null;
+        const current = await this.readTask(this.activeDir, currentFile);
+        if (!current) return null;
+
+        let persisted = false;
+        const persist = async (updated: Task): Promise<void> => {
+          if (persisted) throw new Error('Task mutation attempted more than one persistence write');
+          if (updated.id !== id) throw new Error('Task mutation cannot change task identity');
+          persisted = true;
+
+          const destination = this.describeActive(updated);
+          this.markWrite();
+          await atomicWriteFile(destination.path, this.taskToMarkdown(updated), 'utf8');
+          if (currentFile !== destination.filename) {
+            await this.unlinkOptional(this.containedFile(this.activeDir, currentFile));
+          }
+        };
+
+        return mutation(current, persist);
+      })
+    );
+  }
+
+  async deleteActive(id: string): Promise<boolean> {
+    assertLookupId(id);
+    await this.ensureReady();
+    return this.withTaskLock(id, () =>
+      withFileLock(this.taskLockPath(id), async () => {
+        const filenames = await this.findTaskFilenames(this.activeDir, id);
+        if (filenames.length === 0) return false;
+        this.markWrite();
+        await Promise.all(
+          filenames.map((filename) => unlink(this.containedFile(this.activeDir, filename)))
+        );
+        return true;
+      })
+    );
+  }
+
+  async archiveActive(id: string, archive: Task | ((current: Task) => Task)): Promise<boolean> {
+    assertLookupId(id);
+    await this.ensureReady();
+    return this.withTaskLock(id, () =>
+      withFileLock(this.taskLockPath(id), async () => {
+        const filenames = await this.findTaskFilenames(this.activeDir, id);
+        if (filenames.length === 0) return false;
+        const current = await this.findNewestTaskIn(this.activeDir, filenames);
+        if (!current) return false;
+        const archivedTask = typeof archive === 'function' ? archive(current) : archive;
+        if (archivedTask.id !== id) throw new Error('Archived task identity does not match');
+        const content = this.taskToMarkdown(archivedTask);
+        this.markWrite();
+        await Promise.all(
+          filenames.map(async (filename) => {
+            await atomicWriteFile(this.containedFile(this.archiveDir, filename), content, 'utf8');
+            await unlink(this.containedFile(this.activeDir, filename));
+          })
+        );
+        return true;
+      })
+    );
+  }
+
+  async listArchived(): Promise<Task[]> {
+    await this.ensureReady();
+    return this.sortNewestFirst(await this.listTasksIn(this.archiveDir));
+  }
+
+  async findArchivedById(id: string): Promise<Task | null> {
+    assertLookupId(id);
+    await this.ensureReady();
+    return this.findTaskIn(this.archiveDir, id);
+  }
+
+  async restoreArchived(
+    id: string,
+    restore: Task | ((current: Task) => Task | null)
+  ): Promise<boolean> {
+    assertLookupId(id);
+    await this.ensureReady();
+    return this.withTaskLock(id, () =>
+      withFileLock(this.taskLockPath(id), async () => {
+        const archivedFilename = await this.findTaskFilename(this.archiveDir, id);
+        if (!archivedFilename) return false;
+        const current = await this.readTask(this.archiveDir, archivedFilename);
+        if (!current) return false;
+        const restoredTask = typeof restore === 'function' ? restore(current) : restore;
+        if (!restoredTask) return false;
+        if (restoredTask.id !== id) throw new Error('Restored task identity does not match');
+        const destination = this.describeActive(restoredTask);
+        this.markWrite();
+        await atomicWriteFile(destination.path, this.taskToMarkdown(restoredTask), 'utf8');
+        await unlink(this.containedFile(this.archiveDir, archivedFilename));
+        return true;
+      })
+    );
+  }
+
+  async readActiveFile(filename: string): Promise<Task | null> {
+    await this.ensureReady();
+    return this.readTask(this.activeDir, filename);
+  }
+
+  watchActive(listener: (change: TaskFileChange) => void): void {
+    if (this.watcher) return;
+    try {
+      this.watcher = watch(this.activeDir, (_eventType, filename) => {
+        if (!filename || !filename.endsWith('.md')) return;
+        if (Date.now() - this.lastWriteTime < WRITE_DEBOUNCE_MS) return;
+        this.readActiveFile(filename)
+          .then((task) => listener({ filename, task }))
+          .catch((error) => {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+              listener({ filename, task: null });
+              return;
+            }
+            log.error({ err: error, filename }, 'Error reloading task file');
+          });
+      });
+    } catch (error) {
+      log.warn({ err: error }, 'Could not start task file watcher');
+    }
+  }
+
+  getIdentityScanSources(backlogDir: string | null): TaskIdentityScanSource[] {
+    const sources: TaskIdentityScanSource[] = [
+      { location: 'active', dir: this.activeDir },
+      { location: 'archive', dir: this.archiveDir },
+    ];
+    if (backlogDir) sources.push({ location: 'backlog', dir: backlogDir });
+    return sources;
+  }
+
+  getActiveDirectory(): string {
+    return this.activeDir;
+  }
+
+  getActiveDestinationPath(): string {
+    return this.diagnosticPath(this.activeDir);
+  }
+
+  describeActiveTask(task: Task): TaskFileDescriptor {
+    return this.describeActive(task);
+  }
+
+  describeIdentityCandidate(task: Task, location: TaskIdentityLocation): TaskIdentityCandidate {
+    const descriptor =
+      location === 'archive' ? this.describeTask(this.archiveDir, task) : this.describeActive(task);
+    return {
+      location,
+      path: descriptor.path,
+      filename: descriptor.filename,
+      taskId: task.id,
+      title: task.title,
+      git: task.git,
+      github: task.github,
+    };
+  }
+
+  dispose(): void {
+    this.watcher?.close();
+    this.watcher = null;
+    this.taskMutexes.clear();
+  }
+
+  private async listTasksIn(directory: string): Promise<Task[]> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const filenames = entries
+      .filter((entry) => entry.isFile() && !entry.isSymbolicLink() && entry.name.endsWith('.md'))
+      .map((entry) => entry.name);
+    const tasks = await batchedMap(filenames, (filename) => this.readTask(directory, filename));
+    return tasks.filter((task): task is Task => task !== null);
+  }
+
+  private async findTaskIn(directory: string, id: string): Promise<Task | null> {
+    const filenames = await this.findTaskFilenames(directory, id);
+    return this.findNewestTaskIn(directory, filenames);
+  }
+
+  private async findNewestTaskIn(directory: string, filenames: string[]): Promise<Task | null> {
+    const tasks = await Promise.all(
+      filenames.map((filename) => this.readTask(directory, filename))
+    );
+    const parsed = tasks.filter((task): task is Task => task !== null);
+    return this.sortNewestFirst(parsed)[0] ?? null;
+  }
+
+  private async findTaskFilename(directory: string, id: string): Promise<string | null> {
+    return (await this.findTaskFilenames(directory, id))[0] ?? null;
+  }
+
+  private async findTaskFilenames(directory: string, id: string): Promise<string[]> {
+    assertLookupId(id);
+    const entries = await readdir(directory, { withFileTypes: true });
+    const prefix = `${id}-`;
+    return entries
+      .filter(
+        (entry) =>
+          entry.isFile() &&
+          !entry.isSymbolicLink() &&
+          entry.name.startsWith(prefix) &&
+          entry.name.endsWith('.md')
+      )
+      .map((entry) => entry.name)
+      .sort();
+  }
+
+  private async readTask(directory: string, filename: string): Promise<Task | null> {
+    const filePath = this.containedFile(directory, filename);
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+      const [pathStats, stats] = await Promise.all([lstat(filePath), handle.stat()]);
+      if (
+        pathStats.isSymbolicLink() ||
+        pathStats.dev !== stats.dev ||
+        pathStats.ino !== stats.ino ||
+        !stats.isFile() ||
+        stats.size > MAX_TASK_FILE_BYTES
+      ) {
+        throw new Error('Task storage requires a bounded regular file');
+      }
+      return this.parseTaskFile(await handle.readFile({ encoding: 'utf8' }), filename);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private parseTaskFile(content: string, filename: string): Task | null {
+    try {
+      const { data, content: description } = matter(content);
+      let cleanDescription = description;
+      const reviewComments: Task['reviewComments'] = [];
+      const reviewSection = description.indexOf('## Review Comments');
+      if (reviewSection !== -1) cleanDescription = description.slice(0, reviewSection).trim();
+
+      const id = data.id || filename.split('-')[0];
+      if (!TASK_ID_REGEX.test(id)) {
+        log.warn({ filename, id }, 'Invalid task ID format');
+        return null;
+      }
+
+      return {
+        id,
+        title: data.title || 'Untitled',
+        description: cleanDescription.trim(),
+        type: data.type || 'code',
+        status: data.status || 'todo',
+        priority: data.priority || 'medium',
+        project: data.project,
+        sprint: data.sprint,
+        agent: data.agent,
+        agents: data.agents,
+        executionPolicy: data.executionPolicy,
+        created: data.created || new Date().toISOString(),
+        updated: data.updated || new Date().toISOString(),
+        git: data.git,
+        github: data.github,
+        delegatedWork: data.delegatedWork,
+        externalWorkItems: data.externalWorkItems,
+        attempt: data.attempt,
+        attempts: data.attempts,
+        reviewComments,
+        reviewScores: data.reviewScores,
+        review: data.review,
+        subtasks: data.subtasks,
+        autoCompleteOnSubtasks: data.autoCompleteOnSubtasks,
+        blockedBy: data.blockedBy,
+        blockedReason: data.blockedReason,
+        automation: data.automation,
+        timeTracking: data.timeTracking,
+        comments: data.comments,
+        observations: data.observations,
+        attachments: data.attachments,
+        position: data.position,
+        costPrediction: data.costPrediction,
+        actualCost: data.actualCost,
+        lessonsLearned: data.lessonsLearned,
+        lessonTags: data.lessonTags,
+        checkpoint: data.checkpoint,
+        verificationSteps: data.verificationSteps,
+        deliverables: data.deliverables,
+        dependencies: data.dependencies,
+        runMode: data.runMode,
+        qaGate: data.qaGate,
+        deletedAt: data.deletedAt,
+        deletedBy: data.deletedBy,
+        purgeAfter: data.purgeAfter,
+        revision:
+          typeof data.revision === 'number' && Number.isInteger(data.revision) && data.revision >= 0
+            ? data.revision
+            : undefined,
+      };
+    } catch (error) {
+      log.error({ err: error, filename }, 'Failed to parse task file');
+      return null;
+    }
+  }
+
+  private taskToMarkdown(task: Task): string {
+    const { description, reviewComments, ...rest } = task;
+    const content = matter.stringify(description || '', this.deepCleanUndefined(rest));
+    if (!reviewComments?.length) return content;
+    const comments = reviewComments
+      .map((comment: ReviewComment) => `- **${comment.file}:${comment.line}** - ${comment.content}`)
+      .join('\n');
+    return `${content}\n\n## Review Comments\n\n${comments}`;
+  }
+
+  private deepCleanUndefined(value: Record<string, unknown>): Record<string, unknown> {
+    const clean: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (entry === undefined) continue;
+      if (Array.isArray(entry)) {
+        clean[key] = entry.map((item) =>
+          item && typeof item === 'object' && !Array.isArray(item)
+            ? this.deepCleanUndefined(item as Record<string, unknown>)
+            : item
+        );
+      } else if (entry && typeof entry === 'object') {
+        clean[key] = this.deepCleanUndefined(entry as Record<string, unknown>);
+      } else {
+        clean[key] = entry;
+      }
+    }
+    return clean;
+  }
+
+  private describeActive(task: Task): TaskFileDescriptor {
+    return this.describeTask(this.activeDir, task);
+  }
+
+  private describeTask(directory: string, task: Task): TaskFileDescriptor {
+    assertTaskId(task.id);
+    const filename = `${task.id}-${makeSlug(task.title)}.md`;
+    const filePath = this.containedFile(directory, filename);
+    return { path: filePath, filename, diagnosticPath: this.diagnosticPath(filePath) };
+  }
+
+  private diagnosticPath(filePath: string): string {
+    return path.relative(this.taskRoot, filePath);
+  }
+
+  private containedFile(directory: string, filename: string): string {
+    const safeFilename = path.basename(filename);
+    if (safeFilename !== filename) throw new Error('Task filename must be a single path segment');
+    return ensureWithinBase(directory, path.join(directory, safeFilename));
+  }
+
+  private taskLockPath(id: string): string {
+    assertLookupId(id);
+    return this.containedFile(this.activeDir, `.${id}.task`);
+  }
+
+  private markWrite(): void {
+    this.lastWriteTime = Date.now();
+  }
+
+  private async unlinkOptional(filePath: string): Promise<void> {
+    try {
+      await unlink(filePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+
+  private sortNewestFirst(tasks: Task[]): Task[] {
+    return tasks.sort(
+      (left, right) => new Date(right.updated).getTime() - new Date(left.updated).getTime()
+    );
+  }
+
+  withTaskLock<T>(id: string, callback: () => Promise<T>): Promise<T> {
+    assertLookupId(id);
+    const previous = this.taskMutexes.get(id) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.taskMutexes.set(id, current);
+
+    return previous.then(callback).finally(() => {
+      release();
+      if (this.taskMutexes.get(id) === current) this.taskMutexes.delete(id);
+    });
+  }
+}

--- a/server/src/storage/task-file-repository.ts
+++ b/server/src/storage/task-file-repository.ts
@@ -40,7 +40,8 @@ function makeSlug(text: string): string {
   return text
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '')
     .slice(0, 50);
 }
 

--- a/server/src/storage/task-file-repository.ts
+++ b/server/src/storage/task-file-repository.ts
@@ -37,12 +37,12 @@ export interface TaskFileChange {
 type ActiveMutation<T> = (current: Task, persist: (updated: Task) => Promise<void>) => Promise<T>;
 
 function makeSlug(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+/, '')
-    .replace(/-+$/, '')
-    .slice(0, 50);
+  const normalized = text.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  let start = 0;
+  let end = normalized.length;
+  while (normalized[start] === '-') start += 1;
+  while (normalized[end - 1] === '-') end -= 1;
+  return normalized.slice(start, end).slice(0, 50);
 }
 
 function assertTaskId(id: string): void {


### PR DESCRIPTION
## Summary

- move active-task Markdown parsing, serialization, seeding, watching, and bounded no-follow reads behind a deep file repository
- centralize stable per-task locking, atomic replacement, concurrent mutation, orphan cleanup, archive, restore, and delete behavior
- preserve TaskService APIs, file formats, SQLite behavior, identity diagnostics, cache semantics, and backlog promotion/demotion integration
- add restart, legacy-data, concurrent mutation, archive/restore, traversal, symlink, oversized-state, and missing-state repository contracts
- remove the final #1186 service filesystem import and ratchet the boundary from 35 to 34

## Verification

- 43 focused file repository, TaskService, SQLite, and revision-atomicity tests
- shared and server builds
- service filesystem boundary check
- focused standards and issue-spec review

## Risk

Moderate. This relocates the complete file-backed task persistence lifecycle while preserving the existing Markdown schema and TaskService behavior. SQLite persistence is unchanged. The new repository uses stable task-ID locks and installs replacement/archive copies before removing prior files.

Fixes #1186
