### PR TITLE
refactor: route managed content through storage

### DIFF
--- a/docs/architecture/service-filesystem-boundary.json
+++ b/docs/architecture/service-filesystem-boundary.json
@@ -1,36 +1,12 @@
 {
   "schemaVersion": 1,
-  "maximumEntries": 16,
+  "maximumEntries": 6,
   "entries": [
-    {
-      "path": "server/src/services/attachment-service.ts",
-      "category": "compatibility-debt",
-      "owner": "#1188",
-      "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
     {
       "path": "server/src/services/clawdbot-agent-service.ts",
       "category": "transient-process-io",
       "owner": "#1189",
       "rationale": "Remaining process I/O migration is tracked in issue #1189."
-    },
-    {
-      "path": "server/src/services/config-service.ts",
-      "category": "compatibility-debt",
-      "owner": "#1188",
-      "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
-    {
-      "path": "server/src/services/doc-freshness-service.ts",
-      "category": "packaged-readonly-content",
-      "owner": "#1188",
-      "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
-    {
-      "path": "server/src/services/docs-service.ts",
-      "category": "packaged-readonly-content",
-      "owner": "#1188",
-      "rationale": "Managed-content storage migration is tracked in issue #1188."
     },
     {
       "path": "server/src/services/file-lock.ts",
@@ -45,34 +21,10 @@
       "rationale": "Remaining process I/O migration is tracked in issue #1189."
     },
     {
-      "path": "server/src/services/managed-list-service.ts",
-      "category": "compatibility-debt",
-      "owner": "#1188",
-      "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
-    {
       "path": "server/src/services/pdf-report-service.ts",
       "category": "transient-process-io",
       "owner": "#1189",
       "rationale": "Remaining process I/O migration is tracked in issue #1189."
-    },
-    {
-      "path": "server/src/services/prompt-registry-service.ts",
-      "category": "compatibility-debt",
-      "owner": "#1188",
-      "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
-    {
-      "path": "server/src/services/shared-resources-service.ts",
-      "category": "compatibility-debt",
-      "owner": "#1188",
-      "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
-    {
-      "path": "server/src/services/skill-security-service.ts",
-      "category": "packaged-readonly-content",
-      "owner": "#1188",
-      "rationale": "Managed-content storage migration is tracked in issue #1188."
     },
     {
       "path": "server/src/services/sqlite-portability-service.ts",
@@ -81,22 +33,10 @@
       "rationale": "Remaining process I/O migration is tracked in issue #1189."
     },
     {
-      "path": "server/src/services/template-service.ts",
-      "category": "compatibility-debt",
-      "owner": "#1188",
-      "rationale": "Managed-content storage migration is tracked in issue #1188."
-    },
-    {
       "path": "server/src/services/text-extraction-service.ts",
       "category": "transient-process-io",
       "owner": "#1189",
       "rationale": "Remaining process I/O migration is tracked in issue #1189."
-    },
-    {
-      "path": "server/src/services/tool-policy-service.ts",
-      "category": "compatibility-debt",
-      "owner": "#1188",
-      "rationale": "Managed-content storage migration is tracked in issue #1188."
     }
   ]
 }

--- a/server/src/services/attachment-service.ts
+++ b/server/src/services/attachment-service.ts
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import * as fs from '../storage/fs-helpers.js';
 import path from 'path';
 import { createHash } from 'node:crypto';
 import { nanoid } from 'nanoid';

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import * as fs from '../storage/fs-helpers.js';
 import { watch, type FSWatcher } from '../storage/fs-helpers.js';
 import path from 'path';
 import { simpleGit } from 'simple-git';

--- a/server/src/services/doc-freshness-service.ts
+++ b/server/src/services/doc-freshness-service.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../lib/logger.js';
-import * as fs from 'node:fs/promises';
+import * as fs from '../storage/fs-helpers.js';
 import * as path from 'node:path';
 import { getRuntimeDir } from '../utils/paths.js';
 import type { FreshnessAlert, TrackedDocument } from '@veritas-kanban/shared';

--- a/server/src/services/docs-service.ts
+++ b/server/src/services/docs-service.ts
@@ -8,7 +8,7 @@
  */
 
 import { createLogger } from '../lib/logger.js';
-import * as fs from 'node:fs/promises';
+import * as fs from '../storage/fs-helpers.js';
 import * as path from 'node:path';
 import { getDocsDir } from '../utils/paths.js';
 

--- a/server/src/services/managed-list-service.ts
+++ b/server/src/services/managed-list-service.ts
@@ -1,5 +1,4 @@
-import { readFile, writeFile, mkdir } from 'fs/promises';
-import { fileExists } from '../storage/fs-helpers.js';
+import { fileExists, mkdir, readFile, writeFile } from '../storage/fs-helpers.js';
 import { join } from 'path';
 import { nanoid } from 'nanoid';
 import type { ManagedListItem } from '@veritas-kanban/shared';

--- a/server/src/services/prompt-registry-service.ts
+++ b/server/src/services/prompt-registry-service.ts
@@ -1,5 +1,4 @@
-import { readdir, readFile, writeFile, unlink, mkdir } from 'fs/promises';
-import { fileExists } from '../storage/fs-helpers.js';
+import { fileExists, mkdir, readFile, readdir, unlink, writeFile } from '../storage/fs-helpers.js';
 import { join } from 'path';
 import matter from '../utils/frontmatter.js';
 import type {

--- a/server/src/services/shared-resources-service.ts
+++ b/server/src/services/shared-resources-service.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../lib/logger.js';
-import * as fs from 'node:fs/promises';
+import * as fs from '../storage/fs-helpers.js';
 import * as path from 'node:path';
 import { getRuntimeDir } from '../utils/paths.js';
 import type {

--- a/server/src/services/skill-security-service.ts
+++ b/server/src/services/skill-security-service.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs/promises';
+import * as fs from '../storage/fs-helpers.js';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import type {

--- a/server/src/services/template-service.ts
+++ b/server/src/services/template-service.ts
@@ -1,5 +1,4 @@
-import { readdir, readFile, writeFile, unlink, mkdir } from 'fs/promises';
-import { fileExists } from '../storage/fs-helpers.js';
+import { fileExists, mkdir, readFile, readdir, unlink, writeFile } from '../storage/fs-helpers.js';
 import { join } from 'path';
 import matter from '../utils/frontmatter.js';
 import type {

--- a/server/src/services/tool-policy-service.ts
+++ b/server/src/services/tool-policy-service.ts
@@ -6,7 +6,7 @@
  * specifies a role, that role's tool policy is applied to the agent session.
  */
 
-import fs from 'fs/promises';
+import * as fs from '../storage/fs-helpers.js';
 import path from 'path';
 import type { CreateGovernanceTraceInput } from '@veritas-kanban/shared';
 import type { ToolPolicy } from '../types/workflow.js';

--- a/server/src/storage/fs-helpers.ts
+++ b/server/src/storage/fs-helpers.ts
@@ -17,10 +17,12 @@ import {
   copyFile as copyFileAsync,
   lstat as lstatAsync,
   mkdir as mkdirAsync,
+  open as openAsync,
   readFile as readFileAsync,
   readdir as readdirAsync,
   rename as renameAsync,
   rm as rmAsync,
+  rmdir as rmdirAsync,
   stat as statAsync,
   statfs as statfsAsync,
   unlink as unlinkAsync,
@@ -73,6 +75,7 @@ export const createWriteStream = fs.createWriteStream;
 // ---------------------------------------------------------------------------
 
 export const mkdir = mkdirAsync;
+export const open = openAsync;
 export { access };
 export const copyFile = copyFileAsync;
 export const lstat = lstatAsync;
@@ -81,6 +84,7 @@ export const readdir = readdirAsync;
 export const realpath = fs.promises.realpath;
 export const rename = renameAsync;
 export const rm = rmAsync;
+export const rmdir = rmdirAsync;
 export const stat = statAsync;
 export const statfs = statfsAsync;
 export const unlink = unlinkAsync;


### PR DESCRIPTION
## Summary

- route configuration, documentation, prompt, template, attachment, policy, and shared-resource file access through centralized storage primitives
- add the remaining open and directory-removal primitives required by those services
- preserve existing paths, formats, containment checks, file locks, and SQLite repositories
- reduce the classified service filesystem boundary from 16 to 6

## Verification

- shared and server compile
- service filesystem boundary check reports 6 exceptions

## Risk

Low. This changes the filesystem dependency boundary without changing service behavior or persistent formats.

Closes #1188
Progresses #1163