### PR TITLE
refactor: reduce server lint debt

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dev:watchdog": "bash scripts/dev-watchdog.sh",
     "build": "pnpm --filter @veritas-kanban/shared build && pnpm --filter @veritas-kanban/server build && pnpm --filter @veritas-kanban/web build && pnpm --filter @veritas-kanban/cli build && pnpm --filter @veritas-kanban/mcp build && pnpm --filter @veritas-kanban/desktop build",
     "lint": "eslint .",
-    "lint:budget": "node scripts/lint-warning-budget.mjs --max-warnings=600",
+    "lint:budget": "node scripts/lint-warning-budget.mjs --max-warnings=458",
     "lint:report": "node scripts/lint-warning-budget.mjs --all-rules",
     "lint:fix": "eslint . --fix",
     "check:delivery-cadence": "node --test scripts/check-delivery-cadence.test.mjs && node scripts/check-delivery-cadence.mjs",

--- a/server/src/__tests__/services/agent-registry-service.test.ts
+++ b/server/src/__tests__/services/agent-registry-service.test.ts
@@ -19,9 +19,16 @@ vi.mock('../../storage/fs-helpers.js', () => ({
 // Must import after mock
 const { getAgentRegistryService, disposeAgentRegistryService, createTaskSyncToken } =
   await import('../../services/agent-registry-service.js');
-import type { RegisteredAgent, TaskSyncContext } from '../../services/agent-registry-service.js';
+import type { TaskSyncContext } from '../../services/agent-registry-service.js';
 import { providerRuntimeManifestFixture } from '../fixtures/provider-runtime-manifest.js';
 import { existsSync, readFileSync } from '../../storage/fs-helpers.js';
+
+function requireValue<T>(value: T | null | undefined): T {
+  if (value === null || value === undefined) {
+    throw new Error('Expected a value');
+  }
+  return value;
+}
 
 const TASK_SYNC_CONTEXT: TaskSyncContext = createTaskSyncToken('task-service');
 const TASK_RECONCILE_CONTEXT: TaskSyncContext = createTaskSyncToken('task-reconciler');
@@ -253,9 +260,9 @@ describe('AgentRegistryService', () => {
       });
 
       expect(updated).not.toBeNull();
-      expect(updated!.status).toBe('busy');
-      expect(updated!.currentTaskId).toBe('TASK-1');
-      expect(updated!.currentTaskTitle).toBe('Fix the bug');
+      expect(requireValue(updated).status).toBe('busy');
+      expect(requireValue(updated).currentTaskId).toBe('TASK-1');
+      expect(requireValue(updated).currentTaskTitle).toBe('Fix the bug');
     });
 
     it('should return null for unknown agent', () => {
@@ -283,7 +290,7 @@ describe('AgentRegistryService', () => {
 
       vi.useRealTimers();
 
-      expect(updated!.lastHeartbeat).not.toBe(originalHeartbeat);
+      expect(requireValue(updated).lastHeartbeat).not.toBe(originalHeartbeat);
     });
 
     it('should update task information', () => {
@@ -306,8 +313,8 @@ describe('AgentRegistryService', () => {
         currentTaskTitle: 'Second task',
       });
 
-      expect(updated!.currentTaskId).toBe('TASK-2');
-      expect(updated!.currentTaskTitle).toBe('Second task');
+      expect(requireValue(updated).currentTaskId).toBe('TASK-2');
+      expect(requireValue(updated).currentTaskTitle).toBe('Second task');
     });
 
     it('should clear task on idle status', () => {
@@ -326,9 +333,9 @@ describe('AgentRegistryService', () => {
         currentTaskTitle: '',
       });
 
-      expect(updated!.status).toBe('idle');
-      expect(updated!.currentTaskId).toBeUndefined();
-      expect(updated!.currentTaskTitle).toBeUndefined();
+      expect(requireValue(updated).status).toBe('idle');
+      expect(requireValue(updated).currentTaskId).toBeUndefined();
+      expect(requireValue(updated).currentTaskTitle).toBeUndefined();
     });
 
     it('should merge metadata on heartbeat', () => {
@@ -344,7 +351,7 @@ describe('AgentRegistryService', () => {
       service.heartbeat(agent.id, { metadata: { session: 'abc', ping: Date.now() } });
 
       const updated = service.get(agent.id);
-      expect(updated!.metadata).toEqual({
+      expect(requireValue(updated).metadata).toEqual({
         host: 'mac-mini',
         session: 'abc',
         ping: expect.any(Number),
@@ -443,7 +450,7 @@ describe('AgentRegistryService', () => {
       const found = service.get(agent.id);
 
       expect(found).not.toBeNull();
-      expect(found!.name).toBe('Test Agent');
+      expect(requireValue(found).name).toBe('Test Agent');
     });
 
     it('should return null for unknown ID', () => {
@@ -547,9 +554,9 @@ describe('AgentRegistryService', () => {
       );
 
       expect(updated).not.toBeNull();
-      expect(updated!.status).toBe('busy');
-      expect(updated!.currentTaskId).toBe('task_20260228_syncA');
-      expect(updated!.currentTaskTitle).toBe('Wire backend sync');
+      expect(requireValue(updated).status).toBe('busy');
+      expect(requireValue(updated).currentTaskId).toBe('task_20260228_syncA');
+      expect(requireValue(updated).currentTaskTitle).toBe('Wire backend sync');
     });
 
     it('should set agent idle and clear task on terminal status for same task', () => {
@@ -580,9 +587,9 @@ describe('AgentRegistryService', () => {
       );
 
       expect(updated).not.toBeNull();
-      expect(updated!.status).toBe('idle');
-      expect(updated!.currentTaskId).toBeUndefined();
-      expect(updated!.currentTaskTitle).toBeUndefined();
+      expect(requireValue(updated).status).toBe('idle');
+      expect(requireValue(updated).currentTaskId).toBeUndefined();
+      expect(requireValue(updated).currentTaskTitle).toBeUndefined();
 
       vi.useRealTimers();
     });
@@ -611,9 +618,9 @@ describe('AgentRegistryService', () => {
       );
 
       expect(updated).not.toBeNull();
-      expect(updated!.status).toBe('busy');
-      expect(updated!.currentTaskId).toBe('task_20260228_syncA');
-      expect(updated!.currentTaskTitle).toBe('Current task');
+      expect(requireValue(updated).status).toBe('busy');
+      expect(requireValue(updated).currentTaskId).toBe('task_20260228_syncA');
+      expect(requireValue(updated).currentTaskTitle).toBe('Current task');
     });
 
     it('should resolve agent by name when task.agent stores display name', () => {
@@ -630,8 +637,8 @@ describe('AgentRegistryService', () => {
       );
 
       expect(updated).not.toBeNull();
-      expect(updated!.id).toBe('coder-1');
-      expect(updated!.status).toBe('busy');
+      expect(requireValue(updated).id).toBe('coder-1');
+      expect(requireValue(updated).status).toBe('busy');
     });
 
     it('should prevent rapid busy-to-idle flapping within guard window', () => {
@@ -678,7 +685,7 @@ describe('AgentRegistryService', () => {
             taskId: 'task_20260228_syncA',
             taskStatus: 'in-progress',
           },
-          { source: 'task-service-untrusted' as any }
+          { source: 'task-service-untrusted' } as unknown as TaskSyncContext
         )
       ).toThrow('Unauthorized task sync context');
     });
@@ -766,8 +773,8 @@ describe('AgentRegistryService', () => {
 
       expect(() =>
         service.reconcileFromTasks([{ id: 'task_1', status: 'in-progress', agent: 'coder-1' }], {
-          source: 'task-service-untrusted' as any,
-        })
+          source: 'task-service-untrusted',
+        } as unknown as TaskSyncContext)
       ).toThrow('Unauthorized task reconcile context');
     });
 

--- a/server/src/__tests__/trace-service.test.ts
+++ b/server/src/__tests__/trace-service.test.ts
@@ -8,6 +8,13 @@ import path from 'path';
 import os from 'os';
 import { TraceService } from '../services/trace-service.js';
 
+function requireValue<T>(value: T | null | undefined): T {
+  if (value === null || value === undefined) {
+    throw new Error('Expected a value');
+  }
+  return value;
+}
+
 // Mock telemetry service
 vi.mock('../services/telemetry-service.js', () => ({
   getTelemetryService: () => ({
@@ -28,8 +35,9 @@ describe('TraceService', () => {
 
     service = new TraceService();
     // Override private fields
-    (service as any).tracesDir = tracesDir;
-    (service as any).enabled = true;
+    const internals = service as unknown as { tracesDir: string; enabled: boolean };
+    internals.tracesDir = tracesDir;
+    internals.enabled = true;
   });
 
   afterEach(async () => {
@@ -59,23 +67,24 @@ describe('TraceService', () => {
     });
 
     it('should create a new trace when enabled', () => {
-      const trace = service.startTrace('attempt-1', 'task-1', 'veritas', 'my-project', {
-        clientSource: 'agent-service',
-        mode: 'eng-review',
-        capabilitySet: ['start', 'status', 'logs', 'complete'],
-        workspaceId: 'local',
-        runKey: 'attempt-1',
-        policyProfile: 'codex-cli:workspace-write',
-      });
-      expect(trace).not.toBeNull();
-      expect(trace!.traceId).toBe('attempt-1');
-      expect(trace!.taskId).toBe('task-1');
-      expect(trace!.agent).toBe('veritas');
-      expect(trace!.project).toBe('my-project');
-      expect(trace!.status).toBe('running');
-      expect(trace!.steps).toHaveLength(0);
-      expect(trace!.startedAt).toBeDefined();
-      expect(trace!.metadata).toMatchObject({
+      const trace = requireValue(
+        service.startTrace('attempt-1', 'task-1', 'veritas', 'my-project', {
+          clientSource: 'agent-service',
+          mode: 'eng-review',
+          capabilitySet: ['start', 'status', 'logs', 'complete'],
+          workspaceId: 'local',
+          runKey: 'attempt-1',
+          policyProfile: 'codex-cli:workspace-write',
+        })
+      );
+      expect(trace.traceId).toBe('attempt-1');
+      expect(trace.taskId).toBe('task-1');
+      expect(trace.agent).toBe('veritas');
+      expect(trace.project).toBe('my-project');
+      expect(trace.status).toBe('running');
+      expect(trace.steps).toHaveLength(0);
+      expect(trace.startedAt).toBeDefined();
+      expect(trace.metadata).toMatchObject({
         clientSource: 'agent-service',
         runKey: 'attempt-1',
         policyProfile: 'codex-cli:workspace-write',
@@ -97,16 +106,15 @@ describe('TraceService', () => {
 
     it('should add a step to an existing trace', () => {
       service.startTrace('attempt-1', 'task-1', 'veritas');
-      const step = service.startStep('attempt-1', 'execute', { tool: 'vitest' });
+      const step = requireValue(service.startStep('attempt-1', 'execute', { tool: 'vitest' }));
 
-      expect(step).not.toBeNull();
-      expect(step!.type).toBe('execute');
-      expect(step!.sequence).toBe(1);
-      expect(step!.startedAt).toBeDefined();
-      expect(step!.metadata).toEqual({ tool: 'vitest' });
+      expect(step.type).toBe('execute');
+      expect(step.sequence).toBe(1);
+      expect(step.startedAt).toBeDefined();
+      expect(step.metadata).toEqual({ tool: 'vitest' });
 
-      const trace = service.getActiveTrace('attempt-1');
-      expect(trace!.steps).toHaveLength(1);
+      const trace = requireValue(service.getActiveTrace('attempt-1'));
+      expect(trace.steps).toHaveLength(1);
     });
 
     it('should preserve stream, retry, abort, and finalize lifecycle steps', () => {
@@ -132,14 +140,14 @@ describe('TraceService', () => {
       });
       service.endStep('attempt-lifecycle', 'finalize');
 
-      const trace = service.getActiveTrace('attempt-lifecycle');
-      expect(trace!.steps.map((step) => step.type)).toEqual([
+      const trace = requireValue(service.getActiveTrace('attempt-lifecycle'));
+      expect(trace.steps.map((step) => step.type)).toEqual([
         'stream',
         'retry',
         'abort',
         'finalize',
       ]);
-      expect(trace!.steps.every((step) => step.endedAt)).toBe(true);
+      expect(trace.steps.every((step) => step.endedAt)).toBe(true);
     });
   });
 
@@ -157,11 +165,11 @@ describe('TraceService', () => {
       // Small delay for duration
       service.endStep('attempt-1', 'execute');
 
-      const trace = service.getActiveTrace('attempt-1');
-      const step = trace!.steps[0];
+      const trace = requireValue(service.getActiveTrace('attempt-1'));
+      const step = requireValue(trace.steps[0]);
       expect(step.endedAt).toBeDefined();
       expect(step.durationMs).toBeDefined();
-      expect(step.durationMs!).toBeGreaterThanOrEqual(0);
+      expect(requireValue(step.durationMs)).toBeGreaterThanOrEqual(0);
     });
   });
 
@@ -183,14 +191,13 @@ describe('TraceService', () => {
       service.endStep('attempt-1', 'init');
       service.startStep('attempt-1', 'execute');
 
-      const trace = await service.completeTrace('attempt-1', 'completed');
-      expect(trace).not.toBeNull();
-      expect(trace!.status).toBe('completed');
-      expect(trace!.endedAt).toBeDefined();
-      expect(trace!.totalDurationMs).toBeDefined();
+      const trace = requireValue(await service.completeTrace('attempt-1', 'completed'));
+      expect(trace.status).toBe('completed');
+      expect(trace.endedAt).toBeDefined();
+      expect(trace.totalDurationMs).toBeDefined();
 
       // All open steps should be closed
-      for (const step of trace!.steps) {
+      for (const step of trace.steps) {
         expect(step.endedAt).toBeDefined();
       }
 
@@ -207,8 +214,8 @@ describe('TraceService', () => {
 
     it('should handle failed status', async () => {
       service.startTrace('attempt-2', 'task-2', 'copilot');
-      const trace = await service.completeTrace('attempt-2', 'failed');
-      expect(trace!.status).toBe('failed');
+      const trace = requireValue(await service.completeTrace('attempt-2', 'failed'));
+      expect(trace.status).toBe('failed');
     });
   });
 
@@ -219,18 +226,16 @@ describe('TraceService', () => {
 
     it('should return active trace', () => {
       service.startTrace('attempt-1', 'task-1', 'veritas');
-      const trace = service.getActiveTrace('attempt-1');
-      expect(trace).not.toBeNull();
-      expect(trace!.traceId).toBe('attempt-1');
+      const trace = requireValue(service.getActiveTrace('attempt-1'));
+      expect(trace.traceId).toBe('attempt-1');
     });
   });
 
   describe('getTrace', () => {
     it('should return active trace if available', async () => {
       service.startTrace('attempt-1', 'task-1', 'veritas');
-      const trace = await service.getTrace('attempt-1');
-      expect(trace).not.toBeNull();
-      expect(trace!.traceId).toBe('attempt-1');
+      const trace = requireValue(await service.getTrace('attempt-1'));
+      expect(trace.traceId).toBe('attempt-1');
     });
 
     it('should load completed trace from disk', async () => {
@@ -250,10 +255,9 @@ describe('TraceService', () => {
         'utf-8'
       );
 
-      const trace = await service.getTrace('attempt-saved');
-      expect(trace).not.toBeNull();
-      expect(trace!.traceId).toBe('attempt-saved');
-      expect(trace!.status).toBe('completed');
+      const trace = requireValue(await service.getTrace('attempt-saved'));
+      expect(trace.traceId).toBe('attempt-saved');
+      expect(trace.status).toBe('completed');
     });
 
     it('should return null for non-existent trace', async () => {

--- a/server/src/middleware/validate.ts
+++ b/server/src/middleware/validate.ts
@@ -72,10 +72,12 @@ export function validate(schemas: ValidationSchemas) {
  * Type helper for accessing validated request data.
  * Use with type assertion: (req as ValidatedRequest<...>)
  */
+type ValidatedSegment<Name extends string, Value> = unknown extends Value
+  ? Record<never, never>
+  : Record<Name, Value>;
+
 export type ValidatedRequest<TParams = unknown, TQuery = unknown, TBody = unknown> = Request & {
-  validated: {
-    params?: TParams;
-    query?: TQuery;
-    body?: TBody;
-  };
+  validated: ValidatedSegment<'params', TParams> &
+    ValidatedSegment<'query', TQuery> &
+    ValidatedSegment<'body', TBody>;
 };

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -31,7 +31,7 @@ router.get(
   '/timeline',
   validate({ query: TimelineQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, TimelineQuery>, res) => {
-    const timeline = await analyticsService.getTimeline(req.validated.query!);
+    const timeline = await analyticsService.getTimeline(req.validated.query);
     res.json(timeline);
   })
 );
@@ -56,7 +56,7 @@ router.get(
   '/metrics',
   validate({ query: MetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, MetricsQuery>, res) => {
-    const metrics = await analyticsService.getMetrics(req.validated.query!);
+    const metrics = await analyticsService.getMetrics(req.validated.query);
     res.json(metrics);
   })
 );

--- a/server/src/routes/automation.ts
+++ b/server/src/routes/automation.ts
@@ -31,7 +31,7 @@ router.post(
     // Validate task can start automation
     const validation = automationService.validateCanStart(task);
     if (!validation.valid) {
-      throw new ValidationError(validation.error!);
+      throw new ValidationError(validation.error ?? 'Task cannot start automation');
     }
 
     // Parse input
@@ -48,9 +48,16 @@ router.post(
     // Get update payload and update task
     const payload = automationService.getStartPayload(input.sessionKey);
     const updated = await taskService.updateTask(task.id, payload);
+    if (!updated) {
+      throw new NotFoundError('Task not found');
+    }
+    const attemptId = payload.attempt?.id;
+    if (!attemptId) {
+      throw new ValidationError('Automation start did not create an attempt');
+    }
 
     // Build and return result
-    const result = automationService.buildStartResult(updated!, payload.attempt!.id);
+    const result = automationService.buildStartResult(updated, attemptId);
     res.json(result);
   })
 );
@@ -67,7 +74,7 @@ router.post(
     // Validate task can be completed
     const validation = automationService.validateCanComplete(task);
     if (!validation.valid) {
-      throw new ValidationError(validation.error!);
+      throw new ValidationError(validation.error ?? 'Task cannot complete automation');
     }
 
     // Parse input
@@ -89,9 +96,12 @@ router.post(
       input.status
     );
     const updated = await taskService.updateTask(task.id, payload);
+    if (!updated) {
+      throw new NotFoundError('Task not found');
+    }
 
     // Build and return result
-    const result = automationService.buildCompleteResult(updated!, input.status);
+    const result = automationService.buildCompleteResult(updated, input.status);
     res.json(result);
   })
 );

--- a/server/src/routes/conflicts.ts
+++ b/server/src/routes/conflicts.ts
@@ -22,7 +22,7 @@ router.get(
   '/:taskId',
   validate({ params: ConflictParamsSchema }),
   asyncHandler(async (req: ValidatedRequest<ConflictParams>, res) => {
-    const { taskId } = req.validated.params!;
+    const { taskId } = req.validated.params;
     const status = await conflictService.getConflictStatus(taskId);
     res.json(status);
   })
@@ -33,8 +33,8 @@ router.get(
   '/:taskId/file',
   validate({ params: ConflictParamsSchema, query: ConflictFileQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<ConflictParams, ConflictFileQuery>, res) => {
-    const { taskId } = req.validated.params!;
-    const { path } = req.validated.query!;
+    const { taskId } = req.validated.params;
+    const { path } = req.validated.query;
     const conflict = await conflictService.getFileConflict(taskId, path);
     res.json(conflict);
   })
@@ -50,9 +50,9 @@ router.post(
   }),
   asyncHandler(
     async (req: ValidatedRequest<ConflictParams, ConflictFileQuery, ResolveConflictBody>, res) => {
-      const { taskId } = req.validated.params!;
-      const { path } = req.validated.query!;
-      const { resolution, manualContent } = req.validated.body!;
+      const { taskId } = req.validated.params;
+      const { path } = req.validated.query;
+      const { resolution, manualContent } = req.validated.body;
 
       const result = await conflictService.resolveFile(taskId, path, resolution, manualContent);
       res.json(result);
@@ -65,7 +65,7 @@ router.post(
   '/:taskId/abort',
   validate({ params: ConflictParamsSchema }),
   asyncHandler(async (req: ValidatedRequest<ConflictParams>, res) => {
-    const { taskId } = req.validated.params!;
+    const { taskId } = req.validated.params;
     const status = await conflictService.getConflictStatus(taskId);
 
     if (status.rebaseInProgress) {
@@ -85,8 +85,8 @@ router.post(
   '/:taskId/continue',
   validate({ params: ConflictParamsSchema, body: ContinueMergeBodySchema }),
   asyncHandler(async (req: ValidatedRequest<ConflictParams, unknown, ContinueMergeBody>, res) => {
-    const { taskId } = req.validated.params!;
-    const { message } = req.validated.body!;
+    const { taskId } = req.validated.params;
+    const { message } = req.validated.body;
     const status = await conflictService.getConflictStatus(taskId);
 
     let result;

--- a/server/src/routes/diff.ts
+++ b/server/src/routes/diff.ts
@@ -27,7 +27,7 @@ router.get(
   '/:taskId',
   validate({ params: DiffParamsSchema }),
   asyncHandler(async (req: ValidatedRequest<DiffParams>, res) => {
-    const { taskId } = req.validated.params!;
+    const { taskId } = req.validated.params;
     const summary = await diffService.getDiffSummary(taskId);
     res.json(summary);
   })
@@ -38,8 +38,8 @@ router.get(
   '/:taskId/file',
   validate({ params: DiffParamsSchema, query: DiffFileQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<DiffParams, DiffFileQuery>, res) => {
-    const { taskId } = req.validated.params!;
-    const { path } = req.validated.query!;
+    const { taskId } = req.validated.params;
+    const { path } = req.validated.query;
     const diff = await diffService.getFileDiff(taskId, path);
     res.json(diff);
   })
@@ -50,7 +50,7 @@ router.get(
   '/:taskId/full',
   validate({ params: DiffParamsSchema }),
   asyncHandler(async (req: ValidatedRequest<DiffParams>, res) => {
-    const { taskId } = req.validated.params!;
+    const { taskId } = req.validated.params;
     const diffs = await diffService.getFullDiff(taskId);
     res.json(diffs);
   })
@@ -71,7 +71,7 @@ router.post(
       throw error;
     }
 
-    const { taskId } = req.validated.params!;
+    const { taskId } = req.validated.params;
     const review = await codexReviewService.reviewTask({ taskId, ...body });
     res.status(201).json(review);
   })

--- a/server/src/routes/metrics.ts
+++ b/server/src/routes/metrics.ts
@@ -26,7 +26,7 @@ router.get(
   validate({ query: TaskMetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, TaskMetricsQuery>, res) => {
     const metrics = getMetricsService();
-    const { project, period, from } = req.validated.query!;
+    const { project, period, from } = req.validated.query;
     const { getPeriodStart } = await import('../services/metrics/helpers.js');
     const since = getPeriodStart(period, from);
     const result = await metrics.getTaskMetrics(project, since);
@@ -43,7 +43,7 @@ router.get(
   validate({ query: MetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, MetricsQuery>, res) => {
     const metrics = getMetricsService();
-    const { period, project, from, to } = req.validated.query!;
+    const { period, project, from, to } = req.validated.query;
     const result = await metrics.getRunMetrics(period, project, from, to);
     res.json(result);
   })
@@ -58,7 +58,7 @@ router.get(
   validate({ query: MetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, MetricsQuery>, res) => {
     const metrics = getMetricsService();
-    const { period, project, from, to } = req.validated.query!;
+    const { period, project, from, to } = req.validated.query;
     const result = await metrics.getTokenMetrics(period, project, from, to);
     res.json(result);
   })
@@ -73,7 +73,7 @@ router.get(
   validate({ query: MetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, MetricsQuery>, res) => {
     const metrics = getMetricsService();
-    const { period, project, from, to } = req.validated.query!;
+    const { period, project, from, to } = req.validated.query;
     const result = await metrics.getDurationMetrics(period, project, from, to);
     res.json(result);
   })
@@ -88,7 +88,7 @@ router.get(
   validate({ query: MetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, MetricsQuery>, res) => {
     const metrics = getMetricsService();
-    const { period, project, from, to } = req.validated.query!;
+    const { period, project, from, to } = req.validated.query;
     const result = await metrics.getAllMetrics(period, project, from, to);
     res.json(result);
   })
@@ -103,7 +103,7 @@ router.get(
   validate({ query: MetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, MetricsQuery>, res) => {
     const metrics = getMetricsService();
-    const { period, project, from, to } = req.validated.query!;
+    const { period, project, from, to } = req.validated.query;
     const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 50;
     const result = await metrics.getFailedRuns(period, project, limit, from, to);
     res.json(result);
@@ -119,7 +119,7 @@ router.get(
   validate({ query: MetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, MetricsQuery>, res) => {
     const metrics = getMetricsService();
-    const { period, project, from, to } = req.validated.query!;
+    const { period, project, from, to } = req.validated.query;
 
     const result = await metrics.getTrends(period, project, from, to);
     res.json(result);
@@ -135,7 +135,7 @@ router.get(
   validate({ query: BudgetMetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, BudgetMetricsQuery>, res) => {
     const metrics = getMetricsService();
-    const { project, tokenBudget, costBudget, warningThreshold } = req.validated.query!;
+    const { project, tokenBudget, costBudget, warningThreshold } = req.validated.query;
     const result = await metrics.getBudgetMetrics(
       tokenBudget,
       costBudget,
@@ -155,7 +155,7 @@ router.get(
   validate({ query: AgentComparisonQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, AgentComparisonQuery>, res) => {
     const metrics = getMetricsService();
-    const { period, project, minRuns } = req.validated.query!;
+    const { period, project, minRuns } = req.validated.query;
     const result = await metrics.getAgentComparison(period, project, minRuns);
     res.json(result);
   })
@@ -170,7 +170,7 @@ router.get(
   validate({ query: VelocityQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, VelocityQuery>, res) => {
     const metrics = getMetricsService();
-    const { project, limit } = req.validated.query!;
+    const { project, limit } = req.validated.query;
     const result = await metrics.getVelocityMetrics(project, limit);
     res.json(result);
   })
@@ -185,7 +185,7 @@ router.get(
   validate({ query: MetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, MetricsQuery>, res) => {
     const metrics = getMetricsService();
-    const { period, project, from, to } = req.validated.query!;
+    const { period, project, from, to } = req.validated.query;
     const result = await metrics.getTaskCost(period, project, from, to);
     res.json(result);
   })
@@ -200,7 +200,7 @@ router.get(
   validate({ query: MetricsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, MetricsQuery>, res) => {
     const metrics = getMetricsService();
-    const { period, from, to, tz } = req.validated.query!;
+    const { period, from, to, tz } = req.validated.query;
     const result = await metrics.getUtilization(period, from, to, tz);
     res.json(result);
   })

--- a/server/src/routes/preview.ts
+++ b/server/src/routes/preview.ts
@@ -13,17 +13,20 @@ const router: RouterType = Router();
 const previewService = new PreviewService();
 
 // GET /api/preview - List all running previews
-router.get('/', asyncHandler(async (_req, res) => {
-  const previews = previewService.getAllPreviews();
-  res.json(previews);
-}));
+router.get(
+  '/',
+  asyncHandler(async (_req, res) => {
+    const previews = previewService.getAllPreviews();
+    res.json(previews);
+  })
+);
 
 // GET /api/preview/:taskId - Get preview status for a task
 router.get(
   '/:taskId',
   validate({ params: PreviewParamsSchema }),
   asyncHandler(async (req: ValidatedRequest<PreviewParams>, res) => {
-    const { taskId } = req.validated.params!;
+    const { taskId } = req.validated.params;
     const status = previewService.getPreviewStatus(taskId);
     if (!status) {
       return res.json({ status: 'stopped' });
@@ -37,8 +40,8 @@ router.get(
   '/:taskId/output',
   validate({ params: PreviewParamsSchema, query: PreviewOutputQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<PreviewParams, PreviewOutputQuery>, res) => {
-    const { taskId } = req.validated.params!;
-    const { lines } = req.validated.query!;
+    const { taskId } = req.validated.params;
+    const { lines } = req.validated.query;
     const output = previewService.getPreviewOutput(taskId, lines);
     res.json({ output });
   })
@@ -49,7 +52,7 @@ router.post(
   '/:taskId/start',
   validate({ params: PreviewParamsSchema }),
   asyncHandler(async (req: ValidatedRequest<PreviewParams>, res) => {
-    const { taskId } = req.validated.params!;
+    const { taskId } = req.validated.params;
     const preview = await previewService.startPreview(taskId);
     res.status(201).json(preview);
   })
@@ -60,7 +63,7 @@ router.post(
   '/:taskId/stop',
   validate({ params: PreviewParamsSchema }),
   asyncHandler(async (req: ValidatedRequest<PreviewParams>, res) => {
-    const { taskId } = req.validated.params!;
+    const { taskId } = req.validated.params;
     await previewService.stopPreview(taskId);
     res.json({ success: true });
   })

--- a/server/src/routes/telemetry.ts
+++ b/server/src/routes/telemetry.ts
@@ -46,7 +46,7 @@ router.post(
   validate({ body: TelemetryEventIngestionSchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, unknown, TelemetryEventIngestion>, res) => {
     const telemetry = getTelemetryService();
-    const eventInput = req.validated.body!;
+    const eventInput = req.validated.body;
 
     // Validation: Sanity check for run.completed durationMs
     // Cap at 7 days (604,800,000 ms) to prevent corrupt data
@@ -105,7 +105,7 @@ router.get(
   validate({ query: TelemetryEventsQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, TelemetryEventsQuery>, res) => {
     const telemetry = getTelemetryService();
-    const { type, since, until, taskId, project, limit } = req.validated.query!;
+    const { type, since, until, taskId, project, limit } = req.validated.query;
 
     const options: TelemetryQueryOptions = {};
 
@@ -132,7 +132,7 @@ router.get(
   validate({ params: TelemetryTaskParamsSchema }),
   asyncHandler(async (req: ValidatedRequest<TelemetryTaskParams>, res) => {
     const telemetry = getTelemetryService();
-    const { taskId } = req.validated.params!;
+    const { taskId } = req.validated.params;
     const events = await telemetry.getTaskEvents(taskId);
     res.json(events);
   })
@@ -149,7 +149,7 @@ router.post(
   validate({ body: TelemetryBulkQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, unknown, TelemetryBulkQuery>, res) => {
     const telemetry = getTelemetryService();
-    const { taskIds, perTaskLimit } = req.validated.body!;
+    const { taskIds, perTaskLimit } = req.validated.body;
 
     const eventsMap = await telemetry.getBulkTaskEvents(taskIds, perTaskLimit);
 
@@ -190,7 +190,7 @@ router.get(
   validate({ query: TelemetryCountQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, TelemetryCountQuery>, res) => {
     const telemetry = getTelemetryService();
-    const { type, since, until } = req.validated.query!;
+    const { type, since, until } = req.validated.query;
 
     const count = await telemetry.countEvents(type.length === 1 ? type[0] : type, since, until);
 
@@ -216,7 +216,7 @@ router.get(
   validate({ query: TelemetryExportQuerySchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, TelemetryExportQuery>, res) => {
     const telemetry = getTelemetryService();
-    const { format, taskId, project, from, to } = req.validated.query!;
+    const { format, taskId, project, from, to } = req.validated.query;
 
     // Build query options
     const options: TelemetryQueryOptions = {};

--- a/server/src/services/analytics-service.ts
+++ b/server/src/services/analytics-service.ts
@@ -56,7 +56,7 @@ export class AnalyticsService {
       const timeRanges = allTasks
         .filter((t) => t.timeTracking?.entries && t.timeTracking.entries.length > 0)
         .map((t) => {
-          const entries = t.timeTracking!.entries;
+          const entries = t.timeTracking?.entries ?? [];
           const start = new Date(entries[0].startTime);
           const lastEntry = entries[entries.length - 1];
           const end = lastEntry.endTime ? new Date(lastEntry.endTime) : new Date();
@@ -159,7 +159,7 @@ export class AnalyticsService {
     // Build time periods from all tasks
     const timePeriods: TimePeriod[] = [];
     for (const task of tasksWithTime) {
-      const entries = task.timeTracking!.entries;
+      const entries = task.timeTracking?.entries ?? [];
       for (const entry of entries) {
         const startMs = new Date(entry.startTime).getTime();
         // Handle active entries (no endTime)
@@ -443,7 +443,8 @@ export class AnalyticsService {
             taskCount: 1,
           });
         } else {
-          const existing = agentMap.get(agent)!;
+          const existing = agentMap.get(agent);
+          if (!existing) continue;
           existing.startTime = Math.min(existing.startTime, startMs);
           existing.endTime = Math.max(existing.endTime, endMs);
           existing.totalDuration += duration;

--- a/server/src/services/blocking-service.ts
+++ b/server/src/services/blocking-service.ts
@@ -122,7 +122,8 @@ export class BlockingService {
     const queue = [newBlockerId];
 
     while (queue.length > 0) {
-      const currentId = queue.shift()!;
+      const currentId = queue.shift();
+      if (!currentId) continue;
 
       if (currentId === taskId) {
         return true;

--- a/server/src/services/cost-prediction-service.ts
+++ b/server/src/services/cost-prediction-service.ts
@@ -259,12 +259,12 @@ class CostPredictionService {
 
     const meanAbsoluteError = errors.reduce((sum, e) => sum + e, 0) / errors.length;
     const meanAccuracy = accuracies.reduce((sum, a) => sum + a, 0) / accuracies.length;
+    const midpoint = Math.floor(sortedAccuracies.length / 2);
+    const upperMedian = sortedAccuracies[midpoint] ?? 0;
     const medianAccuracy =
       sortedAccuracies.length % 2 === 0
-        ? (sortedAccuracies[sortedAccuracies.length / 2 - 1]! +
-            sortedAccuracies[sortedAccuracies.length / 2]!) /
-          2
-        : sortedAccuracies[Math.floor(sortedAccuracies.length / 2)]!;
+        ? ((sortedAccuracies[midpoint - 1] ?? upperMedian) + upperMedian) / 2
+        : upperMedian;
 
     const within20 = accuracy.filter((a) => a.accuracy >= 80 && a.accuracy <= 120).length;
     const within50 = accuracy.filter((a) => a.accuracy >= 50 && a.accuracy <= 150).length;

--- a/server/src/services/metrics/dashboard-metrics.ts
+++ b/server/src/services/metrics/dashboard-metrics.ts
@@ -49,6 +49,16 @@ const DASHBOARD_TREND_EVENT_TYPES: TelemetryEventType[] = [
 ];
 const UTILIZATION_EVENT_TYPES: TelemetryEventType[] = ['run.started', 'run.completed'];
 
+function getOrInitialize<K, V>(map: Map<K, V>, key: K, create: () => V): V {
+  const existing = map.get(key);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const created = create();
+  map.set(key, created);
+  return created;
+}
+
 /**
  * Get all metrics in one call (for dashboard).
  * Optimized: streams files once and extracts all metrics in single pass.
@@ -95,10 +105,12 @@ export async function computeAllMetrics(
       const runEvent = event as RunTelemetryEvent;
       const agent = runEvent.agent || 'veritas';
 
-      if (!runAcc.byAgent.has(agent)) {
-        runAcc.byAgent.set(agent, { successes: 0, failures: 0, errors: 0, durations: [] });
-      }
-      const agentAcc = runAcc.byAgent.get(agent)!;
+      const agentAcc = getOrInitialize(runAcc.byAgent, agent, () => ({
+        successes: 0,
+        failures: 0,
+        errors: 0,
+        durations: [],
+      }));
 
       if (eventType === 'run.error') {
         runAcc.errors++;
@@ -136,16 +148,13 @@ export async function computeAllMetrics(
       tokenAcc.cacheTokens += cacheTokens;
       tokenAcc.tokensPerRun.push(totalTokens);
 
-      if (!tokenAcc.byAgent.has(agent)) {
-        tokenAcc.byAgent.set(agent, {
-          totalTokens: 0,
-          inputTokens: 0,
-          outputTokens: 0,
-          cacheTokens: 0,
-          runs: 0,
-        });
-      }
-      const agentTokenAcc = tokenAcc.byAgent.get(agent)!;
+      const agentTokenAcc = getOrInitialize(tokenAcc.byAgent, agent, () => ({
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheTokens: 0,
+        runs: 0,
+      }));
       agentTokenAcc.totalTokens += totalTokens;
       agentTokenAcc.inputTokens += tokenEvent.inputTokens;
       agentTokenAcc.outputTokens += tokenEvent.outputTokens;
@@ -393,23 +402,20 @@ export async function computeTrends(
     to,
     (event) => {
       const dateStr = event.timestamp.slice(0, 10);
-      if (!dailyData.has(dateStr)) {
-        dailyData.set(dateStr, {
-          runs: 0,
-          successes: 0,
-          failures: 0,
-          errors: 0,
-          totalTokens: 0,
-          inputTokens: 0,
-          outputTokens: 0,
-          durations: [],
-          costEstimate: 0,
-          tasksCreated: 0,
-          statusChanges: 0,
-          tasksArchived: 0,
-        });
-      }
-      const dayAcc = dailyData.get(dateStr)!;
+      const dayAcc = getOrInitialize(dailyData, dateStr, () => ({
+        runs: 0,
+        successes: 0,
+        failures: 0,
+        errors: 0,
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        durations: [],
+        costEstimate: 0,
+        tasksCreated: 0,
+        statusChanges: 0,
+        tasksArchived: 0,
+      }));
 
       // Count task activity events
       if (event.type === 'task.created') {
@@ -458,7 +464,8 @@ export async function computeTrends(
   const sortedDates = [...dailyData.keys()].sort();
 
   for (const date of sortedDates) {
-    const data = dailyData.get(date)!;
+    const data = dailyData.get(date);
+    if (!data) continue;
     const avgDurationMs =
       data.durations.length > 0
         ? Math.round(data.durations.reduce((a, b) => a + b, 0) / data.durations.length)
@@ -527,20 +534,17 @@ export async function computeAgentComparison(
         const runEvent = event as RunTelemetryEvent;
         const agent = runEvent.agent || 'veritas';
 
-        if (!agentData.has(agent)) {
-          agentData.set(agent, {
-            runs: 0,
-            successes: 0,
-            failures: 0,
-            errors: 0,
-            durations: [],
-            totalTokens: 0,
-            inputTokens: 0,
-            outputTokens: 0,
-            costEstimate: 0,
-          });
-        }
-        const acc = agentData.get(agent)!;
+        const acc = getOrInitialize(agentData, agent, () => ({
+          runs: 0,
+          successes: 0,
+          failures: 0,
+          errors: 0,
+          durations: [],
+          totalTokens: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          costEstimate: 0,
+        }));
 
         if (eventType === 'run.error') {
           acc.runs++;
@@ -566,20 +570,17 @@ export async function computeAgentComparison(
         const tokenEvent = event as TokenTelemetryEvent;
         const agent = tokenEvent.agent || 'veritas';
 
-        if (!agentData.has(agent)) {
-          agentData.set(agent, {
-            runs: 0,
-            successes: 0,
-            failures: 0,
-            errors: 0,
-            durations: [],
-            totalTokens: 0,
-            inputTokens: 0,
-            outputTokens: 0,
-            costEstimate: 0,
-          });
-        }
-        const acc = agentData.get(agent)!;
+        const acc = getOrInitialize(agentData, agent, () => ({
+          runs: 0,
+          successes: 0,
+          failures: 0,
+          errors: 0,
+          durations: [],
+          totalTokens: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          costEstimate: 0,
+        }));
         const totalTokens =
           tokenEvent.totalTokens ?? tokenEvent.inputTokens + tokenEvent.outputTokens;
 

--- a/server/src/services/metrics/prometheus.ts
+++ b/server/src/services/metrics/prometheus.ts
@@ -48,14 +48,14 @@ export class Counter {
 
   /** Return all (labelKey → value) pairs. */
   entries(): Array<[Record<string, string>, number]> {
-    return [...this.values.entries()].map(([key, val]) => [this.labelSets.get(key)!, val]);
+    return [...this.values.entries()].map(([key, val]) => [this.labelSets.get(key) ?? {}, val]);
   }
 
   /** Render Prometheus text lines (without HELP/TYPE — registry adds those). */
   render(): string[] {
     const lines: string[] = [];
     for (const [key, val] of this.values) {
-      const lbls = this.labelSets.get(key)!;
+      const lbls = this.labelSets.get(key) ?? {};
       lines.push(`${this.meta.name}${formatLabels(lbls)} ${val}`);
     }
     return lines;
@@ -81,9 +81,12 @@ export class Gauge {
       this.labelSets.set(key, {});
       this.values.set(key, labelsOrValue);
     } else {
+      if (value === undefined) {
+        throw new TypeError('Gauge label sets require a value');
+      }
       const key = labelKey(labelsOrValue);
       this.labelSets.set(key, labelsOrValue);
-      this.values.set(key, value!);
+      this.values.set(key, value);
     }
   }
 
@@ -106,7 +109,7 @@ export class Gauge {
   render(): string[] {
     const lines: string[] = [];
     for (const [key, val] of this.values) {
-      const lbls = this.labelSets.get(key)!;
+      const lbls = this.labelSets.get(key) ?? {};
       lines.push(`${this.meta.name}${formatLabels(lbls)} ${val}`);
     }
     return lines;
@@ -139,15 +142,19 @@ export class Histogram {
 
   private getOrCreate(labels: Record<string, string>): HistogramData {
     const key = labelKey(labels);
-    if (!this.data.has(key)) {
-      this.labelSets.set(key, labels);
-      this.data.set(key, {
-        buckets: this.bucketBoundaries.map((le) => ({ le, count: 0 })),
-        sum: 0,
-        count: 0,
-      });
+    const existing = this.data.get(key);
+    if (existing) {
+      return existing;
     }
-    return this.data.get(key)!;
+
+    const created = {
+      buckets: this.bucketBoundaries.map((le) => ({ le, count: 0 })),
+      sum: 0,
+      count: 0,
+    };
+    this.labelSets.set(key, labels);
+    this.data.set(key, created);
+    return created;
   }
 
   observe(labels: Record<string, string>, value: number): void;
@@ -159,8 +166,11 @@ export class Histogram {
       labels = {};
       observedValue = labelsOrValue;
     } else {
+      if (value === undefined) {
+        throw new TypeError('Histogram label sets require a value');
+      }
       labels = labelsOrValue;
-      observedValue = value!;
+      observedValue = value;
     }
 
     const data = this.getOrCreate(labels);
@@ -176,7 +186,7 @@ export class Histogram {
   render(): string[] {
     const lines: string[] = [];
     for (const [key, hd] of this.data) {
-      const lbls = this.labelSets.get(key)!;
+      const lbls = this.labelSets.get(key) ?? {};
       const baseLabelStr = labelKey(lbls);
 
       for (const bucket of hd.buckets) {

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -1149,7 +1149,7 @@ export class TaskService {
     });
 
     fireHook('onArchived', freshArchivedTask).catch((err) => {
-      log.warn({ taskId: freshArchivedTask!.id }, 'onArchived hook failed: %s', err);
+      log.warn({ taskId: freshArchivedTask.id }, 'onArchived hook failed: %s', err);
     });
 
     return true;
@@ -1355,6 +1355,7 @@ export class TaskService {
     }
 
     const now = new Date();
+    const activeEntryId = task.timeTracking.activeEntryId;
     const entries = task.timeTracking.entries.map(
       (entry: {
         id: string;
@@ -1364,7 +1365,7 @@ export class TaskService {
         description?: string;
         manual?: boolean;
       }) => {
-        if (entry.id === task.timeTracking!.activeEntryId) {
+        if (entry.id === activeEntryId) {
           const startTime = new Date(entry.startTime);
           const duration = Math.floor((now.getTime() - startTime.getTime()) / 1000);
           return {
@@ -1593,7 +1594,8 @@ export class TaskService {
     const stack = [startId];
 
     while (stack.length > 0) {
-      const currentId = stack.pop()!;
+      const currentId = stack.pop();
+      if (!currentId) continue;
 
       if (currentId === targetId) {
         return true; // Found a cycle


### PR DESCRIPTION
## Summary

- remove 120 server lint warnings, led by production route, metrics, analytics, and task-service paths
- replace unsafe validated-request and map-access assertions with explicit type narrowing and fallbacks
- make nullable test fixtures fail explicitly instead of relying on non-null assertions
- ratchet the repository warning budget from 600 to the measured 458 warnings

## Verification

- shared and server TypeScript compilation
- repository lint report: 0 errors, 458 warnings
- lint warning budget: 458 of 458

## Risk

Low. Most changes are type narrowing and removal of assertions. Automation routes now fail explicitly if a task disappears during an update or an attempt payload is malformed.

Closes #1173