### PR TITLE
build: enforce Docker image contract

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,11 @@ node_modules
 server/dist
 web/dist
 shared/dist
+desktop/.desktop-release
+desktop/release
+.veritas-desktop-dev
+playwright-report
+test-results
 
 # Git
 .git

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,50 @@
+name: Docker Image Contract
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - server/**
+      - shared/**
+      - web/**
+      - scripts/check-docker-image.mjs
+      - .github/workflows/docker-image.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - server/**
+      - shared/**
+      - web/**
+      - scripts/check-docker-image.mjs
+      - .github/workflows/docker-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Build, Size, and Runtime Contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build production image
+        run: docker build --target production --tag veritas-kanban:contract .
+
+      - name: Enforce image and runtime contract
+        run: node scripts/check-docker-image.mjs veritas-kanban:contract

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,7 +6,7 @@ docs/API-REFERENCE.md:generic-api-key:991
 docs/API-WORKFLOWS.md:generic-api-key:1460
 
 # Operator documentation uses placeholders in curl authentication examples.
-docs/DEPLOYMENT.md:curl-auth-header:917
+docs/DEPLOYMENT.md:curl-auth-header:923
 docs/TROUBLESHOOTING.md:curl-auth-header:229
 docs/TROUBLESHOOTING.md:curl-auth-header:257
 docs/TROUBLESHOOTING.md:curl-auth-header:260

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,7 +6,7 @@ docs/API-REFERENCE.md:generic-api-key:991
 docs/API-WORKFLOWS.md:generic-api-key:1460
 
 # Operator documentation uses placeholders in curl authentication examples.
-docs/DEPLOYMENT.md:curl-auth-header:904
+docs/DEPLOYMENT.md:curl-auth-header:915
 docs/TROUBLESHOOTING.md:curl-auth-header:229
 docs/TROUBLESHOOTING.md:curl-auth-header:257
 docs/TROUBLESHOOTING.md:curl-auth-header:260

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,7 +6,7 @@ docs/API-REFERENCE.md:generic-api-key:991
 docs/API-WORKFLOWS.md:generic-api-key:1460
 
 # Operator documentation uses placeholders in curl authentication examples.
-docs/DEPLOYMENT.md:curl-auth-header:915
+docs/DEPLOYMENT.md:curl-auth-header:917
 docs/TROUBLESHOOTING.md:curl-auth-header:229
 docs/TROUBLESHOOTING.md:curl-auth-header:257
 docs/TROUBLESHOOTING.md:curl-auth-header:260

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@
 #   1. deps        — Install all workspace dependencies (shared cache layer)
 #   2. build-shared — Build the shared package
 #   3. build-web   — Build React frontend with Vite
-#   4. build-server — Compile Express server TypeScript
+#   4. build-server — Compile the Express server TypeScript
 #   5. production  — Minimal runtime image
 #
-# Target image size: < 200MB
+# Target image size: < 625,000,000 bytes
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -67,34 +67,31 @@ RUN pnpm --filter @veritas-kanban/server build
 # ---------------------------------------------------------------------------
 FROM node:22-alpine AS production
 
-RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
-
 # Security: run as non-root
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S veritas -u 1001 -G nodejs
 
 WORKDIR /app
 
-# Copy workspace config for pnpm (include real web/package.json for lockfile integrity)
+# Install only the server workspace and its shared dependency. The Linux Codex
+# SDK runtime is intentionally retained; pnpm's platform pruning excludes the
+# other platform binaries that pnpm deploy currently copies.
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY shared/package.json ./shared/
 COPY server/package.json ./server/
-COPY web/package.json ./web/
-COPY cli/package.json ./cli/
-COPY mcp/package.json ./mcp/
+COPY scripts/ ./scripts/
+RUN corepack enable && \
+    corepack prepare pnpm@11.1.1 --activate && \
+    HUSKY=0 pnpm install --frozen-lockfile --prod --filter @veritas-kanban/server... && \
+    rm -rf /root/.cache/node/corepack /root/.local/share/pnpm/store /root/.local/share/pnpm/.tools && \
+    rm -rf scripts package.json pnpm-lock.yaml pnpm-workspace.yaml && \
+    rm -f /usr/local/bin/pnpm /usr/local/bin/pnpx
 
-# Install production-only dependencies
-# --ignore-scripts: skip husky prepare hook (not needed in container)
-# Note: web deps get installed to satisfy the lockfile, but we remove them
-# since the frontend is pre-built as static assets
-RUN pnpm install --frozen-lockfile --prod --ignore-scripts && \
-    rm -rf web/node_modules && \
-    pnpm store prune
-
-# Copy built artifacts
-COPY --from=build-shared /app/shared/dist ./shared/dist
-COPY --from=build-server /app/server/dist ./server/dist
-COPY --from=build-web /app/web/dist ./web/dist
+# Copy only built runtime artifacts. CLI, MCP, frontend dependencies, source,
+# and build tooling never enter the production stage.
+COPY --from=build-shared --chown=veritas:nodejs /app/shared/dist ./shared/dist
+COPY --from=build-server --chown=veritas:nodejs /app/server/dist ./server/dist
+COPY --from=build-web --chown=veritas:nodejs /app/web/dist ./web/dist
 
 # Create the single volume-backed storage root. Runtime state is stored at
 # /app/data/.veritas-kanban and task data at /app/data/tasks.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@
 #   2. build-shared — Build the shared package
 #   3. build-web   — Build React frontend with Vite
 #   4. build-server — Compile the Express server TypeScript
-#   5. production  — Minimal runtime image
+#   5. production-deps — Install the server-only runtime closure
+#   6. production  — Minimal runtime image
 #
-# Target image size: < 625,000,000 bytes
+# Target image size: < 200,000,000 bytes
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -63,19 +64,12 @@ COPY server/ ./server/
 RUN pnpm --filter @veritas-kanban/server build
 
 # ---------------------------------------------------------------------------
-# Stage 5: Production runtime
+# Stage 5: Install the server-only production dependency closure
 # ---------------------------------------------------------------------------
-FROM node:22-alpine AS production
-
-# Security: run as non-root
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S veritas -u 1001 -G nodejs
+FROM node:22-alpine AS production-deps
 
 WORKDIR /app
 
-# Install only the server workspace and its shared dependency. The Linux Codex
-# SDK runtime is intentionally retained; pnpm's platform pruning excludes the
-# other platform binaries that pnpm deploy currently copies.
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY shared/package.json ./shared/
 COPY server/package.json ./server/
@@ -83,9 +77,28 @@ COPY scripts/ ./scripts/
 RUN corepack enable && \
     corepack prepare pnpm@11.1.1 --activate && \
     HUSKY=0 pnpm install --frozen-lockfile --prod --filter @veritas-kanban/server... && \
-    rm -rf /root/.cache/node/corepack /root/.local/share/pnpm/store /root/.local/share/pnpm/.tools && \
-    rm -rf scripts package.json pnpm-lock.yaml pnpm-workspace.yaml && \
-    rm -f /usr/local/bin/pnpm /usr/local/bin/pnpx
+    rm -rf /root/.cache/node/corepack /root/.local/share/pnpm/store /root/.local/share/pnpm/.tools
+
+# ---------------------------------------------------------------------------
+# Stage 6: Production runtime
+# ---------------------------------------------------------------------------
+# The matching Alpine base keeps Node's musl ABI while excluding npm,
+# Corepack, headers, and package-manager tooling from the runtime image.
+FROM alpine:3.24 AS production
+
+RUN apk add --no-cache libstdc++ && \
+    addgroup -g 1001 -S nodejs && \
+    adduser -S veritas -u 1001 -G nodejs
+
+COPY --from=production-deps /usr/local/bin/node /usr/local/bin/node
+
+WORKDIR /app
+
+# Copy only the resolved server runtime closure. The platform-specific Codex
+# binary remains available, while npm, pnpm, workspace manifests, and build
+# tooling never enter the production stage.
+COPY --from=production-deps --chown=veritas:nodejs /app/node_modules ./node_modules
+COPY --from=production-deps --chown=veritas:nodejs /app/server/node_modules ./server/node_modules
 
 # Copy only built runtime artifacts. CLI, MCP, frontend dependencies, source,
 # and build tooling never enter the production stage.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #   5. production-deps — Install the server-only runtime closure
 #   6. production  — Minimal runtime image
 #
-# Target image size: < 200,000,000 bytes
+# Target image size: < 200,000,000 bytes on arm64; < 600,000,000 bytes on amd64
 # =============================================================================
 
 # ---------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # ---------------------------------------------------------------------------
 # Stage 1: Install dependencies (shared across build stages)
 # ---------------------------------------------------------------------------
-FROM node:22-alpine AS deps
+FROM node:22-alpine3.24 AS deps
 
 RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
 
@@ -66,7 +66,7 @@ RUN pnpm --filter @veritas-kanban/server build
 # ---------------------------------------------------------------------------
 # Stage 5: Install the server-only production dependency closure
 # ---------------------------------------------------------------------------
-FROM node:22-alpine AS production-deps
+FROM node:22-alpine3.24 AS production-deps
 
 WORKDIR /app
 
@@ -86,7 +86,7 @@ RUN corepack enable && \
 # Corepack, headers, and package-manager tooling from the runtime image.
 FROM alpine:3.24 AS production
 
-RUN apk add --no-cache libstdc++ && \
+RUN apk add --no-cache ca-certificates libstdc++ && \
     addgroup -g 1001 -S nodejs && \
     adduser -S veritas -u 1001 -G nodejs
 
@@ -99,6 +99,8 @@ WORKDIR /app
 # tooling never enter the production stage.
 COPY --from=production-deps --chown=veritas:nodejs /app/node_modules ./node_modules
 COPY --from=production-deps --chown=veritas:nodejs /app/server/node_modules ./server/node_modules
+COPY --from=production-deps --chown=veritas:nodejs /app/shared/package.json ./shared/package.json
+COPY --from=production-deps --chown=veritas:nodejs /app/server/package.json ./server/package.json
 
 # Copy only built runtime artifacts. CLI, MCP, frontend dependencies, source,
 # and build tooling never enter the production stage.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -77,8 +77,10 @@ The multi-stage Dockerfile produces a production image smaller than 625,000,000 
 | `build-server` | Compile the server and deploy its production dependency closure          |
 | `production`   | Copy only the server closure and built web assets into Node.js 22 Alpine |
 
-The production stage does not contain pnpm, workspace manifests, CLI dependencies, or MCP
-dependencies. It runs as the non-root `veritas` user (UID 1001).
+The production stage does not contain npm, pnpm, the root workspace/lockfile,
+CLI dependencies, or MCP dependencies. It retains only the server and shared
+package identity manifests required for module resolution and version health.
+It runs as the non-root `veritas` user (UID 1001).
 
 The measured release image is about 600 MB. Roughly 302 MB of its unpacked filesystem is the
 Linux Codex executable bundled by `@openai/codex-sdk`; retaining it keeps the `codex-sdk` provider

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,7 +67,12 @@ Data is persisted in a Docker named volume (`kanban-data`), so it survives conta
 
 ### Dockerfile Overview
 
-The multi-stage Dockerfile produces a production image smaller than 625,000,000 bytes:
+The multi-stage Dockerfile enforces architecture-specific production image budgets:
+
+| Architecture | Maximum compressed image size | Measured release candidate |
+| ------------ | ----------------------------- | -------------------------- |
+| `arm64`      | 200,000,000 bytes             | 195,910,880 bytes          |
+| `amd64`      | 600,000,000 bytes             | 571,590,173 bytes          |
 
 | Stage          | Purpose                                                                  |
 | -------------- | ------------------------------------------------------------------------ |
@@ -82,15 +87,16 @@ CLI dependencies, or MCP dependencies. It retains only the server and shared
 package identity manifests required for module resolution and version health.
 It runs as the non-root `veritas` user (UID 1001).
 
-The measured release image is about 600 MB. Roughly 302 MB of its unpacked filesystem is the
-Linux Codex executable bundled by `@openai/codex-sdk`; retaining it keeps the `codex-sdk` provider
-functional without an operator-supplied binary. The previous 200 MB target was incompatible with
-that required runtime. The 625,000,000-byte ceiling leaves limited patch-version headroom while
-still failing material dependency growth.
+The `amd64` image is larger because the Linux Codex runtime bundled by `@openai/codex-sdk`
+occupies about 302 MB of its unpacked filesystem, including a roughly 245 MB executable.
+Retaining it keeps the `codex-sdk` provider functional without an operator-supplied binary.
+The budgets leave about 2% headroom on `arm64` and 5% on `amd64`, so material dependency growth
+still fails the contract instead of being normalized by one loose cross-platform ceiling.
 
 CI builds the production target and runs `pnpm check:docker-image`. The contract fails when the
-image reaches 625,000,000 bytes or when the runtime smoke cannot prove non-root execution, SQLite
-startup, API authentication, static web serving, health checks, and the native `bcrypt` module.
+image reaches its architecture budget or when the runtime smoke cannot prove non-root execution,
+SQLite startup, API authentication, static web serving, health checks, and the native `bcrypt`
+module. `VERITAS_DOCKER_MAX_BYTES` can set an explicit budget for another architecture.
 
 **Path Resolution (v2.1.3):** All services use the shared `paths.ts` utility for consistent path resolution. The resolution priority is: `DATA_DIR` / `VERITAS_DATA_DIR` env var → auto-discovery of monorepo root (walks up from cwd looking for `pnpm-workspace.yaml`) → fallback to cwd. A filesystem root guard prevents silent `/` resolution, which previously caused `EACCES: permission denied` errors in Docker. The production image uses `WORKDIR /app/server` for backwards compatibility.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,17 +67,28 @@ Data is persisted in a Docker named volume (`kanban-data`), so it survives conta
 
 ### Dockerfile Overview
 
-The multi-stage Dockerfile produces a minimal production image (< 200 MB):
+The multi-stage Dockerfile produces a production image smaller than 625,000,000 bytes:
 
-| Stage          | Purpose                                 |
-| -------------- | --------------------------------------- |
-| `deps`         | Install all pnpm workspace dependencies |
-| `build-shared` | Compile the shared TypeScript package   |
-| `build-web`    | Build the React frontend with Vite      |
-| `build-server` | Compile the Express server TypeScript   |
-| `production`   | Minimal Node.js 22 Alpine runtime       |
+| Stage          | Purpose                                                                  |
+| -------------- | ------------------------------------------------------------------------ |
+| `deps`         | Install all pnpm workspace dependencies                                  |
+| `build-shared` | Compile the shared TypeScript package                                    |
+| `build-web`    | Build the React frontend with Vite                                       |
+| `build-server` | Compile the server and deploy its production dependency closure          |
+| `production`   | Copy only the server closure and built web assets into Node.js 22 Alpine |
 
-The production stage runs as a non-root user (`veritas`, UID 1001) for security.
+The production stage does not contain pnpm, workspace manifests, CLI dependencies, or MCP
+dependencies. It runs as the non-root `veritas` user (UID 1001).
+
+The measured release image is about 600 MB. Roughly 302 MB of its unpacked filesystem is the
+Linux Codex executable bundled by `@openai/codex-sdk`; retaining it keeps the `codex-sdk` provider
+functional without an operator-supplied binary. The previous 200 MB target was incompatible with
+that required runtime. The 625,000,000-byte ceiling leaves limited patch-version headroom while
+still failing material dependency growth.
+
+CI builds the production target and runs `pnpm check:docker-image`. The contract fails when the
+image reaches 625,000,000 bytes or when the runtime smoke cannot prove non-root execution, SQLite
+startup, API authentication, static web serving, health checks, and the native `bcrypt` module.
 
 **Path Resolution (v2.1.3):** All services use the shared `paths.ts` utility for consistent path resolution. The resolution priority is: `DATA_DIR` / `VERITAS_DATA_DIR` env var → auto-discovery of monorepo root (walks up from cwd looking for `pnpm-workspace.yaml`) → fallback to cwd. A filesystem root guard prevents silent `/` resolution, which previously caused `EACCES: permission denied` errors in Docker. The production image uses `WORKDIR /app/server` for backwards compatibility.
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "check:security-artifacts": "node scripts/check-security-artifacts.mjs",
     "check:tracked-ignore": "node --test scripts/check-tracked-ignore.test.mjs && node scripts/check-tracked-ignore.mjs",
     "check:service-filesystem-boundary": "node --test scripts/check-service-filesystem-boundary.test.mjs && node scripts/check-service-filesystem-boundary.mjs",
+    "check:docker-image": "node scripts/check-docker-image.mjs",
     "typecheck": "pnpm --filter @veritas-kanban/shared build && pnpm -r typecheck",
     "test": "pnpm test:unit",
     "test:unit": "node --test scripts/run-workspace-unit-tests.test.mjs && node scripts/run-workspace-unit-tests.mjs",

--- a/scripts/check-docker-image.mjs
+++ b/scripts/check-docker-image.mjs
@@ -114,7 +114,8 @@ const runtimeProbe = String.raw`
   const backupBody = await backup.json();
   assert(backup.status === 200, 'SQLite backup export did not return 200');
   assert(
-    backupBody.bundlePath === '/app/data/backups/docker-contract',
+    backupBody.success === true &&
+      backupBody.data?.bundlePath === '/app/data/backups/docker-contract',
     'SQLite backup export escaped the mounted DATA_DIR'
   );
   await access('/app/data/backups/docker-contract/manifest.json');

--- a/scripts/check-docker-image.mjs
+++ b/scripts/check-docker-image.mjs
@@ -6,6 +6,7 @@ import { randomBytes } from 'node:crypto';
 const image = process.env.VERITAS_DOCKER_IMAGE || process.argv[2] || 'veritas-kanban:contract';
 const maxBytes = Number(process.env.VERITAS_DOCKER_MAX_BYTES || '625000000');
 const containerName = `veritas-kanban-contract-${process.pid}`;
+const volumeName = `${containerName}-data`;
 const adminKey = randomBytes(24).toString('hex');
 
 function run(args) {
@@ -21,25 +22,32 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
+function containerLogs() {
+  const result = spawnSync('docker', ['logs', containerName], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+}
+
 async function waitForHealthyContainer() {
   const deadline = Date.now() + 90_000;
   while (Date.now() < deadline) {
-    const status = run([
-      'inspect',
-      '--format',
-      '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}',
-      containerName,
-    ]);
-    if (status === 'healthy') return;
-    if (status === 'exited' || status === 'dead') {
-      const logs = run(['logs', containerName]);
-      throw new Error(`Container stopped before becoming healthy (${status})\n${logs}`);
+    const state = JSON.parse(
+      run(['inspect', '--format', '{{json .State}}', containerName])
+    );
+    if (state.Health?.Status === 'healthy') return;
+    if (state.Status === 'exited' || state.Status === 'dead') {
+      throw new Error(
+        `Container stopped before becoming healthy (${state.Status})\n${containerLogs()}`
+      );
     }
     await new Promise((resolve) => globalThis.setTimeout(resolve, 1_000));
   }
   const health = run(['inspect', '--format', '{{json .State.Health}}', containerName]);
-  const logs = run(['logs', containerName]);
-  throw new Error(`Container did not become healthy within 90 seconds\nHealth: ${health}\n${logs}`);
+  throw new Error(
+    `Container did not become healthy within 90 seconds\nHealth: ${health}\n${containerLogs()}`
+  );
 }
 
 const runtimeProbe = String.raw`
@@ -82,6 +90,7 @@ const runtimeProbe = String.raw`
 `;
 
 let started = false;
+let volumeCreated = false;
 try {
   assert(Number.isFinite(maxBytes) && maxBytes > 0, 'VERITAS_DOCKER_MAX_BYTES must be positive');
 
@@ -105,11 +114,15 @@ try {
   const configuredUser = run(['image', 'inspect', image, '--format', '{{.Config.User}}']);
   assert(configuredUser === 'veritas', `Expected image user veritas, found ${configuredUser || 'root'}`);
 
+  run(['volume', 'create', volumeName]);
+  volumeCreated = true;
   run([
     'run',
     '--detach',
     '--name',
     containerName,
+    '--mount',
+    `type=volume,source=${volumeName},target=/app/data`,
     '--env',
     `VERITAS_ADMIN_KEY=${adminKey}`,
     '--env',
@@ -136,5 +149,8 @@ try {
 } finally {
   if (started) {
     spawnSync('docker', ['rm', '--force', containerName], { stdio: 'ignore' });
+  }
+  if (volumeCreated) {
+    spawnSync('docker', ['volume', 'rm', volumeName], { stdio: 'ignore' });
   }
 }

--- a/scripts/check-docker-image.mjs
+++ b/scripts/check-docker-image.mjs
@@ -5,7 +5,11 @@ import { randomBytes } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
 const image = process.env.VERITAS_DOCKER_IMAGE || process.argv[2] || 'veritas-kanban:contract';
-const maxBytes = Number(process.env.VERITAS_DOCKER_MAX_BYTES || '200000000');
+const configuredMaxBytes = process.env.VERITAS_DOCKER_MAX_BYTES;
+const defaultMaxBytesByArchitecture = {
+  arm64: 200_000_000,
+  amd64: 600_000_000,
+};
 const containerName = `veritas-kanban-contract-${process.pid}`;
 const volumeName = `${containerName}-data`;
 const adminKey = randomBytes(24).toString('hex');
@@ -127,6 +131,14 @@ const runtimeProbe = String.raw`
 let started = false;
 let volumeCreated = false;
 try {
+  const architecture = run(['image', 'inspect', image, '--format', '{{.Architecture}}']);
+  const maxBytes = configuredMaxBytes
+    ? Number(configuredMaxBytes)
+    : defaultMaxBytesByArchitecture[architecture];
+  assert(
+    maxBytes !== undefined,
+    `No Docker image size budget is defined for architecture ${architecture}; set VERITAS_DOCKER_MAX_BYTES explicitly`
+  );
   assert(Number.isFinite(maxBytes) && maxBytes > 0, 'VERITAS_DOCKER_MAX_BYTES must be positive');
 
   const imageBytes = Number(run(['image', 'inspect', image, '--format', '{{.Size}}']));
@@ -187,7 +199,7 @@ try {
   started = false;
 
   console.log(
-    `Docker image contract passed: ${imageBytes.toLocaleString()} bytes (< ${maxBytes.toLocaleString()})`
+    `Docker image contract passed on ${architecture}: ${imageBytes.toLocaleString()} bytes (< ${maxBytes.toLocaleString()})`
   );
   console.log(
     'Runtime smoke passed: non-root user, version, mounted paths, SQLite, backup, auth, web assets, health, bcrypt, and clean shutdown'

--- a/scripts/check-docker-image.mjs
+++ b/scripts/check-docker-image.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+
+const image = process.env.VERITAS_DOCKER_IMAGE || process.argv[2] || 'veritas-kanban:contract';
+const maxBytes = Number(process.env.VERITAS_DOCKER_MAX_BYTES || '625000000');
+const containerName = `veritas-kanban-contract-${process.pid}`;
+const adminKey = randomBytes(24).toString('hex');
+
+function run(args) {
+  const result = spawnSync('docker', args, { encoding: 'utf8', stdio: 'pipe' });
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(detail || `Docker command failed with status ${result.status}`);
+  }
+  return result.stdout?.trim() ?? '';
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function waitForHealthyContainer() {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const status = run([
+      'inspect',
+      '--format',
+      '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}',
+      containerName,
+    ]);
+    if (status === 'healthy') return;
+    if (status === 'exited' || status === 'dead') {
+      const logs = run(['logs', containerName]);
+      throw new Error(`Container stopped before becoming healthy (${status})\n${logs}`);
+    }
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 1_000));
+  }
+  const health = run(['inspect', '--format', '{{json .State.Health}}', containerName]);
+  const logs = run(['logs', containerName]);
+  throw new Error(`Container did not become healthy within 90 seconds\nHealth: ${health}\n${logs}`);
+}
+
+const runtimeProbe = String.raw`
+  import bcrypt from 'bcrypt';
+
+  const assert = (condition, message) => {
+    if (!condition) throw new Error(message);
+  };
+  const response = async (path, init) => fetch('http://127.0.0.1:3001' + path, init);
+
+  const health = await response('/health');
+  assert(health.status === 200, 'GET /health did not return 200');
+
+  const readiness = await response('/health/ready');
+  const readinessBody = await readiness.json();
+  assert(readiness.status === 200, 'GET /health/ready did not return 200');
+  assert(readinessBody.checks?.sqlite === 'ok', 'SQLite readiness was not healthy');
+
+  const index = await response('/');
+  const html = await index.text();
+  assert(index.status === 200 && html.includes('id="root"'), 'Built web app was not served');
+
+  const unauthenticated = await response('/api/tasks');
+  assert(unauthenticated.status === 401, 'Protected API did not reject an unauthenticated request');
+
+  const authenticated = await response('/api/tasks', {
+    headers: { 'X-API-Key': process.env.VERITAS_ADMIN_KEY },
+  });
+  assert(authenticated.status === 200, 'Admin API key did not authenticate');
+
+  const deepHealth = await response('/api/health/deep', {
+    headers: { 'X-API-Key': process.env.VERITAS_ADMIN_KEY },
+  });
+  const deepHealthBody = await deepHealth.json();
+  assert(deepHealth.status === 200, 'Deep health endpoint did not return 200');
+  assert(deepHealthBody.sqlite?.healthPosture === 'healthy', 'SQLite startup was not healthy');
+
+  const hash = await bcrypt.hash('native-module-probe', 4);
+  assert(await bcrypt.compare('native-module-probe', hash), 'bcrypt native module failed');
+`;
+
+let started = false;
+try {
+  assert(Number.isFinite(maxBytes) && maxBytes > 0, 'VERITAS_DOCKER_MAX_BYTES must be positive');
+
+  const imageBytes = Number(run(['image', 'inspect', image, '--format', '{{.Size}}']));
+  assert(Number.isFinite(imageBytes), `Could not read image size for ${image}`);
+  if (imageBytes >= maxBytes) {
+    const diagnostics = run([
+      'run',
+      '--rm',
+      '--entrypoint',
+      'sh',
+      image,
+      '-c',
+      'du -ak /app /usr/local 2>/dev/null | sort -nr | head -25',
+    ]);
+    throw new Error(
+      `Docker image is ${imageBytes.toLocaleString()} bytes; budget is below ${maxBytes.toLocaleString()} bytes\nLargest runtime paths (KiB):\n${diagnostics}`
+    );
+  }
+
+  const configuredUser = run(['image', 'inspect', image, '--format', '{{.Config.User}}']);
+  assert(configuredUser === 'veritas', `Expected image user veritas, found ${configuredUser || 'root'}`);
+
+  run([
+    'run',
+    '--detach',
+    '--name',
+    containerName,
+    '--env',
+    `VERITAS_ADMIN_KEY=${adminKey}`,
+    '--env',
+    'VERITAS_STORAGE=sqlite',
+    image,
+  ]);
+  started = true;
+
+  await waitForHealthyContainer();
+
+  run([
+    'exec',
+    containerName,
+    'sh',
+    '-c',
+    'test "$(id -u)" = 1001 && test ! -e /app/cli && test ! -e /app/mcp && test ! -e /app/pnpm-lock.yaml && test -f /app/data/.veritas-kanban/veritas.db',
+  ]);
+  run(['exec', containerName, 'node', '--input-type=module', '--eval', runtimeProbe]);
+
+  console.log(
+    `Docker image contract passed: ${imageBytes.toLocaleString()} bytes (< ${maxBytes.toLocaleString()})`
+  );
+  console.log('Runtime smoke passed: non-root user, SQLite, auth, web assets, health, and bcrypt');
+} finally {
+  if (started) {
+    spawnSync('docker', ['rm', '--force', containerName], { stdio: 'ignore' });
+  }
+}

--- a/scripts/check-docker-image.mjs
+++ b/scripts/check-docker-image.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 
 const image = process.env.VERITAS_DOCKER_IMAGE || process.argv[2] || 'veritas-kanban:contract';
-const maxBytes = Number(process.env.VERITAS_DOCKER_MAX_BYTES || '625000000');
+const maxBytes = Number(process.env.VERITAS_DOCKER_MAX_BYTES || '200000000');
 const containerName = `veritas-kanban-contract-${process.pid}`;
 const volumeName = `${containerName}-data`;
 const adminKey = randomBytes(24).toString('hex');

--- a/scripts/check-docker-image.mjs
+++ b/scripts/check-docker-image.mjs
@@ -2,12 +2,16 @@
 
 import { spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 
 const image = process.env.VERITAS_DOCKER_IMAGE || process.argv[2] || 'veritas-kanban:contract';
 const maxBytes = Number(process.env.VERITAS_DOCKER_MAX_BYTES || '200000000');
 const containerName = `veritas-kanban-contract-${process.pid}`;
 const volumeName = `${containerName}-data`;
 const adminKey = randomBytes(24).toString('hex');
+const expectedVersion = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+).version;
 
 function run(args) {
   const result = spawnSync('docker', args, { encoding: 'utf8', stdio: 'pipe' });
@@ -52,6 +56,7 @@ async function waitForHealthyContainer() {
 
 const runtimeProbe = String.raw`
   import bcrypt from 'bcrypt';
+  import { access } from 'node:fs/promises';
 
   const assert = (condition, message) => {
     if (!condition) throw new Error(message);
@@ -83,7 +88,36 @@ const runtimeProbe = String.raw`
   });
   const deepHealthBody = await deepHealth.json();
   assert(deepHealth.status === 200, 'Deep health endpoint did not return 200');
+  assert(deepHealthBody.status === 'ok', 'Deep health reported a degraded runtime');
+  assert(
+    deepHealthBody.version === ${JSON.stringify(expectedVersion)},
+    'Deep health did not report release version ${expectedVersion}'
+  );
+  assert(deepHealthBody.checks?.storage === 'ok', 'Storage integrity check was not healthy');
   assert(deepHealthBody.sqlite?.healthPosture === 'healthy', 'SQLite startup was not healthy');
+  assert(
+    deepHealthBody.dataDirectory?.path === '/app/data/.veritas-kanban',
+    'Runtime state did not resolve beneath the mounted DATA_DIR'
+  );
+
+  const backup = await response('/api/v1/sqlite/export', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': process.env.VERITAS_ADMIN_KEY,
+    },
+    body: JSON.stringify({
+      sqlitePath: '/app/data/.veritas-kanban/veritas.db',
+      outputDir: '/app/data/backups/docker-contract',
+    }),
+  });
+  const backupBody = await backup.json();
+  assert(backup.status === 200, 'SQLite backup export did not return 200');
+  assert(
+    backupBody.bundlePath === '/app/data/backups/docker-contract',
+    'SQLite backup export escaped the mounted DATA_DIR'
+  );
+  await access('/app/data/backups/docker-contract/manifest.json');
 
   const hash = await bcrypt.hash('native-module-probe', 4);
   assert(await bcrypt.compare('native-module-probe', hash), 'bcrypt native module failed');
@@ -142,10 +176,21 @@ try {
   ]);
   run(['exec', containerName, 'node', '--input-type=module', '--eval', runtimeProbe]);
 
+  run(['stop', '--time', '15', containerName]);
+  const stoppedState = JSON.parse(
+    run(['inspect', '--format', '{{json .State}}', containerName])
+  );
+  assert(stoppedState.Status === 'exited', 'Container did not stop cleanly');
+  assert(stoppedState.ExitCode === 0, `Container exited with code ${stoppedState.ExitCode}`);
+  run(['rm', containerName]);
+  started = false;
+
   console.log(
     `Docker image contract passed: ${imageBytes.toLocaleString()} bytes (< ${maxBytes.toLocaleString()})`
   );
-  console.log('Runtime smoke passed: non-root user, SQLite, auth, web assets, health, and bcrypt');
+  console.log(
+    'Runtime smoke passed: non-root user, version, mounted paths, SQLite, backup, auth, web assets, health, bcrypt, and clean shutdown'
+  );
 } finally {
   if (started) {
     spawnSync('docker', ['rm', '--force', containerName], { stdio: 'ignore' });


### PR DESCRIPTION
## Summary

- install only the server production dependency closure in a package-manager-free Alpine runtime
- preserve the Linux Codex SDK runtime, native bcrypt, server/shared package identity, and CA certificates
- enforce measured architecture-specific image ceilings below 200,000,000 bytes on arm64 and 600,000,000 bytes on amd64
- verify non-root execution, release version, canonical mounted paths, SQLite, backup, auth, health, static web assets, bcrypt, and clean shutdown
- exclude generated desktop and test outputs from Docker context

## Verification

- `pnpm typecheck`
- `pnpm build`
- `pnpm check:gitleaks`
- `pnpm check:security-gates`
- `docker build --target production -t veritas-kanban:6.1.2 .`
- `node scripts/check-docker-image.mjs veritas-kanban:6.1.2`
- arm64 image: 195,910,880 bytes against a 200,000,000-byte budget
- amd64 image: 571,590,173 bytes against a 600,000,000-byte budget
- local Docker context: 30.93 MB, reduced from 867.5 MB

The amd64 image is larger because the required Codex SDK runtime occupies about 302 MB of its unpacked filesystem, including a roughly 245 MB executable. The platform budgets leave about 2% headroom on arm64 and 5% on amd64, so material dependency growth still fails the contract. PR CI provides the authoritative amd64 contract run.

## Risk

Medium. The runtime image changes from a full workspace install to a filtered server closure. The runtime contract directly exercises the retained native and provider-critical dependencies.

Closes #1166