### PR TITLE
feat: add causal run file provenance

### DIFF
--- a/cli/src/__tests__/agents-runtime-capabilities.test.ts
+++ b/cli/src/__tests__/agents-runtime-capabilities.test.ts
@@ -199,6 +199,43 @@ describe('vk agent runtime capability controls', () => {
     expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/phase?attemptId=attempt_1&limit=25');
   });
 
+  it('resolves exact file provenance with encoded bounded evidence', async () => {
+    mockApi.mockResolvedValueOnce({
+      schemaVersion: 'run-file-provenance-response/v1',
+      status: 'unknown',
+      query: {},
+      current: null,
+      chain: [],
+      gaps: [],
+    });
+    const program = new Command();
+    program.exitOverride();
+    registerAgentCommands(program);
+
+    await program.parseAsync(
+      [
+        'agent:file-provenance',
+        'task_1',
+        '--attempt',
+        'attempt_1',
+        '--root',
+        'run-artifact',
+        '--path',
+        'reports/final report.pdf',
+        '--sha256',
+        `sha256:${'a'.repeat(64)}`,
+        '--limit',
+        '10',
+        '--json',
+      ],
+      { from: 'user' }
+    );
+
+    expect(mockApi).toHaveBeenCalledWith(
+      `/api/agents/task_1/file-provenance/resolve?attemptId=attempt_1&root=run-artifact&path=reports%2Ffinal+report.pdf&sha256=sha256%3A${'a'.repeat(64)}&limit=10`
+    );
+  });
+
   it('binds the first phase transition to exact evidence and manifest provenance', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-phase-cli-'));
     temporaryRoots.push(root);

--- a/cli/src/__tests__/agents-runtime-capabilities.test.ts
+++ b/cli/src/__tests__/agents-runtime-capabilities.test.ts
@@ -278,6 +278,46 @@ describe('vk agent runtime capability controls', () => {
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('capture-unavailable'));
   });
 
