### PR TITLE
fix: harden request and logging boundaries

### DIFF
--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -40,6 +40,7 @@ import {
   TelemetryExportQuerySchema,
 } from '../schemas/telemetry-schemas.js';
 import {
+  MAX_TASK_REORDER_ITEMS,
   ReorderTasksBodySchema,
   ApplyTemplateBodySchema,
 } from '../schemas/task-mutation-schemas.js';
@@ -698,6 +699,14 @@ describe('Task Mutation Schemas', () => {
 
     it('should reject non-array orderedIds', () => {
       expect(() => ReorderTasksBodySchema.parse({ orderedIds: 'not-an-array' })).toThrow();
+    });
+
+    it('should reject an unbounded reorder payload', () => {
+      const orderedIds = Array.from(
+        { length: MAX_TASK_REORDER_ITEMS + 1 },
+        (_, index) => `task_${index}`
+      );
+      expect(() => ReorderTasksBodySchema.parse({ orderedIds })).toThrow();
     });
   });
 

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 import { createLogger } from '../lib/logger.js';
 import { authenticate, authorize, type AuthenticatedRequest } from '../middleware/auth.js';
 import { asyncHandler } from '../middleware/async-handler.js';
+import { readRateLimit, writeRateLimit } from '../middleware/rate-limit.js';
 import { getAllStatus as getCircuitBreakerStatus } from '../services/circuit-registry.js';
 import { getDependencyCircuitControlService } from '../services/dependency-circuit-control-service.js';
 import {
@@ -359,13 +360,14 @@ async function buildDeepHealthPayload() {
   };
 }
 
