### PR TITLE
test: stabilize mobile responsive assertions

### DIFF
--- a/e2e/mobile-responsive.spec.ts
+++ b/e2e/mobile-responsive.spec.ts
@@ -109,13 +109,15 @@ test.describe('mobile responsive flows', () => {
     await detail.getByRole('button', { name: 'Request Changes' }).click();
     await detail.getByPlaceholder('Describe the changes needed...').fill('Mobile review works.');
     await detail.getByRole('button', { name: 'Submit Changes Requested' }).click();
-    await expect(detail.getByText('Mobile review works.')).toBeVisible();
+    await expect(
+      detail.locator('p:visible', { hasText: 'Mobile review works.' }).first()
+    ).toBeVisible();
 
     await detail.getByRole('tab', { name: 'Details' }).click();
     await detail.getByPlaceholder(/Add a comment/).fill('Mobile comment submitted.');
     await detail.getByRole('button', { name: 'Add Comment' }).click();
     await expect(
-      detail.locator('p', { hasText: 'Mobile comment submitted.' }).first()
+      detail.locator('p:visible', { hasText: 'Mobile comment submitted.' }).first()
     ).toBeVisible();
 
     await detail.getByRole('button', { name: 'Close task details' }).click();


### PR DESCRIPTION
## Summary

- scope the mobile review and comment assertions to visible paragraph content
- avoid hidden responsive and inactive-tab copies mounted in the task detail DOM
- keep the production comment and review behavior unchanged

Closes #1266

## Verification

- focused mobile Chromium flow passed once after the comment fix
- focused mobile Chromium flow passed 20 consecutive repetitions after both selectors were corrected
- `git diff --check`
- commit hooks: security artifacts, pinned actions, tracked-ignore, delivery guidance, ESLint, and Prettier

## Risk

Test-only selector change. The remaining risk is limited to future markup changes that stop rendering the asserted review or comment content as paragraphs.