+  it('reports provenance lookup failures to operators', async () => {
+    mockApi.mockRejectedValueOnce(new Error('Provenance evidence is unavailable.'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+      _code?: number | string | null
+    ) => {
+      throw new Error('process.exit called');
+    }) as typeof process.exit);
+    const program = new Command();
+    program.exitOverride();
+    registerAgentCommands(program);
+
+    try {
+      await expect(
+        program.parseAsync(
+          [
+            'agent:file-provenance',
+            'task_1',
+            '--attempt',
+            'attempt_1',
+            '--root',
+            'run-artifact',
+            '--path',
+            'reports/final.pdf',
+            '--sha256',
+            `sha256:${'a'.repeat(64)}`,
+          ],
+          { from: 'user' }
+        )
+      ).rejects.toThrow('process.exit called');
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Provenance evidence is unavailable.')
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it('reads the versioned access projection for one exact attempt', async () => {
     mockApi.mockResolvedValueOnce({
       current: { schemaVersion: 'run-access-summary/v1', status: 'complete' },

--- a/cli/src/__tests__/agents-runtime-capabilities.test.ts
+++ b/cli/src/__tests__/agents-runtime-capabilities.test.ts
@@ -236,6 +236,48 @@ describe('vk agent runtime capability controls', () => {
     );
   });
 
+  it('renders exact file provenance and capture gaps for operators', async () => {
+    mockApi.mockResolvedValueOnce({
+      schemaVersion: 'run-file-provenance-response/v1',
+      status: 'exact',
+      query: {
+        root: 'run-artifact',
+        relativePath: 'reports/final.pdf',
+        sha256: `sha256:${'a'.repeat(64)}`,
+      },
+      current: {
+        source: 'artifact-registration',
+        operation: 'create',
+        producer: { eventId: 'runevt_000000000001' },
+      },
+      chain: [{ id: 'provenance-1' }],
+      gaps: [{ code: 'capture-unavailable', message: 'Provider omitted a causal event.' }],
+    });
+    const program = new Command();
+    program.exitOverride();
+    registerAgentCommands(program);
+
+    await program.parseAsync(
+      [
+        'agent:file-provenance',
+        'task_1',
+        '--attempt',
+        'attempt_1',
+        '--root',
+        'run-artifact',
+        '--path',
+        'reports/final.pdf',
+        '--sha256',
+        `sha256:${'a'.repeat(64)}`,
+      ],
+      { from: 'user' }
+    );
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('File provenance: exact'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Chain: 1 record(s)'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('capture-unavailable'));
+  });
+
   it('reads the versioned access projection for one exact attempt', async () => {
     mockApi.mockResolvedValueOnce({
       current: { schemaVersion: 'run-access-summary/v1', status: 'complete' },

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -16,6 +16,7 @@ import type {
   PhaseTransitionRecord,
   PhaseTransitionResult,
   RunApprovalRequest,
+  RunFileProvenanceResponse,
   RunRecoveryRecord,
   RunLaunchManifestPreview,
   RunPhaseAuthoritySnapshot,
@@ -657,6 +658,62 @@ export function registerAgentCommands(program: Command): void {
                 )
               );
             }
+          }
+        } catch (err) {
+          console.error(chalk.red(`Error: ${(err as Error).message}`));
+          process.exit(1);
+        }
+      }
+    );
+
+  program
+    .command('agent:file-provenance <id>')
+    .description('Resolve the provenance of exact run-produced file bytes')
+    .requiredOption('--attempt <attemptId>', 'Exact attempt ID')
+    .requiredOption('--root <root>', 'Safe root label: worktree or run-artifact')
+    .requiredOption('--path <path>', 'Root-relative file path')
+    .requiredOption('--sha256 <digest>', 'Exact sha256: content digest')
+    .option('--limit <count>', 'Maximum predecessor records', '25')
+    .option('--json', 'Output the versioned machine-readable contract')
+    .action(
+      async (
+        id: string,
+        options: {
+          attempt: string;
+          root: string;
+          path: string;
+          sha256: string;
+          limit: string;
+          json?: boolean;
+        }
+      ): Promise<void> => {
+        try {
+          const taskId = await resolveTaskId(id);
+          const params = new URLSearchParams({
+            attemptId: options.attempt,
+            root: options.root,
+            path: options.path,
+            sha256: options.sha256,
+            limit: options.limit,
+          });
+          const result = await api<RunFileProvenanceResponse>(
+            `/api/agents/${taskId}/file-provenance/resolve?${params.toString()}`
+          );
+          if (options.json) {
+            console.log(JSON.stringify(result, null, 2));
+            return;
+          }
+          console.log(chalk.cyan(`File provenance: ${result.status}`));
+          console.log(`  Path: ${result.query.root}/${result.query.relativePath}`);
+          console.log(`  Digest: ${result.query.sha256}`);
+          if (result.current) {
+            console.log(`  Source: ${result.current.source}`);
+            console.log(`  Operation: ${result.current.operation}`);
+            console.log(`  Producer: ${result.current.producer.eventId}`);
+            console.log(`  Chain: ${result.chain.length} record(s)`);
+          }
+          for (const gap of result.gaps) {
+            console.log(chalk.yellow(`  ${gap.code}: ${gap.message}`));
           }
         } catch (err) {
           console.error(chalk.red(`Error: ${(err as Error).message}`));

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -6224,6 +6224,17 @@ Registration body:
 
 Direct general Work Product creation rejects `kind: "file"`, and generic updates reject existing file products; governed registration is the only creation and refinement path. Archive preserves downloads. Physical purge is explicit, requires the authenticated workspace and `admin:manage`, rejects active products, and requires `confirm` to exactly match the Work Product ID. See [File-Backed Work Products v1](architecture/FILE-WORK-PRODUCTS-V1.md).
 
+### Run File Provenance (`/api/agents/:taskId/file-provenance`)
+
+Run file provenance projects the append-only run journal into digest-bound file history. Both routes require an authenticated workspace and an exact task attempt whose persisted task envelope belongs to that workspace. Legacy or mismatched attempts fail closed.
+
+| Method | Endpoint                                                                                         | Purpose                                                                                           |
+| ------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `GET`  | `/api/agents/:taskId/file-provenance/resolve?attemptId=...&root=...&relativePath=...&sha256=...` | Resolve current bytes as `exact`, `stale`, `unknown`, or `gap`, with a bounded predecessor chain. |
+| `GET`  | `/api/agents/:taskId/file-provenance?attemptId=...&limit=25`                                     | List the latest bounded records and typed capture gaps for one attempt.                           |
+
+Paths are normalized root-relative identifiers; host paths and traversal are rejected. URLs, connector targets, and metadata are reduced to safe redacted fields. An exact response binds the latest path record to the requested SHA-256 digest. Approval workflows can bind the deterministic `run-file-provenance-approval-evidence/v1` projection rather than trusting a filename or mutable path. See [Run File Provenance v1](architecture/RUN-FILE-PROVENANCE-V1.md).
+
 ---
 
 ### System Health (`/api/v1/system/health`)

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -447,33 +447,34 @@ vk project create "rubicon" --color "#7c3aed" --description "Main product"
 
 Manage AI agents on code tasks.
 
-| Command                                                                             | Description                                                  |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `vk start <id> [--phase <phase>]`                                                   | Start an agent; optionally bind an execution phase           |
-| `vk launch-preview <id> [--phase <phase>]`                                          | Preview effective launch inputs, blockers, and drift         |
-| `vk workspace-trust scan <id>`                                                      | Inventory repository-controlled execution configuration      |
-| `vk workspace-trust decide <id> --mode <mode> --inventory <digest> --reason <text>` | Authorize or deny one exact inventory                        |
-| `vk workspace-trust revoke <id> --inventory <digest> --reason <text>`               | Revoke the current exact-inventory decision                  |
-| `vk stop <id>`                                                                      | Stop a run only when its persisted manifest supports stop    |
-| `vk agent:recovery <id>`                                                            | Inspect the latest retry or fallback decision                |
-| `vk agent:cancel-recovery <id> --attempt <id>`                                      | Cancel the exact pending recovery parent                     |
-| `vk agent:phase <id> --attempt <id>`                                                | Read effective launch phase, sources, and transition history |
-| `vk agent:transition-phase <id> ...`                                                | Apply or request approval for one exact phase transition     |
-| `vk agent:decide-phase-approval <approvalId> ...`                                   | Approve or reject an exact pending phase expansion           |
-| `vk agent:resume <id> --source-attempt <id> -m <text> [--phase <phase>]`            | Resume the exact persisted provider conversation             |
-| `vk agent:follow-up <id> --source-attempt <id> -m <text> [--phase <phase>]`         | Start a provider-native follow-up turn                       |
-| `vk agent:fork <id> --source-attempt <id> -m <text> [--phase <phase>]`              | Fork provider history without mutating its source            |
-| `vk agent:steer <id> --attempt <id> -m <text>`                                      | Steer the exact active provider turn                         |
-| `vk agent:interrupt <id> --attempt <id>`                                            | Interrupt the exact active provider turn                     |
-| `vk agent:compact <id> --attempt <id>`                                              | Compact a supported provider conversation                    |
-| `vk agent:archive <id> --attempt <id>`                                              | Archive a supported provider conversation                    |
-| `vk agent:close <id> --attempt <id>`                                                | Close a supported provider conversation                      |
-| `vk acp status --json`                                                              | Check ACP server-view API and permission readiness           |
-| `vk acp serve --stdio [--task <id>]`                                                | Expose a Veritas-managed task to an ACP v1 client            |
-| `vk agents:pending`                                                                 | List pending agent requests                                  |
-| `vk agents:status <id>`                                                             | Check agent running status                                   |
-| `vk agents:complete <id> -s --attempt-id <id> --manifest-digest <sha256:...>`       | Mark the matching agent attempt complete (success)           |
-| `vk agents:complete <id> -f --attempt-id <id> --manifest-digest <sha256:...>`       | Mark the matching agent attempt complete (failure)           |
+| Command                                                                                      | Description                                                   |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `vk start <id> [--phase <phase>]`                                                            | Start an agent; optionally bind an execution phase            |
+| `vk launch-preview <id> [--phase <phase>]`                                                   | Preview effective launch inputs, blockers, and drift          |
+| `vk workspace-trust scan <id>`                                                               | Inventory repository-controlled execution configuration       |
+| `vk workspace-trust decide <id> --mode <mode> --inventory <digest> --reason <text>`          | Authorize or deny one exact inventory                         |
+| `vk workspace-trust revoke <id> --inventory <digest> --reason <text>`                        | Revoke the current exact-inventory decision                   |
+| `vk stop <id>`                                                                               | Stop a run only when its persisted manifest supports stop     |
+| `vk agent:recovery <id>`                                                                     | Inspect the latest retry or fallback decision                 |
+| `vk agent:file-provenance <id> --attempt <id> --root <root> --path <path> --sha256 <digest>` | Resolve exact, stale, unknown, or unsupported file provenance |
+| `vk agent:cancel-recovery <id> --attempt <id>`                                               | Cancel the exact pending recovery parent                      |
+| `vk agent:phase <id> --attempt <id>`                                                         | Read effective launch phase, sources, and transition history  |
+| `vk agent:transition-phase <id> ...`                                                         | Apply or request approval for one exact phase transition      |
+| `vk agent:decide-phase-approval <approvalId> ...`                                            | Approve or reject an exact pending phase expansion            |
+| `vk agent:resume <id> --source-attempt <id> -m <text> [--phase <phase>]`                     | Resume the exact persisted provider conversation              |
+| `vk agent:follow-up <id> --source-attempt <id> -m <text> [--phase <phase>]`                  | Start a provider-native follow-up turn                        |
+| `vk agent:fork <id> --source-attempt <id> -m <text> [--phase <phase>]`                       | Fork provider history without mutating its source             |
+| `vk agent:steer <id> --attempt <id> -m <text>`                                               | Steer the exact active provider turn                          |
+| `vk agent:interrupt <id> --attempt <id>`                                                     | Interrupt the exact active provider turn                      |
+| `vk agent:compact <id> --attempt <id>`                                                       | Compact a supported provider conversation                     |
+| `vk agent:archive <id> --attempt <id>`                                                       | Archive a supported provider conversation                     |
+| `vk agent:close <id> --attempt <id>`                                                         | Close a supported provider conversation                       |
+| `vk acp status --json`                                                                       | Check ACP server-view API and permission readiness            |
+| `vk acp serve --stdio [--task <id>]`                                                         | Expose a Veritas-managed task to an ACP v1 client             |
+| `vk agents:pending`                                                                          | List pending agent requests                                   |
+| `vk agents:status <id>`                                                                      | Check agent running status                                    |
+| `vk agents:complete <id> -s --attempt-id <id> --manifest-digest <sha256:...>`                | Mark the matching agent attempt complete (success)            |
+| `vk agents:complete <id> -f --attempt-id <id> --manifest-digest <sha256:...>`                | Mark the matching agent attempt complete (failure)            |
 
 Require one or more capabilities before launch:
 
@@ -1117,6 +1118,19 @@ vk work-products purge wp_ID --confirm wp_ID --json
 ```
 
 Registration never accepts a host path. Reuse the same request ID only for an idempotent retry. Use `--product wp_ID` with a new request ID to create a new immutable file version. Download refuses to overwrite an existing destination unless `--force` is supplied. Purge rejects active products and removes every body plus product/version metadata only after archive and an exact ID confirmation.
+
+Inspect provenance for exact bytes before trusting or approving a run-produced file:
+
+```bash
+vk agent:file-provenance task_release \
+  --attempt attempt_release \
+  --root run-artifact \
+  --path release.pdf \
+  --sha256 sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  --json
+```
+
+The result is `exact` only when the supplied digest matches the newest record at the normalized path. `stale`, `unknown`, and `gap` are fail-closed results. The command never accepts or returns an absolute host path.
 
 ---
 

--- a/docs/architecture/RUN-FILE-PROVENANCE-V1.md
+++ b/docs/architecture/RUN-FILE-PROVENANCE-V1.md
@@ -1,0 +1,34 @@
+# Run File Provenance v1
+
+`run-file-provenance/v1` records where run-produced bytes came from without treating a mutable filename as evidence. Records live in the existing append-only `run-event/v1` journal, so file and SQLite storage use the same causal ordering, idempotency, restart replay, redaction, and retention boundary.
+
+## Record boundary
+
+Every record binds the authenticated workspace, task, root objective, execution-tree node, run, attempt, optional workflow step, causal event ID and sequence, producing tool or command identifiers, normalized root-relative path, SHA-256 digest, byte size, media classification, operation, predecessor, and capture time. Supported roots are `worktree` and `run-artifact`; absolute host paths are never persisted or returned.
+
+Source classes distinguish repository baseline, agent, command, tool, attachment, connector, download, operator, and unknown origins. Safe connector targets and HTTP(S) source URLs may be retained after credentials, query strings, fragments, sensitive keys, and host paths are removed.
+
+Create, modify, replace, rename, copy, extract, and download operations form an immutable predecessor chain. Rename, copy, and extract require an explicit prior path. NFC normalization and case-folded identity detect ambiguous Unicode or case-only collisions. Symlinks, hard links, and other uncertified identities fail closed.
+
+## Journal projection
+
+Successful captures append `file.provenance`; unsupported or invalid captures append `file.provenance-gap`. Both are known run-event kinds. Stable dedupe keys make replay idempotent, while the producing event and exact sequence prevent detached evidence from being recorded as causal.
+
+The projector also detects `file.changed` events that have no paired provenance record and returns an `unsupported-provider-path` or `unsupported-tool-path` gap. It never invents an origin for incomplete provider evidence.
+
+## Resolution
+
+A caller supplies the exact workspace, task, attempt, root, relative path, and SHA-256 digest. Resolution returns:
+
+- `exact` when the digest matches the newest record at that path;
+- `stale` when the path has newer bytes;
+- `unknown` when no record or relevant gap exists; or
+- `gap` when capture was unsupported, invalid, ambiguous, or causally incomplete.
+
+Only `exact` is affirmative provenance evidence. The response includes a bounded predecessor chain and typed gaps. `run-file-provenance-approval-evidence/v1` reduces that response to deterministic record, chain, and gap digests so a later approval can bind the exact evidence without persisting mutable UI state.
+
+## Surfaces and limits
+
+The API exposes exact resolution and bounded attempt listing. `vk agent:file-provenance` mirrors exact resolution. The run timeline shows the newest records and gaps without polling beyond the existing live-run refresh path.
+
+The initial automatic producer integration covers governed File Work Product artifact registration. Providers and tools that cannot expose causal digest-bound file operations remain explicitly unsupported. General filesystem interception, certified link identity, and approval-policy enforcement are separate boundaries; they must not be inferred from this ledger.

--- a/docs/security/permission-coverage.json
+++ b/docs/security/permission-coverage.json
@@ -708,6 +708,14 @@
       "denialReason": "Reading active phase state requires task and agent read access."
     },
     {
+      "id": "cli:agents:agent:file-provenance",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read", "agent:read"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Resolving redacted file provenance requires task and agent read access."
+    },
+    {
       "id": "cli:agents:agent:transition-phase",
       "kind": "cli",
       "classification": "agent-scoped",

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -66,6 +66,7 @@
           "src/__tests__/routes/work-product-artifacts.test.ts",
           "src/__tests__/routes/v1-permission-guards.test.ts",
           "src/__tests__/run-launch-manifest-service.test.ts",
+          "src/__tests__/run-file-provenance-service.test.ts",
           "src/__tests__/run-recovery-policy-service.test.ts",
           "src/__tests__/run-supervisor-service.test.ts",
           "src/__tests__/schemas.test.ts",

--- a/server/src/__tests__/routes/phase-transitions.test.ts
+++ b/server/src/__tests__/routes/phase-transitions.test.ts
@@ -13,8 +13,10 @@ import {
   getBuiltInPhaseCapabilityProfile,
 } from '../../services/phase-capability-service.js';
 
-const { mockGetPhase, mockTransition } = vi.hoisted(() => ({
+const { mockGetFileProvenance, mockGetPhase, mockGetTask, mockTransition } = vi.hoisted(() => ({
+  mockGetFileProvenance: vi.fn(),
   mockGetPhase: vi.fn(),
+  mockGetTask: vi.fn(),
   mockTransition: vi.fn(),
 }));
 
@@ -30,13 +32,20 @@ vi.mock('../../services/run-phase-authority-service.js', () => ({
   }),
 }));
 
+vi.mock('../../services/run-file-provenance-service.js', () => ({
+  getRunFileProvenanceService: () => ({
+    resolve: mockGetFileProvenance,
+    list: vi.fn(),
+  }),
+}));
+
 vi.mock('../../services/clawdbot-agent-service.js', () => ({
   AgentReadinessError: class AgentReadinessError extends Error {},
   clawdbotAgentService: {},
 }));
 
 vi.mock('../../services/task-service.js', () => ({
-  getTaskService: () => ({ getTask: vi.fn() }),
+  getTaskService: () => ({ getTask: mockGetTask }),
 }));
 
 vi.mock('../../services/telemetry-service.js', () => ({
@@ -53,6 +62,13 @@ describe('phase transition routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetPhase.mockResolvedValue(null);
+    mockGetTask.mockResolvedValue({
+      id: 'task-1',
+      attempt: {
+        id: 'attempt-1',
+        taskEnvelope: { workspace: { workspaceId: 'local' } },
+      },
+    });
   });
 
   it('reads current state and bounded history for one exact run', async () => {
@@ -101,6 +117,48 @@ describe('phase transition routes', () => {
         }),
       })
     );
+  });
+
+  it('resolves exact file provenance within the authenticated attempt workspace', async () => {
+    mockGetFileProvenance.mockResolvedValue({ status: 'exact', current: { id: 'runfile_1' } });
+
+    const response = await request(app())
+      .get('/api/agents/task-1/file-provenance/resolve')
+      .query({
+        attemptId: 'attempt-1',
+        root: 'run-artifact',
+        path: 'reports/final.pdf',
+        sha256: `sha256:${'a'.repeat(64)}`,
+        limit: 10,
+      });
+
+    expect(response.status).toBe(200);
+    expect(mockGetFileProvenance).toHaveBeenCalledWith({
+      workspaceId: 'local',
+      taskId: 'task-1',
+      attemptId: 'attempt-1',
+      root: 'run-artifact',
+      relativePath: 'reports/final.pdf',
+      sha256: `sha256:${'a'.repeat(64)}`,
+      limit: 10,
+    });
+
+    mockGetTask.mockResolvedValueOnce({
+      id: 'task-1',
+      attempt: {
+        id: 'attempt-1',
+        taskEnvelope: { workspace: { workspaceId: 'other-workspace' } },
+      },
+    });
+    const denied = await request(app())
+      .get('/api/agents/task-1/file-provenance/resolve')
+      .query({
+        attemptId: 'attempt-1',
+        root: 'run-artifact',
+        path: 'reports/final.pdf',
+        sha256: `sha256:${'a'.repeat(64)}`,
+      });
+    expect(denied.status).toBe(404);
   });
 });
 

--- a/server/src/__tests__/run-file-provenance-service.test.ts
+++ b/server/src/__tests__/run-file-provenance-service.test.ts
@@ -1,0 +1,187 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { RunEventEnvelope, RunFileProvenanceScope } from '@veritas-kanban/shared';
+import { RunEventJournalService } from '../services/run-event-journal-service.js';
+import {
+  RunFileProvenanceService,
+  type RecordRunFileProvenanceInput,
+} from '../services/run-file-provenance-service.js';
+import { FileRunEventRepository } from '../storage/run-event-repository.js';
+
+describe('RunFileProvenanceService', () => {
+  let root: string;
+  let journal: RunEventJournalService;
+  let service: RunFileProvenanceService;
+  const now = new Date('2026-08-30T10:00:00.000Z');
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-run-file-provenance-'));
+    journal = new RunEventJournalService(new FileRunEventRepository(root));
+    service = new RunFileProvenanceService(journal, () => now);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('persists causal digest-bound replacements and resolves only the current bytes', async () => {
+    const firstEvent = await causalEvent('file-one');
+    const first = await service.record(recordInput(firstEvent, 'a'.repeat(64)));
+    if (first.status !== 'recorded') throw new Error('Expected provenance record.');
+
+    const secondEvent = await causalEvent('file-two');
+    const second = await service.record({
+      ...recordInput(secondEvent, 'b'.repeat(64)),
+      operation: 'replace',
+    });
+    if (second.status !== 'recorded') throw new Error('Expected replacement record.');
+
+    expect(second.record.predecessorId).toBe(first.record.id);
+    await expect(resolve('b'.repeat(64))).resolves.toMatchObject({
+      status: 'exact',
+      current: { id: second.record.id },
+      chain: [{ id: second.record.id }, { id: first.record.id }],
+    });
+    await expect(resolve('a'.repeat(64))).resolves.toMatchObject({
+      status: 'stale',
+      current: { id: second.record.id },
+      chain: [],
+    });
+    const evidence = await service.approvalEvidence({
+      workspaceId: 'workspace-a',
+      taskId: 'task-a',
+      attemptId: 'attempt-a',
+      root: 'run-artifact',
+      relativePath: 'outputs/report.txt',
+      sha256: `sha256:${'b'.repeat(64)}`,
+    });
+    expect(evidence).toMatchObject({
+      schemaVersion: 'run-file-provenance-approval-evidence/v1',
+      status: 'exact',
+      currentRecordId: second.record.id,
+      currentRecordDigest: second.record.digest,
+      chainDigests: [second.record.digest, first.record.digest],
+      gapCodes: [],
+    });
+    expect(evidence.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it('replays idempotently after restart without duplicating the causal ledger', async () => {
+    const event = await causalEvent('restart-safe');
+    const input = recordInput(event, 'c'.repeat(64));
+    const first = await service.record(input);
+    const restarted = new RunFileProvenanceService(journal, () => now);
+    const replay = await restarted.record(input);
+    const records = await restarted.list('workspace-a', 'task-a', 'attempt-a');
+
+    expect(first.status).toBe('recorded');
+    expect(replay).toMatchObject({ status: 'recorded', appended: false });
+    expect(records.records).toHaveLength(1);
+  });
+
+  it('redacts source metadata and fails closed on path identity collisions', async () => {
+    const event = await causalEvent('redaction');
+    const input = recordInput(event, 'd'.repeat(64));
+    input.location.relativePath = 'reports/Résumé.txt';
+    input.producer.sourceUrl = 'https://user:pass@example.com/report?token=signed-secret#private';
+    input.producer.connectorTarget = 'teams/reviewed-channel';
+    input.producer.metadata = {
+      authorization: 'Bearer secret',
+      output: '/Users/operator/private/report.txt',
+      label: 'reviewed',
+    };
+    const recorded = await service.record(input);
+    if (recorded.status !== 'recorded') throw new Error('Expected provenance record.');
+
+    expect(recorded.record.producer).toMatchObject({
+      sourceUrl: 'https://example.com/report',
+      connectorTarget: 'teams/reviewed-channel',
+      safeMetadata: { output: '[host-path-redacted]', label: 'reviewed' },
+    });
+    expect(JSON.stringify(recorded.record)).not.toContain('signed-secret');
+    expect(JSON.stringify(recorded.record)).not.toContain('Bearer secret');
+
+    const collisionEvent = await causalEvent('collision');
+    const collision = recordInput(collisionEvent, 'e'.repeat(64));
+    collision.location.relativePath = 'reports/RÉSUMÉ.TXT';
+    await expect(service.record(collision)).resolves.toMatchObject({
+      status: 'gap',
+      gap: { code: 'path-collision' },
+    });
+  });
+
+  it('records typed gaps for uncertified links and unsupported capture paths', async () => {
+    const event = await causalEvent('unsupported');
+    const linked = recordInput(event, 'f'.repeat(64));
+    linked.location.linkKind = 'symlink';
+    const unsupported = recordInput(event, 'f'.repeat(64));
+    unsupported.location.relativePath = 'outputs/unsupported.txt';
+    unsupported.captureSupport = 'unsupported-provider';
+
+    await expect(service.record(linked)).resolves.toMatchObject({
+      status: 'gap',
+      gap: { code: 'link-identity-uncertified' },
+    });
+    await expect(service.record(unsupported)).resolves.toMatchObject({
+      status: 'gap',
+      gap: { code: 'unsupported-provider-path' },
+    });
+    await expect(resolve('f'.repeat(64))).resolves.toMatchObject({ status: 'gap' });
+  });
+
+  async function causalEvent(key: string): Promise<RunEventEnvelope> {
+    return (
+      await journal.append({
+        workspaceId: 'workspace-a',
+        taskId: 'task-a',
+        attemptId: 'attempt-a',
+        kind: 'file.changed',
+        source: { provider: 'system', adapter: 'test' },
+        payload: { key },
+        dedupeKey: `causal:${key}`,
+      })
+    ).event;
+  }
+
+  function resolve(sha256: string) {
+    return service.resolve({
+      workspaceId: 'workspace-a',
+      taskId: 'task-a',
+      attemptId: 'attempt-a',
+      root: 'run-artifact',
+      relativePath: 'outputs/report.txt',
+      sha256: `sha256:${sha256}`,
+    });
+  }
+});
+
+const scope: RunFileProvenanceScope = {
+  workspaceId: 'workspace-a',
+  taskId: 'task-a',
+  rootObjectiveId: 'root-a',
+  executionNodeId: 'node-a',
+  runId: 'run-a',
+  attemptId: 'attempt-a',
+  workflowStepId: null,
+};
+
+function recordInput(event: RunEventEnvelope, sha256: string): RecordRunFileProvenanceInput {
+  return {
+    scope,
+    source: 'agent-created',
+    operation: 'create',
+    producer: { eventId: event.eventId, eventSequence: event.sequence },
+    location: {
+      root: 'run-artifact',
+      relativePath: 'outputs/report.txt',
+      linkKind: 'regular',
+    },
+    content: {
+      sha256,
+      byteSize: 42,
+      mediaType: 'text/plain',
+      mediaClass: 'text',
+    },
+  };
+}

--- a/server/src/__tests__/work-product-artifact-service.test.ts
+++ b/server/src/__tests__/work-product-artifact-service.test.ts
@@ -6,6 +6,7 @@ vi.mock('../services/task-service.js', () => ({
   getTaskService: () => taskServiceMocks,
 }));
 import { RunEventJournalService } from '../services/run-event-journal-service.js';
+import { RunFileProvenanceService } from '../services/run-file-provenance-service.js';
 import {
   getWorkProductArtifactService,
   resetWorkProductArtifactServiceForTests,
@@ -42,21 +43,25 @@ async function fixture(
   const events = new RunEventJournalService(
     new FileRunEventRepository(path.join(root, 'run-events'))
   );
+  const provenance = new RunFileProvenanceService(events);
   const service = new WorkProductArtifactService({
     repository: new FileWorkProductArtifactRepository(path.join(root, 'stored-artifacts')),
     workProducts,
     events,
+    provenance,
     resolveGrant: async () =>
       options.granted === false
         ? null
         : {
             artifactRoot,
             manifestDigest: `sha256:${'a'.repeat(64)}`,
+            rootObjectiveId: 'root-1247',
+            executionNodeId: 'node-1247',
           },
     maxArtifactBytes: options.maxArtifactBytes,
     sourceReader: options.sourceReader,
   });
-  return { root, artifactRoot, events, service, workProducts };
+  return { root, artifactRoot, events, provenance, service, workProducts };
 }
 
 describe('WorkProductArtifactService', () => {
@@ -92,7 +97,7 @@ describe('WorkProductArtifactService', () => {
   });
 
   it('registers immutable run output once and preserves causal provenance', async () => {
-    const { artifactRoot, events, service } = await fixture();
+    const { artifactRoot, events, provenance, service } = await fixture();
     const content = Buffer.from('%PDF-1.7\nverified deliverable\n', 'utf8');
     await fs.writeFile(path.join(artifactRoot, 'release-report.pdf'), content);
     const input = {
@@ -164,7 +169,7 @@ describe('WorkProductArtifactService', () => {
       service.inspect({ workspaceId: 'another-workspace', productId: first.product.id })
     ).rejects.toThrow('another workspace');
     const journal = await events.list({ taskId: 'task_1247', attemptId: 'attempt_1247' });
-    expect(journal.events).toHaveLength(1);
+    expect(journal.events).toHaveLength(2);
     expect(journal.events[0]).toMatchObject({
       kind: 'artifact.created',
       causalEventId: 'runevt_provider_output',
@@ -172,6 +177,24 @@ describe('WorkProductArtifactService', () => {
         artifactId: first.metadata.id,
         workProductId: first.product.id,
         version: 1,
+      },
+    });
+    await expect(
+      provenance.resolve({
+        workspaceId: 'local',
+        taskId: 'task_1247',
+        attemptId: 'attempt_1247',
+        root: 'run-artifact',
+        relativePath: 'release-report.pdf',
+        sha256: `sha256:${first.metadata.sha256}`,
+      })
+    ).resolves.toMatchObject({
+      status: 'exact',
+      current: {
+        source: 'agent-created',
+        operation: 'create',
+        scope: { rootObjectiveId: 'root-1247', executionNodeId: 'node-1247' },
+        producer: { eventId: journal.events[0]?.eventId, eventSequence: 1 },
       },
     });
   });
@@ -215,7 +238,7 @@ describe('WorkProductArtifactService', () => {
     });
     expect(
       (await events.list({ taskId: 'task_1247', attemptId: 'attempt_1247' })).events
-    ).toHaveLength(2);
+    ).toHaveLength(4);
   });
 
   it('rejects a stable request ID reused with different registration inputs', async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -22,11 +22,7 @@ import {
   TASK_VERIFICATION_STATUSES,
 } from '@veritas-kanban/shared';
 import { asyncHandler } from '../middleware/async-handler.js';
-import {
-  ConflictError,
-  NotFoundError,
-  ValidationError,
-} from '../middleware/error-handler.js';
+import { ConflictError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { requireLocalAgentCapability } from '../middleware/local-agent-capability.js';
 import { AgentBudgetPolicySchema } from '../schemas/agent-budget-schemas.js';
 import {
@@ -41,7 +37,12 @@ import {
   RunOutputArtifactDownloadQuerySchema,
   RunOutputArtifactHttpQuerySchema,
 } from '../schemas/run-output-artifact-schemas.js';
+import {
+  RunFileProvenanceListQuerySchema,
+  RunFileProvenanceReadQuerySchema,
+} from '../schemas/run-file-provenance-schemas.js';
 import { RunOutputArtifactService } from '../services/run-output-artifact-service.js';
+import { getRunFileProvenanceService } from '../services/run-file-provenance-service.js';
 import {
   workspaceExecutionTrustDecisionInputSchema,
   workspaceExecutionTrustRevokeInputSchema,
@@ -510,6 +511,40 @@ router.get(
   })
 );
 
+// GET /api/agents/:taskId/file-provenance/resolve - Resolve provenance for exact bytes.
+router.get(
+  '/:taskId/file-provenance/resolve',
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const query = RunFileProvenanceReadQuerySchema.parse(req.query);
+    const taskId = req.params.taskId as string;
+    const workspaceId = await authorizedTaskWorkspace(req, taskId, query.attemptId);
+    res.json(
+      await getRunFileProvenanceService().resolve({
+        workspaceId,
+        taskId,
+        attemptId: query.attemptId,
+        root: query.root,
+        relativePath: query.path,
+        sha256: query.sha256,
+        limit: query.limit,
+      })
+    );
+  })
+);
+
+// GET /api/agents/:taskId/file-provenance - List bounded redacted run evidence.
+router.get(
+  '/:taskId/file-provenance',
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const query = RunFileProvenanceListQuerySchema.parse(req.query);
+    const taskId = req.params.taskId as string;
+    const workspaceId = await authorizedTaskWorkspace(req, taskId, query.attemptId);
+    res.json(
+      await getRunFileProvenanceService().list(workspaceId, taskId, query.attemptId, query.limit)
+    );
+  })
+);
+
 // GET /api/agents/:taskId/output-artifacts/:artifactId - Query governed run output.
 router.get(
   '/:taskId/output-artifacts/:artifactId',
@@ -579,10 +614,7 @@ router.get(
     if (!range) throw new ConflictError('Run output artifact body is unavailable.');
     res.status(206);
     res.setHeader('Content-Type', range.metadata.mediaType);
-    res.setHeader(
-      'Content-Disposition',
-      `attachment; filename="${range.metadata.id}.bin"`
-    );
+    res.setHeader('Content-Disposition', `attachment; filename="${range.metadata.id}.bin"`);
     res.setHeader(
       'Content-Range',
       `bytes ${range.offset}-${Math.max(range.offset, range.offset + range.length - 1)}/${range.metadata.storedBytes}`
@@ -1013,6 +1045,22 @@ router.post(
 
 // Export service for WebSocket use
 export { router as agentRoutes, clawdbotAgentService as agentService };
+
+async function authorizedTaskWorkspace(
+  req: AuthenticatedRequest,
+  taskId: string,
+  attemptId: string
+): Promise<string> {
+  const workspaceId = req.auth?.workspaceId || 'local';
+  const task = await getTaskService().getTask(taskId);
+  const attempt = task
+    ? [task.attempt, ...(task.attempts ?? [])].find((candidate) => candidate?.id === attemptId)
+    : undefined;
+  if (!task || !attempt || attempt.taskEnvelope?.workspace.workspaceId !== workspaceId) {
+    throw new NotFoundError('Task not found');
+  }
+  return workspaceId;
+}
 
 function getProgressWatchdogControl(): ProgressWatchdogControlService {
   progressWatchdogControl ??= new ProgressWatchdogControlService(undefined, clawdbotAgentService);

--- a/server/src/schemas/run-file-provenance-schemas.ts
+++ b/server/src/schemas/run-file-provenance-schemas.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod';
+import {
+  RUN_FILE_MEDIA_CLASSES,
+  RUN_FILE_PROVENANCE_OPERATIONS,
+  RUN_FILE_PROVENANCE_ROOTS,
+  RUN_FILE_PROVENANCE_SCHEMA_VERSION,
+  RUN_FILE_PROVENANCE_SOURCES,
+  type RunFileProvenanceRecord,
+  type RunFileProvenanceGap,
+} from '@veritas-kanban/shared';
+
+const identifier = z.string().trim().min(1).max(160);
+const digest = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+const safePath = z.string().trim().min(1).max(2_000);
+
+export const RunFileProvenanceRecordSchema: z.ZodType<RunFileProvenanceRecord> = z
+  .object({
+    schemaVersion: z.literal(RUN_FILE_PROVENANCE_SCHEMA_VERSION),
+    id: z.string().regex(/^runfile_[a-f0-9]{32}$/),
+    scope: z
+      .object({
+        workspaceId: identifier,
+        taskId: identifier,
+        rootObjectiveId: identifier,
+        executionNodeId: identifier,
+        runId: identifier,
+        attemptId: identifier,
+        workflowStepId: identifier.nullable(),
+      })
+      .strict(),
+    source: z.enum(RUN_FILE_PROVENANCE_SOURCES),
+    operation: z.enum(RUN_FILE_PROVENANCE_OPERATIONS),
+    producer: z
+      .object({
+        eventId: identifier,
+        eventSequence: z.number().int().positive(),
+        toolCallId: identifier.nullable(),
+        commandId: identifier.nullable(),
+        attachmentId: identifier.nullable(),
+        connectorTarget: z.string().trim().min(1).max(500).nullable(),
+        sourceUrl: z.string().trim().min(1).max(2_000).nullable(),
+        safeMetadata: z.record(z.string().min(1).max(100), z.string().max(500)),
+      })
+      .strict(),
+    location: z
+      .object({
+        root: z.enum(RUN_FILE_PROVENANCE_ROOTS),
+        relativePath: safePath,
+        normalizedPath: safePath,
+        caseFoldedPath: safePath,
+      })
+      .strict(),
+    content: z
+      .object({
+        sha256: digest,
+        byteSize: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+        mediaType: z.string().trim().min(1).max(240),
+        mediaClass: z.enum(RUN_FILE_MEDIA_CLASSES),
+      })
+      .strict(),
+    predecessorId: z
+      .string()
+      .regex(/^runfile_[a-f0-9]{32}$/)
+      .nullable(),
+    previousPath: safePath.nullable(),
+    capturedAt: z.iso.datetime({ offset: true }),
+    digest,
+  })
+  .strict();
+
+export const RunFileProvenanceGapSchema: z.ZodType<RunFileProvenanceGap> = z
+  .object({
+    code: z.enum([
+      'unsupported-provider-path',
+      'unsupported-tool-path',
+      'link-identity-uncertified',
+      'path-collision',
+      'causal-event-missing',
+      'record-invalid',
+    ]),
+    message: z.string().trim().min(1).max(1_000),
+    root: z.enum(RUN_FILE_PROVENANCE_ROOTS).optional(),
+    relativePath: safePath.optional(),
+    eventId: identifier.optional(),
+    eventSequence: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const RunFileProvenanceReadQuerySchema = z
+  .object({
+    attemptId: identifier,
+    root: z.enum(RUN_FILE_PROVENANCE_ROOTS),
+    path: safePath,
+    sha256: digest,
+    limit: z.coerce.number().int().min(1).max(100).default(25),
+  })
+  .strict();
+
+export const RunFileProvenanceListQuerySchema = z
+  .object({
+    attemptId: identifier,
+    limit: z.coerce.number().int().min(1).max(100).default(25),
+  })
+  .strict();

--- a/server/src/services/run-event-journal-service.ts
+++ b/server/src/services/run-event-journal-service.ts
@@ -79,6 +79,7 @@ function normalizeJson(
     addOriginalBytes(state, value);
     const safeEvidenceValue =
       /^sha256:[a-f0-9]{64}$/.test(value) ||
+      /^runfile_[a-f0-9]{32}$/.test(value) ||
       /^watchdog_[a-f0-9]{8}(?:-[a-f0-9]{8}){3}$/.test(value);
     const redacted = safeEvidenceValue ? value : redactString(value);
     const bounded =

--- a/server/src/services/run-file-provenance-service.ts
+++ b/server/src/services/run-file-provenance-service.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { scryptSync } from 'node:crypto';
 import path from 'node:path';
 import {
   RUN_FILE_PROVENANCE_RESPONSE_SCHEMA_VERSION,
@@ -491,7 +491,7 @@ function boundedMediaType(value: string): string {
 }
 
 function hash(value: string): string {
-  return createHash('sha256').update(value).digest('hex');
+  return scryptSync(value, 'run-file-provenance/v1', 32).toString('hex');
 }
 
 function digest(value: string): string {

--- a/server/src/services/run-file-provenance-service.ts
+++ b/server/src/services/run-file-provenance-service.ts
@@ -1,0 +1,521 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import {
+  RUN_FILE_PROVENANCE_RESPONSE_SCHEMA_VERSION,
+  RUN_FILE_PROVENANCE_SCHEMA_VERSION,
+  RUN_FILE_PROVENANCE_APPROVAL_EVIDENCE_SCHEMA_VERSION,
+  type RunEventEnvelope,
+  type RunFileProvenanceGap,
+  type RunFileProvenanceApprovalEvidence,
+  type RunFileProvenanceListResponse,
+  type RunFileProvenanceOperation,
+  type RunFileProvenanceQuery,
+  type RunFileProvenanceRecord,
+  type RunFileProvenanceResponse,
+  type RunFileProvenanceRoot,
+  type RunFileProvenanceScope,
+  type RunFileProvenanceSource,
+  type RunFileMediaClass,
+} from '@veritas-kanban/shared';
+import { BadRequestError } from '../middleware/error-handler.js';
+import {
+  RunFileProvenanceGapSchema,
+  RunFileProvenanceRecordSchema,
+} from '../schemas/run-file-provenance-schemas.js';
+import { redactString } from '../lib/redact.js';
+import { validatePathSegment } from '../utils/sanitize.js';
+import type { RunEventJournalService } from './run-event-journal-service.js';
+import { getRunEventJournalService } from './run-event-journal-service.js';
+
+const MAX_JOURNAL_EVENTS = 50_000;
+const PAGE_SIZE = 500;
+const SENSITIVE_METADATA_KEY =
+  /(?:authorization|api.?key|token|secret|password|credential|private.?key|cookie|header|environment)/i;
+
+export interface RecordRunFileProvenanceInput {
+  scope: RunFileProvenanceScope;
+  source: RunFileProvenanceSource;
+  operation: RunFileProvenanceOperation;
+  producer: {
+    eventId: string;
+    eventSequence: number;
+    toolCallId?: string;
+    commandId?: string;
+    attachmentId?: string;
+    connectorTarget?: string;
+    sourceUrl?: string;
+    metadata?: Record<string, unknown>;
+  };
+  location: {
+    root: RunFileProvenanceRoot;
+    relativePath: string;
+    previousPath?: string;
+    linkKind: 'regular' | 'symlink' | 'hardlink' | 'unknown';
+  };
+  content: {
+    sha256: string;
+    byteSize: number;
+    mediaType: string;
+    mediaClass: RunFileMediaClass;
+  };
+  captureSupport?: 'captured' | 'unsupported-provider' | 'unsupported-tool';
+}
+
+export type RecordRunFileProvenanceResult =
+  | { status: 'recorded'; record: RunFileProvenanceRecord; appended: boolean }
+  | { status: 'gap'; gap: RunFileProvenanceGap; appended: boolean };
+
+export class RunFileProvenanceService {
+  constructor(
+    private readonly journal: Pick<
+      RunEventJournalService,
+      'append' | 'list'
+    > = getRunEventJournalService(),
+    private readonly now: () => Date = () => new Date()
+  ) {}
+
+  async record(input: RecordRunFileProvenanceInput): Promise<RecordRunFileProvenanceResult> {
+    this.validateScope(input.scope);
+    const normalizedPath = normalizeRelativePath(input.location.relativePath);
+    const previousPath = input.location.previousPath
+      ? normalizeRelativePath(input.location.previousPath)
+      : null;
+    if (input.captureSupport === 'unsupported-provider') {
+      return this.recordGap(input, {
+        code: 'unsupported-provider-path',
+        message: 'The selected provider cannot certify file-producing operations.',
+      });
+    }
+    if (input.captureSupport === 'unsupported-tool') {
+      return this.recordGap(input, {
+        code: 'unsupported-tool-path',
+        message: 'The producing tool path does not expose certifiable file evidence.',
+      });
+    }
+    if (input.location.linkKind !== 'regular') {
+      return this.recordGap(input, {
+        code: 'link-identity-uncertified',
+        message: `${input.location.linkKind} file identity cannot be certified.`,
+      });
+    }
+    if (['rename', 'copy', 'extract'].includes(input.operation) && previousPath === null) {
+      return this.recordGap(input, {
+        code: 'record-invalid',
+        message: `${input.operation} provenance requires an explicit predecessor path.`,
+      });
+    }
+
+    const events = await this.readAll(input.scope.taskId, input.scope.attemptId);
+    const causalEvent = events.find(
+      (event) =>
+        event.eventId === input.producer.eventId && event.sequence === input.producer.eventSequence
+    );
+    if (!causalEvent) {
+      return this.recordGap(input, {
+        code: 'causal-event-missing',
+        message: 'The producing event is not present at the claimed causal sequence.',
+      });
+    }
+
+    const { records } = projectEvents(events);
+    const caseFoldedPath = normalizedPath.toLocaleLowerCase('en-US');
+    const collision = records.find(
+      (record) =>
+        record.location.root === input.location.root &&
+        record.location.caseFoldedPath === caseFoldedPath &&
+        record.location.normalizedPath !== normalizedPath
+    );
+    if (collision) {
+      return this.recordGap(input, {
+        code: 'path-collision',
+        message: 'Case-folded or Unicode-normalized path identity conflicts with prior evidence.',
+      });
+    }
+
+    const predecessorPath = previousPath ?? normalizedPath;
+    const predecessor = records
+      .filter(
+        (record) =>
+          record.location.root === input.location.root &&
+          record.location.normalizedPath === predecessorPath
+      )
+      .sort((left, right) => right.producer.eventSequence - left.producer.eventSequence)[0];
+    const contentSha256 = normalizeSha256(input.content.sha256);
+    if (!Number.isSafeInteger(input.content.byteSize) || input.content.byteSize < 0) {
+      throw new BadRequestError('File provenance byte size must be a non-negative safe integer.');
+    }
+    const capturedAt = this.now().toISOString();
+    const material = {
+      schemaVersion: RUN_FILE_PROVENANCE_SCHEMA_VERSION,
+      scope: input.scope,
+      source: input.source,
+      operation: input.operation,
+      producer: {
+        eventId: causalEvent.eventId,
+        eventSequence: causalEvent.sequence,
+        toolCallId: boundedIdentifier(input.producer.toolCallId),
+        commandId: boundedIdentifier(input.producer.commandId),
+        attachmentId: boundedIdentifier(input.producer.attachmentId),
+        connectorTarget: safeTarget(input.producer.connectorTarget),
+        sourceUrl: safeUrl(input.producer.sourceUrl),
+        safeMetadata: safeMetadata(input.producer.metadata),
+      },
+      location: {
+        root: input.location.root,
+        relativePath: normalizedPath,
+        normalizedPath,
+        caseFoldedPath,
+      },
+      content: {
+        sha256: contentSha256,
+        byteSize: input.content.byteSize,
+        mediaType: boundedMediaType(input.content.mediaType),
+        mediaClass: input.content.mediaClass,
+      },
+      predecessorId: predecessor?.id ?? null,
+      previousPath,
+      capturedAt,
+    };
+    const identity = stableJson({
+      scope: material.scope,
+      producer: material.producer.eventId,
+      sequence: material.producer.eventSequence,
+      path: material.location.normalizedPath,
+      sha256: material.content.sha256,
+      operation: material.operation,
+    });
+    const record = RunFileProvenanceRecordSchema.parse({
+      ...material,
+      id: `runfile_${hash(identity).slice(0, 32)}`,
+      digest: digest(stableJson(material)),
+    });
+    const appended = await this.journal.append({
+      workspaceId: input.scope.workspaceId,
+      taskId: input.scope.taskId,
+      attemptId: input.scope.attemptId,
+      causalEventId: causalEvent.eventId,
+      kind: 'file.provenance',
+      source: { provider: 'system', adapter: RUN_FILE_PROVENANCE_SCHEMA_VERSION },
+      payload: { record },
+      dedupeKey: `file-provenance:${record.id}`,
+    });
+    const persisted = RunFileProvenanceRecordSchema.parse(appended.event.payload.record);
+    return { status: 'recorded', record: persisted, appended: appended.appended };
+  }
+
+  async resolve(query: RunFileProvenanceQuery): Promise<RunFileProvenanceResponse> {
+    this.validateScope(query);
+    const normalizedPath = normalizeRelativePath(query.relativePath);
+    const sha256 = normalizeSha256(query.sha256);
+    const projected = projectEvents(await this.readAll(query.taskId, query.attemptId));
+    const matchingPath = projected.records
+      .filter(
+        (record) =>
+          record.scope.workspaceId === query.workspaceId &&
+          record.location.root === query.root &&
+          record.location.normalizedPath === normalizedPath
+      )
+      .sort((left, right) => right.producer.eventSequence - left.producer.eventSequence);
+    const current = matchingPath[0] ?? null;
+    const exact = current?.content.sha256 === sha256 ? current : null;
+    const limit = Math.min(Math.max(query.limit ?? 25, 1), 100);
+    const chain = exact ? buildChain(exact, projected.records, limit) : [];
+    const relevantGaps = projected.gaps.filter(
+      (gap) =>
+        (!gap.root || gap.root === query.root) &&
+        (!gap.relativePath || gap.relativePath === normalizedPath) &&
+        (!gap.eventSequence || gap.eventSequence <= (current?.producer.eventSequence ?? Infinity))
+    );
+    const status = exact
+      ? 'exact'
+      : relevantGaps.length > 0
+        ? 'gap'
+        : current
+          ? 'stale'
+          : 'unknown';
+    return {
+      schemaVersion: RUN_FILE_PROVENANCE_RESPONSE_SCHEMA_VERSION,
+      status,
+      query: { ...query, relativePath: normalizedPath, sha256, limit },
+      current,
+      chain,
+      gaps: relevantGaps.slice(-limit),
+      generatedAt: this.now().toISOString(),
+    };
+  }
+
+  async list(
+    workspaceId: string,
+    taskId: string,
+    attemptId: string,
+    limit = 25
+  ): Promise<RunFileProvenanceListResponse> {
+    this.validateScope({ workspaceId, taskId, attemptId });
+    const projected = projectEvents(await this.readAll(taskId, attemptId));
+    const bounded = Math.min(Math.max(limit, 1), 100);
+    return {
+      schemaVersion: RUN_FILE_PROVENANCE_RESPONSE_SCHEMA_VERSION,
+      taskId,
+      attemptId,
+      records: projected.records
+        .filter((record) => record.scope.workspaceId === workspaceId)
+        .sort((left, right) => right.producer.eventSequence - left.producer.eventSequence)
+        .slice(0, bounded),
+      gaps: projected.gaps.slice(-bounded),
+      generatedAt: this.now().toISOString(),
+    };
+  }
+
+  async approvalEvidence(
+    query: RunFileProvenanceQuery
+  ): Promise<RunFileProvenanceApprovalEvidence> {
+    const resolved = await this.resolve(query);
+    const material = {
+      schemaVersion: RUN_FILE_PROVENANCE_APPROVAL_EVIDENCE_SCHEMA_VERSION,
+      status: resolved.status,
+      query: resolved.query,
+      currentRecordId: resolved.current?.id ?? null,
+      currentRecordDigest: resolved.current?.digest ?? null,
+      chainDigests: resolved.chain.map((record) => record.digest),
+      gapCodes: [...new Set(resolved.gaps.map((gap) => gap.code))].sort(),
+    };
+    return {
+      ...material,
+      generatedAt: this.now().toISOString(),
+      digest: digest(stableJson(material)),
+    };
+  }
+
+  private async recordGap(
+    input: RecordRunFileProvenanceInput,
+    gapInput: Omit<RunFileProvenanceGap, 'eventId' | 'eventSequence'>
+  ): Promise<RecordRunFileProvenanceResult> {
+    const gap = RunFileProvenanceGapSchema.parse({
+      ...gapInput,
+      root: input.location.root,
+      relativePath: normalizeRelativePath(input.location.relativePath),
+      eventId: input.producer.eventId,
+      eventSequence: input.producer.eventSequence,
+    });
+    const result = await this.journal.append({
+      workspaceId: input.scope.workspaceId,
+      taskId: input.scope.taskId,
+      attemptId: input.scope.attemptId,
+      causalEventId: input.producer.eventId,
+      kind: 'file.provenance-gap',
+      source: { provider: 'system', adapter: RUN_FILE_PROVENANCE_SCHEMA_VERSION },
+      payload: { gap },
+      dedupeKey: `file-provenance-gap:${hash(stableJson({ scope: input.scope, gap }))}`,
+    });
+    return {
+      status: 'gap',
+      gap: RunFileProvenanceGapSchema.parse(result.event.payload.gap),
+      appended: result.appended,
+    };
+  }
+
+  private async readAll(taskId: string, attemptId: string): Promise<RunEventEnvelope[]> {
+    validatePathSegment(taskId);
+    validatePathSegment(attemptId);
+    const events: RunEventEnvelope[] = [];
+    let cursor = 0;
+    while (events.length < MAX_JOURNAL_EVENTS) {
+      const page = await this.journal.list({
+        taskId,
+        attemptId,
+        afterSequence: cursor,
+        limit: PAGE_SIZE,
+      });
+      events.push(...page.events);
+      if (!page.hasMore || page.nextCursor <= cursor) break;
+      cursor = page.nextCursor;
+    }
+    return events;
+  }
+
+  private validateScope(scope: { workspaceId: string; taskId: string; attemptId: string }): void {
+    validatePathSegment(scope.workspaceId);
+    validatePathSegment(scope.taskId);
+    validatePathSegment(scope.attemptId);
+  }
+}
+
+function projectEvents(events: RunEventEnvelope[]): {
+  records: RunFileProvenanceRecord[];
+  gaps: RunFileProvenanceGap[];
+} {
+  const records: RunFileProvenanceRecord[] = [];
+  const gaps: RunFileProvenanceGap[] = [];
+  for (const event of events) {
+    if (event.kind === 'file.provenance') {
+      const parsed = RunFileProvenanceRecordSchema.safeParse(event.payload.record);
+      if (parsed.success) records.push(parsed.data);
+      else
+        gaps.push({
+          code: 'record-invalid',
+          message: 'A persisted provenance event could not be validated.',
+          eventId: event.eventId,
+          eventSequence: event.sequence,
+        });
+    } else if (event.kind === 'file.provenance-gap') {
+      const parsed = RunFileProvenanceGapSchema.safeParse(event.payload.gap);
+      if (parsed.success) gaps.push(parsed.data);
+    }
+  }
+  const capturedEventIds = new Set(records.map((record) => record.producer.eventId));
+  const persistedGapEvents = new Set(gaps.map((gap) => gap.eventId).filter(Boolean));
+  for (const event of events) {
+    if (
+      event.kind !== 'file.changed' ||
+      capturedEventIds.has(event.eventId) ||
+      persistedGapEvents.has(event.eventId)
+    ) {
+      continue;
+    }
+    const candidatePath = typeof event.payload.path === 'string' ? event.payload.path : undefined;
+    let relativePath: string | undefined;
+    if (candidatePath) {
+      try {
+        relativePath = normalizeRelativePath(candidatePath);
+      } catch {
+        relativePath = undefined;
+      }
+    }
+    gaps.push({
+      code:
+        event.payload.toolCallId || event.payload.commandId
+          ? 'unsupported-tool-path'
+          : 'unsupported-provider-path',
+      message: 'A file-change event did not include certified digest-bound provenance.',
+      ...(event.payload.root === 'worktree' || event.payload.root === 'run-artifact'
+        ? { root: event.payload.root }
+        : {}),
+      ...(relativePath ? { relativePath } : {}),
+      eventId: event.eventId,
+      eventSequence: event.sequence,
+    });
+  }
+  return { records, gaps };
+}
+
+function buildChain(
+  start: RunFileProvenanceRecord,
+  records: RunFileProvenanceRecord[],
+  limit: number
+): RunFileProvenanceRecord[] {
+  const byId = new Map(records.map((record) => [record.id, record]));
+  const chain: RunFileProvenanceRecord[] = [];
+  const seen = new Set<string>();
+  let current: RunFileProvenanceRecord | undefined = start;
+  while (current && chain.length < limit && !seen.has(current.id)) {
+    chain.push(current);
+    seen.add(current.id);
+    current = current.predecessorId ? byId.get(current.predecessorId) : undefined;
+  }
+  return chain;
+}
+
+function normalizeRelativePath(value: string): string {
+  if (!value || value.length > 2_000 || path.isAbsolute(value)) {
+    throw new BadRequestError('File provenance path must be a bounded relative path.');
+  }
+  const normalized = value.replaceAll('\\', '/').normalize('NFC');
+  const segments = normalized.split('/');
+  if (segments.some((segment) => !segment || segment === '.' || segment === '..')) {
+    throw new BadRequestError('File provenance path contains an invalid segment.');
+  }
+  for (const segment of segments) validatePathSegment(segment);
+  return segments.join('/');
+}
+
+function normalizeSha256(value: string): string {
+  const normalized = value.startsWith('sha256:') ? value : `sha256:${value}`;
+  if (!/^sha256:[a-f0-9]{64}$/.test(normalized)) {
+    throw new BadRequestError('File provenance requires a lowercase SHA-256 digest.');
+  }
+  return normalized;
+}
+
+function boundedIdentifier(value: string | undefined): string | null {
+  if (!value) return null;
+  const bounded = redactString(value).trim().slice(0, 160);
+  return bounded || null;
+}
+
+function safeTarget(value: string | undefined): string | null {
+  if (!value) return null;
+  if (value.includes('://')) return safeUrl(value);
+  const redacted = redactString(value).trim().slice(0, 500);
+  if (!redacted || path.isAbsolute(redacted) || /^[A-Za-z]:[\\/]/.test(redacted)) return null;
+  return redacted;
+}
+
+function safeUrl(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (!['https:', 'http:'].includes(url.protocol)) return null;
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString().slice(0, 2_000);
+  } catch {
+    return null;
+  }
+}
+
+function safeMetadata(value: Record<string, unknown> | undefined): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, candidate] of Object.entries(value ?? {}).slice(0, 50)) {
+    if (!/^[A-Za-z0-9._-]{1,100}$/.test(key) || SENSITIVE_METADATA_KEY.test(key)) continue;
+    if (
+      typeof candidate !== 'string' &&
+      typeof candidate !== 'number' &&
+      typeof candidate !== 'boolean'
+    )
+      continue;
+    const safe = redactString(String(candidate)).slice(0, 500);
+    result[key] =
+      path.isAbsolute(safe) || /^[A-Za-z]:[\\/]/.test(safe) ? '[host-path-redacted]' : safe;
+  }
+  return result;
+}
+
+function boundedMediaType(value: string): string {
+  const mediaType = value.trim().toLowerCase().slice(0, 240);
+  if (!/^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*(?:;.*)?$/.test(mediaType)) {
+    throw new BadRequestError('File provenance media type is invalid.');
+  }
+  return mediaType;
+}
+
+function hash(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function digest(value: string): string {
+  return `sha256:${hash(value)}`;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stableJson(child)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+let runFileProvenanceService: RunFileProvenanceService | undefined;
+
+export function getRunFileProvenanceService(): RunFileProvenanceService {
+  runFileProvenanceService ??= new RunFileProvenanceService();
+  return runFileProvenanceService;
+}
+
+export function resetRunFileProvenanceServiceForTests(): void {
+  runFileProvenanceService = undefined;
+}

--- a/server/src/services/work-product-artifact-service.ts
+++ b/server/src/services/work-product-artifact-service.ts
@@ -23,6 +23,8 @@ import { validatePathSegment } from '../utils/sanitize.js';
 import { redactRunOutputText } from './run-output-spill-service.js';
 import type { RunEventJournalService } from './run-event-journal-service.js';
 import { getRunEventJournalService } from './run-event-journal-service.js';
+import type { RunFileProvenanceService } from './run-file-provenance-service.js';
+import { getRunFileProvenanceService } from './run-file-provenance-service.js';
 import { getTaskService } from './task-service.js';
 import type { WorkProductService } from './work-product-service.js';
 import { getWorkProductService } from './work-product-service.js';
@@ -44,6 +46,9 @@ export interface WorkProductArtifactScope {
 export interface WorkProductArtifactGrant {
   artifactRoot: string;
   manifestDigest: string;
+  rootObjectiveId?: string;
+  executionNodeId?: string;
+  workflowStepId?: string;
 }
 
 export interface RegisterWorkProductArtifactInput extends WorkProductArtifactScope {
@@ -73,6 +78,7 @@ export interface WorkProductArtifactServiceOptions {
     'create' | 'get' | 'update' | 'list' | 'listVersions' | 'purge'
   >;
   events: Pick<RunEventJournalService, 'append'>;
+  provenance?: Pick<RunFileProvenanceService, 'record'>;
   resolveGrant: (scope: WorkProductArtifactScope) => Promise<WorkProductArtifactGrant | null>;
   sourceReader?: WorkProductArtifactSourceReader;
   maxArtifactBytes?: number;
@@ -144,7 +150,8 @@ export class WorkProductArtifactService {
             'The request ID is already bound to a different artifact registration.'
           );
         }
-        await this.appendCreatedEvent(input, idempotentVersion.render.artifact);
+        const event = await this.appendCreatedEvent(input, idempotentVersion.render.artifact);
+        await this.recordProvenance(input, idempotentVersion.render.artifact, grant, event);
         return {
           product: {
             ...existing,
@@ -243,7 +250,8 @@ export class WorkProductArtifactService {
         );
     if (!product) throw new NotFoundError('Work product disappeared during artifact registration.');
 
-    await this.appendCreatedEvent(input, stored.metadata);
+    const event = await this.appendCreatedEvent(input, stored.metadata);
+    await this.recordProvenance(input, stored.metadata, grant, event);
     return { product, metadata: stored.metadata };
   }
 
@@ -363,8 +371,8 @@ export class WorkProductArtifactService {
   private async appendCreatedEvent(
     input: RegisterWorkProductArtifactInput,
     metadata: WorkProductArtifactMetadata
-  ): Promise<void> {
-    await this.options.events.append({
+  ) {
+    return this.options.events.append({
       workspaceId: input.workspaceId,
       taskId: input.taskId,
       attemptId: input.attemptId,
@@ -382,6 +390,48 @@ export class WorkProductArtifactService {
         state: metadata.state,
       },
       dedupeKey: `work-product-artifact:${metadata.requestIdDigest}`,
+    });
+  }
+
+  private async recordProvenance(
+    input: RegisterWorkProductArtifactInput,
+    metadata: WorkProductArtifactMetadata,
+    grant: WorkProductArtifactGrant,
+    event: Awaited<ReturnType<RunEventJournalService['append']>>
+  ): Promise<void> {
+    if (!this.options.provenance) return;
+    await this.options.provenance.record({
+      scope: {
+        workspaceId: input.workspaceId,
+        taskId: input.taskId,
+        rootObjectiveId: grant.rootObjectiveId ?? 'unavailable',
+        executionNodeId: grant.executionNodeId ?? 'unavailable',
+        runId: input.runId,
+        attemptId: input.attemptId,
+        workflowStepId: grant.workflowStepId ?? null,
+      },
+      source: 'agent-created',
+      operation: metadata.version === 1 ? 'create' : 'replace',
+      producer: {
+        eventId: event.event.eventId,
+        eventSequence: event.event.sequence,
+        metadata: {
+          artifactId: metadata.id,
+          workProductId: metadata.productId,
+          launchManifestDigest: metadata.launchManifestDigest,
+        },
+      },
+      location: {
+        root: 'run-artifact',
+        relativePath: input.relativePath,
+        linkKind: 'regular',
+      },
+      content: {
+        sha256: metadata.sha256,
+        byteSize: metadata.byteSize,
+        mediaType: metadata.mediaType,
+        mediaClass: classifyMedia(metadata.mediaType),
+      },
     });
   }
 
@@ -483,6 +533,18 @@ function looksExecutable(content: Uint8Array): boolean {
   return content.byteLength >= 2 && content[0] === 0x4d && content[1] === 0x5a;
 }
 
+function classifyMedia(mediaType: string) {
+  const normalized = mediaType.toLowerCase().split(';', 1)[0] ?? '';
+  if (normalized === 'application/json' || normalized.endsWith('+json')) return 'json' as const;
+  if (normalized.startsWith('text/')) return 'text' as const;
+  if (normalized.startsWith('image/')) return 'image' as const;
+  if (normalized.startsWith('audio/')) return 'audio' as const;
+  if (normalized.startsWith('video/')) return 'video' as const;
+  if (/zip|gzip|tar|compressed|archive/.test(normalized)) return 'archive' as const;
+  if (EXECUTABLE_MEDIA_TYPES.has(normalized)) return 'executable' as const;
+  return normalized ? ('binary' as const) : ('unknown' as const);
+}
+
 function digest(value: string): string {
   return `sha256:${createHash('sha256').update(value).digest('hex')}`;
 }
@@ -524,7 +586,14 @@ export async function resolveWorkProductArtifactGrant(
       root.pathDigest === artifactRootDigest
   );
   if (!granted || !manifest.enforcement.enforceable) return null;
-  return { artifactRoot: directories.artifactPath, manifestDigest: manifest.digest };
+  return {
+    artifactRoot: directories.artifactPath,
+    manifestDigest: manifest.digest,
+    rootObjectiveId: attempt.executionTree?.rootObjectiveId,
+    executionNodeId: attempt.executionTree?.nodeId,
+    workflowStepId:
+      attempt.executionTree?.edge === 'workflow-step' ? attempt.executionTree.nodeId : undefined,
+  };
 }
 
 let workProductArtifactService: WorkProductArtifactService | undefined;
@@ -537,6 +606,7 @@ export function getWorkProductArtifactService(): WorkProductArtifactService {
         : new FileWorkProductArtifactRepository(),
     workProducts: getWorkProductService(),
     events: getRunEventJournalService(),
+    provenance: getRunFileProvenanceService(),
     resolveGrant: resolveWorkProductArtifactGrant,
   });
   return workProductArtifactService;

--- a/shared/schemas/run-event-envelope.v1.schema.json
+++ b/shared/schemas/run-event-envelope.v1.schema.json
@@ -95,6 +95,8 @@
             "command.detached",
             "command.completed",
             "file.changed",
+            "file.provenance",
+            "file.provenance-gap",
             "workspace.checkpoint.created",
             "tool.started",
             "tool.completed",

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -62,6 +62,7 @@ export * from './run-launch-manifest.types.js';
 export * from './run-event.types.js';
 export * from './progress-watchdog.types.js';
 export * from './run-output-artifact.types.js';
+export * from './run-file-provenance.types.js';
 export * from './dependency-circuit.types.js';
 export * from './run-terminal.types.js';
 export * from './run-recovery.types.js';

--- a/shared/src/types/run-event.types.ts
+++ b/shared/src/types/run-event.types.ts
@@ -28,6 +28,8 @@ export const RUN_EVENT_KINDS = [
   'command.detached',
   'command.completed',
   'file.changed',
+  'file.provenance',
+  'file.provenance-gap',
   'workspace.checkpoint.created',
   'tool.started',
   'tool.completed',

--- a/shared/src/types/run-file-provenance.types.ts
+++ b/shared/src/types/run-file-provenance.types.ts
@@ -1,0 +1,151 @@
+export const RUN_FILE_PROVENANCE_SCHEMA_VERSION = 'run-file-provenance/v1' as const;
+export const RUN_FILE_PROVENANCE_RESPONSE_SCHEMA_VERSION =
+  'run-file-provenance-response/v1' as const;
+export const RUN_FILE_PROVENANCE_APPROVAL_EVIDENCE_SCHEMA_VERSION =
+  'run-file-provenance-approval-evidence/v1' as const;
+
+export const RUN_FILE_PROVENANCE_SOURCES = [
+  'repository-baseline',
+  'agent-created',
+  'command-created',
+  'tool-created',
+  'attachment-derived',
+  'connector-derived',
+  'downloaded-external',
+  'operator-provided',
+  'unknown',
+] as const;
+
+export const RUN_FILE_PROVENANCE_OPERATIONS = [
+  'create',
+  'modify',
+  'replace',
+  'rename',
+  'copy',
+  'extract',
+  'download',
+] as const;
+
+export const RUN_FILE_PROVENANCE_ROOTS = ['worktree', 'run-artifact'] as const;
+export const RUN_FILE_MEDIA_CLASSES = [
+  'text',
+  'json',
+  'image',
+  'audio',
+  'video',
+  'archive',
+  'executable',
+  'binary',
+  'unknown',
+] as const;
+
+export type RunFileProvenanceSource = (typeof RUN_FILE_PROVENANCE_SOURCES)[number];
+export type RunFileProvenanceOperation = (typeof RUN_FILE_PROVENANCE_OPERATIONS)[number];
+export type RunFileProvenanceRoot = (typeof RUN_FILE_PROVENANCE_ROOTS)[number];
+export type RunFileMediaClass = (typeof RUN_FILE_MEDIA_CLASSES)[number];
+
+export interface RunFileProvenanceScope {
+  workspaceId: string;
+  taskId: string;
+  rootObjectiveId: string;
+  executionNodeId: string;
+  runId: string;
+  attemptId: string;
+  workflowStepId: string | null;
+}
+
+export interface RunFileProvenanceProducer {
+  eventId: string;
+  eventSequence: number;
+  toolCallId: string | null;
+  commandId: string | null;
+  attachmentId: string | null;
+  connectorTarget: string | null;
+  sourceUrl: string | null;
+  safeMetadata: Record<string, string>;
+}
+
+export interface RunFileProvenanceLocation {
+  root: RunFileProvenanceRoot;
+  relativePath: string;
+  normalizedPath: string;
+  caseFoldedPath: string;
+}
+
+export interface RunFileProvenanceContent {
+  sha256: string;
+  byteSize: number;
+  mediaType: string;
+  mediaClass: RunFileMediaClass;
+}
+
+export interface RunFileProvenanceRecord {
+  schemaVersion: typeof RUN_FILE_PROVENANCE_SCHEMA_VERSION;
+  id: string;
+  scope: RunFileProvenanceScope;
+  source: RunFileProvenanceSource;
+  operation: RunFileProvenanceOperation;
+  producer: RunFileProvenanceProducer;
+  location: RunFileProvenanceLocation;
+  content: RunFileProvenanceContent;
+  predecessorId: string | null;
+  previousPath: string | null;
+  capturedAt: string;
+  digest: string;
+}
+
+export interface RunFileProvenanceGap {
+  code:
+    | 'unsupported-provider-path'
+    | 'unsupported-tool-path'
+    | 'link-identity-uncertified'
+    | 'path-collision'
+    | 'causal-event-missing'
+    | 'record-invalid';
+  message: string;
+  root?: RunFileProvenanceRoot;
+  relativePath?: string;
+  eventId?: string;
+  eventSequence?: number;
+}
+
+export interface RunFileProvenanceQuery {
+  workspaceId: string;
+  taskId: string;
+  attemptId: string;
+  root: RunFileProvenanceRoot;
+  relativePath: string;
+  sha256: string;
+  limit?: number;
+}
+
+export interface RunFileProvenanceResponse {
+  schemaVersion: typeof RUN_FILE_PROVENANCE_RESPONSE_SCHEMA_VERSION;
+  status: 'exact' | 'stale' | 'unknown' | 'gap';
+  query: RunFileProvenanceQuery;
+  current: RunFileProvenanceRecord | null;
+  chain: RunFileProvenanceRecord[];
+  gaps: RunFileProvenanceGap[];
+  generatedAt: string;
+}
+
+export interface RunFileProvenanceListResponse {
+  schemaVersion: typeof RUN_FILE_PROVENANCE_RESPONSE_SCHEMA_VERSION;
+  taskId: string;
+  attemptId: string;
+  records: RunFileProvenanceRecord[];
+  gaps: RunFileProvenanceGap[];
+  generatedAt: string;
+}
+
+export interface RunFileProvenanceApprovalEvidence {
+  schemaVersion: typeof RUN_FILE_PROVENANCE_APPROVAL_EVIDENCE_SCHEMA_VERSION;
+  status: RunFileProvenanceResponse['status'];
+  query: RunFileProvenanceQuery;
+  currentRecordId: string | null;
+  currentRecordDigest: string | null;
+  chainDigests: string[];
+  gapCodes: RunFileProvenanceGap['code'][];
+  generatedAt: string;
+  digest: string;
+}

--- a/web/src/__tests__/agent-run-timeline-mantine.test.tsx
+++ b/web/src/__tests__/agent-run-timeline-mantine.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   useActiveRuns: vi.fn(),
   usePendingAgentApprovals: vi.fn(),
   useAgentPhase: vi.fn(),
+  useRunFileProvenance: vi.fn(),
   decideApprovalMutateAsync: vi.fn(),
   useRecentRuns: vi.fn(),
   useTaskTelemetryEvents: vi.fn(),
@@ -38,6 +39,7 @@ vi.mock('@/hooks/useAgentRunTimeline', () => ({
 vi.mock('@/hooks/useAgent', () => ({
   usePendingAgentApprovals: mocks.usePendingAgentApprovals,
   useAgentPhase: mocks.useAgentPhase,
+  useRunFileProvenance: mocks.useRunFileProvenance,
   useDecideRunApproval: () => ({
     mutateAsync: mocks.decideApprovalMutateAsync,
     isPending: false,
@@ -341,6 +343,7 @@ describe('agent run timeline Mantine surface', () => {
     mocks.useActiveRuns.mockReturnValue({ data: [workflowRun], isLoading: false });
     mocks.usePendingAgentApprovals.mockReturnValue({ data: [approval], isLoading: false });
     mocks.useAgentPhase.mockReturnValue({ data: null, isLoading: false });
+    mocks.useRunFileProvenance.mockReturnValue({ data: null, isLoading: false });
     mocks.useRecentRuns.mockReturnValue({ data: [], isLoading: false });
     mocks.useTaskTelemetryEvents.mockReturnValue({ data: telemetryEvents, isLoading: false });
     mocks.useTaskNotifications.mockReturnValue({ data: [notification], isLoading: false });
@@ -596,6 +599,36 @@ describe('agent run timeline Mantine surface', () => {
     expect(screen.getByText('profile: agent-profile')).toBeDefined();
     expect(screen.getByText('sandbox: run')).toBeDefined();
     expect(screen.getByText(/Override until/)).toBeDefined();
+  });
+
+  it('renders bounded redacted file provenance and typed gaps', () => {
+    mocks.useRunFileProvenance.mockReturnValue({
+      data: {
+        records: [
+          {
+            id: 'runfile_1234567890abcdef1234567890abcdef',
+            source: 'agent-created',
+            operation: 'create',
+            location: { root: 'run-artifact', relativePath: 'reports/final.pdf' },
+            content: { sha256: `sha256:${'a'.repeat(64)}` },
+          },
+        ],
+        gaps: [
+          {
+            code: 'unsupported-tool-path',
+            message: 'The tool did not expose certifiable file evidence.',
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    renderWithProviders(<AgentRunTimelinePanel task={task} />);
+
+    expect(screen.getByText('File Provenance')).toBeDefined();
+    expect(screen.getByText('run-artifact/reports/final.pdf')).toBeDefined();
+    expect(screen.getByText(/agent-created · create/)).toBeDefined();
+    expect(screen.getByText(/unsupported-tool-path/)).toBeDefined();
   });
 
   it('pages long timelines so replay rendering stays bounded', async () => {

--- a/web/src/components/task/AgentRunTimelinePanel.tsx
+++ b/web/src/components/task/AgentRunTimelinePanel.tsx
@@ -49,6 +49,7 @@ import {
   useDecideRunApproval,
   useAgentPhase,
   usePendingAgentApprovals,
+  useRunFileProvenance,
   type AgentApprovalRequest,
 } from '@/hooks/useAgent';
 import { useAgentRunTraces, useTaskTelemetryEvents } from '@/hooks/useAgentRunTimeline';
@@ -1089,6 +1090,11 @@ export function AgentRunTimelinePanel({
     selectedAttemptId ?? undefined,
     hasLiveAttempt && selectedAttemptId === task.attempt?.id
   );
+  const { data: fileProvenance, isLoading: fileProvenanceLoading } = useRunFileProvenance(
+    task.id,
+    selectedAttemptId ?? undefined,
+    hasLiveAttempt && selectedAttemptId === task.attempt?.id
+  );
   const [filter, setFilter] = useState<AgentRunTimelineEventType | 'all'>('all');
   const [visibleCount, setVisibleCount] = useState(TIMELINE_PAGE_SIZE);
   const highlightedEventRef = useRef<HTMLDivElement | null>(null);
@@ -1172,6 +1178,7 @@ export function AgentRunTimelinePanel({
     notificationsLoading ||
     approvalsLoading ||
     phaseLoading ||
+    fileProvenanceLoading ||
     activeRunsLoading ||
     recentRunsLoading;
   const phaseIdentity = phase?.effectiveEvidence.identity;
@@ -1609,6 +1616,41 @@ export function AgentRunTimelinePanel({
                 <Badge size="xs" variant="outline">
                   v{product.version}
                 </Badge>
+              </Group>
+            ))}
+          </Stack>
+        </Paper>
+      )}
+
+      {fileProvenance && (fileProvenance.records.length > 0 || fileProvenance.gaps.length > 0) && (
+        <Paper withBorder p="md" radius="md">
+          <Stack gap="xs">
+            <Group gap="xs">
+              <GitBranch className="h-4 w-4 text-muted-foreground" />
+              <Text fw={600} size="sm">
+                File Provenance
+              </Text>
+              <Badge variant="light">{fileProvenance.records.length}</Badge>
+            </Group>
+            {fileProvenance.records.slice(0, 4).map((record) => (
+              <Group key={record.id} gap="xs" wrap="nowrap" align="flex-start">
+                <FileText className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" />
+                <div className="min-w-0">
+                  <Text size="sm" truncate>
+                    {record.location.root}/{record.location.relativePath}
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    {record.source} · {record.operation} · {record.content.sha256.slice(0, 19)}
+                  </Text>
+                </div>
+              </Group>
+            ))}
+            {fileProvenance.gaps.slice(0, 3).map((gap, index) => (
+              <Group key={`${gap.code}:${gap.eventId ?? index}`} gap="xs" wrap="nowrap">
+                <AlertTriangle className="h-3 w-3 shrink-0 text-yellow-600" />
+                <Text size="xs" c="yellow">
+                  {gap.code}: {gap.message}
+                </Text>
               </Group>
             ))}
           </Stack>

--- a/web/src/hooks/useAgent.ts
+++ b/web/src/hooks/useAgent.ts
@@ -12,6 +12,7 @@ import type {
   ProviderRuntimeCapabilityId,
   RunApprovalDecisionInput,
   RunApprovalRequest,
+  RunFileProvenanceListResponse,
   RunPhaseAuthoritySnapshot,
   TaskCommitPolicy,
 } from '@veritas-kanban/shared';
@@ -195,6 +196,22 @@ export function useAgentPhase(
       apiFetch<{ phase: RunPhaseAuthoritySnapshot | null }>(
         `${API_BASE}/agents/${encodeURIComponent(requiredQueryParam(taskId, 'taskId'))}/phase?attemptId=${encodeURIComponent(requiredQueryParam(attemptId, 'attemptId'))}`
       ).then((result) => result.phase),
+    enabled: !!taskId && !!attemptId,
+    refetchInterval: live ? 2_000 : false,
+  });
+}
+
+export function useRunFileProvenance(
+  taskId: string | undefined,
+  attemptId: string | undefined,
+  live = false
+) {
+  return useQuery({
+    queryKey: ['agent', 'file-provenance', taskId, attemptId],
+    queryFn: () =>
+      apiFetch<RunFileProvenanceListResponse>(
+        `${API_BASE}/agents/${encodeURIComponent(requiredQueryParam(taskId, 'taskId'))}/file-provenance?attemptId=${encodeURIComponent(requiredQueryParam(attemptId, 'attemptId'))}&limit=25`
+      ),
     enabled: !!taskId && !!attemptId,
     refetchInterval: live ? 2_000 : false,
   });


### PR DESCRIPTION
## Summary

- add append-only `run-file-provenance/v1` and provenance-gap events for exact run-produced bytes
- bind records to workspace, task, execution tree, run, attempt, workflow step, causal event, normalized root/path, content digest, source, operation, and predecessor evidence
- resolve exact, stale, unknown, gap, and unsupported states without exposing absolute paths or storage locations
- integrate artifact registration, authenticated API reads, CLI parity, and Run Timeline evidence
- project deterministic approval evidence for later destructive-action enforcement without granting authority in this slice

## Verification

- focused server provenance and route tests: 8 passed
- focused CLI provenance and Run Access tests: 19 passed
- focused Run Timeline tests: 9 passed
- shared, server, CLI, and web typechecks passed
- permission coverage and critical-path policy checks passed

## Risk

This is append-only evidence and a read-only operator surface. It does not authorize overwrite or deletion. Missing, conflicting, cross-workspace, or unlinked evidence fails closed. Full CI is requested because provenance crosses the event journal, artifact registration, API, CLI, and UI.

Closes #1251
