### PR TITLE
fix: reject unsafe URI prefixes

### DIFF
--- a/web/src/lib/__tests__/sanitize.test.ts
+++ b/web/src/lib/__tests__/sanitize.test.ts
@@ -69,6 +69,11 @@ describe('sanitizeHtml', () => {
     expect(result).toContain('blocked');
   });
 
+  it('preserves safe digit-prefixed relative links', () => {
+    const result = sanitizeHtml('<a href="1-release-notes.html">release notes</a>');
+    expect(result).toContain('href="1-release-notes.html"');
+  });
+
   it('preserves tables', () => {
     const input = '<table><tr><td>Cell</td></tr></table>';
     expect(sanitizeHtml(input)).toContain('<td>Cell</td>');

--- a/web/src/lib/sanitize.ts
+++ b/web/src/lib/sanitize.ts
@@ -68,7 +68,8 @@ const ALLOWED_ATTR = [
  * URI schemes allowed in href/src attributes.
  * Blocks javascript:, data:, vbscript:, etc.
  */
-const ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto|tel|ftp):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i;
+const ALLOWED_URI_REGEXP =
+  /^(?:(?:https?|mailto|tel|ftp):|[^a-z0-9]|[a-z0-9+.-]+(?:[^a-z0-9+.:-]|$))/i;
 
 /**
  * Sanitize HTML content for safe rendering.


### PR DESCRIPTION
## Summary

- Makes the sanitizer URI allowlist treat digits conservatively inside URI-like prefixes.
- Removes digit-prefixed unsafe attributes while preserving safe digit-prefixed relative links.

## Verification

- Sanitizer regression tests: 29/29 passing.
- Web typecheck passed after the required shared build.
- Focused ESLint passed with no warnings.

## Risk

- Explicit HTTP, HTTPS, mail, telephone, and FTP schemes remain supported.
- Safe relative paths remain supported.

Fixes #1242