### PR TITLE
docs: record v6.1.2 publication evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,9 @@ storage, provider-runtime, CI, container, and supportability audit tracked in
   bounded file reads and writes, and sandbox metadata reads identified by the
   initial CodeQL baseline (#1231, #1232-#1235).
 - Integrated coordinated validation hardening for a privately reported input
-  boundary. Technical details remain under the repository security-advisory
-  process until supported artifacts are available and disclosure is approved
-  (#1236).
+  boundary. The repository security advisory was published after supported
+  6.1.2 artifacts were verified and disclosure was approved (#1236,
+  [GHSA-4r99-qpvh-wrqf](https://github.com/BradGroux/veritas-kanban/security/advisories/GHSA-4r99-qpvh-wrqf)).
 - Corrected recovery-key alphabet generation and WebSocket upgrade header
   forwarding defects exposed by the final release validation (#1238, #1239).
 - Serialized complete same-task update and lifecycle operations before their

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-![Veritas Kanban v5 board, workflow, and audit tour](docs/assets/v5/v5-board-to-workflow.gif)
+![Veritas Kanban board, workflow, and audit tour](docs/assets/v5/v5-board-to-workflow.gif)
 
 > 🎬 [Watch the full demo video](https://bradgroux.github.io/veritas-kanban/demo/)
 
@@ -40,7 +40,7 @@ Want to take the easy way out? Ask your agent:
 Clone and set up veritas-kanban locally using the board-only setup path first. Install dependencies with pnpm, copy server/.env.example to server/.env, and start the dev server. Verify the UI at localhost:3000 and the API health endpoint at localhost:3001/api/health. Do not configure OpenClaw, MCP, Squad Chat webhooks, workflows, or notifications unless I explicitly ask for that layer.
 ```
 
-Want to do it yourself? Get up and running in under 5 minutes:
+Want to do it yourself? Choose the packaged Mac app or a local source checkout:
 
 For the packaged Mac desktop app:
 
@@ -103,14 +103,13 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 - [Veritas Cutover Operating Guide](docs/VERITAS-CUTOVER.md) — authority model, HermesAgent roster, QA evidence gate, and GitHub-backed task templates.
 - [Codex Integration SOP](docs/SOP-codex-integration.md) & [Codex Workflow Examples](docs/EXAMPLES-codex-workflows.md) — operational playbooks for using Codex as a first-class Veritas agent.
 - [API Reference](docs/API-REFERENCE.md) — Auth, endpoints, request/response examples, WebSocket, common workflows.
-- [v5 Identity and RBAC Model](docs/IDENTITY-RBAC.md) — users, workspaces, memberships, roles, agent tokens, permission matrix, migration, and UX flows.
-- [v5 Mantine Migration Plan](docs/UI-MANTINE-MIGRATION.md) — component inventory, migration order, retained custom surfaces, rollback strategy, and cleanup gates.
+- [Identity and RBAC Model](docs/IDENTITY-RBAC.md) — users, workspaces, memberships, roles, agent tokens, permission matrix, migration, and UX flows.
 - [v6 GA Checklist](docs/V6-GA-CHECKLIST.md) — release gates for harness certification, migration, runtime, desktop, and distribution evidence.
 - [v6 Visual Tour](docs/V6-VISUAL-TOUR.md) — release-safe views of provider support, Buzz setup, approvals, and run evidence.
 - [v6 Upgrade, Install, Remote, And Admin Guide](docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md) — fresh install, v5-to-v6 upgrade, harness setup, desktop, backup, and diagnostics paths.
 - [v6 Compatibility And Release Policy](docs/V6-COMPATIBILITY-AND-RELEASE-POLICY.md) — provider support tiers, tested builds, platform combinations, update channels, and rollback limits.
 - [v6 Release Notes](docs/V6-RELEASE-NOTES.md) — user-facing highlights, stabilization fixes, install/upgrade steps, behavior changes, and known limits.
-- [v5 Desktop Architecture ADR](docs/architecture/ADR-0001-v5-desktop-architecture.md) — shell decision, native/server boundaries, connection modes, lifecycle, packaging, and security model.
+- [Desktop Architecture ADR](docs/architecture/ADR-0001-v5-desktop-architecture.md) — shell decision, native/server boundaries, connection modes, lifecycle, packaging, and security model.
 - [Post-GA Desktop Agent Workbench Spec](docs/DESKTOP-AGENT-WORKBENCH.md) — desktop workbench UX, run controls, approvals, evidence, native affordances, and safety coverage.
 - [Post-GA Native Mobile Offline ADR](docs/architecture/ADR-0003-post-ga-native-mobile-offline.md) — native mobile authority model, offline queue semantics, conflict handling, and security review.
 - [Post-GA Cloud Sync And Hosted SaaS ADR](docs/architecture/ADR-0004-post-ga-cloud-sync-hosted-saas.md) — optional hosted model, tenant isolation, lifecycle, support, cost, and migration boundaries.
@@ -155,7 +154,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 
 8. **Isolate environments.** Run agents in containers, VMs, or sandboxed environments when possible. Keep agent workspaces separate from sensitive data, use deny-by-default network presets for untrusted work, and broker credentials instead of exposing broad environment variables.
 
-**The bottom line:** Agentic AI is transformational, but it amplifies both your capabilities and your mistakes. Plan accordingly, start small, and add autonomy gradually as you build confidence in your guardrails.
+**The bottom line:** Agents amplify both useful work and mistakes. Start locally, keep permissions narrow, and add autonomy only after the smaller setup is understood and verified.
 
 ---
 
@@ -179,9 +178,9 @@ keep the board, header, close control, and keyboard recovery paths reachable.
 
 ![Squad Chat threaded coordination](docs/assets/v5/v5-squad-chat-threaded-coordination.png)
 
-### 🧭 Veritas Cutover + Hermes Support
+### 🧭 Provider And Cutover Operations
 
-Veritas now documents the GitHub-backed operating model for Codex and HermesAgent work. The new cutover guide names Veritas as the source of truth, routes HermesAgent/Hermes Gateway as the control plane for agent execution, keeps Mission Control focused on display/control, and makes GitHub Issues/PRs/reviews/CI the implementation record. It also adds the active Hermes roster, required QA evidence gates, and copy/paste task templates for product specs, research/revenue intake, and approval-gated client workflows.
+The cutover guide documents a GitHub-backed operating model for Codex and HermesAgent work. Veritas remains the source of truth, HermesAgent/Hermes Gateway can provide the execution control plane, and GitHub Issues, pull requests, reviews, and CI remain the durable implementation record. Copy/paste task templates cover product specs, research intake, and approval-gated client workflows.
 
 ### 🧠 OpenAI Codex Integration
 
@@ -377,12 +376,12 @@ complete configured storage root, not only the Git-tracked board files.
 
 | Layer               | Technology                            | Version                                     |
 | ------------------- | ------------------------------------- | ------------------------------------------- |
-| **Frontend**        | React, Vite, Tailwind CSS, Mantine UI | React 19, Vite 8, Tailwind 4.3, Mantine 9.3 |
+| **Frontend**        | React, Vite, Tailwind CSS, Mantine UI | React 19, Vite 8, Tailwind 4.3, Mantine 9.5 |
 | **Backend**         | Express, WebSocket                    | Express 5.2                                 |
 | **Language**        | TypeScript (strict mode)              | 6.0                                         |
 | **Storage**         | Markdown files with YAML frontmatter  | yaml + local frontmatter helper             |
 | **Git**             | simple-git, worktree management       | —                                           |
-| **Testing**         | Playwright (E2E), Vitest (unit)       | Playwright 1.61, Vitest 4.1                 |
+| **Testing**         | Playwright (E2E), Vitest (unit)       | Playwright 1.62, Vitest 4.1                 |
 | **Runtime**         | Node.js                               | 22.22.1+                                    |
 | **Package Manager** | pnpm                                  | 11.1.1 (pinned)                             |
 
@@ -487,7 +486,7 @@ veritas-kanban/                  ← pnpm monorepo
     └── agent-requests/
 ```
 
-**Data flow:** Web ↔ REST API / WebSocket ↔ Server ↔ Markdown/YAML files on disk
+**Data flow:** Web ↔ REST API / WebSocket ↔ Server ↔ configured file or SQLite storage
 
 ---
 
@@ -516,7 +515,7 @@ curl -H "X-API-Version: v1" http://localhost:3001/api/tasks
 
 > 📖 **Comprehensive CLI guide:** [docs/CLI-GUIDE.md](docs/CLI-GUIDE.md) — installation, every command, scripting examples, and tips.
 
-Manage your entire task lifecycle with two commands.
+Handle the common start-and-complete task lifecycle with two commands.
 
 ```bash
 # Install globally
@@ -799,7 +798,7 @@ Verify discovery with `openclaw mcp list`. See [Troubleshooting](docs/TROUBLESHO
 **Troubleshooting MCP connection issues:**
 
 - **Always restart the MCP client after MCP config changes** — MCP servers are discovered at startup
-- **Verify tools are available:** Run `openclaw mcp list` to confirm 41 Veritas Kanban tools appear
+- **Verify tools are available:** Run `openclaw mcp list` to confirm 42 Veritas Kanban tools appear
 - **When reporting issues, provide:**
   - OpenClaw version (`openclaw --version`)
   - VK version and health (`curl http://localhost:3001/api/health`)
@@ -851,27 +850,27 @@ pnpm validate:release # Release readiness checks
 
 ## 📚 Documentation
 
-| Document                                       | Description                                      |
-| ---------------------------------------------- | ------------------------------------------------ |
-| [Features](docs/FEATURES.md)                   | Complete feature reference                       |
-| [v6 Visual Tour](docs/V6-VISUAL-TOUR.md)       | Provider, Buzz, approval, and run evidence views |
-| [API Reference](docs/API-REFERENCE.md)         | Auth, endpoints, WebSocket docs                  |
-| [CLI Guide](docs/CLI-GUIDE.md)                 | Comprehensive CLI usage guide                    |
-| [Self-Hosting Guide](docs/guides/SELF_HOST.md) | Production deployment, reverse proxy, Docker     |
-| [Deployment](docs/DEPLOYMENT.md)               | Docker, bare metal, env config                   |
-| [Troubleshooting](docs/TROUBLESHOOTING.md)     | Common issues & solutions                        |
-| [Contributing](CONTRIBUTING.md)                | How to contribute, PR guidelines                 |
-| [Security Policy](SECURITY.md)                 | Vulnerability reporting                          |
-| [Code of Conduct](CODE_OF_CONDUCT.md)          | Community guidelines                             |
-| [Changelog](CHANGELOG.md)                      | Release history                                  |
-| [Sprint Docs](docs/)                           | Sprint planning & audit reports                  |
+| Document                                       | Description                                         |
+| ---------------------------------------------- | --------------------------------------------------- |
+| [Features](docs/FEATURES.md)                   | Complete feature reference                          |
+| [v6 Visual Tour](docs/V6-VISUAL-TOUR.md)       | Provider, Buzz, approval, and run evidence views    |
+| [API Reference](docs/API-REFERENCE.md)         | Auth, endpoints, WebSocket docs                     |
+| [CLI Guide](docs/CLI-GUIDE.md)                 | Comprehensive CLI usage guide                       |
+| [Self-Hosting Guide](docs/guides/SELF_HOST.md) | Production deployment, reverse proxy, Docker        |
+| [Deployment](docs/DEPLOYMENT.md)               | Docker, bare metal, env config                      |
+| [Troubleshooting](docs/TROUBLESHOOTING.md)     | Common issues and solutions                         |
+| [Contributing](CONTRIBUTING.md)                | How to contribute and pull request guidelines       |
+| [Security Policy](SECURITY.md)                 | Vulnerability reporting                             |
+| [Code of Conduct](CODE_OF_CONDUCT.md)          | Community guidelines                                |
+| [Changelog](CHANGELOG.md)                      | Release history                                     |
+| [Documentation Index](docs/)                   | Operator, developer, architecture, and release docs |
 
 ---
 
-## 📸 v5 Visuals
+## 📸 Visuals
 
 <details>
-<summary><strong>Click to expand v5 screenshots and GIFs</strong></summary>
+<summary><strong>Click to expand screenshots and GIFs</strong></summary>
 
 These captures use release-safe dummy content against the current app surfaces. See the [v6 Visual Tour](docs/V6-VISUAL-TOUR.md) for the current release views and retained v5 shell captures.
 
@@ -905,19 +904,22 @@ These captures use release-safe dummy content against the current app surfaces. 
 
 ## 🗺️ Roadmap
 
-Current planning lives in GitHub, not in a stale README checklist:
+Current work and priorities live in GitHub, not in a version-specific README checklist:
 
 - [Open issues](https://github.com/BradGroux/veritas-kanban/issues)
-- [v5.0 roadmap issues](https://github.com/BradGroux/veritas-kanban/issues?q=is%3Aissue%20state%3Aopen%20label%3Arelease%3Av5.0)
-- [v5.0 SQLite schema and migration strategy](docs/SQLITE-SCHEMA.md)
-- [v5.0 SQLite migration recovery drill](docs/MIGRATION-RECOVERY.md)
-- [v5.0 desktop architecture decision](docs/architecture/ADR-0001-v5-desktop-architecture.md)
-- [post-GA desktop agent workbench spec](docs/DESKTOP-AGENT-WORKBENCH.md)
+- [Release history](CHANGELOG.md)
+- [GitHub releases](https://github.com/BradGroux/veritas-kanban/releases)
+
+Longer-lived product and architecture direction is recorded separately:
+
+- [v6 agent runtime control plane](docs/architecture/V6-AGENT-RUNTIME-CONTROL-PLANE.md)
+- [phase capability profiles](docs/architecture/PHASE-CAPABILITY-PROFILES.md)
+- [tool control plane v1](docs/architecture/TOOL-CONTROL-PLANE-V1.md)
+- [post-GA desktop agent workbench](docs/DESKTOP-AGENT-WORKBENCH.md)
 - [post-GA native mobile offline decision](docs/architecture/ADR-0003-post-ga-native-mobile-offline.md)
 - [post-GA cloud sync and hosted SaaS decision](docs/architecture/ADR-0004-post-ga-cloud-sync-hosted-saas.md)
-- [Release history](CHANGELOG.md)
 
-Use issues for current work and the changelog for shipped work.
+Use issues for current work, architecture records for durable direction, and the changelog and releases for shipped work.
 
 ---
 

--- a/docs/DOC-FRESHNESS.md
+++ b/docs/DOC-FRESHNESS.md
@@ -65,18 +65,18 @@ update the authoritative registry record.
 
 ### Last Sweep
 
-| Date       | Scope                                                               | Agent   |
-| ---------- | ------------------------------------------------------------------- | ------- |
-| 2026-08-24 | v6.1.2 audit, storage, provider, CI, security, release, distribution, and SOP docs | Release |
-| 2026-08-22 | v6.1.1 maintenance, dependency, release, upgrade, and evidence docs | Release |
-| 2026-07-26 | v6.1.0 roadmap, harness, governance, knowledge, and release docs    | Release |
-| 2026-07-24 | v6.0.2 desktop recovery, version support, release, and evidence     | Release |
-| 2026-07-24 | v6.0.1 stabilization, release, upgrade, API, MCP, and evidence      | Release |
-| 2026-07-24 | v6.0.0 harness, Buzz, release, upgrade, compatibility, and evidence | Release |
-| 2026-07-12 | v5.2.2 UI-audit fixes, release gates, desktop state, and evidence   | Release |
-| 2026-06-05 | v5.0.0 stable release docs, install paths, release assets, RC notes | Codex   |
-| 2026-03-25 | Full v3→v4 version references, governance docs, CHANGELOG, examples | VERITAS |
-| 2026-03-21 | v4.0 release documentation                                          | TARS    |
+| Date       | Scope                                                                                      | Agent   |
+| ---------- | ------------------------------------------------------------------------------------------ | ------- |
+| 2026-08-24 | README; v6.1.2 audit, storage, provider, CI, security, release, distribution, and SOP docs | Release |
+| 2026-08-22 | v6.1.1 maintenance, dependency, release, upgrade, and evidence docs                        | Release |
+| 2026-07-26 | v6.1.0 roadmap, harness, governance, knowledge, and release docs                           | Release |
+| 2026-07-24 | v6.0.2 desktop recovery, version support, release, and evidence                            | Release |
+| 2026-07-24 | v6.0.1 stabilization, release, upgrade, API, MCP, and evidence                             | Release |
+| 2026-07-24 | v6.0.0 harness, Buzz, release, upgrade, compatibility, and evidence                        | Release |
+| 2026-07-12 | v5.2.2 UI-audit fixes, release gates, desktop state, and evidence                          | Release |
+| 2026-06-05 | v5.0.0 stable release docs, install paths, release assets, RC notes                        | Codex   |
+| 2026-03-25 | Full v3→v4 version references, governance docs, CHANGELOG, examples                        | VERITAS |
+| 2026-03-21 | v4.0 release documentation                                                                 | TARS    |
 
 ## Automation Plan
 

--- a/docs/DOC-FRESHNESS.md
+++ b/docs/DOC-FRESHNESS.md
@@ -67,7 +67,7 @@ update the authoritative registry record.
 
 | Date       | Scope                                                               | Agent   |
 | ---------- | ------------------------------------------------------------------- | ------- |
-| 2026-08-24 | v6.1.2 audit, storage, provider, CI, security, release, and SOP docs | Release |
+| 2026-08-24 | v6.1.2 audit, storage, provider, CI, security, release, distribution, and SOP docs | Release |
 | 2026-08-22 | v6.1.1 maintenance, dependency, release, upgrade, and evidence docs | Release |
 | 2026-07-26 | v6.1.0 roadmap, harness, governance, knowledge, and release docs    | Release |
 | 2026-07-24 | v6.0.2 desktop recovery, version support, release, and evidence     | Release |

--- a/docs/V6-GA-CHECKLIST.md
+++ b/docs/V6-GA-CHECKLIST.md
@@ -9,9 +9,8 @@ Documentation freshness: 2026-08-24 for Veritas Kanban 6.1.2.
 
 ## 6.1.2 Release Gate
 
-- [x] Audit issues #1162, #1163, and #1165-#1173 are closed through merged,
-      evidence-linked pull requests; #1164 implementation is merged and awaits
-      the single final regression milestone before closure.
+- [x] Audit issues #1162-#1173 are closed through merged, evidence-linked pull
+      requests and the single final regression milestone.
 - [x] Root, shared, server, web, CLI, MCP, and desktop manifests are 6.1.2.
 - [x] README, canonical instructions, API reference, compatibility policy,
       upgrade guide, release notes, canonical GitHub body, freshness record, and
@@ -22,16 +21,17 @@ Documentation freshness: 2026-08-24 for Veritas Kanban 6.1.2.
       production Docker contract are represented in release documentation.
 - [x] Independent and cross-model review remain optional; they are not part of
       the default delivery or release gate.
-- [x] The coordinated private security fix is integrated into the candidate and
-      remains private until supported artifacts exist and disclosure is approved.
-- [ ] One clean final candidate passes the complete Node-floor and current-Node
+- [x] The coordinated security fix is integrated, released in supported
+      artifacts, and published through the approved repository advisory.
+- [x] One clean final candidate passes the complete Node-floor and current-Node
       verification matrix with exact counts, skips, retries, image size, and
       limitations recorded in the evidence packet.
-- [ ] The release PR merges and its exact merge is published as annotated
+- [x] The release PR merges and its exact merge is published as annotated
       `v6.1.2` with a live body matching `docs/releases/v6.1.2.md`.
-- [ ] Signed/notarized macOS assets, updater metadata, installed-app readiness,
-      the live Homebrew cask, and the private advisory disposition are verified.
-- [ ] Release tracker #1174 closes only after every publication readback passes.
+- [x] Signed/notarized macOS assets, updater metadata, installed-app readiness,
+      the live Homebrew cask, and the advisory disposition are verified.
+- [x] Every publication readback required before closing release tracker #1174
+      has passed; close the tracker after this evidence update merges.
 
 ## Historical 6.1.1 Completed Release Gate
 
@@ -127,10 +127,11 @@ gates at Node 22.22.1 and the current supported Node runtime.
 
 ## Distribution And Post-Publication
 
-The 6.1.2 publication gate is pending the final candidate, release merge, tag,
-signed/notarized artifacts, independent launch verification, post-publication
-validator, live Homebrew cask, and approved advisory disposition. Completed
-6.1.1 evidence remains recorded below and in the evidence packet.
+The 6.1.2 publication gate is complete. The final candidate, release merge,
+annotated tag, signed/notarized artifacts, independent launch verification,
+post-publication validator, live Homebrew cask, and approved advisory
+disposition are verified in the evidence packet. Completed 6.1.1 evidence
+remains recorded below.
 
 ## Historical 6.0.2 Source And Scope
 

--- a/docs/V6-RC-EVIDENCE-PACKET.md
+++ b/docs/V6-RC-EVIDENCE-PACKET.md
@@ -6,10 +6,10 @@ stabilization release, and the 6.0.2 desktop recovery hotfix. It separates
 merged implementation, deterministic conformance, local runtime proof, signed
 publication, and Homebrew availability.
 
-Veritas Kanban 6.1.1 remains the supported stable v6 release until 6.1.2 is
-published and verified. Do not use 6.0.0 for installation or upgrade validation.
+Veritas Kanban 6.1.2 is the supported stable v6 release. Do not use 6.0.0 for
+installation or upgrade validation.
 
-Documentation freshness: 2026-08-24 for the Veritas Kanban 6.1.2 candidate.
+Documentation freshness: 2026-08-24 for the published Veritas Kanban 6.1.2 release.
 
 ## 6.1.2 Audit Release Candidate
 
@@ -19,10 +19,10 @@ Documentation freshness: 2026-08-24 for the Veritas Kanban 6.1.2 candidate.
 | Source branch            | `release/6.1.2-audit`                                                                                                                                                                                                                              |
 | Source baseline          | `3851fea93ecfe5119e4092739662443d29059ac7`, `main` after release-gate fix PR #1243                                                                                                                                                                 |
 | Validated candidate      | `2a21178df97a00395cfc6c43774a57496a5c1f6a`, the frozen release PR head before this evidence-only update                                                                                                                                            |
-| Included issues          | Audit tracker [#1174](https://github.com/BradGroux/veritas-kanban/issues/1174), findings #1162-#1173, and CodeQL baseline #1231                                                                                                                    |
-| Public implementation    | #1162, #1163, and #1165-#1173 are closed through merged work; #1164 implementation is merged and remains open only for final regression evidence; coordinated remediation and release-gate fixes are merged through #1236, #1239, #1241, and #1243 |
-| Private security blocker | Remediation is integrated into the candidate. Release verification and disclosure disposition remain pending, and no exploit-relevant detail is included here                                                                                      |
-| Publication state        | Not published. The final matrix is complete on the frozen candidate; merge, tag, GitHub release, signed desktop workflow, Homebrew cask, and advisory disposition remain pending                                                                   |
+| Included issues          | Audit tracker [#1174](https://github.com/BradGroux/veritas-kanban/issues/1174), closed findings #1162-#1173, and closed CodeQL baseline #1231                                                                                                           |
+| Public implementation    | #1162-#1173 are closed through merged work. Coordinated remediation and release-gate fixes are merged through #1236, #1239, #1241, and #1243                                                                                                              |
+| Security disposition     | Remediation is integrated into supported 6.1.2 artifacts. The approved [repository security advisory](https://github.com/BradGroux/veritas-kanban/security/advisories/GHSA-4r99-qpvh-wrqf) was published after artifact verification                                     |
+| Publication state        | Complete. Release PR #1237, annotated `v6.1.2`, the stable GitHub release, signed/notarized assets, updater metadata, post-publication validator, Homebrew cask/install, and advisory disposition are verified                                               |
 
 ### 6.1.2 issue and pull request traceability
 
@@ -53,20 +53,20 @@ evidence-backed dispositions. The post-merge default-branch Security Gates run
 completed successfully at `1cdcd6ec60e3f48b6017146b2583fa82f7061c68`
 with zero open alerts.
 
-The 2026-08-24 pre-release GitHub security readback confirms Dependabot
-vulnerability alerts and security updates are enabled, secret scanning and
-push protection are enabled, and open Dependabot, secret-scanning, and
-default-branch CodeQL alert counts are all zero. Every external workflow action
-reference is pinned to a full commit SHA. These drift-prone settings are
-rechecked against the final release merge before publication.
+The 2026-08-24 pre-release and post-publication GitHub security readbacks
+confirm Dependabot security updates, secret scanning, and push protection are
+enabled, and open Dependabot, secret-scanning, and default-branch CodeQL alert
+counts are all zero. Every external workflow action reference is pinned to a
+full commit SHA. The final readback was taken after the exact-main Security
+Gates run passed.
 
 Final-milestone preflight on 2026-08-24 found local Node 26.7.0, pnpm 11.1.1,
 Git 2.55.0, and an available Docker 29.2.1 server. The Node 22 floor remains
 the `ci:full` runner gate; no separate local Node 22 installation is present.
 The required macOS signing secret names and the complete App Store Connect
-notarization secret-name set are configured, without reading their values. No
-Veritas Kanban app or Homebrew cask is currently installed on the validation
-host, so the post-publication installation will not replace an active install.
+notarization secret-name set are configured, without reading their values. The
+validation host had no existing Veritas Kanban app or cask before publication.
+The live Homebrew install therefore replaced no active application or user data.
 
 ### 6.1.2 verification matrix
 
@@ -83,7 +83,7 @@ evidence update is documentation-only and does not alter the validated runtime.
 | Build, Mantine QA, CLI/MCP smoke                                                          | Local clean worktree and CI Node 22                                                                                               | Pass. Build and Mantine QA passed; initial JS/CSS were 242.3/53.7 KiB gzip. CLI/MCP compatibility had zero failures or warnings; two live read/write checks were explicitly skipped because the isolated profile had no `VK_API_KEY`                                                                                                                                                                                                                               |
 | Desktop tests, build, readiness, native lifecycle, and unsigned package                   | macOS arm64 isolated profile and [artifact run 32732019898](https://github.com/BradGroux/veritas-kanban/actions/runs/32732019898) | Pass. Desktop 67/67, Electron artifacts 4/4, readiness 7/7, package smoke, visible setup/readiness, single-instance, close/reopen, and clean quit all passed. Mounted DMG and ZIP report 6.1.2 arm64. DMG: 265,821,857 bytes, SHA-256 `562aa08c1d93653227aa0deee7cc0020f42bfe4ead9e404005fbe67a87822d7a`; ZIP: 270,676,980 bytes, SHA-256 `e1dc99f95e1c3396cda78c5e38582cdc7554baf2757aa57cfee411ba6a94de60`. CI macOS/Linux/Windows unsigned artifacts all passed |
 | Production Docker build, image-size contract, and runtime smoke                           | amd64 [Docker contract run 32732019831](https://github.com/BradGroux/veritas-kanban/actions/runs/32732019831)                     | Pass. Image size 571,628,184 bytes, below 600,000,000; non-root user, version, mounted paths, SQLite, backup, auth, static web, health, bcrypt, and clean shutdown passed                                                                                                                                                                                                                                                                                          |
-| Release-format and release validators                                                     | Version 6.1.2                                                                                                                     | Pass with one classified host limitation. Canonical release format passed 3/3 and every source/build-output check passed. The local Docker-enabled wrapper reached image assembly before Docker Desktop returned an `overlayfs` containerd metadata I/O error on a full host filesystem; the clean CI Docker build and complete runtime contract passed on the same frozen source. Live GitHub/tag/body validation remains a post-publication gate                 |
+| Release-format and release validators                                                     | Version 6.1.2                                                                                                                     | Pass with one classified host limitation. Canonical release format passed 3/3 and every source/build-output check passed. Post-publication GitHub, tag, and body validation passed. The local Docker-enabled wrapper reached image assembly before Docker Desktop returned an `overlayfs` containerd metadata I/O error on a full host filesystem; the clean CI Docker build and complete runtime contract passed on the same frozen source |
 
 ## 6.1.1 Maintenance Release Candidate
 
@@ -394,11 +394,26 @@ runtime profile is retained in this packet.
 
 ## 6.1.2 Publication Evidence
 
-Publication has not started. This section will record the release PR merge SHA,
-annotated tag object and peeled commit, GitHub release URL and exact body
-readback, Desktop Release workflow, signed/notarized artifact names, sizes,
-SHA-256 values, blockmaps, updater metadata, Gatekeeper/stapling/launch proof,
-Homebrew PR and merge SHA, live cask validation, and approved advisory state.
+Source publication, signed-macOS verification, full-width release-note
+validation, isolated installed-app readiness, Homebrew distribution, and the
+approved advisory disposition are complete.
+
+| Publication item | Result |
+| --- | --- |
+| Release PR and merge | [#1237](https://github.com/BradGroux/veritas-kanban/pull/1237); frozen full-matrix head `2a21178df97a00395cfc6c43774a57496a5c1f6a`; final evidence-only head `ec1d3a7e106e2dd2753d41b5e351cdf665e2cd7c`; verified squash merge `dfae7911cc282e32262a006e2171ce5fe4865714` |
+| Annotated `v6.1.2` tag object and peeled commit | `819aad9ae8eae3f2f40593d4567647963f7bfbc3`; `dfae7911cc282e32262a006e2171ce5fe4865714` |
+| GitHub release URL and body | [Veritas Kanban 6.1.2](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.1.2); stable release published 2026-08-24; the live body exactly matches `docs/releases/v6.1.2.md` |
+| Exact-main CI and security | [CI run 32734012479](https://github.com/BradGroux/veritas-kanban/actions/runs/32734012479) and [Security Gates run 32734012461](https://github.com/BradGroux/veritas-kanban/actions/runs/32734012461) passed on the exact release merge; CodeQL, Dependabot, secret scanning, push protection, gitleaks, and immutable-action gates have no unresolved release blockers |
+| Desktop Release workflow | [Run 32734749604](https://github.com/BradGroux/veritas-kanban/actions/runs/32734749604); exact release merge SHA; signed and notarized macOS job passed in 11m1s |
+| Signed/notarized DMG | `Veritas-Kanban-6.1.2-mac-arm64.dmg`; 267,430,041 bytes; SHA-256/GitHub digest and published sidecar value `1b2a75c241642a8af14e48827dfc48c5e7846f2709af2359dc1ae34ba2588baa`; Apple notarization accepted, stapling validated, and Gatekeeper accepted Notarized Developer ID `RLBHD62MPW` |
+| Signed/notarized ZIP | `Veritas-Kanban-6.1.2-mac-arm64.zip`; 271,666,610 bytes; SHA-256/GitHub digest and published sidecar value `81ea146d20d2ab279331e73c01bc3c4eafdda8a4082be3607e9ca535a7d2be85`; the independently downloaded Homebrew cache matched this digest and contained bundle version 6.1.2 |
+| DMG/ZIP blockmaps and SHA-256 sidecars | Blockmap digests `9c99a416dbc518306456bf7025cbe478ea1242a40eb8acf349eb3dc67946ee97` and `77e55eb209f04b10bc1d38e2600032a1b2e808b4eeb11389d9e02819d306c935`; sidecar-file digests `30a6aa1831ed8f8f9c93c0e7e705c5f5e18805d092033732352f4513b6077c5a` and `9608ca6f5b365d9f74d0e6f9b3f71164dee4212af136b8cc8adf5650908b9790` |
+| `latest-mac.yml` | Version 6.1.2; 530 bytes; SHA-256 `591073ea888481ffdf1b0d2dc1d026b751422d44954ff2084bf7f8e64151992b`; ZIP and DMG names, sizes, and SHA-512 values match the published assets |
+| Installed signed-app isolated launch | Homebrew installed 6.1.2 without replacing an existing app or cask. `CFBundleShortVersionString` and `CFBundleVersion` report 6.1.2; deep strict code-signature validation, hardened runtime, Gatekeeper acceptance, and stapling validation pass. A disposable user-data root launched the installed app on isolated port 3101; exact-version readiness passed in 209ms and proved the packaged app owned the listener. `/api/health` reported 6.1.2, first-run onboarding showed all local readiness checks healthy, native menus rendered, and the task-owned process tree and listener stopped without touching the separate development build |
+| Release validator | Post-publication `pnpm validate:release -- --version 6.1.2 --github --repo BradGroux/veritas-kanban` passes and proves the live release and body match the annotated tag and canonical checked-in file |
+| Homebrew cask | [Issue #50](https://github.com/BradGroux/homebrew-tap/issues/50); [PR #51](https://github.com/BradGroux/homebrew-tap/pull/51); reviewed head `a3269d43eb657c0480e549e4d1fc15bc21baddea`; verified merge `2b29b79a26b269ed832f38b7173c7459c3db508d`; registered `bradgroux/tap/veritas-kanban` resolves 6.1.2 with the published ZIP checksum and passes Ruby syntax, cask style, strict online audit, dry-run install, livecheck, actual installation, signature/stapling/Gatekeeper verification, and exact-version packaged readiness |
+| Advisory disposition | Owner approved publication after supported artifacts were available. The [repository security advisory](https://github.com/BradGroux/veritas-kanban/security/advisories/GHSA-4r99-qpvh-wrqf) was published 2026-08-24 with the affected range and `>= 6.1.2` patched version verified |
+| Classified host limitation | The first local Docker wrapper and first Homebrew audit encountered the validation host's exhausted filesystem. No gate was weakened: clean CI proved the Docker contract, owner-approved removal of 1.67 GB of regenerable release output restored capacity, and the same live Homebrew audit/install then passed. No source, evidence, active development build, or user workspace was removed |
 
 ## 6.1.1 Publication Evidence
 

--- a/docs/V6-RELEASE-NOTES.md
+++ b/docs/V6-RELEASE-NOTES.md
@@ -2,7 +2,7 @@
 
 Veritas Kanban 6.1.2 completes the reliability, security, persistence, provider-runtime, CI, container, and supportability audit tracked by [#1174](https://github.com/BradGroux/veritas-kanban/issues/1174). It is a backward-compatible patch release for 6.1.1.
 
-> Veritas Kanban 6.0.0 remains a quarantined prerelease. Version 6.1.2 becomes the supported stable v6 release only after the annotated tag, signed assets, updater metadata, and Homebrew cask are published and verified.
+> Veritas Kanban 6.0.0 remains a quarantined prerelease. Version 6.1.2 is the supported stable v6 release; its annotated tag, signed assets, updater metadata, and Homebrew cask are published and verified.
 
 ## Audit Outcomes And Traceability
 
@@ -40,9 +40,9 @@ Ordinary pull requests now run source-policy, lint, typecheck, build, dependency
 
 The complete final release matrix is recorded in [v6 Release Candidate Evidence Packet](V6-RC-EVIDENCE-PACKET.md). Historical test counts are not reused as 6.1.2 evidence.
 
-The production Docker closure excludes unrelated workspace dependencies, runs as a non-root user, and has architecture-specific size ceilings. The implementation baseline measured 195,910,880 bytes on arm64 against a 200,000,000-byte ceiling and 571,590,173 bytes on amd64 against a 600,000,000-byte ceiling; the release candidate is remeasured before publication.
+The production Docker closure excludes unrelated workspace dependencies, runs as a non-root user, and has architecture-specific size ceilings. The implementation baseline measured 195,910,880 bytes on arm64 against a 200,000,000-byte ceiling. The final release candidate measured 571,628,184 bytes on amd64 against its 600,000,000-byte ceiling.
 
-Four verified unused direct dependencies were removed. The server lint-warning budget dropped from 600 to 458 without weakening rules or adding broad suppressions. A coordinated private remediation is integrated through #1236; technical details stay in the advisory workflow pending supported artifacts and explicit disclosure approval. Final milestone validation also corrected recovery-key alphabet generation, WebSocket upgrade header forwarding, same-task lifecycle ordering, and sanitized URI prefix handling through #1239, #1241, and #1243.
+Four verified unused direct dependencies were removed. The server lint-warning budget dropped from 600 to 458 without weakening rules or adding broad suppressions. A coordinated security remediation is integrated through #1236 and the [repository security advisory](https://github.com/BradGroux/veritas-kanban/security/advisories/GHSA-4r99-qpvh-wrqf) was published after the supported 6.1.2 artifacts were verified. Final milestone validation also corrected recovery-key alphabet generation, WebSocket upgrade header forwarding, same-task lifecycle ordering, and sanitized URI prefix handling through #1239, #1241, and #1243.
 
 The initial 195-alert CodeQL baseline was reviewed alert by alert: 67 findings were fixed and 128 non-exploitable alerts received evidence-backed dispositions. Validated request, logging, persisted-key, file-handling, and sandbox-read findings were fixed in #1232-#1235. Alerts that were limited to test fixtures or were already contained by explicit authentication, path, descriptor, ownership, or atomic-write controls received documented dispositions rather than speculative code churn. The post-merge default-branch analysis reports zero open alerts.
 
@@ -61,7 +61,7 @@ For a first installation:
 brew install --cask bradgroux/tap/veritas-kanban
 ```
 
-Manual installation uses the signed and notarized macOS arm64 DMG or ZIP from the [v6.1.2 release](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.1.2) after publication. Back up the complete stopped-writer workspace before upgrading and keep the backup until the new runtime is accepted.
+Manual installation uses the signed and notarized macOS arm64 DMG or ZIP from the [v6.1.2 release](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.1.2). Back up the complete stopped-writer workspace before upgrading and keep the backup until the new runtime is accepted.
 
 ## Breaking Changes And Migration Warnings
 
@@ -77,7 +77,7 @@ Deterministic compatibility does not prove provider authentication, subscription
 
 ## Release Artifacts
 
-The supported stable desktop release publishes signed and notarized `Veritas-Kanban-6.1.2-mac-arm64.dmg` and `Veritas-Kanban-6.1.2-mac-arm64.zip`, blockmaps, SHA-256 sidecars, and `latest-mac.yml` updater metadata from the annotated `v6.1.2` tag. Exact sizes, hashes, signing, notarization, stapling, Gatekeeper, launch, updater, workflow, release, and Homebrew evidence are recorded after publication in [v6 Release Candidate Evidence Packet](V6-RC-EVIDENCE-PACKET.md).
+The supported stable desktop release provides signed and notarized `Veritas-Kanban-6.1.2-mac-arm64.dmg` and `Veritas-Kanban-6.1.2-mac-arm64.zip`, blockmaps, SHA-256 sidecars, and `latest-mac.yml` updater metadata from the annotated `v6.1.2` tag. Exact sizes, hashes, signing, notarization, stapling, Gatekeeper, launch, updater, workflow, release, and Homebrew evidence are recorded in [v6 Release Candidate Evidence Packet](V6-RC-EVIDENCE-PACKET.md).
 
 ## Documentation And Evidence
 

--- a/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -9,7 +9,7 @@ in [Buzz Integration](BUZZ-INTEGRATION.md).
 Documentation freshness: 2026-08-24 for Veritas Kanban 6.1.2.
 
 Do not install 6.0.0. It is retained as a quarantined prerelease. Version 6.1.2
-supersedes 6.1.1 after the signed release and Homebrew cask are published.
+is the supported stable v6 release and supersedes 6.1.1.
 
 ## Fresh Mac Desktop Install
 


### PR DESCRIPTION
## Summary

- Record the final v6.1.2 tag, release, signed artifacts, Homebrew distribution, and advisory disposition.
- Mark the GA checklist complete and correct active upgrade and release wording.
- Refresh the README roadmap, current toolchain facts, architecture wording, navigation, and support guidance.

## Verification

- `git diff --check`
- Prettier: README and documentation freshness record pass.
- README links: 141 checked, 0 missing relative targets.
- Repository Markdown targets: 166 files checked, 0 missing.
- Current-state release wording scan: no stale pending-publication matches.
- No application tests rerun; this is a docs-only post-publication evidence update.

Refs #1174