### PR TITLE
test: stabilize workflow recovery coverage

### DIFF
--- a/server/src/__tests__/workflow-admission.test.ts
+++ b/server/src/__tests__/workflow-admission.test.ts
@@ -21,6 +21,7 @@ const roots: string[] = [];
 const admissions: AdmissionControlService[] = [];
 const runs: WorkflowRunService[] = [];
 const databases: SqliteDatabase[] = [];
+const RECOVERED_EXECUTION_TIMEOUT_MS = 5_000;
 
 afterEach(async () => {
   for (const run of runs.splice(0)) run.dispose();
@@ -593,7 +594,7 @@ describe('workflow admission', () => {
 
       await vi.waitFor(async () => {
         expect((await restarted.service.getRun(run.id))?.status).toBe('completed');
-      });
+      }, RECOVERED_EXECUTION_TIMEOUT_MS);
       expect(executeStep).toHaveBeenCalledTimes(1);
       await vi.waitFor(async () => {
         expect(
@@ -601,7 +602,7 @@ describe('workflow admission', () => {
             (reservation) => reservation.state === 'released'
           )
         ).toBe(true);
-      });
+      }, RECOVERED_EXECUTION_TIMEOUT_MS);
     }
   );
 


### PR DESCRIPTION
## Summary

- give asynchronous post-restart workflow completion an explicit 5-second polling window
- apply the same bound to the subsequent reservation-release assertion
- preserve exact-once execution and the production fire-and-forget recovery contract

## Verification

- controlled 1.1-second recovered-step delay reproduces the original 1-second `vi.waitFor` failure
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/workflow-admission.test.ts --maxWorkers=4 --reporter=dot`
- 50 repeated focused runs covering both file and SQLite recovery
- `pnpm exec eslint server/src/__tests__/workflow-admission.test.ts`
- `pnpm --filter @veritas-kanban/server typecheck`

Fixes #1264