### PR TITLE
fix: announce authentication validation errors

### DIFF
--- a/web/src/__tests__/auth-screens-mantine.test.tsx
+++ b/web/src/__tests__/auth-screens-mantine.test.tsx
@@ -171,4 +171,88 @@ describe('auth screens Mantine migration', () => {
       expect(mocks.recover).toHaveBeenCalledWith('ABCD-EFGH-1234-5678', 'NewStrongPass1!')
     );
   });
+
+  it('associates setup guidance and announces one failure until the field changes', async () => {
+    mocks.setup.mockResolvedValue({ success: false, error: 'Setup could not be completed' });
+    renderWithProviders(<SetupScreen />);
+
+    const password = screen.getByLabelText('Password');
+    const confirmation = screen.getByLabelText('Confirm Password');
+    fireEvent.change(password, { target: { value: 'StrongPass1!' } });
+    expect(password.getAttribute('aria-describedby')).toBe('setup-password-strength');
+    expect(screen.getByText(/Password strength:/).getAttribute('aria-live')).toBeNull();
+
+    fireEvent.change(confirmation, { target: { value: 'different' } });
+    expect(confirmation.getAttribute('aria-invalid')).toBe('true');
+    expect(confirmation.getAttribute('aria-describedby')).toBe('setup-password-mismatch');
+    fireEvent.change(confirmation, { target: { value: 'StrongPass1!' } });
+    expect(confirmation.getAttribute('aria-invalid')).toBeNull();
+    expect(confirmation.getAttribute('aria-describedby')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Password' }));
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe('Setup could not be completed');
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+    expect(password.getAttribute('aria-invalid')).toBe('true');
+    expect(password.getAttribute('aria-describedby')?.split(/\s+/)).toEqual(
+      expect.arrayContaining(['setup-password-strength', 'setup-submission-error'])
+    );
+
+    fireEvent.change(password, { target: { value: 'ChangedPass1!' } });
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(password.getAttribute('aria-invalid')).toBeNull();
+    expect(password.getAttribute('aria-describedby')).toBe('setup-password-strength');
+  });
+
+  it('announces a login failure once and clears stale field semantics on correction', async () => {
+    mocks.login.mockResolvedValue({ success: false, error: 'Invalid password' });
+    renderWithProviders(<LoginScreen />);
+
+    const password = screen.getByLabelText('Password');
+    fireEvent.change(password, { target: { value: 'WrongPass1!' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Login' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe('Invalid password');
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+    expect(password.getAttribute('aria-invalid')).toBe('true');
+    expect(password.getAttribute('aria-describedby')).toBe('login-submission-error');
+
+    fireEvent.change(password, { target: { value: 'CorrectedPass1!' } });
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(password.getAttribute('aria-invalid')).toBeNull();
+    expect(password.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('associates recovery mismatch and server failure without moving focus to the alert', async () => {
+    mocks.recover.mockResolvedValue({ success: false, error: 'Recovery failed' });
+    renderWithProviders(<LoginScreen />);
+    fireEvent.click(screen.getByRole('button', { name: 'Forgot password?' }));
+
+    const recoveryKey = screen.getByLabelText('Recovery Key');
+    const newPassword = screen.getByLabelText('New Password');
+    const confirmation = screen.getByLabelText('Confirm New Password');
+    fireEvent.change(recoveryKey, { target: { value: 'abcd-efgh-1234-5678' } });
+    fireEvent.change(newPassword, { target: { value: 'NewStrongPass1!' } });
+    fireEvent.change(confirmation, { target: { value: 'different' } });
+    expect(confirmation.getAttribute('aria-invalid')).toBe('true');
+    expect(confirmation.getAttribute('aria-describedby')).toBe('recovery-password-mismatch');
+
+    fireEvent.change(confirmation, { target: { value: 'NewStrongPass1!' } });
+    expect(confirmation.getAttribute('aria-invalid')).toBeNull();
+    expect(confirmation.getAttribute('aria-describedby')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Reset Password' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe('Recovery failed');
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+    expect(document.activeElement).not.toBe(alert);
+    expect(recoveryKey.getAttribute('aria-invalid')).toBe('true');
+    expect(recoveryKey.getAttribute('aria-describedby')).toBe('recovery-submission-error');
+
+    fireEvent.change(recoveryKey, { target: { value: 'WXYZ-EFGH-1234-5678' } });
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(recoveryKey.getAttribute('aria-invalid')).toBeNull();
+    expect(recoveryKey.getAttribute('aria-describedby')).toBeNull();
+  });
 });

--- a/web/src/components/auth/LoginScreen.tsx
+++ b/web/src/components/auth/LoginScreen.tsx
@@ -22,6 +22,10 @@ export function LoginScreen() {
   const [copiedKey, setCopiedKey] = useState(false);
   const [savedConfirmed, setSavedConfirmed] = useState(false);
 
+  const clearSubmissionError = () => {
+    if (error) setError(null);
+  };
+
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!password || isSubmitting) return;
@@ -166,13 +170,19 @@ export function LoginScreen() {
               name="recovery-key"
               label="Recovery Key"
               value={recoveryKey}
-              onChange={(e) => setRecoveryKey(e.target.value.toUpperCase())}
+              onChange={(e) => {
+                setRecoveryKey(e.target.value.toUpperCase());
+                clearSubmissionError();
+              }}
               placeholder="XXXX-XXXX-XXXX-XXXX"
               classNames={{ input: 'font-mono tracking-wider' }}
               size="md"
               autoCapitalize="characters"
               spellCheck={false}
               autoFocus
+              error={error || undefined}
+              errorProps={{ id: 'recovery-submission-error', role: 'alert' }}
+              aria-invalid={error ? true : undefined}
             />
 
             <PasswordInput
@@ -180,7 +190,10 @@ export function LoginScreen() {
               name="new-password"
               label="New Password"
               value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
+              onChange={(e) => {
+                setNewPassword(e.target.value);
+                clearSubmissionError();
+              }}
               placeholder="Enter new password (8+ characters)"
               visible={showPassword}
               onVisibilityChange={setShowPassword}
@@ -194,23 +207,20 @@ export function LoginScreen() {
                 name="confirm-new-password"
                 label="Confirm New Password"
                 value={confirmNewPassword}
-                onChange={(e) => setConfirmNewPassword(e.target.value)}
+                onChange={(e) => {
+                  setConfirmNewPassword(e.target.value);
+                  clearSubmissionError();
+                }}
                 placeholder="Confirm new password"
                 visible={showPassword}
                 onVisibilityChange={setShowPassword}
                 autoComplete="new-password"
                 size="md"
+                error={confirmNewPassword && !passwordsMatch ? 'Passwords do not match' : undefined}
+                errorProps={{ id: 'recovery-password-mismatch' }}
+                aria-invalid={confirmNewPassword && !passwordsMatch ? true : undefined}
               />
-              {confirmNewPassword && !passwordsMatch && (
-                <p className="mt-2 text-xs text-destructive">Passwords do not match</p>
-              )}
             </div>
-
-            {error && (
-              <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg text-sm text-destructive">
-                {error}
-              </div>
-            )}
 
             <Stack gap="xs">
               <Button type="submit" fullWidth size="md" disabled={!isValid || isSubmitting}>
@@ -254,13 +264,19 @@ export function LoginScreen() {
             name="password"
             label="Password"
             value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            onChange={(e) => {
+              setPassword(e.target.value);
+              clearSubmissionError();
+            }}
             placeholder="Enter your password"
             visible={showPassword}
             onVisibilityChange={setShowPassword}
             autoComplete="current-password"
             size="md"
             autoFocus
+            error={error || undefined}
+            errorProps={{ id: 'login-submission-error', role: 'alert' }}
+            aria-invalid={error ? true : undefined}
           />
 
           <Checkbox
@@ -270,12 +286,6 @@ export function LoginScreen() {
             label="Remember me for 30 days"
             classNames={{ label: 'text-sm cursor-pointer' }}
           />
-
-          {error && (
-            <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg text-sm text-destructive">
-              {error}
-            </div>
-          )}
 
           <Stack gap="xs">
             <Button type="submit" fullWidth size="md" disabled={!password || isSubmitting}>

--- a/web/src/components/auth/SetupScreen.tsx
+++ b/web/src/components/auth/SetupScreen.tsx
@@ -177,11 +177,19 @@ export function SetupScreen() {
               id="password"
               label="Password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                if (error) setError(null);
+              }}
               placeholder="Enter password (8+ characters)"
               visible={showPassword}
               onVisibilityChange={setShowPassword}
               autoFocus
+              description={password ? `Password strength: ${strength.label}` : undefined}
+              descriptionProps={{ id: 'setup-password-strength' }}
+              error={error || undefined}
+              errorProps={{ id: 'setup-submission-error', role: 'alert' }}
+              aria-invalid={error ? true : undefined}
             />
             {password && (
               <div className="space-y-1">
@@ -195,9 +203,6 @@ export function SetupScreen() {
                     />
                   ))}
                 </div>
-                <p className="text-xs text-muted-foreground">
-                  Password strength: <span className="font-medium">{strength.label}</span>
-                </p>
               </div>
             )}
           </div>
@@ -207,21 +212,18 @@ export function SetupScreen() {
               id="confirm-password"
               label="Confirm Password"
               value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
+              onChange={(e) => {
+                setConfirmPassword(e.target.value);
+                if (error) setError(null);
+              }}
               placeholder="Confirm password"
               visible={showPassword}
               onVisibilityChange={setShowPassword}
+              error={confirmPassword && !passwordsMatch ? 'Passwords do not match' : undefined}
+              errorProps={{ id: 'setup-password-mismatch' }}
+              aria-invalid={confirmPassword && !passwordsMatch ? true : undefined}
             />
-            {confirmPassword && !passwordsMatch && (
-              <p className="text-xs text-destructive">Passwords do not match</p>
-            )}
           </div>
-
-          {error && (
-            <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg text-sm text-destructive">
-              {error}
-            </div>
-          )}
 
           <Button type="submit" className="w-full" disabled={!isValid || isSubmitting}>
             {isSubmitting ? 'Creating...' : 'Create Password'}


### PR DESCRIPTION
## Summary

- associate setup password strength and mismatch guidance with the relevant fields
- announce setup, login, and recovery submission failures exactly once without moving focus
- clear stale invalid state and descriptions as users correct their input
- add focused regression coverage for setup, login, and recovery semantics

Advances #1256. Packaged macOS VoiceOver, keyboard, and 200% zoom acceptance remains a release-candidate gate in #1262.

## Verification

- `pnpm --filter web exec vitest run src/__tests__/auth-screens-mantine.test.tsx`
- `pnpm --filter web typecheck`
- focused ESLint and Prettier checks
- `git diff --check`