### PR TITLE
fix: harden persisted record key handling

### DIFF
--- a/server/src/__tests__/safe-record.test.ts
+++ b/server/src/__tests__/safe-record.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSafeRecord,
+  deleteSafeRecordValue,
+  getSafeRecordValue,
+  safeRecordFrom,
+  setSafeRecordValue,
+} from '../utils/safe-record.js';
+
+describe('safe record utilities', () => {
+  it('stores, reads, and deletes own values without an object prototype', () => {
+    const record = createSafeRecord<string>();
+
+    setSafeRecordValue(record, 'task-1', 'value');
+
+    expect(Object.getPrototypeOf(record)).toBeNull();
+    expect(getSafeRecordValue(record, 'task-1')).toBe('value');
+    expect(deleteSafeRecordValue(record, 'task-1')).toBe(true);
+    expect(getSafeRecordValue(record, 'task-1')).toBeUndefined();
+  });
+
+  it.each(['__proto__', 'constructor', 'prototype'])('rejects the reserved key %s', (key) => {
+    const record = createSafeRecord<string>();
+    expect(() => setSafeRecordValue(record, key, 'blocked')).toThrow('not allowed');
+    expect(() => getSafeRecordValue(record, key)).toThrow('not allowed');
+  });
+
+  it('fails closed when persisted JSON contains a prototype key', () => {
+    const parsed = JSON.parse('{"safe":"value","__proto__":{"polluted":true}}');
+
+    expect(() => safeRecordFrom<string>(parsed, 'persisted state')).toThrow('not allowed');
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/server/src/services/buzz-workflow-trigger-service.ts
+++ b/server/src/services/buzz-workflow-trigger-service.ts
@@ -14,6 +14,12 @@ import {
 import { atomicWriteFile, mkdir, readFile } from '../storage/fs-helpers.js';
 import { redactString } from '../lib/redact.js';
 import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import {
+  createSafeRecord,
+  getSafeRecordValue,
+  safeRecordFrom,
+  setSafeRecordValue,
+} from '../utils/safe-record.js';
 import { withFileLock } from './file-lock.js';
 import {
   getRuntimeHookBusService,
@@ -115,7 +121,7 @@ export class BuzzWorkflowTriggerService {
       createdAt: timestamp,
       updatedAt: timestamp,
     };
-    this.state.rules[rule.id] = rule;
+    setSafeRecordValue(this.state.rules, rule.id, rule, 'Buzz workflow rule ID');
     await this.saveState();
     return structuredClone(rule);
   }
@@ -124,7 +130,7 @@ export class BuzzWorkflowTriggerService {
     validatePathSegment(adapterId);
     validatePathSegment(ruleId);
     await this.ensureLoaded();
-    const rule = this.state.rules[ruleId];
+    const rule = getSafeRecordValue(this.state.rules, ruleId, 'Buzz workflow rule ID');
     if (!rule || rule.adapterId !== adapterId) {
       throw new Error(`Buzz workflow trigger rule ${ruleId} not found`);
     }
@@ -178,17 +184,27 @@ export class BuzzWorkflowTriggerService {
       return this.appendAudit(rule, event, causalKey, 'echo');
     }
 
-    const dispatch = this.state.dispatches[causalKey];
+    const dispatch = getSafeRecordValue(
+      this.state.dispatches,
+      causalKey,
+      'Buzz workflow dispatch key'
+    );
     if (dispatch?.status === 'dispatched') {
       return this.appendAudit(rule, event, causalKey, 'duplicate', dispatch.runId);
     }
 
-    this.state.dispatches[causalKey] = {
+    const acceptedDispatch: BuzzWorkflowTriggerDispatch = {
       causalKey,
       workflowId: rule.workflowId,
       status: 'accepted',
       updatedAt: this.now().toISOString(),
     };
+    setSafeRecordValue(
+      this.state.dispatches,
+      causalKey,
+      acceptedDispatch,
+      'Buzz workflow dispatch key'
+    );
     await this.appendAudit(rule, event, causalKey, 'accepted');
 
     const existingRun = await this.findExistingRun(rule.workflowId, causalKey);
@@ -200,8 +216,8 @@ export class BuzzWorkflowTriggerService {
       this.ensureHooks();
       const hookResult = await this.hooks().dispatch(this.hookEnvelope(rule, event, causalKey));
       if (!hookResult.allowed) {
-        this.state.dispatches[causalKey].status = 'failed';
-        this.state.dispatches[causalKey].updatedAt = this.now().toISOString();
+        acceptedDispatch.status = 'failed';
+        acceptedDispatch.updatedAt = this.now().toISOString();
         return this.appendAudit(
           rule,
           event,
@@ -231,8 +247,8 @@ export class BuzzWorkflowTriggerService {
       });
       return this.recordDispatched(rule, event, causalKey, run.id);
     } catch (error) {
-      this.state.dispatches[causalKey].status = 'failed';
-      this.state.dispatches[causalKey].updatedAt = this.now().toISOString();
+      acceptedDispatch.status = 'failed';
+      acceptedDispatch.updatedAt = this.now().toISOString();
       return this.appendAudit(
         rule,
         event,
@@ -281,13 +297,18 @@ export class BuzzWorkflowTriggerService {
     causalKey: string,
     runId: string
   ): Promise<BuzzWorkflowTriggerAudit> {
-    this.state.dispatches[causalKey] = {
+    setSafeRecordValue(
+      this.state.dispatches,
       causalKey,
-      workflowId: rule.workflowId,
-      status: 'dispatched',
-      runId,
-      updatedAt: this.now().toISOString(),
-    };
+      {
+        causalKey,
+        workflowId: rule.workflowId,
+        status: 'dispatched',
+        runId,
+        updatedAt: this.now().toISOString(),
+      },
+      'Buzz workflow dispatch key'
+    );
     return this.appendAudit(rule, event, causalKey, 'dispatched', runId);
   }
 
@@ -393,14 +414,11 @@ export class BuzzWorkflowTriggerService {
       ) as Partial<BuzzWorkflowTriggerState>;
       this.state = {
         version: 1,
-        rules:
-          parsed.rules && typeof parsed.rules === 'object'
-            ? (parsed.rules as Record<string, BuzzWorkflowTriggerRule>)
-            : {},
-        dispatches:
-          parsed.dispatches && typeof parsed.dispatches === 'object'
-            ? (parsed.dispatches as Record<string, BuzzWorkflowTriggerDispatch>)
-            : {},
+        rules: safeRecordFrom<BuzzWorkflowTriggerRule>(parsed.rules, 'Buzz workflow rules'),
+        dispatches: safeRecordFrom<BuzzWorkflowTriggerDispatch>(
+          parsed.dispatches,
+          'Buzz workflow dispatches'
+        ),
         audits: Array.isArray(parsed.audits)
           ? (parsed.audits as BuzzWorkflowTriggerAudit[]).slice(-MAX_AUDITS)
           : [],
@@ -430,8 +448,8 @@ export class BuzzWorkflowTriggerService {
   private emptyState(): BuzzWorkflowTriggerState {
     return {
       version: 1,
-      rules: {},
-      dispatches: {},
+      rules: createSafeRecord<BuzzWorkflowTriggerRule>(),
+      dispatches: createSafeRecord<BuzzWorkflowTriggerDispatch>(),
       audits: [],
       updatedAt: this.now().toISOString(),
     };

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -20,6 +20,7 @@ import type {
 } from '@veritas-kanban/shared';
 import { getNotificationService, parseMentions } from './notification-service.js';
 import { validatePathSegment } from '../utils/sanitize.js';
+import { getSafeRecordValue, setSafeRecordValue } from '../utils/safe-record.js';
 import { createLogger } from '../lib/logger.js';
 import { redactString } from '../lib/redact.js';
 import { getChatsDir } from '../utils/paths.js';
@@ -248,7 +249,7 @@ export class ChatService {
   private async applySquadMetadata(messages: SquadMessage[]): Promise<SquadMessage[]> {
     const metadata = await this.readSquadMetadata();
     const merged = messages.map((message) => {
-      const overlay = metadata.messages[message.id];
+      const overlay = getSafeRecordValue(metadata.messages, message.id, 'Squad message ID');
       if (!overlay) return message;
 
       const { updatedAt: _updatedAt, ...messageOverlay } = overlay;
@@ -425,7 +426,7 @@ export class ChatService {
 
     if (this.hasSquadMessageMetadata(messageMetadata)) {
       await this.updateSquadMetadata((metadata) => {
-        metadata.messages[messageId] = messageMetadata;
+        setSafeRecordValue(metadata.messages, messageId, messageMetadata, 'Squad message ID');
       });
     }
 
@@ -536,7 +537,7 @@ export class ChatService {
   async getSquadUnreadState(actor: string): Promise<SquadUnreadState> {
     const normalizedActor = this.normalizeActor(actor);
     const metadata = await this.readSquadMetadata();
-    const readState = metadata.reads[normalizedActor];
+    const readState = getSafeRecordValue(metadata.reads, normalizedActor, 'Squad actor');
     const lastReadTime = readState?.lastReadAt ? Date.parse(readState.lastReadAt) : 0;
     const messages = await this.getSquadMessages({ includeSystem: true });
     const unreadMessages = messages.filter((message) => {
@@ -569,12 +570,17 @@ export class ChatService {
     const timestamp = targetMessage?.timestamp ?? new Date().toISOString();
 
     await this.updateSquadMetadata((metadata) => {
-      metadata.reads[normalizedActor] = {
-        actor: input.actor,
-        lastReadAt: timestamp,
-        lastReadMessageId: targetMessage?.id,
-        updatedAt: new Date().toISOString(),
-      };
+      setSafeRecordValue(
+        metadata.reads,
+        normalizedActor,
+        {
+          actor: input.actor,
+          lastReadAt: timestamp,
+          lastReadMessageId: targetMessage?.id,
+          updatedAt: new Date().toISOString(),
+        },
+        'Squad actor'
+      );
     });
 
     return this.getSquadUnreadState(input.actor);
@@ -588,13 +594,18 @@ export class ChatService {
     if (!existing) return null;
 
     await this.updateSquadMetadata((metadata) => {
-      const current = metadata.messages[messageId] ?? {};
-      metadata.messages[messageId] = {
-        ...current,
-        pinned: update.pinned ?? current.pinned,
-        decision: update.decision ?? current.decision,
-        updatedAt: new Date().toISOString(),
-      };
+      const current = getSafeRecordValue(metadata.messages, messageId, 'Squad message ID') ?? {};
+      setSafeRecordValue(
+        metadata.messages,
+        messageId,
+        {
+          ...current,
+          pinned: update.pinned ?? current.pinned,
+          decision: update.decision ?? current.decision,
+          updatedAt: new Date().toISOString(),
+        },
+        'Squad message ID'
+      );
     });
 
     return this.findSquadMessage(messageId);
@@ -609,7 +620,8 @@ export class ChatService {
     if (!existing) return null;
 
     await this.updateSquadMetadata((metadata) => {
-      const current = metadata.messages[input.messageId] ?? {};
+      const current =
+        getSafeRecordValue(metadata.messages, input.messageId, 'Squad message ID') ?? {};
       const reactions = (current.reactions ?? []).filter(
         (reaction) =>
           !(
@@ -622,11 +634,16 @@ export class ChatService {
         reaction: input.reaction,
         createdAt: new Date().toISOString(),
       });
-      metadata.messages[input.messageId] = {
-        ...current,
-        reactions,
-        updatedAt: new Date().toISOString(),
-      };
+      setSafeRecordValue(
+        metadata.messages,
+        input.messageId,
+        {
+          ...current,
+          reactions,
+          updatedAt: new Date().toISOString(),
+        },
+        'Squad message ID'
+      );
     });
 
     return this.findSquadMessage(input.messageId);

--- a/server/src/services/communication-adapter-service.ts
+++ b/server/src/services/communication-adapter-service.ts
@@ -39,6 +39,13 @@ import { withFileLock } from './file-lock.js';
 import { redactString } from '../lib/redact.js';
 import { ensureWithinBase, sanitizeCommentText, validatePathSegment } from '../utils/sanitize.js';
 import { getRuntimeDir } from '../utils/paths.js';
+import {
+  createSafeRecord,
+  deleteSafeRecordValue,
+  getSafeRecordValue,
+  safeRecordFrom,
+  setSafeRecordValue,
+} from '../utils/safe-record.js';
 import { atomicWriteFile, mkdir, readFile } from '../storage/fs-helpers.js';
 import {
   BuzzCompatibilityService,
@@ -456,7 +463,7 @@ export class CommunicationAdapterService {
 
   async getAdapter(adapterId: string): Promise<CommunicationAdapterRecord | null> {
     await this.ensureLoaded();
-    const adapter = this.state.adapters[adapterId];
+    const adapter = getSafeRecordValue(this.state.adapters, adapterId, 'Communication adapter ID');
     return adapter ? this.publicAdapter(adapter) : null;
   }
 
@@ -506,7 +513,11 @@ export class CommunicationAdapterService {
     await this.ensureLoaded();
     const adapter = this.requireAdapter(adapterId);
     if (adapter.kind !== 'buzz') throw new Error('Workflow triggers require a Buzz adapter');
-    const mapping = this.state.buzzChannelMappings[input.mappingId];
+    const mapping = getSafeRecordValue(
+      this.state.buzzChannelMappings,
+      input.mappingId,
+      'Buzz channel mapping ID'
+    );
     if (!mapping || mapping.adapterId !== adapterId || !mapping.enabled) {
       throw new Error('Workflow triggers require an active Buzz channel mapping');
     }
@@ -586,7 +597,12 @@ export class CommunicationAdapterService {
       updatedAt: timestamp,
       createdBy: existing?.createdBy ?? trimOrUndefined(input.actor),
     };
-    this.state.buzzChannelMappings[mapping.id] = mapping;
+    setSafeRecordValue(
+      this.state.buzzChannelMappings,
+      mapping.id,
+      mapping,
+      'Buzz channel mapping ID'
+    );
     const delivery = this.recordDelivery({
       adapterId,
       operation: 'configure',
@@ -618,7 +634,12 @@ export class CommunicationAdapterService {
     );
     if (!existing) throw new Error('Buzz channel mapping not found');
     const mapping = { ...existing, enabled: false, updatedAt: nowIso() };
-    this.state.buzzChannelMappings[mapping.id] = mapping;
+    setSafeRecordValue(
+      this.state.buzzChannelMappings,
+      mapping.id,
+      mapping,
+      'Buzz channel mapping ID'
+    );
     const delivery = this.recordDelivery({
       adapterId,
       operation: 'disconnect',
@@ -645,7 +666,7 @@ export class CommunicationAdapterService {
     await this.ensureLoaded();
 
     const timestamp = nowIso();
-    const existing = this.state.adapters[adapterId];
+    const existing = getSafeRecordValue(this.state.adapters, adapterId, 'Communication adapter ID');
     const kind = input.kind ?? existing?.kind ?? 'msteams';
     if (existing && input.kind && input.kind !== existing.kind) {
       throw new Error('Communication adapter kind cannot be changed after creation');
@@ -681,7 +702,7 @@ export class CommunicationAdapterService {
       lastHealth: existing?.lastHealth,
     };
 
-    this.state.adapters[adapterId] = adapter;
+    setSafeRecordValue(this.state.adapters, adapterId, adapter, 'Communication adapter ID');
     const delivery = this.recordDelivery({
       adapterId,
       operation: 'configure',
@@ -714,7 +735,7 @@ export class CommunicationAdapterService {
       lastHealth: undefined,
       compatibility: undefined,
     };
-    this.state.adapters[adapterId] = disconnected;
+    setSafeRecordValue(this.state.adapters, adapterId, disconnected, 'Communication adapter ID');
     const delivery = this.recordDelivery({
       adapterId,
       operation: 'disconnect',
@@ -875,7 +896,9 @@ export class CommunicationAdapterService {
     const replyKey = input.externalReplyId
       ? `${adapterId}:${externalThreadId}:${input.externalReplyId}`
       : undefined;
-    const existingReplyMessageId = replyKey ? this.state.replyIds[replyKey] : undefined;
+    const existingReplyMessageId = replyKey
+      ? getSafeRecordValue(this.state.replyIds, replyKey, 'Communication reply ID')
+      : undefined;
     if (existingReplyMessageId) {
       const squadMessage = await this.findSquadMessage(existingReplyMessageId);
       const delivery = this.recordDelivery({
@@ -927,7 +950,7 @@ export class CommunicationAdapterService {
     );
 
     if (replyKey) {
-      this.state.replyIds[replyKey] = squadMessage.id;
+      setSafeRecordValue(this.state.replyIds, replyKey, squadMessage.id, 'Communication reply ID');
     }
 
     const delivery = this.recordDelivery({
@@ -993,7 +1016,11 @@ export class CommunicationAdapterService {
     if (adapter.kind !== 'buzz' || !adapter.enabled) {
       throw new Error('Buzz adapter is not enabled');
     }
-    const mapping = this.state.buzzChannelMappings[mappingInput.id];
+    const mapping = getSafeRecordValue(
+      this.state.buzzChannelMappings,
+      mappingInput.id,
+      'Buzz channel mapping ID'
+    );
     if (
       !mapping ||
       !mapping.enabled ||
@@ -1027,9 +1054,9 @@ export class CommunicationAdapterService {
     const coordinate = inbound.coordinate;
     const eventId = inbound.event.id;
     const key = buzzEventKey(mapping.community, eventId);
-    const outbound = this.state.buzzOutbound[eventId];
+    const outbound = getSafeRecordValue(this.state.buzzOutbound, eventId, 'Buzz event ID');
     const adapterOrigin = isVeritasBuzzOrigin(inbound.event, adapter.publicKey);
-    const existing = this.state.buzzEvents[key];
+    const existing = getSafeRecordValue(this.state.buzzEvents, key, 'Buzz event key');
     if (existing && !outbound && !adapterOrigin) {
       if (inbound.event.kind === BUZZ_MESSAGE_KIND) {
         await this.processBuzzWorkflowTrigger({
@@ -1059,7 +1086,7 @@ export class CommunicationAdapterService {
       return delivery;
     }
 
-    delete this.state.buzzPendingEvents[key];
+    deleteSafeRecordValue(this.state.buzzPendingEvents, key, 'Buzz event key');
     if (outbound || adapterOrigin) {
       if (inbound.event.kind === BUZZ_MESSAGE_KIND) {
         await this.processBuzzWorkflowTrigger({
@@ -1132,19 +1159,28 @@ export class CommunicationAdapterService {
       throw new Error('Buzz event kind is not supported by the message projection');
     }
     const replyReference = coordinate.rootEventId
-      ? this.state.buzzEvents[buzzEventKey(mapping.community, coordinate.rootEventId)]
+      ? getSafeRecordValue(
+          this.state.buzzEvents,
+          buzzEventKey(mapping.community, coordinate.rootEventId),
+          'Buzz event key'
+        )
       : undefined;
     const replyToId = coordinate.rootEventId
       ? replyReference?.squadMessageId
       : mapping.target.squadMessageId;
     if (coordinate.rootEventId && !replyToId) {
-      this.state.buzzPendingEvents[key] = {
+      setSafeRecordValue(
+        this.state.buzzPendingEvents,
         key,
-        adapterId,
-        mappingId: mapping.id,
-        event: inbound.event,
-        recordedAt: nowIso(),
-      };
+        {
+          key,
+          adapterId,
+          mappingId: mapping.id,
+          event: inbound.event,
+          recordedAt: nowIso(),
+        },
+        'Buzz event key'
+      );
       this.trimBuzzPendingEvents();
       const delivery = this.recordDelivery({
         adapterId,
@@ -1235,7 +1271,12 @@ export class CommunicationAdapterService {
       createdBy: coordinate.authorPubkey,
       buzz: coordinate,
     });
-    this.state.replyIds[`${adapterId}:${externalThreadId}:${eventId}`] = squadMessage.id;
+    setSafeRecordValue(
+      this.state.replyIds,
+      `${adapterId}:${externalThreadId}:${eventId}`,
+      squadMessage.id,
+      'Communication reply ID'
+    );
     const delivery = this.recordDelivery({
       adapterId,
       operation: 'event-ingest',
@@ -1434,7 +1475,7 @@ export class CommunicationAdapterService {
         createdAt: timestamp,
         updatedAt: timestamp,
       };
-      this.state.buzzOutbound[prepared.event.id] = outbound;
+      setSafeRecordValue(this.state.buzzOutbound, prepared.event.id, outbound, 'Buzz event ID');
       this.recordBuzzEvent({
         key: buzzEventKey(channelMapping.community, prepared.event.id),
         adapterId: adapter.id,
@@ -1719,7 +1760,7 @@ export class CommunicationAdapterService {
       createdBy: existing?.createdBy ?? input.createdBy,
       buzz: input.buzz ?? existing?.buzz,
     };
-    this.state.mappings[mapping.id] = mapping;
+    setSafeRecordValue(this.state.mappings, mapping.id, mapping, 'Communication mapping ID');
     return mapping;
   }
 
@@ -1757,13 +1798,15 @@ export class CommunicationAdapterService {
   }
 
   private recordBuzzEvent(record: BuzzEventRecord): void {
-    this.state.buzzEvents[record.key] = record;
+    setSafeRecordValue(this.state.buzzEvents, record.key, record, 'Buzz event key');
     const records = Object.values(this.state.buzzEvents);
     if (records.length <= MAX_BUZZ_EVENTS) return;
     records
       .sort((a, b) => a.recordedAt.localeCompare(b.recordedAt))
       .slice(0, records.length - MAX_BUZZ_EVENTS)
-      .forEach((candidate) => delete this.state.buzzEvents[candidate.key]);
+      .forEach((candidate) =>
+        deleteSafeRecordValue(this.state.buzzEvents, candidate.key, 'Buzz event key')
+      );
   }
 
   private trimBuzzPendingEvents(): void {
@@ -1772,7 +1815,9 @@ export class CommunicationAdapterService {
     records
       .sort((a, b) => a.recordedAt.localeCompare(b.recordedAt))
       .slice(0, records.length - MAX_BUZZ_PENDING_EVENTS)
-      .forEach((candidate) => delete this.state.buzzPendingEvents[candidate.key]);
+      .forEach((candidate) =>
+        deleteSafeRecordValue(this.state.buzzPendingEvents, candidate.key, 'Buzz event key')
+      );
   }
 
   private trimBuzzOutboundRecords(): void {
@@ -1783,26 +1828,31 @@ export class CommunicationAdapterService {
       .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
     for (const record of removable) {
       if (Object.keys(this.state.buzzOutbound).length <= MAX_BUZZ_OUTBOUND_RECORDS) break;
-      delete this.state.buzzOutbound[record.eventId];
+      deleteSafeRecordValue(this.state.buzzOutbound, record.eventId, 'Buzz event ID');
     }
   }
 
   private commitBuzzCursor(mapping: BuzzChannelMapping, event: VerifiedEvent): void {
     const key = buzzCursorKey(mapping.adapterId, mapping.community, mapping.channelId);
-    const existing = this.state.buzzCursors[key];
+    const existing = getSafeRecordValue(this.state.buzzCursors, key, 'Buzz cursor key');
     const shouldAdvance =
       !existing ||
       event.created_at > existing.createdAt ||
       (event.created_at === existing.createdAt && event.id.localeCompare(existing.eventId) > 0);
     if (!shouldAdvance) return;
-    this.state.buzzCursors[key] = {
-      adapterId: mapping.adapterId,
-      community: mapping.community,
-      channelId: mapping.channelId,
-      createdAt: event.created_at,
-      eventId: event.id,
-      committedAt: nowIso(),
-    };
+    setSafeRecordValue(
+      this.state.buzzCursors,
+      key,
+      {
+        adapterId: mapping.adapterId,
+        community: mapping.community,
+        channelId: mapping.channelId,
+        createdAt: event.created_at,
+        eventId: event.id,
+        committedAt: nowIso(),
+      },
+      'Buzz cursor key'
+    );
   }
 
   private async replayPendingBuzzReplies(
@@ -1831,22 +1881,27 @@ export class CommunicationAdapterService {
   }
 
   private updateLastBuzzSend(adapterId: string, delivery: CommunicationDeliveryAudit): void {
-    const current = this.state.buzzRuntime[adapterId] ?? {
+    const current = getSafeRecordValue(this.state.buzzRuntime, adapterId, 'Buzz runtime ID') ?? {
       relayConnected: false,
       subscriptionActive: false,
       mappedChannels: 0,
       reconnectAttempts: 0,
     };
-    this.state.buzzRuntime[adapterId] = {
-      ...current,
-      lastSendAt: delivery.createdAt,
-      lastSendStatus: delivery.status,
-    };
+    setSafeRecordValue(
+      this.state.buzzRuntime,
+      adapterId,
+      {
+        ...current,
+        lastSendAt: delivery.createdAt,
+        lastSendStatus: delivery.status,
+      },
+      'Buzz runtime ID'
+    );
   }
 
   private async refreshBuzzWorker(adapterId: string): Promise<void> {
     await this.stopBuzzWorker(adapterId);
-    const adapter = this.state.adapters[adapterId];
+    const adapter = getSafeRecordValue(this.state.adapters, adapterId, 'Communication adapter ID');
     if (!adapter || adapter.kind !== 'buzz') return;
     const validated = validateStoredBuzzConfig(adapter);
     const mappings = Object.values(this.state.buzzChannelMappings).filter(
@@ -1863,11 +1918,21 @@ export class CommunicationAdapterService {
       mappedChannels: mappings.length,
       reconnectAttempts: 0,
     };
-    this.state.buzzRuntime[adapterId] = {
-      ...baseRuntime,
-      lastSendAt: this.state.buzzRuntime[adapterId]?.lastSendAt,
-      lastSendStatus: this.state.buzzRuntime[adapterId]?.lastSendStatus,
-    };
+    const previousRuntime = getSafeRecordValue(
+      this.state.buzzRuntime,
+      adapterId,
+      'Buzz runtime ID'
+    );
+    setSafeRecordValue(
+      this.state.buzzRuntime,
+      adapterId,
+      {
+        ...baseRuntime,
+        lastSendAt: previousRuntime?.lastSendAt,
+        lastSendStatus: previousRuntime?.lastSendStatus,
+      },
+      'Buzz runtime ID'
+    );
     if (
       !validated ||
       !adapter.enabled ||
@@ -1892,17 +1957,25 @@ export class CommunicationAdapterService {
         onEvent: async (mapping, event) => {
           if (this.buzzWorkerGenerations.get(adapterId) !== generation) return;
           await this.ingestBuzzEvent(adapterId, mapping, event);
-          return this.state.buzzCursors[
-            buzzCursorKey(mapping.adapterId, mapping.community, mapping.channelId)
-          ];
+          return getSafeRecordValue(
+            this.state.buzzCursors,
+            buzzCursorKey(mapping.adapterId, mapping.community, mapping.channelId),
+            'Buzz cursor key'
+          );
         },
         onHealth: async (patch) => {
           if (this.buzzWorkerGenerations.get(adapterId) !== generation) return;
-          this.state.buzzRuntime[adapterId] = {
-            ...(this.state.buzzRuntime[adapterId] ?? baseRuntime),
-            ...patch,
-            mappedChannels: mappings.length,
-          };
+          setSafeRecordValue(
+            this.state.buzzRuntime,
+            adapterId,
+            {
+              ...(getSafeRecordValue(this.state.buzzRuntime, adapterId, 'Buzz runtime ID') ??
+                baseRuntime),
+              ...patch,
+              mappedChannels: mappings.length,
+            },
+            'Buzz runtime ID'
+          );
           this.applyBuzzRuntimeHealth(adapterId);
           await this.saveState();
         },
@@ -1922,9 +1995,9 @@ export class CommunicationAdapterService {
   }
 
   private applyBuzzRuntimeHealth(adapterId: string): void {
-    const adapter = this.state.adapters[adapterId];
+    const adapter = getSafeRecordValue(this.state.adapters, adapterId, 'Communication adapter ID');
     if (!adapter || adapter.kind !== 'buzz') return;
-    const runtime = this.state.buzzRuntime[adapterId];
+    const runtime = getSafeRecordValue(this.state.buzzRuntime, adapterId, 'Buzz runtime ID');
     if (!runtime) return;
     const compatibility = adapter.compatibility;
     const compatibilityHealthy = compatibility?.status === 'healthy';
@@ -1984,7 +2057,7 @@ export class CommunicationAdapterService {
   }
 
   private requireAdapter(adapterId: string): InternalCommunicationAdapterRecord {
-    const adapter = this.state.adapters[adapterId];
+    const adapter = getSafeRecordValue(this.state.adapters, adapterId, 'Communication adapter ID');
     if (!adapter) {
       throw new Error(`Communication adapter ${adapterId} not found`);
     }
@@ -2064,42 +2137,27 @@ export class CommunicationAdapterService {
       const parsed = JSON.parse(raw) as Partial<CommunicationAdapterState>;
       this.state = {
         version: 2,
-        adapters:
-          parsed.adapters && typeof parsed.adapters === 'object'
-            ? (parsed.adapters as Record<string, InternalCommunicationAdapterRecord>)
-            : {},
-        mappings:
-          parsed.mappings && typeof parsed.mappings === 'object'
-            ? (parsed.mappings as Record<string, CommunicationThreadMapping>)
-            : {},
-        buzzChannelMappings:
-          parsed.buzzChannelMappings && typeof parsed.buzzChannelMappings === 'object'
-            ? (parsed.buzzChannelMappings as Record<string, BuzzChannelMapping>)
-            : {},
-        buzzCursors:
-          parsed.buzzCursors && typeof parsed.buzzCursors === 'object'
-            ? (parsed.buzzCursors as Record<string, BuzzCursor>)
-            : {},
-        buzzEvents:
-          parsed.buzzEvents && typeof parsed.buzzEvents === 'object'
-            ? (parsed.buzzEvents as Record<string, BuzzEventRecord>)
-            : {},
-        buzzPendingEvents:
-          parsed.buzzPendingEvents && typeof parsed.buzzPendingEvents === 'object'
-            ? (parsed.buzzPendingEvents as Record<string, BuzzPendingEvent>)
-            : {},
-        buzzOutbound:
-          parsed.buzzOutbound && typeof parsed.buzzOutbound === 'object'
-            ? (parsed.buzzOutbound as Record<string, BuzzOutboundRecord>)
-            : {},
-        buzzRuntime:
-          parsed.buzzRuntime && typeof parsed.buzzRuntime === 'object'
-            ? (parsed.buzzRuntime as Record<string, BuzzRuntimeHealth>)
-            : {},
-        replyIds:
-          parsed.replyIds && typeof parsed.replyIds === 'object'
-            ? (parsed.replyIds as Record<string, string>)
-            : {},
+        adapters: safeRecordFrom<InternalCommunicationAdapterRecord>(
+          parsed.adapters,
+          'Communication adapters'
+        ),
+        mappings: safeRecordFrom<CommunicationThreadMapping>(parsed.mappings, 'Thread mappings'),
+        buzzChannelMappings: safeRecordFrom<BuzzChannelMapping>(
+          parsed.buzzChannelMappings,
+          'Buzz channel mappings'
+        ),
+        buzzCursors: safeRecordFrom<BuzzCursor>(parsed.buzzCursors, 'Buzz cursors'),
+        buzzEvents: safeRecordFrom<BuzzEventRecord>(parsed.buzzEvents, 'Buzz events'),
+        buzzPendingEvents: safeRecordFrom<BuzzPendingEvent>(
+          parsed.buzzPendingEvents,
+          'Buzz pending events'
+        ),
+        buzzOutbound: safeRecordFrom<BuzzOutboundRecord>(
+          parsed.buzzOutbound,
+          'Buzz outbound records'
+        ),
+        buzzRuntime: safeRecordFrom<BuzzRuntimeHealth>(parsed.buzzRuntime, 'Buzz runtime state'),
+        replyIds: safeRecordFrom<string>(parsed.replyIds, 'Communication reply IDs'),
         deliveries: Array.isArray(parsed.deliveries)
           ? (parsed.deliveries as CommunicationDeliveryAudit[]).slice(-MAX_DELIVERIES)
           : [],
@@ -2130,15 +2188,15 @@ export class CommunicationAdapterService {
   private emptyState(): CommunicationAdapterState {
     return {
       version: 2,
-      adapters: {},
-      mappings: {},
-      buzzChannelMappings: {},
-      buzzCursors: {},
-      buzzEvents: {},
-      buzzPendingEvents: {},
-      buzzOutbound: {},
-      buzzRuntime: {},
-      replyIds: {},
+      adapters: createSafeRecord<InternalCommunicationAdapterRecord>(),
+      mappings: createSafeRecord<CommunicationThreadMapping>(),
+      buzzChannelMappings: createSafeRecord<BuzzChannelMapping>(),
+      buzzCursors: createSafeRecord<BuzzCursor>(),
+      buzzEvents: createSafeRecord<BuzzEventRecord>(),
+      buzzPendingEvents: createSafeRecord<BuzzPendingEvent>(),
+      buzzOutbound: createSafeRecord<BuzzOutboundRecord>(),
+      buzzRuntime: createSafeRecord<BuzzRuntimeHealth>(),
+      replyIds: createSafeRecord<string>(),
       deliveries: [],
       updatedAt: nowIso(),
     };
@@ -2257,7 +2315,7 @@ export class CommunicationAdapterService {
       compatibility: evidenceIsCurrent ? existing?.compatibility : undefined,
     };
 
-    this.state.adapters[adapterId] = adapter;
+    setSafeRecordValue(this.state.adapters, adapterId, adapter, 'Communication adapter ID');
     const delivery = this.recordDelivery({
       adapterId,
       operation: 'configure',

--- a/server/src/services/queue-intake-monitor-service.ts
+++ b/server/src/services/queue-intake-monitor-service.ts
@@ -27,6 +27,12 @@ import type {
 import { createLogger } from '../lib/logger.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { getRuntimeDir } from '../utils/paths.js';
+import {
+  createSafeRecord,
+  getSafeRecordValue,
+  safeRecordFrom,
+  setSafeRecordValue,
+} from '../utils/safe-record.js';
 import { JsonFileRepository } from '../storage/json-file-repository.js';
 import { getAgentBudgetService, type AgentBudgetService } from './agent-budget-service.js';
 import { getBreaker } from './circuit-registry.js';
@@ -247,13 +253,18 @@ export class QueueIntakeMonitorService {
     };
     store.monitors[index] = normalizeDefinition(updated);
     if (patch.enabled === true) {
-      store.state[monitorId] = {
-        ...this.stateFor(monitorId),
-        failureStreak: 0,
-        lastError: undefined,
-        actionItem: undefined,
-        nextRunAt: now.toISOString(),
-      };
+      setSafeRecordValue(
+        store.state,
+        monitorId,
+        {
+          ...this.stateFor(monitorId),
+          failureStreak: 0,
+          lastError: undefined,
+          actionItem: undefined,
+          nextRunAt: now.toISOString(),
+        },
+        'Queue monitor ID'
+      );
     }
     await this.saveStore();
     return this.snapshot(store.monitors[index], now);
@@ -833,22 +844,27 @@ export class QueueIntakeMonitorService {
           ? state.actionItem
           : undefined;
 
-    store.state[monitor.id] = {
-      ...state,
-      lastScanAt:
-        type === 'manual-run' || type === 'due-run' || type === 'explain'
-          ? now.toISOString()
-          : state.lastScanAt,
-      lastActionAt: now.toISOString(),
-      nextRunAt: nextRunAt(monitor, now),
-      failureStreak,
-      lastStatus: action.status,
-      lastSummary: action.summary,
-      lastError: action.error,
-      lastPacket: packet,
-      lastAction: action,
-      actionItem,
-    };
+    setSafeRecordValue(
+      store.state,
+      monitor.id,
+      {
+        ...state,
+        lastScanAt:
+          type === 'manual-run' || type === 'due-run' || type === 'explain'
+            ? now.toISOString()
+            : state.lastScanAt,
+        lastActionAt: now.toISOString(),
+        nextRunAt: nextRunAt(monitor, now),
+        failureStreak,
+        lastStatus: action.status,
+        lastSummary: action.summary,
+        lastError: action.error,
+        lastPacket: packet,
+        lastAction: action,
+        actionItem,
+      },
+      'Queue monitor ID'
+    );
 
     const event: QueueMonitorEvent = {
       id: `qm_evt_${nanoid(10)}`,
@@ -959,8 +975,11 @@ export class QueueIntakeMonitorService {
 
   private stateFor(monitorId: string): QueueMonitorState {
     const store = this.currentStore();
-    store.state[monitorId] ??= { failureStreak: 0 };
-    return store.state[monitorId];
+    const existing = getSafeRecordValue(store.state, monitorId, 'Queue monitor ID');
+    if (existing) return existing;
+    const created: QueueMonitorState = { failureStreak: 0 };
+    setSafeRecordValue(store.state, monitorId, created, 'Queue monitor ID');
+    return created;
   }
 
   private async ensureLoaded(): Promise<void> {
@@ -993,7 +1012,7 @@ function defaultStore(): QueueMonitorStore {
   return {
     version: STORE_VERSION,
     monitors: [defaultBacklogMonitor()],
-    state: {},
+    state: createSafeRecord<QueueMonitorState>(),
     events: [],
   };
 }
@@ -1034,7 +1053,7 @@ function normalizeStore(input: Partial<QueueMonitorStore>): QueueMonitorStore {
   return {
     version: STORE_VERSION,
     monitors: monitors.map(normalizeDefinition),
-    state: input.state ?? {},
+    state: safeRecordFrom<QueueMonitorState>(input.state, 'Queue monitor state'),
     events: Array.isArray(input.events) ? input.events.slice(-MAX_EVENTS) : [],
   };
 }

--- a/server/src/services/run-egress-gateway-service.ts
+++ b/server/src/services/run-egress-gateway-service.ts
@@ -13,7 +13,6 @@ import {
   type RunEgressPolicy,
 } from '@veritas-kanban/shared';
 import { ConflictError } from '../middleware/error-handler.js';
-import { setSafeRecordValue } from '../utils/safe-record.js';
 import { EgressPolicyService, getEgressPolicyService } from './egress-policy-service.js';
 
 const LOOPBACK_HOST = '127.0.0.1';
@@ -965,16 +964,20 @@ function forwardHeaders(
   headers: IncomingHttpHeaders,
   host: string | undefined,
   preserveUpgrade: boolean
-): IncomingHttpHeaders {
-  const result: IncomingHttpHeaders = {};
+): string[] {
+  const result: string[] = [];
   for (const [name, value] of Object.entries(headers)) {
     const lower = name.toLowerCase();
     if (lower === 'proxy-authorization' || lower === 'proxy-connection') continue;
     if (!preserveUpgrade && HOP_BY_HOP_HEADERS.has(lower)) continue;
     if (value === undefined) continue;
-    setSafeRecordValue(result, lower, value, 'HTTP header name');
+    if (Array.isArray(value)) {
+      for (const item of value) result.push(lower, item);
+    } else {
+      result.push(lower, value);
+    }
   }
-  if (host) result.host = host;
+  if (host) result.push('host', host);
   return result;
 }
 

--- a/server/src/services/run-egress-gateway-service.ts
+++ b/server/src/services/run-egress-gateway-service.ts
@@ -13,6 +13,7 @@ import {
   type RunEgressPolicy,
 } from '@veritas-kanban/shared';
 import { ConflictError } from '../middleware/error-handler.js';
+import { setSafeRecordValue } from '../utils/safe-record.js';
 import { EgressPolicyService, getEgressPolicyService } from './egress-policy-service.js';
 
 const LOOPBACK_HOST = '127.0.0.1';
@@ -383,7 +384,7 @@ async function handleHttpRequest(
   });
   upstream.once('response', (upstreamResponse) => {
     response.writeHead(
-      upstreamResponse.statusCode ?? 502,
+      normalizeUpstreamStatusCode(upstreamResponse.statusCode),
       forwardHeaders(upstreamResponse.headers, undefined, false)
     );
     upstreamResponse.pipe(response);
@@ -955,6 +956,11 @@ function portFor(url: URL, fallback: number): number {
   return url.port ? Number.parseInt(url.port, 10) : fallback;
 }
 
+function normalizeUpstreamStatusCode(statusCode: number | undefined): number {
+  if (typeof statusCode !== 'number' || !Number.isInteger(statusCode)) return 502;
+  return statusCode >= 100 && statusCode <= 599 ? statusCode : 502;
+}
+
 function forwardHeaders(
   headers: IncomingHttpHeaders,
   host: string | undefined,
@@ -966,7 +972,7 @@ function forwardHeaders(
     if (lower === 'proxy-authorization' || lower === 'proxy-connection') continue;
     if (!preserveUpgrade && HOP_BY_HOP_HEADERS.has(lower)) continue;
     if (value === undefined) continue;
-    result[lower] = value;
+    setSafeRecordValue(result, lower, value, 'HTTP header name');
   }
   if (host) result.host = host;
   return result;

--- a/server/src/services/skill-security-service.ts
+++ b/server/src/services/skill-security-service.ts
@@ -29,6 +29,7 @@ import type {
 } from '@veritas-kanban/shared';
 import type { WorkflowDefinition } from '../types/workflow.js';
 import { getRuntimeDir } from '../utils/paths.js';
+import { getSafeRecordValue, safeRecordFrom, setSafeRecordValue } from '../utils/safe-record.js';
 import { redactString } from '../lib/redact.js';
 import { auditLog } from './audit-service.js';
 import { profileSkillResource } from './skill-capability-service.js';
@@ -839,7 +840,11 @@ export class SkillSecurityService {
         ).length,
         latestReportId: latestReport?.id,
         latestReportPath: latestReport?.persistedJsonPath,
-        remediationTaskId: state.remediationTasks[resource.id],
+        remediationTaskId: getSafeRecordValue(
+          state.remediationTasks,
+          resource.id,
+          'Skill resource ID'
+        ),
         exception,
       };
       return item;
@@ -933,7 +938,7 @@ export class SkillSecurityService {
     });
 
     const state = await this.readState();
-    state.remediationTasks[skillId] = task.id;
+    setSafeRecordValue(state.remediationTasks, skillId, task.id, 'Skill resource ID');
     await this.writeState(state);
 
     await auditLog({
@@ -1114,11 +1119,14 @@ export class SkillSecurityService {
       const parsed = JSON.parse(content) as Partial<SkillSecurityState>;
       return {
         exceptions: parsed.exceptions ?? [],
-        remediationTasks: parsed.remediationTasks ?? {},
+        remediationTasks: safeRecordFrom<string>(
+          parsed.remediationTasks,
+          'Skill remediation tasks'
+        ),
       };
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-        return { exceptions: [], remediationTasks: {} };
+        return { exceptions: [], remediationTasks: safeRecordFrom<string>(undefined) };
       }
       throw err;
     }

--- a/server/src/utils/safe-record.ts
+++ b/server/src/utils/safe-record.ts
@@ -1,0 +1,58 @@
+const FORBIDDEN_RECORD_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export function assertSafeRecordKey(key: string, label = 'record key'): string {
+  if (!key || FORBIDDEN_RECORD_KEYS.has(key)) {
+    throw new Error(`${label} is not allowed`);
+  }
+  return key;
+}
+
+export function createSafeRecord<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+export function safeRecordFrom<T>(input: unknown, label = 'record'): Record<string, T> {
+  const output = createSafeRecord<T>();
+  if (input === undefined || input === null) return output;
+  if (typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error(`${label} must be an object`);
+  }
+
+  for (const [key, value] of Object.entries(input)) {
+    setSafeRecordValue(output, key, value as T, label);
+  }
+  return output;
+}
+
+export function getSafeRecordValue<T>(
+  record: Readonly<Record<string, T>>,
+  key: string,
+  label = 'record key'
+): T | undefined {
+  assertSafeRecordKey(key, label);
+  return Object.getOwnPropertyDescriptor(record, key)?.value as T | undefined;
+}
+
+export function setSafeRecordValue<T>(
+  record: Record<string, T>,
+  key: string,
+  value: T,
+  label = 'record key'
+): void {
+  assertSafeRecordKey(key, label);
+  Object.defineProperty(record, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
+export function deleteSafeRecordValue<T>(
+  record: Record<string, T>,
+  key: string,
+  label = 'record key'
+): boolean {
+  assertSafeRecordKey(key, label);
+  return Reflect.deleteProperty(record, key);
+}

--- a/server/src/utils/safe-record.ts
+++ b/server/src/utils/safe-record.ts
@@ -40,12 +40,7 @@ export function setSafeRecordValue<T>(
   label = 'record key'
 ): void {
   assertSafeRecordKey(key, label);
-  Object.defineProperty(record, key, {
-    configurable: true,
-    enumerable: true,
-    value,
-    writable: true,
-  });
+  Object.assign(record, Object.fromEntries([[key, value]]));
 }
 
 export function deleteSafeRecordValue<T>(


### PR DESCRIPTION
## Summary

- reject reserved dynamic keys before reading or mutating record-backed state
- normalize persisted maps to null-prototype records and migrate affected services
- preserve outbound header safety and clamp untrusted upstream status codes

## Security and compatibility

Malformed persisted maps now fail closed instead of inheriting object prototype behavior. The JSON storage shape is unchanged, so valid existing state requires no migration.

## Verification

- focused source review
- formatting and lint fixes for changed files
- security artifact, immutable action, and tracked-ignore guards
- workspace tests intentionally deferred to the final v6.1.2 milestone

Refs #1231