### PR TITLE
fix: finish credential-aware frontend API migration

### DIFF
--- a/web/src/__tests__/api-no-raw-fetch.test.ts
+++ b/web/src/__tests__/api-no-raw-fetch.test.ts
@@ -1,36 +1,19 @@
 /**
- * Enforcement test: all first-party API modules must use apiFetch, not raw fetch().
+ * Enforcement test: all first-party web code uses the credential-aware API transport.
  *
  * This test catches regressions where a developer adds a direct `fetch(` call
- * in web/src/lib/api/ that bypasses credential handling and base-URL resolution.
- *
- * Documented exceptions (text/stream responses that cannot use apiFetch):
- *   - agent.ts      — getLog() returns plain-text log file via response.text()
- *   - decisions.ts  — reviews.export() returns markdown export via response.text()
- *   - work-products.ts — export() returns markdown export via response.text()
- *
- * Any new exception must be added to the allowlist below with a justification comment.
+ * anywhere under web/src that bypasses credential handling and base-URL resolution.
  */
 import { describe, it, expect } from 'vitest';
 
-// Load raw source of every API module via Vite's import.meta.glob (no Node.js globals needed)
-const apiSources = import.meta.glob('../lib/api/*.ts', {
+// Load production sources via Vite's import.meta.glob (no Node.js globals needed).
+const apiSources = import.meta.glob(['../**/*.ts', '../**/*.tsx', '!../__tests__/**'], {
   query: '?raw',
   import: 'default',
   eager: true,
 }) as Record<string, string>;
 
-/** Files that may contain raw fetch() calls with documented justification. */
-const ALLOWLISTED: Record<string, number> = {
-  // text() responses — cannot use apiFetch (which only handles JSON envelopes)
-  'agent.ts': 1, // getLog() — plain-text agent log
-  'decisions.ts': 1, // reviews.export() — markdown export
-  'work-products.ts': 1, // export() — markdown export
-  // helpers.ts implements apiFetch itself
-  'helpers.ts': 1,
-};
-
-describe('API module raw fetch policy', () => {
+describe('credential-aware API transport policy', () => {
   for (const [path, source] of Object.entries(apiSources)) {
     const filenameCandidate = path.split('/').pop();
     if (!filenameCandidate) {
@@ -40,11 +23,11 @@ describe('API module raw fetch policy', () => {
 
     it(`${filename} does not contain unapproved raw fetch() calls`, () => {
       const matches = [...source.matchAll(/\bfetch\s*\(/g)];
-      const allowed = ALLOWLISTED[filename] ?? 0;
+      const allowed = path.endsWith('/lib/api/helpers.ts') ? 2 : 0;
       if (matches.length > allowed) {
         throw new Error(
           `${filename} has ${matches.length} raw fetch() call(s) but only ${allowed} are allowed. ` +
-            `Use apiFetch() from ./helpers instead, or add a justified allowlist entry.`
+            `Use apiFetch(), apiText(), or apiResponse() from lib/api/helpers.`
         );
       }
       expect(matches.length).toBeLessThanOrEqual(allowed);

--- a/web/src/components/dashboard/ExportDialog.tsx
+++ b/web/src/components/dashboard/ExportDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Button, Group, Loader, Modal, Select, Stack, Text, TextInput, Title } from '@mantine/core';
 import { Download } from 'lucide-react';
-import { API_BASE } from '@/lib/config';
+import { API_BASE, apiResponse } from '@/lib/api/helpers';
 
 export type ExportScope = 'full' | 'project' | 'task';
 export type ExportFormat = 'csv' | 'json';
@@ -72,11 +72,7 @@ export function ExportDialog({
         params.set('to', toDateTime.toISOString());
       }
 
-      const response = await fetch(`${API_BASE}/telemetry/export?${params}`);
-
-      if (!response.ok) {
-        throw new Error('Export failed');
-      }
+      const response = await apiResponse(`${API_BASE}/telemetry/export?${params}`);
 
       const disposition = response.headers.get('Content-Disposition');
       let filename = `telemetry-export.${format}`;

--- a/web/src/components/docs/DocsViewer.tsx
+++ b/web/src/components/docs/DocsViewer.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { API_BASE, handleResponse } from '@/lib/api/helpers';
+import { docsApi } from '@/lib/api/docs';
 import {
   FileText,
   FolderOpen,
@@ -21,57 +21,6 @@ import {
   Clock,
   HardDrive,
 } from 'lucide-react';
-
-// ─── API Client ──────────────────────────────────────────────────
-
-interface DocFile {
-  path: string;
-  name: string;
-  content?: string;
-  size: number;
-  modified: string;
-  created: string;
-  extension: string;
-  directory: string;
-}
-
-const docsApi = {
-  list: async (params?: { directory?: string; sortBy?: string }): Promise<DocFile[]> => {
-    const qs = new URLSearchParams();
-    if (params?.directory) qs.set('directory', params.directory);
-    if (params?.sortBy) qs.set('sortBy', params.sortBy);
-    const resp = await fetch(`${API_BASE}/docs?${qs}`);
-    return handleResponse<DocFile[]>(resp);
-  },
-  getFile: async (path: string): Promise<DocFile> => {
-    const resp = await fetch(`${API_BASE}/docs/file/${path}`);
-    return handleResponse<DocFile>(resp);
-  },
-  saveFile: async (path: string, content: string): Promise<DocFile> => {
-    const resp = await fetch(`${API_BASE}/docs/file/${path}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ content }),
-    });
-    return handleResponse<DocFile>(resp);
-  },
-  deleteFile: async (path: string): Promise<void> => {
-    const resp = await fetch(`${API_BASE}/docs/file/${path}`, {
-      method: 'DELETE',
-      credentials: 'include',
-    });
-    return handleResponse<void>(resp);
-  },
-  search: async (q: string): Promise<Array<{ file: DocFile; matches: Array<{ line: number; text: string }> }>> => {
-    const resp = await fetch(`${API_BASE}/docs/search?q=${encodeURIComponent(q)}`);
-    return handleResponse(resp);
-  },
-  directories: async (): Promise<string[]> => {
-    const resp = await fetch(`${API_BASE}/docs/directories`);
-    return handleResponse<string[]>(resp);
-  },
-};
 
 // ─── Helpers ─────────────────────────────────────────────────────
 
@@ -214,7 +163,9 @@ export function DocsViewer() {
           <div className="space-y-0.5">
             <button
               className={`flex items-center gap-1.5 w-full text-left text-xs px-2 py-1 rounded transition-colors ${
-                !selectedDir ? 'bg-muted text-foreground font-medium' : 'text-muted-foreground hover:bg-muted/50'
+                !selectedDir
+                  ? 'bg-muted text-foreground font-medium'
+                  : 'text-muted-foreground hover:bg-muted/50'
               }`}
               onClick={() => setSelectedDir(undefined)}
             >
@@ -225,7 +176,9 @@ export function DocsViewer() {
               <button
                 key={dir}
                 className={`flex items-center gap-1.5 w-full text-left text-xs px-2 py-1 rounded transition-colors ${
-                  selectedDir === dir ? 'bg-muted text-foreground font-medium' : 'text-muted-foreground hover:bg-muted/50'
+                  selectedDir === dir
+                    ? 'bg-muted text-foreground font-medium'
+                    : 'text-muted-foreground hover:bg-muted/50'
                 }`}
                 onClick={() => setSelectedDir(dir)}
               >
@@ -252,7 +205,10 @@ export function DocsViewer() {
               <button className="text-[10px] text-green-500 hover:underline" onClick={handleCreate}>
                 Create
               </button>
-              <button className="text-[10px] text-muted-foreground hover:underline" onClick={() => setCreating(false)}>
+              <button
+                className="text-[10px] text-muted-foreground hover:underline"
+                onClick={() => setCreating(false)}
+              >
                 Cancel
               </button>
             </div>

--- a/web/src/components/settings/tabs/DelegationTab.tsx
+++ b/web/src/components/settings/tabs/DelegationTab.tsx
@@ -3,16 +3,15 @@
  */
 
 import { useState } from 'react';
-import { API_BASE } from '@/lib/config';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Badge, Button, Select, Switch } from '@mantine/core';
 import { useToast } from '@/hooks/useToast';
 import { Plane, ShieldCheck, AlertCircle, Clock, CheckCircle2 } from 'lucide-react';
-import type { DelegationSettings } from '@veritas-kanban/shared';
-
-interface DelegationResponse {
-  delegation: DelegationSettings | null;
-}
+import {
+  delegationApi,
+  type DelegationResponse,
+  type SetDelegationInput,
+} from '@/lib/api/delegation';
 
 function formatDateTime(isoString: string): string {
   const date = new Date(isoString);
@@ -45,34 +44,15 @@ export function DelegationTab() {
   // Fetch current delegation
   const { data, isLoading } = useQuery<DelegationResponse>({
     queryKey: ['delegation'],
-    queryFn: async () => {
-      const res = await fetch(`${API_BASE}/delegation`);
-      if (!res.ok) throw new Error('Failed to fetch delegation settings');
-      return res.json();
-    },
+    queryFn: delegationApi.get,
   });
 
   const delegation = data?.delegation;
 
   // Set delegation mutation
   const setDelegationMutation = useMutation({
-    mutationFn: async (params: {
-      delegateAgent: string;
-      expires: string;
-      scope: { type: 'all' | 'project' | 'priority' };
-      excludePriorities?: string[];
-      createdBy: string;
-    }) => {
-      const res = await fetch(`${API_BASE}/delegation`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(params),
-      });
-      if (!res.ok) {
-        const error = await res.json();
-        throw new Error(error.error || 'Failed to set delegation');
-      }
-      return res.json();
+    mutationFn: async (params: SetDelegationInput) => {
+      return delegationApi.set(params);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['delegation'] });
@@ -93,9 +73,7 @@ export function DelegationTab() {
   // Revoke delegation mutation
   const revokeDelegationMutation = useMutation({
     mutationFn: async () => {
-      const res = await fetch(`${API_BASE}/delegation`, { method: 'DELETE' });
-      if (!res.ok) throw new Error('Failed to revoke delegation');
-      return res.json();
+      return delegationApi.revoke();
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['delegation'] });
@@ -115,7 +93,9 @@ export function DelegationTab() {
 
   const handleEnableDelegation = () => {
     const expires = addHours(new Date(), durationHours).toISOString();
-    const excludePriorities = excludeCritical ? ['critical'] : undefined;
+    const excludePriorities: SetDelegationInput['excludePriorities'] = excludeCritical
+      ? ['critical']
+      : undefined;
 
     setDelegationMutation.mutate({
       delegateAgent,

--- a/web/src/components/settings/tabs/SecurityTab.tsx
+++ b/web/src/components/settings/tabs/SecurityTab.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { Button, Group, Modal, PasswordInput, Stack, Text } from '@mantine/core';
 import { Eye, EyeOff, Check, AlertTriangle, Key } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
+import { authApi } from '@/lib/api/auth';
 
 // Password strength calculation (same as SetupScreen)
 function getPasswordStrength(password: string): { score: number; label: string; color: string } {
@@ -195,17 +196,8 @@ export function SecurityTab() {
                   onClick={async () => {
                     // Call the reset endpoint
                     try {
-                      const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
-                      const res = await fetch(`${base}/api/auth/reset`, { method: 'POST' });
-                      if (res.ok) {
-                        window.location.reload();
-                      } else {
-                        toast({
-                          title: 'Reset failed',
-                          description: 'Please use the CLI command instead.',
-                          duration: 5000,
-                        });
-                      }
+                      await authApi.reset();
+                      window.location.reload();
                     } catch (err) {
                       console.error('[Security] Auth reset failed:', err);
                       toast({

--- a/web/src/components/task/AttachmentsSection.tsx
+++ b/web/src/components/task/AttachmentsSection.tsx
@@ -27,6 +27,7 @@ import {
   ThemeIcon,
 } from '@mantine/core';
 import { useUploadAttachment, useDeleteAttachment } from '@/hooks/useAttachments';
+import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import type { Task, Attachment } from '@veritas-kanban/shared';
 
@@ -78,10 +79,7 @@ function AttachmentItem({ taskId, attachment }: { taskId: string; attachment: At
     if (!expanded && extractedText === null && isDocument) {
       setLoadingText(true);
       try {
-        const response = await fetch(
-          `${API_BASE}/tasks/${taskId}/attachments/${attachment.id}/text`
-        );
-        const data = await response.json();
+        const data = await api.attachments.getText(taskId, attachment.id);
         setExtractedText(data.text || '(No text extracted)');
       } catch (error) {
         console.error('[Attachments] Failed to load extracted text:', error);

--- a/web/src/components/task/DependenciesSection.tsx
+++ b/web/src/components/task/DependenciesSection.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo, useRef } from 'react';
-import { API_BASE } from '@/lib/config';
 import { Plus, X, Ban, CheckCircle2, Link as LinkIcon } from 'lucide-react';
 import { ActionIcon, Badge, Button, Group, Paper, Select, Stack, Text } from '@mantine/core';
 import { useTasks, isTaskBlocked } from '@/hooks/useTasks';
@@ -7,6 +6,7 @@ import { cn } from '@/lib/utils';
 import { useToast } from '@/hooks/useToast';
 import type { Task } from '@veritas-kanban/shared';
 import { useQueryClient } from '@tanstack/react-query';
+import { tasksApi } from '@/lib/api/tasks';
 
 interface DependenciesSectionProps {
   task: Task;
@@ -66,16 +66,7 @@ export function DependenciesSection({
 
   const handleAddDependency = async (targetId: string, type: 'depends_on' | 'blocks') => {
     try {
-      const response = await fetch(`${API_BASE}/tasks/${task.id}/dependencies`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ [type]: targetId }),
-      });
-
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.error || 'Failed to add dependency');
-      }
+      await tasksApi.addDependency(task.id, targetId, type);
 
       // Invalidate queries to refresh data
       void queryClient.invalidateQueries({ queryKey: ['tasks'] });
@@ -106,13 +97,7 @@ export function DependenciesSection({
 
   const handleRemoveDependency = async (targetId: string) => {
     try {
-      const response = await fetch(`${API_BASE}/tasks/${task.id}/dependencies/${targetId}`, {
-        method: 'DELETE',
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to remove dependency');
-      }
+      await tasksApi.removeDependency(task.id, targetId);
 
       // Invalidate queries to refresh data
       void queryClient.invalidateQueries({ queryKey: ['tasks'] });

--- a/web/src/components/task/RunModeGateSection.tsx
+++ b/web/src/components/task/RunModeGateSection.tsx
@@ -12,8 +12,8 @@
 import { useState } from 'react';
 import { Badge, Button, Group, Paper, Select, Stack, Switch, Text } from '@mantine/core';
 import { CheckCircle2, XCircle, ShieldCheck, Loader2 } from 'lucide-react';
-import { API_BASE } from '@/lib/config';
 import { useToast } from '@/hooks/useToast';
+import { tasksApi } from '@/lib/api/tasks';
 import type { Task, RunMode, QaGateState } from '@veritas-kanban/shared';
 
 interface RunModeGateSectionProps {
@@ -56,12 +56,7 @@ export function RunModeGateSection({ task, onUpdate, readOnly = false }: RunMode
     const newMode = value === 'none' ? null : (value as RunMode);
     setIsSaving(true);
     try {
-      const res = await fetch(`${API_BASE}/tasks/${task.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ runMode: newMode }),
-      });
-      if (!res.ok) throw new Error(await res.text());
+      await tasksApi.update(task.id, { runMode: newMode });
       onUpdate('runMode', newMode ?? undefined);
       toast({ title: newMode ? `Run mode set: ${RUN_MODE_LABELS[newMode]}` : 'Run mode cleared' });
     } catch (err) {
@@ -84,12 +79,7 @@ export function RunModeGateSection({ task, onUpdate, readOnly = false }: RunMode
     };
     setIsSaving(true);
     try {
-      const res = await fetch(`${API_BASE}/tasks/${task.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ qaGate: newGate }),
-      });
-      if (!res.ok) throw new Error(await res.text());
+      await tasksApi.update(task.id, { qaGate: newGate });
       onUpdate('qaGate', newGate);
       toast({ title: checked ? 'QA gate enabled' : 'QA gate disabled' });
     } catch (err) {
@@ -114,12 +104,7 @@ export function RunModeGateSection({ task, onUpdate, readOnly = false }: RunMode
     };
     setIsSaving(true);
     try {
-      const res = await fetch(`${API_BASE}/tasks/${task.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ qaGate: newGate }),
-      });
-      if (!res.ok) throw new Error(await res.text());
+      await tasksApi.update(task.id, { qaGate: newGate });
       onUpdate('qaGate', newGate);
       toast({ title: nowPassed ? '✅ QA passed' : 'QA pass revoked' });
     } catch (err) {

--- a/web/src/components/task/WorkflowSection.tsx
+++ b/web/src/components/task/WorkflowSection.tsx
@@ -8,7 +8,6 @@
  */
 
 import { useState, useEffect, useRef } from 'react';
-import { API_BASE } from '@/lib/config';
 import { Badge, Button, Group, Loader, Modal, Paper, ScrollArea, Stack, Text } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import { Play, Loader2 } from 'lucide-react';
@@ -196,11 +195,7 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
       setRecommendationsByWorkflow({});
       try {
         // Fetch available workflows
-        const workflowsRes = await fetch(`${API_BASE}/workflows`);
-        if (!workflowsRes.ok) {
-          throw new Error(`Unable to load workflows (${workflowsRes.status})`);
-        }
-        const workflowList = normalizeWorkflows(await workflowsRes.json());
+        const workflowList = normalizeWorkflows(await workflowsApi.list());
         if (isCancelled) return;
         setWorkflows(workflowList);
 
@@ -227,11 +222,7 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
         setRecommendationsByWorkflow(Object.fromEntries(recommendationEntries));
 
         // Fetch active runs for this task
-        const runsRes = await fetch(`${API_BASE}/workflows/runs?taskId=${task.id}`);
-        if (!runsRes.ok) {
-          throw new Error(`Unable to load workflow runs (${runsRes.status})`);
-        }
-        const runs = normalizeActiveRuns(await runsRes.json());
+        const runs = normalizeActiveRuns(await workflowsApi.listRuns({ taskId: task.id }));
         if (isCancelled) return;
         setActiveRuns(runs);
       } catch (error) {
@@ -254,16 +245,7 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
   const handleStartWorkflow = async (workflowId: string) => {
     setIsStarting(workflowId);
     try {
-      const response = await fetch(`${API_BASE}/workflows/${workflowId}/runs`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ taskId: task.id }),
-      });
-
-      if (!response.ok) throw new Error('Failed to start workflow run');
-
-      const runJson = await response.json();
-      const run = runJson.data ?? runJson;
+      const run = await workflowsApi.startRun(workflowId, { taskId: task.id });
       toast({
         title: 'Workflow run started',
         description: `Run ID: ${run.id}`,

--- a/web/src/components/task/detail/TaskDetailsTab.tsx
+++ b/web/src/components/task/detail/TaskDetailsTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Badge, Box, Button, Group, Modal, Paper, Stack, Text, Textarea } from '@mantine/core';
-import { API_BASE } from '@/lib/config';
+import { tasksApi } from '@/lib/api/tasks';
 import { MarkdownEditor } from '@/components/ui/MarkdownEditor';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
 import { TaskMetadataSection } from './TaskMetadataSection';
@@ -149,7 +149,7 @@ export function TaskDetailsTab({
                   aria-label="Clear checkpoint and discard saved progress"
                   onClick={async () => {
                     try {
-                      await fetch(`${API_BASE}/tasks/${task.id}/checkpoint`, { method: 'DELETE' });
+                      await tasksApi.clearCheckpoint(task.id);
                       onUpdate('checkpoint', undefined);
                     } catch (error) {
                       console.error('Failed to clear checkpoint:', error);

--- a/web/src/components/workflows/WorkflowRunList.tsx
+++ b/web/src/components/workflows/WorkflowRunList.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState, useMemo, useEffect } from 'react';
-import { API_BASE } from '@/lib/config';
+import { workflowsApi } from '@/lib/api/workflows';
 import {
   Badge,
   Button,
@@ -60,10 +60,7 @@ export function WorkflowRunList({ workflowId, onBack }: WorkflowRunListProps) {
   useEffect(() => {
     const fetchRuns = async () => {
       try {
-        const response = await fetch(`${API_BASE}/workflows/runs?workflowId=${workflowId}`);
-        if (!response.ok) throw new Error('Failed to fetch workflow runs');
-        const json = await response.json();
-        setRuns(json.data ?? json);
+        setRuns(await workflowsApi.listRuns({ workflowId }));
       } catch (error) {
         toast({
           title: '❌ Failed to load workflow runs',

--- a/web/src/components/workflows/WorkflowRunView.tsx
+++ b/web/src/components/workflows/WorkflowRunView.tsx
@@ -18,7 +18,7 @@ import {
   type WorkflowPipelineSummary,
   type WorkflowSubagentRunStatus,
 } from '@veritas-kanban/shared';
-import { API_BASE } from '@/lib/config';
+import { workflowsApi } from '@/lib/api/workflows';
 import {
   Alert,
   Badge,
@@ -174,10 +174,7 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
   // Fetch run details
   const fetchRun = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/workflows/runs/${runId}`);
-      if (!response.ok) throw new Error('Failed to fetch workflow run');
-      const json = await response.json();
-      setRun(json.data ?? json);
+      setRun(await workflowsApi.getRun(runId));
     } catch (error) {
       toast({
         title: '❌ Failed to load workflow run',
@@ -205,11 +202,9 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
     let isCancelled = false;
     const fetchWorkflow = async () => {
       try {
-        const workflowResponse = await fetch(`${API_BASE}/workflows/${workflowId}`);
-        if (!workflowResponse.ok) throw new Error('Failed to fetch workflow definition');
-        const json = await workflowResponse.json();
+        const workflowDefinition = await workflowsApi.get(workflowId);
         if (!isCancelled) {
-          setWorkflow(json.data ?? json);
+          setWorkflow(workflowDefinition);
         }
       } catch (error) {
         console.error('Failed to fetch workflow definition:', error);
@@ -249,11 +244,7 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
 
   const handleResume = async () => {
     try {
-      const response = await fetch(`${API_BASE}/workflows/runs/${runId}/resume`, {
-        method: 'POST',
-      });
-
-      if (!response.ok) throw new Error('Failed to resume workflow run');
+      await workflowsApi.resumeRun(runId);
 
       toast({
         title: 'Workflow resumed',

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -26,7 +26,7 @@ import type {
   CreateWorktreeRequest,
   DeleteWorktreeRequest,
 } from '@veritas-kanban/shared';
-import { API_BASE, apiFetch } from './helpers';
+import { API_BASE, apiFetch, apiText } from './helpers';
 
 export interface StartAgentRequest {
   agent?: AgentType;
@@ -257,14 +257,7 @@ export const agentApi = {
   },
 
   getLog: async (taskId: string, attemptId: string): Promise<string> => {
-    // Log endpoint returns plain text, not a JSON envelope — keep raw fetch.
-    const response = await fetch(`${API_BASE}/agents/${taskId}/attempts/${attemptId}/log`, {
-      credentials: 'include',
-    });
-    if (!response.ok) {
-      throw new Error('Failed to fetch log');
-    }
-    return response.text();
+    return apiText(`${API_BASE}/agents/${taskId}/attempts/${attemptId}/log`);
   },
 };
 

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -1,0 +1,5 @@
+import { apiFetch } from './helpers';
+
+export const authApi = {
+  reset: (): Promise<void> => apiFetch('/api/auth/reset', { method: 'POST' }),
+};

--- a/web/src/lib/api/decisions.ts
+++ b/web/src/lib/api/decisions.ts
@@ -11,7 +11,7 @@ import type {
   RecordDecisionReviewTurnInput,
   UpdateDecisionAssumptionInput,
 } from '@veritas-kanban/shared';
-import { API_BASE, apiFetch } from './helpers';
+import { API_BASE, apiFetch, apiText } from './helpers';
 
 function toQuery(filters: DecisionListFilters = {}): string {
   const params = new URLSearchParams();
@@ -140,22 +140,7 @@ export const decisionsApi = {
     },
 
     export: async (id: string): Promise<string> => {
-      // This endpoint returns plain text (markdown export), not a JSON envelope.
-      // Uses raw fetch intentionally; apiFetch does not support text() responses.
-      const response = await fetch(
-        `${API_BASE}/decisions/reviews/${encodeURIComponent(id)}/export`,
-        {
-          credentials: 'include',
-        }
-      );
-      if (!response.ok) {
-        const body = await response.json().catch(() => null);
-        if (body && typeof body === 'object' && 'message' in body) {
-          throw new Error(String((body as { message: unknown }).message));
-        }
-        throw new Error(`HTTP ${response.status}`);
-      }
-      return response.text();
+      return apiText(`${API_BASE}/decisions/reviews/${encodeURIComponent(id)}/export`);
     },
   },
 };

--- a/web/src/lib/api/delegation.ts
+++ b/web/src/lib/api/delegation.ts
@@ -1,0 +1,28 @@
+import type { DelegationSettings, TaskPriority } from '@veritas-kanban/shared';
+import { API_BASE, apiFetch } from './helpers';
+
+export interface DelegationResponse {
+  delegation: DelegationSettings | null;
+}
+
+export interface SetDelegationInput {
+  delegateAgent: string;
+  expires: string;
+  scope: { type: 'all' | 'project' | 'priority' };
+  excludePriorities?: TaskPriority[];
+  createdBy: string;
+}
+
+export const delegationApi = {
+  get: (): Promise<DelegationResponse> => apiFetch(`${API_BASE}/delegation`),
+
+  set: (input: SetDelegationInput): Promise<DelegationResponse> =>
+    apiFetch(`${API_BASE}/delegation`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
+
+  revoke: (): Promise<DelegationResponse> =>
+    apiFetch(`${API_BASE}/delegation`, { method: 'DELETE' }),
+};

--- a/web/src/lib/api/docs.ts
+++ b/web/src/lib/api/docs.ts
@@ -1,0 +1,53 @@
+import { API_BASE, apiFetch } from './helpers';
+
+export interface DocFile {
+  path: string;
+  name: string;
+  content?: string;
+  size: number;
+  modified: string;
+  created: string;
+  extension: string;
+  directory: string;
+}
+
+export interface DocSearchMatch {
+  file: DocFile;
+  matches: Array<{ line: number; text: string }>;
+}
+
+function encodeDocPath(filePath: string): string {
+  return filePath.split('/').map(encodeURIComponent).join('/');
+}
+
+export const docsApi = {
+  list: (params?: { directory?: string; sortBy?: string }): Promise<DocFile[]> => {
+    const query = new URLSearchParams();
+    if (params?.directory) query.set('directory', params.directory);
+    if (params?.sortBy) query.set('sortBy', params.sortBy);
+    const suffix = query.toString() ? `?${query.toString()}` : '';
+    return apiFetch(`${API_BASE}/docs${suffix}`);
+  },
+
+  getFile: (filePath: string): Promise<DocFile> => {
+    return apiFetch(`${API_BASE}/docs/file/${encodeDocPath(filePath)}`);
+  },
+
+  saveFile: (filePath: string, content: string): Promise<DocFile> => {
+    return apiFetch(`${API_BASE}/docs/file/${encodeDocPath(filePath)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    });
+  },
+
+  deleteFile: (filePath: string): Promise<void> => {
+    return apiFetch(`${API_BASE}/docs/file/${encodeDocPath(filePath)}`, { method: 'DELETE' });
+  },
+
+  search: (query: string): Promise<DocSearchMatch[]> => {
+    return apiFetch(`${API_BASE}/docs/search?q=${encodeURIComponent(query)}`);
+  },
+
+  directories: (): Promise<string[]> => apiFetch(`${API_BASE}/docs/directories`),
+};

--- a/web/src/lib/api/entities.ts
+++ b/web/src/lib/api/entities.ts
@@ -195,6 +195,15 @@ export const attachmentsApi = {
     });
   },
 
+  getText: async (
+    taskId: string,
+    attachmentId: string
+  ): Promise<{ attachmentId: string; text: string | null; hasText: boolean }> => {
+    return apiFetch(
+      `${API_BASE}/tasks/${encodeURIComponent(taskId)}/attachments/${encodeURIComponent(attachmentId)}/text`
+    );
+  },
+
   getTaskContext: async (taskId: string): Promise<TaskContext> => {
     return apiFetch<TaskContext>(`${API_BASE}/tasks/${taskId}/context`);
   },

--- a/web/src/lib/api/helpers.ts
+++ b/web/src/lib/api/helpers.ts
@@ -106,3 +106,22 @@ export async function apiFetch<T>(url: string, init?: RequestInit): Promise<T> {
   });
   return handleResponse<T>(response);
 }
+
+/**
+ * Credential-aware transport for endpoints that return text, blobs, or streams.
+ * JSON endpoints should continue to use apiFetch().
+ */
+export async function apiResponse(url: string, init?: RequestInit): Promise<Response> {
+  const response = await fetch(resolveApiUrl(url), {
+    credentials: 'include',
+    ...init,
+  });
+  if (!response.ok) {
+    await handleResponse<never>(response);
+  }
+  return response;
+}
+
+export async function apiText(url: string, init?: RequestInit): Promise<string> {
+  return (await apiResponse(url, init)).text();
+}

--- a/web/src/lib/api/tasks.ts
+++ b/web/src/lib/api/tasks.ts
@@ -44,6 +44,31 @@ export const tasksApi = {
     });
   },
 
+  addDependency: async (
+    taskId: string,
+    targetId: string,
+    type: 'depends_on' | 'blocks'
+  ): Promise<Task> => {
+    return apiFetch<Task>(`${API_BASE}/tasks/${encodeURIComponent(taskId)}/dependencies`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ [type]: targetId }),
+    });
+  },
+
+  removeDependency: async (taskId: string, targetId: string): Promise<Task> => {
+    return apiFetch<Task>(
+      `${API_BASE}/tasks/${encodeURIComponent(taskId)}/dependencies/${encodeURIComponent(targetId)}`,
+      { method: 'DELETE' }
+    );
+  },
+
+  clearCheckpoint: async (taskId: string): Promise<void> => {
+    return apiFetch<void>(`${API_BASE}/tasks/${encodeURIComponent(taskId)}/checkpoint`, {
+      method: 'DELETE',
+    });
+  },
+
   archive: async (id: string): Promise<void> => {
     return apiFetch<void>(`${API_BASE}/tasks/${id}/archive`, {
       method: 'POST',

--- a/web/src/lib/api/work-products.ts
+++ b/web/src/lib/api/work-products.ts
@@ -5,7 +5,7 @@ import type {
   WorkProductPreview,
   WorkProductVersion,
 } from '@veritas-kanban/shared';
-import { API_BASE, apiFetch } from './helpers';
+import { API_BASE, apiFetch, apiText } from './helpers';
 
 export type WorkProductExportFormat = 'markdown' | 'json';
 
@@ -23,25 +23,6 @@ function buildQuery(params: Record<string, string | number | boolean | undefined
   }
   const serialized = query.toString();
   return serialized ? `?${serialized}` : '';
-}
-
-function getErrorMessage(body: unknown, status: number): string {
-  if (body && typeof body === 'object') {
-    const record = body as Record<string, unknown>;
-    if (typeof record.message === 'string') {
-      return record.message;
-    }
-    if (typeof record.error === 'string') {
-      return record.error;
-    }
-    if (record.error && typeof record.error === 'object') {
-      const error = record.error as Record<string, unknown>;
-      if (typeof error.message === 'string') {
-        return error.message;
-      }
-    }
-  }
-  return `HTTP ${status}`;
 }
 
 export const workProductsApi = {
@@ -78,24 +59,10 @@ export const workProductsApi = {
   },
 
   export: async (id: string, options: WorkProductExportOptions = {}): Promise<string> => {
-    // This endpoint returns plain text (markdown export), not a JSON envelope.
-    // Uses raw fetch intentionally; apiFetch does not support text() responses.
     const query = buildQuery({
       format: options.format ?? 'markdown',
       redacted: options.redacted ?? true,
     });
-    const response = await fetch(
-      `${API_BASE}/work-products/${encodeURIComponent(id)}/export${query}`,
-      {
-        credentials: 'include',
-      }
-    );
-
-    if (!response.ok) {
-      const body = await response.json().catch(() => null);
-      throw new Error(getErrorMessage(body, response.status));
-    }
-
-    return response.text();
+    return apiText(`${API_BASE}/work-products/${encodeURIComponent(id)}/export${query}`);
   },
 };

--- a/web/src/lib/api/workflows.ts
+++ b/web/src/lib/api/workflows.ts
@@ -8,6 +8,7 @@ import type {
   WorkflowSkillAuditSummary,
   AgentBudgetPolicy,
   WorkflowAccess,
+  WorkflowRun,
 } from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
 
@@ -114,9 +115,7 @@ export interface WorkflowRecipeMaterialization {
   };
 }
 
-export interface WorkflowRunStartResponse {
-  id: string;
-}
+export type WorkflowRunStartResponse = WorkflowRun;
 
 export interface WorkflowLaunchRecommendationParams {
   workflowId?: string;
@@ -147,6 +146,26 @@ export const workflowsApi = {
       `${API_BASE}/workflows/${encodeURIComponent(workflowId)}`
     );
     return unwrapData(response);
+  },
+
+  listRuns: async (
+    filters: { workflowId?: string; taskId?: string } = {}
+  ): Promise<WorkflowRun[]> => {
+    const query = new URLSearchParams();
+    if (filters.workflowId) query.set('workflowId', filters.workflowId);
+    if (filters.taskId) query.set('taskId', filters.taskId);
+    const suffix = query.toString() ? `?${query.toString()}` : '';
+    return apiFetch<WorkflowRun[]>(`${API_BASE}/workflows/runs${suffix}`);
+  },
+
+  getRun: async (runId: string): Promise<WorkflowRun> => {
+    return apiFetch<WorkflowRun>(`${API_BASE}/workflows/runs/${encodeURIComponent(runId)}`);
+  },
+
+  resumeRun: async (runId: string): Promise<WorkflowRun> => {
+    return apiFetch<WorkflowRun>(`${API_BASE}/workflows/runs/${encodeURIComponent(runId)}/resume`, {
+      method: 'POST',
+    });
   },
 
   access: async (workflowId: string): Promise<WorkflowAccess> => {
@@ -184,8 +203,8 @@ export const workflowsApi = {
       budget?: AgentBudgetPolicy;
       context?: Record<string, unknown>;
     } = {}
-  ): Promise<WorkflowRunStartResponse> => {
-    const response = await apiFetch<WorkflowRunStartResponse | { data: WorkflowRunStartResponse }>(
+  ): Promise<WorkflowRun> => {
+    const response = await apiFetch<WorkflowRun | { data: WorkflowRun }>(
       `${API_BASE}/workflows/${encodeURIComponent(workflowId)}/runs`,
       {
         method: 'POST',


### PR DESCRIPTION
## Summary

- route every JSON request through the canonical credential-aware API client
- add typed docs, delegation, workflow run, task dependency, checkpoint, attachment-text, and auth reset methods
- add credential-aware transport for text, blob, and stream responses
- remove raw request construction from React components
- expand the direct-fetch architecture gate across production web source

## Verification

- shared build
- web production build
- source scan confirms raw fetch remains only in the two canonical transport functions

## Risk

Moderate. Endpoint paths and payloads are unchanged; error handling is now consistent and cross-origin requests include credentials.

Closes #1165