### PR TITLE
refactor: isolate audit file storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,13 +1,7 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 34,
+  "maximumEntries": 31,
   "entries": [
-    {
-      "path": "server/src/services/agent-health-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1187",
-      "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
     {
       "path": "server/src/services/attachment-service.ts",
       "category": "compatibility-debt",
@@ -25,12 +19,6 @@
       "category": "transient-process-io",
       "owner": "#1189",
       "rationale": "Remaining process I/O migration is tracked in issue #1189."
-    },
-    {
-      "path": "server/src/services/codex-health-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1187",
-      "rationale": "Operational evidence storage migration is tracked in issue #1187."
     },
     {
       "path": "server/src/services/config-service.ts",
@@ -91,12 +79,6 @@
       "category": "compatibility-debt",
       "owner": "#1188",
       "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
-    {
-      "path": "server/src/services/metrics/task-metrics.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1187",
-      "rationale": "Operational evidence storage migration is tracked in issue #1187."
     },
     {
       "path": "server/src/services/metrics/telemetry-reader.ts",

--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 31,
+  "maximumEntries": 29,
   "entries": [
     {
       "path": "server/src/services/attachment-service.ts",
@@ -81,12 +81,6 @@
       "rationale": "Managed-content storage migration is tracked in issue #1188."
     },
     {
-      "path": "server/src/services/metrics/telemetry-reader.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1187",
-      "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
-    {
       "path": "server/src/services/notification-service.ts",
       "category": "authoritative-persistence",
       "owner": "#1187",
@@ -148,12 +142,6 @@
     },
     {
       "path": "server/src/services/task-identity-diagnostics.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1187",
-      "rationale": "Operational evidence storage migration is tracked in issue #1187."
-    },
-    {
-      "path": "server/src/services/telemetry-service.ts",
       "category": "authoritative-persistence",
       "owner": "#1187",
       "rationale": "Operational evidence storage migration is tracked in issue #1187."

--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,18 +1,12 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 29,
+  "maximumEntries": 28,
   "entries": [
     {
       "path": "server/src/services/attachment-service.ts",
       "category": "compatibility-debt",
       "owner": "#1188",
       "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
-    {
-      "path": "server/src/services/audit-service.ts",
-      "category": "authoritative-persistence",
-      "owner": "#1187",
-      "rationale": "Operational evidence storage migration is tracked in issue #1187."
     },
     {
       "path": "server/src/services/clawdbot-agent-service.ts",

--- a/server/src/services/agent-health-service.ts
+++ b/server/src/services/agent-health-service.ts
@@ -1,10 +1,11 @@
-import fs from 'fs/promises';
-import { constants as fsConstants } from 'fs';
-import path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import type { AgentConfig } from '@veritas-kanban/shared';
 import { hasClaudeCodeBareAuthentication } from './claude-code-adapter.js';
+import {
+  OperationalMetadataRepository,
+  operationalMetadataRepository,
+} from '../storage/operational-metadata-repository.js';
 
 const execFileAsync = promisify(execFile);
 const PROVIDER_VERSION_TIMEOUT_MS = 5_000;
@@ -64,7 +65,10 @@ export interface AgentHealthChecker {
 }
 
 export class AgentHealthService implements AgentHealthChecker {
-  constructor(private readonly runCommand: AgentHealthCommandRunner = defaultCommandRunner) {}
+  constructor(
+    private readonly runCommand: AgentHealthCommandRunner = defaultCommandRunner,
+    private readonly operationalMetadata: OperationalMetadataRepository = operationalMetadataRepository
+  ) {}
 
   async checkAgent(agent: AgentConfig): Promise<AgentHealthStatus> {
     const checkedAt = new Date().toISOString();
@@ -98,14 +102,8 @@ export class AgentHealthService implements AgentHealthChecker {
   private async findExecutable(command: string): Promise<{ found: boolean; path?: string }> {
     if (!command.trim()) return { found: false };
 
-    if (command.includes(path.sep)) {
-      try {
-        await fs.access(command, fsConstants.X_OK);
-        return { found: true, path: command };
-      } catch {
-        return { found: false };
-      }
-    }
+    const directPath = await this.operationalMetadata.probeExecutablePath(command);
+    if (directPath.directPath) return { found: directPath.found, path: directPath.path };
 
     try {
       const { stdout } = await this.runCommand('which', [command]);
@@ -119,7 +117,7 @@ export class AgentHealthService implements AgentHealthChecker {
     agent: AgentConfig,
     versionProbe: ProviderVersionProbe
   ): Promise<{ authenticated: boolean | null; error?: string; diagnostics?: string[] }> {
-    const command = path.basename(agent.command);
+    const command = this.operationalMetadata.basename(agent.command);
     const provider = agent.provider ?? '';
 
     if (provider === 'codex-cloud' || command === 'gh') {
@@ -264,7 +262,7 @@ export class AgentHealthService implements AgentHealthChecker {
     command: string,
     args: string[]
   ): Promise<ProviderVersionProbe> {
-    const source = `${path.basename(command)} ${args.join(' ')}`;
+    const source = `${this.operationalMetadata.basename(command)} ${args.join(' ')}`;
     try {
       const { stdout, stderr } = await this.runCommand(command, args, {
         timeout: PROVIDER_VERSION_TIMEOUT_MS,

--- a/server/src/services/audit-service.ts
+++ b/server/src/services/audit-service.ts
@@ -7,14 +7,11 @@
  * Log files are stored as JSONL (one JSON object per line) with monthly rotation:
  *   {dataDir}/audit/audit-{YYYY-MM}.log
  */
-import fs from 'fs/promises';
-import { createReadStream } from 'fs';
-import path from 'path';
 import crypto from 'crypto';
-import readline from 'readline';
 import { createLogger } from '../lib/logger.js';
 import { SqliteDatabase } from '../storage/sqlite/database.js';
 import { SqliteAuditRepository } from '../storage/sqlite/audit-policy-repositories.js';
+import { AuditFileRepository } from '../storage/audit-file-repository.js';
 
 const log = createLogger('audit');
 
@@ -57,6 +54,7 @@ import { getAuditDir } from '../utils/paths.js';
 
 const AUDIT_DIR = getAuditDir();
 const SQLITE_AUDIT_LOG_PATH = 'sqlite://audit/current';
+const auditFileRepository = new AuditFileRepository(AUDIT_DIR);
 
 // ---------------------------------------------------------------------------
 // Internal State
@@ -89,21 +87,19 @@ function logFilePath(date: Date = new Date()): string {
     return SQLITE_AUDIT_LOG_PATH;
   }
 
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const month = `${yyyy}-${mm}`;
+  const month = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
 
   // Cache to avoid path.join on every write
   if (month !== currentMonth) {
     currentMonth = month;
-    currentLogPath = path.join(AUDIT_DIR, `audit-${month}.log`);
+    currentLogPath = auditFileRepository.getMonthlyLogPath(date);
   }
   return currentLogPath;
 }
 
 /** Ensure the audit directory exists. */
 async function ensureAuditDir(): Promise<void> {
-  await fs.mkdir(AUDIT_DIR, { recursive: true });
+  await auditFileRepository.ensureReady();
 }
 
 function isSqliteAuditEnabled(): boolean {
@@ -131,22 +127,7 @@ async function seedLastHash(filePath: string): Promise<void> {
     return;
   }
 
-  try {
-    const content = await fs.readFile(filePath, 'utf8');
-    const lines = content.trimEnd().split('\n').filter(Boolean);
-    if (lines.length > 0) {
-      lastHash = sha256(lines[lines.length - 1]);
-    } else {
-      lastHash = '';
-    }
-  } catch (err: unknown) {
-    // File doesn't exist yet — first entry
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      lastHash = '';
-    } else {
-      throw err;
-    }
-  }
+  lastHash = await auditFileRepository.getLastHash(filePath);
 }
 
 /** Track whether we've seeded for the current file. */
@@ -198,7 +179,7 @@ async function writeEntry(event: AuditEvent): Promise<void> {
   if (isSqliteAuditEnabled()) {
     getAuditRepository().save(entry, line);
   } else {
-    await fs.appendFile(filePath, line + '\n', 'utf8');
+    await auditFileRepository.append(filePath, line);
   }
 
   // Update the running hash
@@ -216,71 +197,7 @@ export async function verifyAuditLog(filePath: string): Promise<VerifyResult> {
     return getAuditRepository().verify();
   }
 
-  // Check if file exists
-  try {
-    await fs.access(filePath);
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { valid: true, entries: 0 };
-    }
-    throw err;
-  }
-
-  return new Promise((resolve, reject) => {
-    const stream = createReadStream(filePath, { encoding: 'utf8' });
-    const rl = readline.createInterface({
-      input: stream,
-      crlfDelay: Infinity,
-    });
-
-    let prevHash = '';
-    let lineIndex = 0;
-    let totalLines = 0;
-    let invalidResult: VerifyResult | null = null;
-
-    rl.on('line', (line) => {
-      if (invalidResult) return; // Already found an error
-
-      const trimmed = line.trim();
-      if (!trimmed) {
-        lineIndex++;
-        return;
-      }
-
-      totalLines++;
-
-      let entry: AuditEntry;
-      try {
-        entry = JSON.parse(trimmed) as AuditEntry;
-      } catch {
-        invalidResult = { valid: false, entries: totalLines, firstBroken: lineIndex };
-        rl.close();
-        stream.destroy();
-        return;
-      }
-
-      if (entry.integrity !== prevHash) {
-        invalidResult = { valid: false, entries: totalLines, firstBroken: lineIndex };
-        rl.close();
-        stream.destroy();
-        return;
-      }
-
-      prevHash = sha256(trimmed);
-      lineIndex++;
-    });
-
-    rl.on('close', () => {
-      if (invalidResult) {
-        resolve(invalidResult);
-      } else {
-        resolve({ valid: true, entries: totalLines });
-      }
-    });
-
-    rl.on('error', reject);
-    stream.on('error', reject);
-  });
+  return auditFileRepository.verify(filePath);
 }
 
 /**
@@ -293,20 +210,7 @@ export async function readRecentAuditEntries(limit = 100): Promise<AuditEntry[]>
     return getAuditRepository().readRecent(limit) as AuditEntry[];
   }
 
-  let content: string;
-  try {
-    content = await fs.readFile(filePath, 'utf8');
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return [];
-    }
-    throw err;
-  }
-
-  const lines = content.trimEnd().split('\n').filter(Boolean);
-  // Take the last `limit` entries and reverse for newest-first
-  const slice = lines.slice(-limit).reverse();
-  return slice.map((line) => JSON.parse(line) as AuditEntry);
+  return auditFileRepository.readRecent(filePath, limit);
 }
 
 /**

--- a/server/src/services/codex-health-service.ts
+++ b/server/src/services/codex-health-service.ts
@@ -1,7 +1,10 @@
 import { execFile } from 'child_process';
-import { readFile } from 'fs/promises';
 import { promisify } from 'util';
 import { ConfigService } from './config-service.js';
+import {
+  OperationalMetadataRepository,
+  operationalMetadataRepository,
+} from '../storage/operational-metadata-repository.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -38,7 +41,9 @@ export interface CodexHealthStatus {
 export class CodexHealthService {
   private configService: ConfigService;
 
-  constructor() {
+  constructor(
+    private readonly operationalMetadata: OperationalMetadataRepository = operationalMetadataRepository
+  ) {
     this.configService = new ConfigService();
   }
 
@@ -111,12 +116,9 @@ export class CodexHealthService {
       await import('@openai/codex-sdk');
       const moduleUrl = import.meta.resolve('@openai/codex-sdk');
       const packageUrl = new URL('../package.json', moduleUrl);
-      const packageMetadata = JSON.parse(await readFile(packageUrl, 'utf8')) as {
-        version?: unknown;
-      };
       return {
         available: true,
-        version: typeof packageMetadata.version === 'string' ? packageMetadata.version : undefined,
+        version: await this.operationalMetadata.readPackageVersion(packageUrl),
       };
     } catch (error: any) {
       return { available: false, error: error.message || 'Codex SDK is not available' };

--- a/server/src/services/metrics/task-metrics.ts
+++ b/server/src/services/metrics/task-metrics.ts
@@ -1,11 +1,13 @@
 /**
  * Task-related metrics: task counts by status and sprint velocity.
  */
-import fs from 'fs/promises';
-import path from 'path';
 import type { BlockedCategory } from '@veritas-kanban/shared';
 import { TaskService } from '../task-service.js';
 import { getRuntimeDir } from '../../utils/paths.js';
+import {
+  OperationalMetadataRepository,
+  operationalMetadataRepository,
+} from '../../storage/operational-metadata-repository.js';
 import type {
   TaskMetrics,
   VelocityTrend,
@@ -101,7 +103,8 @@ export async function computeTaskMetrics(
 export async function computeVelocityMetrics(
   taskService: TaskService,
   project?: string,
-  limit = 10
+  limit = 10,
+  operationalMetadata: OperationalMetadataRepository = operationalMetadataRepository
 ): Promise<VelocityMetrics> {
   // Get all tasks (active + archived) to calculate velocity
   const [activeTasks, archivedTasks] = await Promise.all([
@@ -112,12 +115,8 @@ export async function computeVelocityMetrics(
   // Load sprint labels from sprints.json for display
   const sprintLabels = new Map<string, string>();
   try {
-    const sprintsFile = path.join(getRuntimeDir(), 'sprints.json');
-    const sprintsData = await fs.readFile(sprintsFile, 'utf-8');
-    const sprints = JSON.parse(sprintsData) as Array<{ id: string; label: string }>;
-    for (const s of sprints) {
-      sprintLabels.set(s.id, s.label);
-    }
+    const persistedLabels = await operationalMetadata.readSprintLabels(getRuntimeDir());
+    for (const [id, label] of persistedLabels) sprintLabels.set(id, label);
   } catch {
     // No sprints file or can't read it - will use IDs as labels
   }

--- a/server/src/services/metrics/telemetry-reader.ts
+++ b/server/src/services/metrics/telemetry-reader.ts
@@ -2,15 +2,11 @@
  * Telemetry file I/O utilities.
  * Handles reading NDJSON event files (plain and gzipped) with streaming support.
  */
-import { createReadStream } from '../../storage/fs-helpers.js';
-import fs from 'fs/promises';
-import path from 'path';
-import readline from 'readline';
-import { createGunzip } from 'zlib';
 import type { SQLInputValue } from 'node:sqlite';
 import type { AnyTelemetryEvent, TelemetryEventType, StreamEventHandler } from './types.js';
 import { createLogger } from '../../lib/logger.js';
 import { SqliteDatabase } from '../../storage/sqlite/database.js';
+import { TelemetryFileRepository } from '../../storage/telemetry-file-repository.js';
 const log = createLogger('telemetry-reader');
 
 interface SqliteTelemetryPayloadRow {
@@ -27,14 +23,15 @@ interface SqliteTelemetryStartRow {
  */
 export async function getEventFiles(telemetryDir: string, since: string | null): Promise<string[]> {
   try {
-    const files = await fs.readdir(telemetryDir);
+    const repository = new TelemetryFileRepository(telemetryDir);
+    const files = await repository.listFiles();
     const eventFiles = files.filter(
       (f) => f.startsWith('events-') && (f.endsWith('.ndjson') || f.endsWith('.ndjson.gz'))
     );
 
     if (!since) {
       // Return all event files (for 'all' period)
-      return eventFiles.map((f) => path.join(telemetryDir, f));
+      return eventFiles.map((f) => repository.eventPath(f));
     }
 
     const sinceDate = since.slice(0, 10);
@@ -44,7 +41,7 @@ export async function getEventFiles(telemetryDir: string, since: string | null):
         if (!match) return false;
         return match[1] >= sinceDate;
       })
-      .map((f) => path.join(telemetryDir, f));
+      .map((f) => repository.eventPath(f));
   } catch (error: any) {
     if (error.code === 'ENOENT') {
       return [];
@@ -56,21 +53,8 @@ export async function getEventFiles(telemetryDir: string, since: string | null):
 /**
  * Create a readline interface for an event file (handles both .ndjson and .ndjson.gz)
  */
-export function createLineReader(filePath: string): readline.Interface {
-  if (filePath.endsWith('.gz')) {
-    const fileStream = createReadStream(filePath);
-    const gunzip = createGunzip();
-    const decompressed = fileStream.pipe(gunzip);
-    return readline.createInterface({
-      input: decompressed,
-      crlfDelay: Infinity,
-    });
-  }
-  const fileStream = createReadStream(filePath, { encoding: 'utf-8' });
-  return readline.createInterface({
-    input: fileStream,
-    crlfDelay: Infinity,
-  });
+export function createLineReader(filePath: string) {
+  return TelemetryFileRepository.createLineReader(filePath);
 }
 
 /**

--- a/server/src/services/telemetry-service.ts
+++ b/server/src/services/telemetry-service.ts
@@ -1,10 +1,4 @@
-import fs from 'fs/promises';
-import { createReadStream, createWriteStream } from '../storage/fs-helpers.js';
-import path from 'path';
 import { getTelemetryDir } from '../utils/paths.js';
-import { createGzip, createGunzip } from 'zlib';
-import { pipeline } from 'stream/promises';
-import readline from 'readline';
 import { nanoid } from 'nanoid';
 import type {
   TelemetryEvent,
@@ -17,6 +11,7 @@ import { createLogger } from '../lib/logger.js';
 import type { TelemetryRepository } from '../storage/interfaces.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteTelemetryRepository } from '../storage/sqlite/telemetry-repository.js';
+import { TelemetryFileRepository } from '../storage/telemetry-file-repository.js';
 const log = createLogger('telemetry-service');
 
 // Default paths - resolve via shared paths helper (respects DATA_DIR/VERITAS_DATA_DIR)
@@ -53,9 +48,11 @@ export class TelemetryService {
   private repository: TelemetryRepository | null = null;
   private sqliteDatabase: SqliteDatabase | null = null;
   private ownsSqliteDatabase = false;
+  private readonly fileRepository: TelemetryFileRepository;
 
   constructor(options: TelemetryServiceOptions = {}) {
     this.telemetryDir = options.telemetryDir || TELEMETRY_DIR;
+    this.fileRepository = new TelemetryFileRepository(this.telemetryDir);
 
     // Read retention from env var, falling back to options, then default
     const envRetention = process.env.TELEMETRY_RETENTION_DAYS;
@@ -102,7 +99,7 @@ export class TelemetryService {
       return;
     }
 
-    await fs.mkdir(this.telemetryDir, { recursive: true });
+    await this.fileRepository.ensureReady();
     await this.cleanupOldEvents();
     this.initialized = true;
   }
@@ -372,11 +369,11 @@ export class TelemetryService {
     }
 
     await this.init();
-    const files = await fs.readdir(this.telemetryDir);
+    const files = await this.fileRepository.listFiles();
 
     for (const file of files) {
       if (file.endsWith('.ndjson') || file.endsWith('.ndjson.gz')) {
-        await fs.unlink(path.join(this.telemetryDir, file));
+        await this.fileRepository.remove(file);
       }
     }
   }
@@ -482,10 +479,9 @@ export class TelemetryService {
    */
   private async writeEvent(event: TelemetryEvent): Promise<void> {
     const filename = this.getFilenameForDate(new Date(event.timestamp));
-    const filepath = path.join(this.telemetryDir, filename);
     const line = JSON.stringify(event) + '\n';
 
-    await fs.appendFile(filepath, line, 'utf-8');
+    await this.fileRepository.append(filename, line);
   }
 
   /**
@@ -497,49 +493,15 @@ export class TelemetryService {
     filename: string,
     callback: (event: AnyTelemetryEvent) => boolean | void
   ): Promise<void> {
-    const filepath = path.join(this.telemetryDir, filename);
-    const isGzipped = filename.endsWith('.gz');
-
-    try {
-      await fs.access(filepath);
-    } catch {
-      return; // File doesn't exist
-    }
-
-    return new Promise((resolve, reject) => {
-      let stream = createReadStream(filepath);
-
-      if (isGzipped) {
-        const gunzip = createGunzip();
-        stream = stream.pipe(gunzip) as unknown as ReturnType<typeof createReadStream>;
+    if (!(await this.fileRepository.exists(filename))) return;
+    await this.fileRepository.streamLines(filename, (line) => {
+      if (!line.trim()) return;
+      try {
+        const event = JSON.parse(line) as AnyTelemetryEvent;
+        return callback(event);
+      } catch {
+        log.error({ err: line }, '[Telemetry] Failed to parse line');
       }
-
-      const rl = readline.createInterface({
-        input: stream as NodeJS.ReadableStream,
-        crlfDelay: Infinity,
-      });
-
-      let stopped = false;
-
-      rl.on('line', (line) => {
-        if (stopped || !line.trim()) return;
-
-        try {
-          const event = JSON.parse(line) as AnyTelemetryEvent;
-          const shouldContinue = callback(event);
-          if (shouldContinue === false) {
-            stopped = true;
-            rl.close();
-            stream.destroy();
-          }
-        } catch {
-          log.error({ err: line }, '[Telemetry] Failed to parse line');
-        }
-      });
-
-      rl.on('close', () => resolve());
-      rl.on('error', reject);
-      stream.on('error', reject);
     });
   }
 
@@ -559,7 +521,7 @@ export class TelemetryService {
    * Get list of event files within a date range (includes both .ndjson and .ndjson.gz)
    */
   private async getEventFiles(since?: string, until?: string): Promise<string[]> {
-    const files = await fs.readdir(this.telemetryDir);
+    const files = await this.fileRepository.listFiles();
     const eventFiles = files.filter(
       (f) => f.startsWith('events-') && (f.endsWith('.ndjson') || f.endsWith('.ndjson.gz'))
     );
@@ -607,7 +569,7 @@ export class TelemetryService {
     compressCutoff.setDate(compressCutoff.getDate() - this.compressAfterDays);
     const compressCutoffStr = compressCutoff.toISOString().slice(0, 10);
 
-    const files = await fs.readdir(this.telemetryDir);
+    const files = await this.fileRepository.listFiles();
     let deleted = 0;
     let compressed = 0;
 
@@ -617,11 +579,9 @@ export class TelemetryService {
 
       const fileDate = match[1];
       const isCompressed = !!match[2];
-      const filepath = path.join(this.telemetryDir, filename);
-
       // Delete files older than retention period
       if (fileDate < retentionCutoffStr) {
-        await fs.unlink(filepath);
+        await this.fileRepository.remove(filename);
         deleted++;
         continue;
       }
@@ -629,7 +589,7 @@ export class TelemetryService {
       // Compress uncompressed files older than compress threshold
       if (this.compressAfterDays > 0 && !isCompressed && fileDate < compressCutoffStr) {
         try {
-          await this.compressFile(filepath);
+          await this.fileRepository.compress(filename);
           compressed++;
         } catch (err) {
           log.error({ err: err }, `[Telemetry] Failed to compress ${filename}`);
@@ -643,15 +603,6 @@ export class TelemetryService {
           `(retention=${this.config.retention}d, compress=${this.compressAfterDays}d)`
       );
     }
-  }
-
-  /**
-   * Compress an NDJSON file to gzip and remove the original.
-   */
-  private async compressFile(filepath: string): Promise<void> {
-    const gzPath = filepath + '.gz';
-    await pipeline(createReadStream(filepath), createGzip(), createWriteStream(gzPath));
-    await fs.unlink(filepath);
   }
 
   dispose(): void {

--- a/server/src/storage/audit-file-repository.ts
+++ b/server/src/storage/audit-file-repository.ts
@@ -1,0 +1,108 @@
+import crypto from 'node:crypto';
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import readline from 'node:readline';
+import { createReadStream } from './fs-helpers.js';
+
+export interface StoredAuditEntry {
+  timestamp: string;
+  action: string;
+  actor: string;
+  resource?: string;
+  details?: Record<string, unknown>;
+  integrity: string;
+}
+
+export interface AuditFileVerifyResult {
+  valid: boolean;
+  entries: number;
+  firstBroken?: number;
+}
+
+function sha256(data: string): string {
+  return crypto.createHash('sha256').update(data, 'utf8').digest('hex');
+}
+
+export class AuditFileRepository {
+  constructor(private readonly directory: string) {}
+
+  getMonthlyLogPath(date: Date): string {
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    return path.join(this.directory, `audit-${yyyy}-${mm}.log`);
+  }
+
+  ensureReady(): Promise<void> {
+    return mkdir(this.directory, { recursive: true }).then(() => undefined);
+  }
+
+  async getLastHash(filePath: string): Promise<string> {
+    try {
+      const content = await readFile(filePath, 'utf8');
+      const lines = content.trimEnd().split('\n').filter(Boolean);
+      return lines.length > 0 ? sha256(lines[lines.length - 1]) : '';
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return '';
+      throw error;
+    }
+  }
+
+  append(filePath: string, line: string): Promise<void> {
+    return appendFile(filePath, `${line}\n`, 'utf8');
+  }
+
+  async verify(filePath: string): Promise<AuditFileVerifyResult> {
+    const stream = createReadStream(filePath, { encoding: 'utf8' });
+    const reader = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    let previousHash = '';
+    let lineIndex = 0;
+    let totalEntries = 0;
+
+    try {
+      for await (const line of reader) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          lineIndex += 1;
+          continue;
+        }
+
+        totalEntries += 1;
+        let entry: StoredAuditEntry;
+        try {
+          entry = JSON.parse(trimmed) as StoredAuditEntry;
+        } catch {
+          return { valid: false, entries: totalEntries, firstBroken: lineIndex };
+        }
+
+        if (entry.integrity !== previousHash) {
+          return { valid: false, entries: totalEntries, firstBroken: lineIndex };
+        }
+        previousHash = sha256(trimmed);
+        lineIndex += 1;
+      }
+      return { valid: true, entries: totalEntries };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { valid: true, entries: 0 };
+      throw error;
+    } finally {
+      reader.close();
+      stream.destroy();
+    }
+  }
+
+  async readRecent(filePath: string, limit: number): Promise<StoredAuditEntry[]> {
+    try {
+      const content = await readFile(filePath, 'utf8');
+      return content
+        .trimEnd()
+        .split('\n')
+        .filter(Boolean)
+        .slice(-limit)
+        .reverse()
+        .map((line) => JSON.parse(line) as StoredAuditEntry);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+  }
+}

--- a/server/src/storage/operational-metadata-repository.ts
+++ b/server/src/storage/operational-metadata-repository.ts
@@ -1,0 +1,39 @@
+import { constants } from 'node:fs';
+import { access, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export interface ExecutablePathProbe {
+  directPath: boolean;
+  found: boolean;
+  path?: string;
+}
+
+export class OperationalMetadataRepository {
+  async probeExecutablePath(command: string): Promise<ExecutablePathProbe> {
+    if (!command.includes(path.sep)) return { directPath: false, found: false };
+
+    try {
+      await access(command, constants.X_OK);
+      return { directPath: true, found: true, path: command };
+    } catch {
+      return { directPath: true, found: false };
+    }
+  }
+
+  basename(filePath: string): string {
+    return path.basename(filePath);
+  }
+
+  async readPackageVersion(packageUrl: URL): Promise<string | undefined> {
+    const metadata = JSON.parse(await readFile(packageUrl, 'utf8')) as { version?: unknown };
+    return typeof metadata.version === 'string' ? metadata.version : undefined;
+  }
+
+  async readSprintLabels(runtimeDir: string): Promise<Map<string, string>> {
+    const content = await readFile(path.join(runtimeDir, 'sprints.json'), 'utf8');
+    const sprints = JSON.parse(content) as Array<{ id: string; label: string }>;
+    return new Map(sprints.map((sprint) => [sprint.id, sprint.label]));
+  }
+}
+
+export const operationalMetadataRepository = new OperationalMetadataRepository();

--- a/server/src/storage/telemetry-file-repository.ts
+++ b/server/src/storage/telemetry-file-repository.ts
@@ -1,0 +1,75 @@
+import { access, appendFile, mkdir, readdir, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import readline from 'node:readline';
+import { pipeline } from 'node:stream/promises';
+import { createGunzip, createGzip } from 'node:zlib';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import { createReadStream, createWriteStream } from './fs-helpers.js';
+
+export class TelemetryFileRepository {
+  private readonly directory: string;
+
+  constructor(directory: string) {
+    this.directory = path.resolve(directory);
+  }
+
+  ensureReady(): Promise<void> {
+    return mkdir(this.directory, { recursive: true }).then(() => undefined);
+  }
+
+  async listFiles(): Promise<string[]> {
+    return readdir(this.directory);
+  }
+
+  eventPath(filename: string): string {
+    const safeFilename = path.basename(filename);
+    if (safeFilename !== filename) throw new Error('Telemetry filename must be a path segment');
+    return ensureWithinBase(this.directory, path.join(this.directory, safeFilename));
+  }
+
+  async append(filename: string, content: string): Promise<void> {
+    await appendFile(this.eventPath(filename), content, 'utf8');
+  }
+
+  async remove(filename: string): Promise<void> {
+    await unlink(this.eventPath(filename));
+  }
+
+  async exists(filename: string): Promise<boolean> {
+    try {
+      await access(this.eventPath(filename));
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      throw error;
+    }
+  }
+
+  async streamLines(filename: string, visitor: (line: string) => boolean | void): Promise<void> {
+    const reader = TelemetryFileRepository.createLineReader(this.eventPath(filename));
+    for await (const line of reader) {
+      if (visitor(line) === false) {
+        reader.close();
+        break;
+      }
+    }
+  }
+
+  async compress(filename: string): Promise<void> {
+    const source = this.eventPath(filename);
+    const destination = this.eventPath(`${filename}.gz`);
+    await pipeline(createReadStream(source), createGzip(), createWriteStream(destination));
+    await unlink(source);
+  }
+
+  static createLineReader(filePath: string): readline.Interface {
+    if (filePath.endsWith('.gz')) {
+      const decompressed = createReadStream(filePath).pipe(createGunzip());
+      return readline.createInterface({ input: decompressed, crlfDelay: Infinity });
+    }
+    return readline.createInterface({
+      input: createReadStream(filePath, { encoding: 'utf8' }),
+      crlfDelay: Infinity,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- move monthly audit paths, directory creation, hash seeding, appends, verification, and recent reads behind a file repository
- preserve the append-only JSONL hash chain and SQLite behavior
- reduce the classified service filesystem boundary from 29 to 28

## Verification

- shared and server compile
- service filesystem boundary check reports 28 exceptions

## Risk

Moderate. Audit schemas and integrity hashing are unchanged; the file lifecycle now has one storage owner.

Depends on #1214. Progresses #1187