### PR TITLE
refactor: centralize attempt lifecycle mutations

### DIFF
--- a/server/src/__tests__/attempt-lifecycle-coordinator.test.ts
+++ b/server/src/__tests__/attempt-lifecycle-coordinator.test.ts
@@ -71,13 +71,28 @@ class MemoryAttemptLifecycleStore implements AttemptLifecycleStore {
 
   async updateTask(taskId: string, input: UpdateTaskInput): Promise<Task | null> {
     if (taskId !== this.task.id) return null;
-    if (input.expectedRevision !== this.task.revision) {
+    if (input.expectedRevision !== undefined && input.expectedRevision !== this.task.revision) {
       throw new Error('Task revision conflict');
     }
     const { expectedRevision: _expectedRevision, ...patch } = input;
     this.task = {
       ...this.task,
       ...patch,
+      revision: (this.task.revision ?? 0) + 1,
+      updated: completedAt,
+    };
+    return structuredClone(this.task);
+  }
+
+  async patchTaskAttempt(
+    taskId: string,
+    attemptId: string,
+    patch: Partial<Omit<TaskAttempt, 'id'>>
+  ): Promise<Task | null> {
+    if (taskId !== this.task.id || this.task.attempt?.id !== attemptId) return null;
+    this.task = {
+      ...this.task,
+      attempt: { ...this.task.attempt, ...patch },
       revision: (this.task.revision ?? 0) + 1,
       updated: completedAt,
     };
@@ -125,6 +140,156 @@ async function completionFixture(summary = 'Lifecycle work completed.') {
 }
 
 describe('AttemptLifecycleCoordinator', () => {
+  it('persists an active-attempt transition with revision and history invariants', async () => {
+    const task = baseTask();
+    const attempt: TaskAttempt = {
+      id: 'attempt_active',
+      agent: 'codex',
+      provider: 'codex-cli',
+      status: 'running',
+    };
+    const activeTask = { ...task, attempt, attempts: [attempt] };
+    const store = new MemoryAttemptLifecycleStore(activeTask);
+    const coordinator = new AttemptLifecycleCoordinator(store);
+    const recoveredAttempt: TaskAttempt = {
+      ...attempt,
+      runRecovery: {
+        code: 'terminal-result-missing',
+        detail: 'Supervisor has no terminal result.',
+        nextAction: 'Inspect the provider log.',
+        recordedAt: completedAt,
+      },
+    };
+
+    const updated = await coordinator.persistActiveAttempt({
+      task: activeTask,
+      attempt: recoveredAttempt,
+      status: 'blocked',
+    });
+
+    expect(updated).toMatchObject({
+      status: 'blocked',
+      revision: 5,
+      attempt: { id: attempt.id, runRecovery: recoveredAttempt.runRecovery },
+    });
+    expect(updated?.attempts).toEqual([recoveredAttempt]);
+  });
+
+  it('rejects an active-attempt transition for a stale owner', async () => {
+    const task = baseTask();
+    const activeAttempt: TaskAttempt = {
+      id: 'attempt_active',
+      agent: 'codex',
+      provider: 'codex-cli',
+      status: 'running',
+    };
+    const staleAttempt: TaskAttempt = {
+      ...activeAttempt,
+      id: 'attempt_stale',
+    };
+    const activeTask = { ...task, attempt: activeAttempt, attempts: [activeAttempt] };
+    const coordinator = new AttemptLifecycleCoordinator(
+      new MemoryAttemptLifecycleStore(activeTask)
+    );
+
+    await expect(
+      coordinator.persistActiveAttempt({ task: activeTask, attempt: staleAttempt })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      details: expect.objectContaining({
+        activeAttemptId: activeAttempt.id,
+        requestedAttemptId: staleAttempt.id,
+      }),
+    });
+  });
+
+  it('begins a new running attempt while archiving the displaced attempt', async () => {
+    const task = baseTask();
+    const previousAttempt: TaskAttempt = {
+      id: 'attempt_previous',
+      agent: 'hermes',
+      provider: 'hermes-cli',
+      status: 'complete',
+    };
+    const nextAttempt: TaskAttempt = {
+      id: 'attempt_next',
+      agent: 'codex',
+      provider: 'codex-cli',
+      status: 'running',
+    };
+    const queuedTask: Task = {
+      ...task,
+      status: 'todo',
+      attempt: previousAttempt,
+      attempts: [],
+    };
+    const coordinator = new AttemptLifecycleCoordinator(
+      new MemoryAttemptLifecycleStore(queuedTask)
+    );
+
+    const updated = await coordinator.beginAttempt({
+      task: queuedTask,
+      attempt: nextAttempt,
+    });
+
+    expect(updated).toMatchObject({
+      status: 'in-progress',
+      attempt: nextAttempt,
+      attempts: [previousAttempt],
+    });
+  });
+
+  it('records launch failure without losing the displaced attempt', async () => {
+    const task = baseTask();
+    const previousAttempt: TaskAttempt = {
+      id: 'attempt_previous',
+      agent: 'hermes',
+      provider: 'hermes-cli',
+      status: 'complete',
+    };
+    const failedAttempt: TaskAttempt = {
+      id: 'attempt_failed',
+      agent: 'codex',
+      provider: 'codex-cli',
+      status: 'failed',
+      ended: completedAt,
+    };
+    const launchingTask = {
+      ...task,
+      attempt: { ...failedAttempt, status: 'running' as const, ended: undefined },
+      attempts: [previousAttempt],
+    };
+    const coordinator = new AttemptLifecycleCoordinator(
+      new MemoryAttemptLifecycleStore(launchingTask)
+    );
+
+    const updated = await coordinator.persistLaunchFailure(task.id, failedAttempt);
+
+    expect(updated).toMatchObject({ status: 'todo', attempt: failedAttempt });
+    expect(updated?.attempts).toEqual([previousAttempt, failedAttempt]);
+  });
+
+  it('patches only the attempt that still owns the task', async () => {
+    const task = baseTask();
+    const attempt: TaskAttempt = {
+      id: 'attempt_active',
+      agent: 'codex',
+      provider: 'codex-cli',
+      status: 'running',
+    };
+    const activeTask = { ...task, attempt, attempts: [attempt] };
+    const coordinator = new AttemptLifecycleCoordinator(
+      new MemoryAttemptLifecycleStore(activeTask)
+    );
+
+    await expect(
+      coordinator.patchActiveAttempt(task.id, attempt.id, { sessionKey: 'session-1' })
+    ).resolves.toMatchObject({ attempt: { id: attempt.id, sessionKey: 'session-1' } });
+    await expect(
+      coordinator.patchActiveAttempt(task.id, 'attempt_stale', { sessionKey: 'session-2' })
+    ).resolves.toBeNull();
+  });
+
   it('persists terminal completion through the lifecycle seam', async () => {
     const { task, attempt, completionResult } = await completionFixture();
     const store = new MemoryAttemptLifecycleStore(task);

--- a/server/src/services/attempt-lifecycle-coordinator.ts
+++ b/server/src/services/attempt-lifecycle-coordinator.ts
@@ -19,6 +19,22 @@ const COMPLETION_PERSISTENCE_ATTEMPTS = 3;
 export interface AttemptLifecycleStore {
   getTask(taskId: string): Promise<Task | null>;
   updateTask(taskId: string, input: UpdateTaskInput): Promise<Task | null>;
+  patchTaskAttempt(
+    taskId: string,
+    attemptId: string,
+    patch: Partial<Omit<TaskAttempt, 'id'>>
+  ): Promise<Task | null>;
+}
+
+export interface PersistActiveAttemptInput {
+  task: Task;
+  attempt: TaskAttempt;
+  status?: UpdateTaskInput['status'];
+}
+
+export interface BeginAttemptInput {
+  task: Task;
+  attempt: TaskAttempt;
 }
 
 export interface PersistAttemptCompletionInput {
@@ -37,14 +53,90 @@ export interface PersistAttemptCompletionOutcome {
 }
 
 export class CompletionOwnershipError extends ConflictError {}
+export class AttemptOwnershipError extends ConflictError {}
 
 /**
- * Owns terminal attempt mutation and its immutable persistence invariants.
- * Provider orchestration prepares completion evidence, then crosses this seam
- * exactly once to claim the terminal task state.
+ * Owns attempt mutation and its persistence invariants from launch through
+ * terminal completion. Provider orchestration prepares state and evidence,
+ * then crosses this seam instead of writing attempt fields directly.
  */
 export class AttemptLifecycleCoordinator {
   constructor(private readonly store: AttemptLifecycleStore) {}
+
+  /**
+   * Replaces the currently active attempt while preserving one canonical
+   * history entry for that same attempt ID.
+   */
+  async persistActiveAttempt(input: PersistActiveAttemptInput): Promise<Task | null> {
+    this.assertActiveAttempt(input.task, input.attempt.id, 'Attempt update');
+    return this.store.updateTask(input.task.id, {
+      expectedRevision: normalizedTaskRevision(input.task),
+      ...(input.status !== undefined ? { status: input.status } : {}),
+      attempt: input.attempt,
+      attempts: upsertAttemptHistory(input.task.attempts, input.attempt),
+    });
+  }
+
+  /**
+   * Installs a new running attempt and archives the displaced active attempt.
+   * The new attempt remains solely in `task.attempt` until it reaches a state
+   * transition that belongs in history.
+   */
+  async beginAttempt(input: BeginAttemptInput): Promise<Task | null> {
+    if (input.task.attempt?.id === input.attempt.id) {
+      throw new AttemptOwnershipError('New attempt already owns the task', {
+        taskId: input.task.id,
+        attemptId: input.attempt.id,
+      });
+    }
+    if (input.attempt.status !== 'running') {
+      throw new AttemptOwnershipError('New attempt must begin in the running state', {
+        taskId: input.task.id,
+        attemptId: input.attempt.id,
+        attemptStatus: input.attempt.status,
+      });
+    }
+    return this.store.updateTask(input.task.id, {
+      expectedRevision: normalizedTaskRevision(input.task),
+      status: 'in-progress',
+      attempt: input.attempt,
+      attempts: input.task.attempt
+        ? upsertAttemptHistory(input.task.attempts, input.task.attempt)
+        : input.task.attempts,
+    });
+  }
+
+  /** Records a provider launch failure without losing the displaced attempt. */
+  async persistLaunchFailure(taskId: string, attempt: TaskAttempt): Promise<Task | null> {
+    if (attempt.status !== 'failed') {
+      throw new AttemptOwnershipError('Launch failure must persist a failed attempt', {
+        taskId,
+        attemptId: attempt.id,
+        attemptStatus: attempt.status,
+      });
+    }
+    const task = await this.store.getTask(taskId);
+    if (!task) return null;
+    this.assertActiveAttempt(task, attempt.id, 'Launch failure');
+    return this.store.updateTask(taskId, {
+      expectedRevision: normalizedTaskRevision(task),
+      status: 'todo',
+      attempt,
+      attempts: upsertAttemptHistory(
+        task.attempt ? upsertAttemptHistory(task.attempts, task.attempt) : task.attempts,
+        attempt
+      ),
+    });
+  }
+
+  /** Applies a partial mutation only while the same attempt still owns the task. */
+  async patchActiveAttempt(
+    taskId: string,
+    attemptId: string,
+    patch: Partial<Omit<TaskAttempt, 'id'>>
+  ): Promise<Task | null> {
+    return this.store.patchTaskAttempt(taskId, attemptId, patch);
+  }
 
   parsePersistedCompletion(attempt: TaskAttempt): CompletionResult {
     if (!attempt.taskEnvelope || !attempt.completionResult) {
@@ -238,6 +330,15 @@ export class AttemptLifecycleCoordinator {
     throw lastError instanceof Error
       ? lastError
       : new Error('Provider completion persistence retry budget was exhausted');
+  }
+
+  private assertActiveAttempt(task: Task, attemptId: string, operation: string): void {
+    if (task.attempt?.id === attemptId) return;
+    throw new AttemptOwnershipError(`${operation} does not match the active attempt`, {
+      taskId: task.id,
+      activeAttemptId: task.attempt?.id,
+      requestedAttemptId: attemptId,
+    });
   }
 
   private assertRetryBinding(

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -623,12 +623,6 @@ class CompletionPersistenceError extends Error {
   }
 }
 
-function normalizedTaskRevision(task: Pick<Task, 'revision'>): number {
-  return typeof task.revision === 'number' && Number.isInteger(task.revision) && task.revision >= 0
-    ? task.revision
-    : 1;
-}
-
 function executableProvider(value: string | undefined): ExecutableAgentProvider | 'system' {
   return EXECUTABLE_AGENT_PROVIDERS.includes(value as ExecutableAgentProvider)
     ? (value as ExecutableAgentProvider)
@@ -1069,10 +1063,10 @@ export class ClawdbotAgentService {
               status: 'failed',
               ended: new Date().toISOString(),
             };
-            await this.taskService.updateTask(task.id, {
-              ...(task.status === 'in-progress' ? { status: 'blocked' } : {}),
+            await this.attemptLifecycle.persistActiveAttempt({
+              task,
               attempt: failedAttempt,
-              attempts: upsertAttemptHistory(task.attempts, failedAttempt),
+              ...(task.status === 'in-progress' ? { status: 'blocked' } : {}),
             });
           }
           recoveryRequiredCount += 1;
@@ -1169,11 +1163,10 @@ export class ClawdbotAgentService {
               runSupervisorId: recovery.record.id,
               runRecovery,
             };
-            await this.taskService.updateTask(task.id, {
-              expectedRevision: normalizedTaskRevision(task),
-              ...(task.status === 'in-progress' ? { status: 'blocked' } : {}),
+            await this.attemptLifecycle.persistActiveAttempt({
+              task,
               attempt: recoveredAttempt,
-              attempts: upsertAttemptHistory(task.attempts, recoveredAttempt),
+              ...(task.status === 'in-progress' ? { status: 'blocked' } : {}),
             });
             recoveryRequiredCount += 1;
           }
@@ -1205,11 +1198,10 @@ export class ClawdbotAgentService {
           runSupervisorId: recovery.record.id,
           runRecovery,
         };
-        await this.taskService.updateTask(task.id, {
-          expectedRevision: normalizedTaskRevision(task),
-          ...(task.status === 'in-progress' ? { status: 'blocked' } : {}),
+        await this.attemptLifecycle.persistActiveAttempt({
+          task,
           attempt: recoveredAttempt,
-          attempts: upsertAttemptHistory(task.attempts, recoveredAttempt),
+          ...(task.status === 'in-progress' ? { status: 'blocked' } : {}),
         });
         recoveryRequiredCount += 1;
       } catch (err) {
@@ -1265,10 +1257,9 @@ export class ClawdbotAgentService {
             reason: `${record.reason} Re-queued after server restart before child launch.`,
           };
           const recoveredAttempt = { ...attempt, runRetry: record };
-          const updated = await this.taskService.updateTask(task.id, {
-            expectedRevision: normalizedTaskRevision(task),
+          const updated = await this.attemptLifecycle.persistActiveAttempt({
+            task,
             attempt: recoveredAttempt,
-            attempts: upsertAttemptHistory(task.attempts, recoveredAttempt),
           });
           if (!updated) continue;
           await this.appendRunEvent(
@@ -1352,10 +1343,9 @@ export class ClawdbotAgentService {
       },
     };
     const cancelledAttempt = { ...attempt, runRetry: cancelled };
-    const updated = await this.taskService.updateTask(taskId, {
-      expectedRevision: normalizedTaskRevision(task),
+    const updated = await this.attemptLifecycle.persistActiveAttempt({
+      task,
       attempt: cancelledAttempt,
-      attempts: upsertAttemptHistory(task.attempts, cancelledAttempt),
     });
     if (!updated) throw new Error(`Task "${taskId}" disappeared during recovery cancellation`);
     this.clearScheduledRecovery(taskId, expectedAttemptId);
@@ -1472,11 +1462,10 @@ export class ClawdbotAgentService {
 
     const recoveredAttempt = { ...currentAttempt, runRetry: decision };
     try {
-      const updated = await this.taskService.updateTask(taskId, {
-        expectedRevision: normalizedTaskRevision(task),
-        ...(decision.state === 'approval-required' ? { status: 'blocked' as const } : {}),
+      const updated = await this.attemptLifecycle.persistActiveAttempt({
+        task,
         attempt: recoveredAttempt,
-        attempts: upsertAttemptHistory(task.attempts, recoveredAttempt),
+        ...(decision.state === 'approval-required' ? { status: 'blocked' as const } : {}),
       });
       if (!updated) return null;
     } catch (error) {
@@ -1584,10 +1573,9 @@ export class ClawdbotAgentService {
 
     const launching: RunRecoveryRecord = { ...current, state: 'launching' };
     const claimedAttempt = { ...parentAttempt, runRetry: launching };
-    const claimed = await this.taskService.updateTask(taskId, {
-      expectedRevision: normalizedTaskRevision(task),
+    const claimed = await this.attemptLifecycle.persistActiveAttempt({
+      task,
       attempt: claimedAttempt,
-      attempts: upsertAttemptHistory(task.attempts, claimedAttempt),
     });
     if (!claimed) throw new NotFoundError(`Task "${taskId}" disappeared during recovery launch`);
     await this.appendRunEvent(
@@ -2908,11 +2896,9 @@ export class ClawdbotAgentService {
               runLaunchManifestDigest: runLaunchManifest.digest,
             })
           : undefined;
-      await this.taskService.updateTask(taskId, {
-        ...(options.recovery ? { expectedRevision: normalizedTaskRevision(task) } : {}),
-        status: 'in-progress',
+      await this.attemptLifecycle.beginAttempt({
+        task,
         attempt,
-        attempts: task.attempt ? upsertAttemptHistory(task.attempts, task.attempt) : task.attempts,
       });
     } catch (error) {
       pendingAgents.delete(taskId);
@@ -2976,7 +2962,7 @@ export class ClawdbotAgentService {
         });
       }
       pending.supervisorId = supervisorId;
-      await this.taskService.patchTaskAttempt(taskId, attemptId, {
+      await this.attemptLifecycle.patchActiveAttempt(taskId, attemptId, {
         runSupervisorId: supervisorId,
       });
       if (queuedClaim) {
@@ -3291,14 +3277,7 @@ export class ClawdbotAgentService {
         status: 'failed',
         ended: new Date().toISOString(),
       };
-      await this.taskService.updateTask(taskId, {
-        status: 'todo',
-        attempt: failedAttempt,
-        attempts: upsertAttemptHistory(
-          task.attempt ? upsertAttemptHistory(task.attempts, task.attempt) : task.attempts,
-          failedAttempt
-        ),
-      });
+      await this.attemptLifecycle.persistLaunchFailure(taskId, failedAttempt);
       if (supervisorId) {
         await this.runSupervisor
           .markTerminal(
@@ -4748,7 +4727,7 @@ export class ClawdbotAgentService {
     };
     pending.conversation = conversation;
     pending.threadId = conversationId;
-    await this.taskService.patchTaskAttempt(pending.taskId, pending.attemptId, {
+    await this.attemptLifecycle.patchActiveAttempt(pending.taskId, pending.attemptId, {
       threadId: conversationId,
       conversation,
     });
@@ -5056,7 +5035,7 @@ export class ClawdbotAgentService {
   ): Promise<ConversationLifecycleRecord> {
     const conversation = this.conversationLifecycle.transition(pending.conversation, state);
     pending.conversation = conversation;
-    await this.taskService.patchTaskAttempt(taskId, pending.attemptId, { conversation });
+    await this.attemptLifecycle.patchActiveAttempt(taskId, pending.attemptId, { conversation });
     return conversation;
   }
 
@@ -5808,7 +5787,7 @@ export class ClawdbotAgentService {
           prompt: transport.content,
           timeoutSeconds: 900,
         });
-        await this.taskService.patchTaskAttempt(task.id, attemptId, {
+        await this.attemptLifecycle.patchActiveAttempt(task.id, attemptId, {
           sessionKey: result.sessionKey,
         });
         await this.recordConversationIdentity(task.id, attemptId, {
@@ -9010,7 +8989,7 @@ export class ClawdbotAgentService {
     const conversation = this.conversationLifecycle.bind(pending.conversation, identity);
     pending.conversation = conversation;
     if (identity.conversationId) pending.threadId = identity.conversationId;
-    await this.taskService.patchTaskAttempt(taskId, attemptId, {
+    await this.attemptLifecycle.patchActiveAttempt(taskId, attemptId, {
       ...(identity.conversationId ? { threadId: identity.conversationId } : {}),
       conversation,
     });
@@ -9042,7 +9021,7 @@ export class ClawdbotAgentService {
       limitTokens
     );
     pending.conversation = conversation;
-    await this.taskService.patchTaskAttempt(taskId, attemptId, { conversation });
+    await this.attemptLifecycle.patchActiveAttempt(taskId, attemptId, { conversation });
     return conversation;
   }
 
@@ -10281,13 +10260,6 @@ function admissionReleaseReason(
 ): AdmissionReservationRelease['reason'] {
   if (status === 'success' || success === true) return 'completed';
   return status === 'interrupted' ? 'interrupted' : 'failed';
-}
-
-function upsertAttemptHistory(
-  history: TaskAttempt[] | undefined,
-  attempt: TaskAttempt
-): TaskAttempt[] {
-  return [...(history ?? []).filter((candidate) => candidate.id !== attempt.id), attempt];
 }
 
 function mergeThresholdEvents(


### PR DESCRIPTION
## Summary

- route all attempt-state writes through `AttemptLifecycleCoordinator`
- enforce active-attempt ownership and optimistic revision claims for full transitions
- centralize attempt start, launch failure, recovery, and partial patch persistence
- add coordinator contract coverage for ownership, history, start, failure, and patch invariants

Progresses #1164

## Verification

- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm exec eslint server/src/services/attempt-lifecycle-coordinator.ts server/src/services/clawdbot-agent-service.ts server/src/__tests__/attempt-lifecycle-coordinator.test.ts`
- `git diff --check`
- confirmed `ClawdbotAgentService` has no direct attempt-state writes

Workspace tests were intentionally not run for this ordinary implementation PR. They remain reserved for the final 6.1.2 milestone.