-healthRouter.get('/deep', authenticate, authorize('admin'), async (_req, res) => {
+healthRouter.get('/deep', readRateLimit, authenticate, authorize('admin'), async (_req, res) => {
   const payload = await buildDeepHealthPayload();
   res.json(payload);
 });
 
 healthRouter.post(
   '/dependency-circuits/:key/reset',
+  writeRateLimit,
   authenticate,
   authorize('admin'),
   asyncHandler(async (req: AuthenticatedRequest, res) => {
@@ -389,6 +391,7 @@ healthRouter.post(
 
 healthRouter.post(
   '/dependency-circuits/:key/override',
+  writeRateLimit,
   authenticate,
   authorize('admin'),
   asyncHandler(async (req: AuthenticatedRequest, res) => {
@@ -405,6 +408,7 @@ healthRouter.post(
 
 healthRouter.delete(
   '/dependency-circuits/:key/override',
+  writeRateLimit,
   authenticate,
   authorize('admin'),
   asyncHandler(async (req: AuthenticatedRequest, res) => {
@@ -445,7 +449,7 @@ healthRouter.get('/', (_req, res) => {
  * Returns a minimal JSON payload that is cheap to compute and safe to call
  * frequently.
  */
-apiHealthRouter.get('/', async (_req, res) => {
+apiHealthRouter.get('/', readRateLimit, async (_req, res) => {
   // Read version from package.json (best-effort)
   let version = 'unknown';
   try {
@@ -470,7 +474,7 @@ apiHealthRouter.get('/', async (_req, res) => {
  *
  * Same payload as /health/deep, exposed under /api for watchdogs and tooling.
  */
-apiHealthRouter.get('/deep', authenticate, authorize('admin'), async (_req, res) => {
+apiHealthRouter.get('/deep', readRateLimit, authenticate, authorize('admin'), async (_req, res) => {
   const payload = await buildDeepHealthPayload();
   res.json(payload);
 });

--- a/server/src/routes/prometheus.ts
+++ b/server/src/routes/prometheus.ts
@@ -5,6 +5,7 @@ import {
   authorizePermission,
   type AuthenticatedRequest,
 } from '../middleware/auth.js';
+import { readRateLimit } from '../middleware/rate-limit.js';
 import { getPrometheusCollector } from '../services/metrics/prometheus.js';
 
 export const prometheusMetricsRouter = Router();
@@ -66,7 +67,7 @@ function protectPrometheusMetrics(req: Request, res: Response, next: NextFunctio
   });
 }
 
-prometheusMetricsRouter.get('/metrics', protectPrometheusMetrics, (_req, res) => {
+prometheusMetricsRouter.get('/metrics', readRateLimit, protectPrometheusMetrics, (_req, res) => {
   const collector = getPrometheusCollector();
   res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
   res.send(collector.scrape());

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -24,6 +24,7 @@ import { authorizePermission, type AuthenticatedRequest } from '../middleware/au
 import { actorFromRequest, assertFreshRevision, setRevisionHeaders } from '../utils/concurrency.js';
 import type { TaskIdentityDiagnostics } from '../services/task-identity-diagnostics.js';
 import { TaskExecutionPolicySchema } from '../schemas/task-envelope-schemas.js';
+import { ReorderTasksBodySchema } from '../schemas/task-mutation-schemas.js';
 
 const router: RouterType = Router();
 const taskService = getTaskService();
@@ -174,10 +175,6 @@ const automationSchema = z
     result: z.string().optional(),
   })
   .optional();
-
-const reorderTasksSchema = z.object({
-  orderedIds: z.array(z.string().min(1)).min(1, 'orderedIds must be a non-empty array of task IDs'),
-});
 
 const applyTemplateSchema = z.object({
   templateId: z.string().min(1, 'Template ID is required'),
@@ -552,7 +549,7 @@ router.post(
   asyncHandler(async (req, res) => {
     let orderedIds: string[];
     try {
-      ({ orderedIds } = reorderTasksSchema.parse(req.body));
+      ({ orderedIds } = ReorderTasksBodySchema.parse(req.body));
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new ValidationError('Validation failed', error.issues);

--- a/server/src/routes/transcripts.ts
+++ b/server/src/routes/transcripts.ts
@@ -91,7 +91,8 @@ router.post(
     const result = isProcessed(subject);
 
     log.info(
-      `dedup-check subject="${subject}" emailId=${emailId ?? '(none)'} found=${result.found} match=${result.matchedFile ?? 'none'}`
+      { found: result.found, hasEmailId: typeof emailId === 'string' && emailId.length > 0 },
+      'Transcript deduplication check completed'
     );
 
     res.json({

--- a/server/src/schemas/task-mutation-schemas.ts
+++ b/server/src/schemas/task-mutation-schemas.ts
@@ -1,10 +1,15 @@
 import { z } from 'zod';
 
+export const MAX_TASK_REORDER_ITEMS = 1_000;
+
 /**
  * POST /api/tasks/reorder - Reorder tasks within a column
  */
 export const ReorderTasksBodySchema = z.object({
-  orderedIds: z.array(z.string().min(1)).min(1, 'orderedIds must be a non-empty array of task IDs'),
+  orderedIds: z
+    .array(z.string().min(1))
+    .min(1, 'orderedIds must be a non-empty array of task IDs')
+    .max(MAX_TASK_REORDER_ITEMS, `orderedIds cannot exceed ${MAX_TASK_REORDER_ITEMS} task IDs`),
 });
 
 export type ReorderTasksBody = z.infer<typeof ReorderTasksBodySchema>;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -59,7 +59,12 @@ import authRoutes from './routes/auth.js';
 import { checkJwtSecretConfig } from './config/security.js';
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './config/swagger.js';
-import { apiRateLimit, authRateLimit } from './middleware/rate-limit.js';
+import {
+  apiRateLimit,
+  authRateLimit,
+  authStatusRateLimit,
+  readRateLimit,
+} from './middleware/rate-limit.js';
 import { apiVersionMiddleware } from './middleware/api-version.js';
 import { apiCacheHeaders } from './middleware/cache-control.js';
 import type { RunEventEnvelope } from '@veritas-kanban/shared';
@@ -400,12 +405,24 @@ app.use(
 
 // Auth diagnostic endpoint (admin-only, requires authentication)
 // Available at both /api/auth/diagnostics and /api/v1/auth/diagnostics
-app.get('/api/auth/diagnostics', authenticate, authorize('admin'), (_req, res) => {
-  res.json(getAuthStatus());
-});
-app.get('/api/v1/auth/diagnostics', authenticate, authorize('admin'), (_req, res) => {
-  res.json(getAuthStatus());
-});
+app.get(
+  '/api/auth/diagnostics',
+  authStatusRateLimit,
+  authenticate,
+  authorize('admin'),
+  (_req, res) => {
+    res.json(getAuthStatus());
+  }
+);
+app.get(
+  '/api/v1/auth/diagnostics',
+  authStatusRateLimit,
+  authenticate,
+  authorize('admin'),
+  (_req, res) => {
+    res.json(getAuthStatus());
+  }
+);
 
 // ============================================
 // Auth Routes (unauthenticated - for login/setup)
@@ -522,7 +539,7 @@ if (process.env.NODE_ENV === 'production') {
 
   // SPA fallback: serve index.html for any non-API route
   // Express 5 / path-to-regexp v8+ requires named wildcards (fixes #150)
-  app.get('{*path}', (_req, res, next) => {
+  app.get('{*path}', readRateLimit, (_req, res, next) => {
     // Don't serve index.html for API routes or WebSocket
     if (_req.path.startsWith('/api') || _req.path.startsWith('/ws') || _req.path === '/health') {
       return next();

--- a/server/src/services/agent-registry-service.ts
+++ b/server/src/services/agent-registry-service.ts
@@ -424,7 +424,7 @@ class AgentRegistryService {
     this.lastBusyAtByAgent.delete(agentId);
     if (existed) {
       this.persist();
-      log.info({ agentId }, `Agent deregistered: ${agentId}`);
+      log.info({ agentId }, 'Agent deregistered');
     }
     return existed;
   }

--- a/server/src/services/attachment-service.ts
+++ b/server/src/services/attachment-service.ts
@@ -259,7 +259,7 @@ export class AttachmentService {
     try {
       await fs.unlink(filepath);
     } catch (err) {
-      log.error({ err: err }, `Failed to delete attachment file: ${filepath}`);
+      log.error({ err, filepath }, 'Failed to delete attachment file');
     }
 
     // Delete extracted text
@@ -320,7 +320,7 @@ export class AttachmentService {
     } catch (err) {
       // Ignore if source doesn't exist
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        log.error({ err: err }, `Failed to archive attachments for task ${taskId}`);
+        log.error({ err, taskId }, 'Failed to archive task attachments');
       }
     }
   }
@@ -344,7 +344,7 @@ export class AttachmentService {
     } catch (err) {
       // Ignore if source doesn't exist
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        log.error({ err: err }, `Failed to restore attachments for task ${taskId}`);
+        log.error({ err, taskId }, 'Failed to restore task attachments');
       }
     }
   }
@@ -358,7 +358,7 @@ export class AttachmentService {
     try {
       await fs.rm(taskDir, { recursive: true, force: true });
     } catch (err) {
-      log.error({ err: err }, `Failed to delete attachments directory for task ${taskId}`);
+      log.error({ err, taskId }, 'Failed to delete task attachments directory');
     }
   }
 

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -2171,7 +2171,13 @@ export class ClawdbotAgentService {
       routingReason = `Agent profile ${profileLaunch.profile.id}@${profileLaunch.profile.version} selected ${agent}.`;
       routingFallback = profileLaunch.profile.runtime.fallbackAgent;
       log.info(
-        `[ClawdbotAgent] Profile ${profileLaunch.profile.id}@${profileLaunch.profile.version} selected ${agent} for task ${taskId}`
+        {
+          agent,
+          profileId: profileLaunch.profile.id,
+          profileVersion: profileLaunch.profile.version,
+          taskId,
+        },
+        '[ClawdbotAgent] Profile selected agent for task'
       );
     } else if (!agentType || agentType === 'auto') {
       const routing = getAgentRoutingService();
@@ -2179,9 +2185,7 @@ export class ClawdbotAgentService {
       agent = result.agent;
       routingReason = result.reason;
       routingFallback = result.fallback;
-      log.info(
-        `[ClawdbotAgent] Routing resolved agent for task ${taskId}: ${agent} (${routingReason})`
-      );
+      log.info({ agent, routingReason, taskId }, '[ClawdbotAgent] Routing resolved agent for task');
     } else {
       agent = agentType;
       routingReason = `Operator explicitly selected ${agent}.`;
@@ -4190,7 +4194,7 @@ export class ClawdbotAgentService {
       });
     }
 
-    log.info(`[ClawdbotAgent] Task ${taskId} completed with status: ${status}`);
+    log.info({ status, taskId }, '[ClawdbotAgent] Task completed');
   }
 
   private scheduleReflectionExtraction(

--- a/server/src/services/prompt-registry-service.ts
+++ b/server/src/services/prompt-registry-service.ts
@@ -201,7 +201,7 @@ export class PromptRegistryService {
       const { data } = matter(content);
       return data as PromptTemplate;
     } catch (err) {
-      log.error({ err: err }, `Error reading template ${id}`);
+      log.error({ err, templateId: id }, 'Error reading prompt template');
       return null;
     }
   }
@@ -433,7 +433,7 @@ export class PromptRegistryService {
         usageData = JSON.parse(content);
       }
     } catch (err) {
-      log.warn({ err: err }, `Error reading usage file for ${templateId}`);
+      log.warn({ err, templateId }, 'Error reading prompt usage file');
     }
 
     usageData.push(usage);
@@ -460,7 +460,7 @@ export class PromptRegistryService {
       const content = await readFile(usageFile, 'utf-8');
       return JSON.parse(content);
     } catch (err) {
-      log.error({ err: err }, `Error reading usage file for ${templateId}`);
+      log.error({ err, templateId }, 'Error reading prompt usage file');
       return [];
     }
   }

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -41,6 +41,7 @@ import {
   type TaskIdentityScanSource,
 } from './task-identity-diagnostics.js';
 import { getCeremonyService, type CeremonyService } from './ceremony-service.js';
+import { MAX_TASK_REORDER_ITEMS } from '../schemas/task-mutation-schemas.js';
 
 const log = createLogger('task-cache');
 const TASK_SYNC_CONTEXT: TaskSyncContext = createTaskSyncToken('task-service');
@@ -1774,6 +1775,11 @@ export class TaskService {
    * Accepts an ordered array of task IDs and assigns sequential position values.
    */
   async reorderTasks(orderedIds: string[]): Promise<Task[]> {
+    if (orderedIds.length > MAX_TASK_REORDER_ITEMS) {
+      throw new ValidationError(
+        `Cannot reorder more than ${MAX_TASK_REORDER_ITEMS} tasks in one request`
+      );
+    }
     const tasks = await this.listTasks();
     const updated: Task[] = [];
 

--- a/server/src/services/template-service.ts
+++ b/server/src/services/template-service.ts
@@ -168,7 +168,7 @@ export class TemplateService {
       const { data } = matter(content);
       return this.migrateTemplate(data);
     } catch (err) {
-      log.error({ err: err }, `Error reading template ${id}`);
+      log.error({ err, templateId: id }, 'Error reading task template');
       return null;
     }
   }


### PR DESCRIPTION
## Summary

- rate-limit authenticated health, metrics, diagnostics, and SPA fallback handlers
- bound task reorder payloads at both schema and service layers
- move user-controlled log values into structured fields and stop logging transcript subjects

## Security and compatibility

Existing routes and response shapes are unchanged. The reorder endpoint now rejects payloads above 1,000 IDs instead of allowing unbounded sequential mutations.

## Verification

- focused source review
- formatting for changed files
- workspace tests intentionally deferred to the final v6.1.2 milestone

Refs #1231