### PR TITLE
fix: stabilize release validation boundaries

### DIFF
--- a/server/src/config/security.ts
+++ b/server/src/config/security.ts
@@ -376,7 +376,7 @@ export function saveSecurityConfig(config: SecurityConfig): void {
  * Format: XXXX-XXXX-XXXX-XXXX (16 alphanumeric chars)
  */
 export function generateRecoveryKey(): string {
-  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // Omit confusing chars (0/O, 1/I/L)
+  const chars = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'; // Omit confusing chars (0/O, 1/I/L)
   let key = '';
 
   for (let i = 0; i < 16; i++) {

--- a/server/src/services/run-egress-gateway-service.ts
+++ b/server/src/services/run-egress-gateway-service.ts
@@ -508,10 +508,11 @@ async function handleUpgrade(
   upstream.write(
     `${request.method ?? 'GET'} ${target.pathname}${target.search} HTTP/${request.httpVersion}\r\n`
   );
-  for (const [name, value] of Object.entries(forwardHeaders(request.headers, target.host, true))) {
-    for (const item of Array.isArray(value) ? value : [value]) {
-      if (item !== undefined) upstream.write(`${name}: ${item}\r\n`);
-    }
+  const headers = forwardHeaders(request.headers, target.host, true);
+  for (let index = 0; index < headers.length; index += 2) {
+    const name = headers[index];
+    const value = headers[index + 1];
+    if (name !== undefined && value !== undefined) upstream.write(`${name}: ${value}\r\n`);
   }
   upstream.write('\r\n');
   if (transport.head.length > 0) client.write(transport.head);


### PR DESCRIPTION
## Summary

- Removes the ambiguous `L` character from generated recovery keys, matching the existing documented contract and regression test.
- Forwards WebSocket upgrade headers as actual name/value pairs instead of numeric array indexes.

## Verification

- 8/8 targeted server tests passed.
- Workspace typecheck passed.
- Focused ESLint passed with one unchanged baseline warning.

## Risk

- Recovery keys retain 16 random characters and the existing grouped format.
- The gateway change only corrects header serialization on the already allowed plaintext WebSocket path.

Fixes #1238