### PR TITLE
feat: activate governed recurring automations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,13 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   Completion, interruption, cancellation, and start failure release once;
   restart recovery may reclaim only after the durable run supervisor verifies
   the original live process or session.
+- Activate recurring work only through `automation-activation-preview/v1` and
+  an exact critical human approval. Persist one immutable
+  `automation-version/v1`, a compare-and-set scheduler binding, and a stable
+  due-window claim before workflow admission. The saved standing scope is a
+  ceiling: current workflow, phase, provider, tool, integration, credential,
+  and budget policy may narrow or block each run and may never be widened by
+  the automation version.
 - Bind every executable reservation to `execution-tree-identity/v1`. Descendants
   retain the root objective and exact parent edge across resume, follow-up,
   fork, retry, fallback, provider handoff, workflow step, and child-agent

--- a/cli/src/__tests__/scheduler-drafts.test.ts
+++ b/cli/src/__tests__/scheduler-drafts.test.ts
@@ -125,4 +125,78 @@ describe('vk scheduler draft commands', () => {
     expect(api.mock.calls.some(([url]) => String(url).includes('/run'))).toBe(false);
     output.mockRestore();
   });
+
+  it('keeps activation bound to the reviewed request revision and approval', async () => {
+    const requestRevision = `sha256:${'a'.repeat(64)}`;
+    api
+      .mockResolvedValueOnce({
+        draftId: 'automation_123',
+        draftRevision: 2,
+        requestRevision,
+        evidence: {
+          workflowId: 'workflow-1',
+          workflowVersion: 4,
+          provider: 'openclaw',
+          blockers: [],
+        },
+        schedule: { expiresAt: '2026-12-31T00:00:00.000Z' },
+        effectiveRunAccess: { tools: [], integrations: [], externalTargets: [] },
+      })
+      .mockResolvedValueOnce({
+        approvalId: 'runapproval_Automation123456',
+        approvalStatus: 'pending',
+      });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await program().parseAsync([
+      'node',
+      'vk',
+      'scheduler',
+      'draft',
+      'activation-preview',
+      'automation_123',
+      '--request-id',
+      'activation-1',
+      '--revision',
+      '2',
+      '--json',
+    ]);
+    await program().parseAsync([
+      'node',
+      'vk',
+      'scheduler',
+      'draft',
+      'activate',
+      'automation_123',
+      '--request-id',
+      'activation-1',
+      '--expected-request-revision',
+      requestRevision,
+      '--revision',
+      '2',
+      '--json',
+    ]);
+
+    expect(api.mock.calls).toEqual([
+      [
+        '/api/scheduler/drafts/automation_123/activation-preview',
+        {
+          method: 'POST',
+          body: JSON.stringify({ requestId: 'activation-1', revision: 2 }),
+        },
+      ],
+      [
+        '/api/scheduler/drafts/automation_123/activate',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            requestId: 'activation-1',
+            expectedRequestRevision: requestRevision,
+            revision: 2,
+          }),
+        },
+      ],
+    ]);
+    output.mockRestore();
+  });
 });

--- a/cli/src/commands/scheduler.ts
+++ b/cli/src/commands/scheduler.ts
@@ -5,6 +5,10 @@ import type {
   AutomationDraft,
   AutomationDraftHints,
   AutomationDraftListResponse,
+  AutomationActivationPreview,
+  AutomationActivationResult,
+  AutomationVersionListResponse,
+  AutomationBinding,
   SchedulerDueRunResult,
   SchedulerItem,
   SchedulerListResponse,
@@ -134,6 +138,118 @@ export function registerSchedulerCommands(program: Command): void {
       }
     });
 
+  drafts
+    .command('activation-preview <draftId>')
+    .description('Preview the exact standing authority for an inactive draft')
+    .requiredOption('--request-id <id>', 'Stable activation request ID')
+    .option('--revision <number>', 'Specific immutable draft revision')
+    .option('--json', 'Output as JSON')
+    .action(async (draftId, options) => {
+      try {
+        const preview = await api<AutomationActivationPreview>(
+          `/api/scheduler/drafts/${encodeURIComponent(draftId)}/activation-preview`,
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              requestId: options.requestId,
+              ...(options.revision ? { revision: Number(options.revision) } : {}),
+            }),
+          }
+        );
+        printActivationPreview(preview, Boolean(options.json));
+      } catch (err) {
+        printError(err);
+      }
+    });
+
+  drafts
+    .command('activate <draftId>')
+    .description('Request approval or activate an exact reviewed automation draft')
+    .requiredOption('--request-id <id>', 'Stable activation request ID')
+    .requiredOption('--expected-request-revision <digest>', 'Exact preview request revision')
+    .option('--revision <number>', 'Specific immutable draft revision')
+    .option('--approval-id <id>', 'Approved exact-action request ID')
+    .option('--json', 'Output as JSON')
+    .action(async (draftId, options) => {
+      try {
+        const result = await api<AutomationActivationResult>(
+          `/api/scheduler/drafts/${encodeURIComponent(draftId)}/activate`,
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              requestId: options.requestId,
+              expectedRequestRevision: options.expectedRequestRevision,
+              ...(options.revision ? { revision: Number(options.revision) } : {}),
+              ...(options.approvalId ? { approvalId: options.approvalId } : {}),
+            }),
+          }
+        );
+        if (options.json) console.log(JSON.stringify(result, null, 2));
+        else if (result.version) {
+          console.log(chalk.green(`Activated ${result.version.id}`));
+          console.log(chalk.dim(`Binding: ${result.binding?.id}`));
+        } else {
+          console.log(chalk.yellow(`Approval required: ${result.approvalId}`));
+        }
+      } catch (err) {
+        printError(err);
+      }
+    });
+
+  const automations = scheduler
+    .command('automation')
+    .description('Inspect and control immutable active automation versions');
+
+  automations
+    .command('list')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const result = await api<AutomationVersionListResponse>('/api/scheduler/automations');
+        if (options.json) console.log(JSON.stringify(result, null, 2));
+        else {
+          for (const binding of result.bindings) {
+            const version = result.versions.find(
+              (candidate) => candidate.id === binding.automationVersionId
+            );
+            console.log(`${chalk.bold(binding.id)} ${binding.status}`);
+            console.log(`  ${version?.objective ?? binding.automationVersionId}`);
+            console.log(
+              `  version=${binding.automationVersionId} next=${binding.nextRunAt ?? 'none'}`
+            );
+          }
+        }
+      } catch (err) {
+        printError(err);
+      }
+    });
+
+  for (const action of ['pause', 'resume', 'revoke'] as const) {
+    automations
+      .command(`${action} <bindingId>`)
+      .requiredOption('--expected-revision <number>', 'Exact binding revision')
+      .requiredOption('--reason <text>', 'Operator reason')
+      .option('--json', 'Output as JSON')
+      .action(async (bindingId, options) => {
+        try {
+          const binding = await api<AutomationBinding>(
+            `/api/scheduler/automations/${encodeURIComponent(bindingId)}/${action}`,
+            {
+              method: 'POST',
+              body: JSON.stringify({
+                expectedRevision: Number(options.expectedRevision),
+                reason: options.reason,
+              }),
+            }
+          );
+          if (options.json) console.log(JSON.stringify(binding, null, 2));
+          else console.log(chalk.green(`${action}: ${binding.id} is ${binding.status}`));
+        } catch (err) {
+          printError(err);
+        }
+      });
+  }
+
   scheduler
     .command('list')
     .alias('status')
@@ -253,6 +369,22 @@ function printDraft(draft: AutomationDraft, json: boolean): void {
   console.log(
     `  schedule=${draft.schedule.expression.value ?? 'unresolved'} timezone=${draft.schedule.timezone.value ?? 'unresolved'}`
   );
+}
+
+function printActivationPreview(preview: AutomationActivationPreview, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(preview, null, 2));
+    return;
+  }
+  console.log(chalk.bold(`${preview.draftId} revision=${preview.draftRevision}`));
+  console.log(`  requestRevision=${preview.requestRevision}`);
+  console.log(`  workflow=${preview.evidence.workflowId}@${preview.evidence.workflowVersion}`);
+  console.log(`  provider=${preview.evidence.provider} expires=${preview.schedule.expiresAt}`);
+  console.log(`  tools=${preview.effectiveRunAccess.tools.join(', ') || 'none'}`);
+  if (preview.evidence.blockers.length > 0) {
+    for (const blocker of preview.evidence.blockers)
+      console.log(chalk.red(`  blocked: ${blocker}`));
+  }
 }
 
 async function runItemAction(

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1897,6 +1897,7 @@ Item IDs use the source prefix:
 - `scheduled-deliverable:<deliverableId>`
 - `workflow:<workflowId>`
 - `queue-monitor:<monitorId>`
+- `automation:<bindingId>`
 
 ### Run Item Now
 
@@ -1965,6 +1966,28 @@ DELETE /api/scheduler/drafts/:id?confirm=:id
 ```
 
 Revision accepts the same body as preview and appends an immutable version. Clone requires a new stable `requestId`. Delete requires the exact draft ID in the `confirm` query parameter and removes only inactive draft revisions. These write endpoints require `workflow:write`; none can activate recurring work.
+
+### Preview and Activate an Immutable Automation Version
+
+```
+POST /api/scheduler/drafts/:id/activation-preview
+POST /api/scheduler/drafts/:id/activate
+```
+
+Preview accepts a stable `requestId` and optional exact draft `revision`. It returns `automation-activation-preview/v1`, including the effective Run Access ceiling, safe tool/integration/target names, current workflow and provider evidence, expiry, budgets, blockers, and deterministic `requestRevision`.
+
+Activate requires the same request identity plus `expectedRequestRevision`. Without `approvalId`, it creates a critical exact-action Run Approval and returns `202`. After human approval, retry the identical body with the approval ID. A current-evidence mismatch returns `409`; an enforceability blocker returns a validation error. Success returns the immutable `automation-version/v1` and its compare-and-set scheduler binding.
+
+### Inspect and Control Active Automations
+
+```
+GET /api/scheduler/automations
+POST /api/scheduler/automations/:bindingId/pause
+POST /api/scheduler/automations/:bindingId/resume
+POST /api/scheduler/automations/:bindingId/revoke
+```
+
+The list returns immutable versions, current bindings, and recent durable run claims. Control bodies require `expectedRevision` and `reason`. Revocation is permanent. Every due or manual run claims one exact due window before entering normal workflow admission; duplicate claims never create a second provider-side launch.
 
 ---
 

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -798,25 +798,33 @@ Manage automation tasks.
 
 Inspect and control recurring work from the terminal.
 
-| Command                      | Description                                       |
-| ---------------------------- | ------------------------------------------------- |
-| `vk scheduler list`          | List recurring scheduler items and recent events  |
-| `vk scheduler run-due`       | Run all due scheduler items                       |
-| `vk scheduler run <id>`      | Run one scheduler item now                        |
-| `vk scheduler pause <id>`    | Pause one scheduler item                          |
-| `vk scheduler resume <id>`   | Resume one scheduler item                         |
-| `vk scheduler validate <id>` | Validate one scheduler item                       |
-| `vk scheduler draft preview` | Compile intent without saving or activating       |
-| `vk scheduler draft save`    | Save an inactive draft                            |
-| `vk scheduler draft list`    | List latest inactive draft revisions              |
-| `vk scheduler draft show`    | Inspect a latest or exact draft revision          |
-| `vk scheduler draft revise`  | Append an immutable inactive revision             |
-| `vk scheduler draft clone`   | Clone an inactive draft                           |
-| `vk scheduler draft delete`  | Delete inactive revisions with exact confirmation |
+| Command                                 | Description                                       |
+| --------------------------------------- | ------------------------------------------------- |
+| `vk scheduler list`                     | List recurring scheduler items and recent events  |
+| `vk scheduler run-due`                  | Run all due scheduler items                       |
+| `vk scheduler run <id>`                 | Run one scheduler item now                        |
+| `vk scheduler pause <id>`               | Pause one scheduler item                          |
+| `vk scheduler resume <id>`              | Resume one scheduler item                         |
+| `vk scheduler validate <id>`            | Validate one scheduler item                       |
+| `vk scheduler draft preview`            | Compile intent without saving or activating       |
+| `vk scheduler draft save`               | Save an inactive draft                            |
+| `vk scheduler draft list`               | List latest inactive draft revisions              |
+| `vk scheduler draft show`               | Inspect a latest or exact draft revision          |
+| `vk scheduler draft revise`             | Append an immutable inactive revision             |
+| `vk scheduler draft clone`              | Clone an inactive draft                           |
+| `vk scheduler draft delete`             | Delete inactive revisions with exact confirmation |
+| `vk scheduler draft activation-preview` | Review exact standing authority and evidence      |
+| `vk scheduler draft activate`           | Request approval or activate the approved version |
+| `vk scheduler automation list`          | List immutable versions, bindings, and claims     |
+| `vk scheduler automation pause`         | Pause a binding with compare-and-set              |
+| `vk scheduler automation resume`        | Resume a binding with compare-and-set             |
+| `vk scheduler automation revoke`        | Permanently revoke a binding                      |
 
 Item IDs include a source prefix: `scheduled-deliverable:<id>`, `workflow:<id>`, or `queue-monitor:<id>`.
 
-Draft preview, save, and revise require `--intent` and `--request-id`; optional structured values are supplied through `--hints '<json>'`. Use `--json` to receive the exact `automation-draft/v1` body shown by the Settings preview. Preview requires `workflow:read`; mutations require `workflow:write`. Draft commands never activate a schedule.
+Draft preview, save, and revise require `--intent` and `--request-id`; optional structured values are supplied through `--hints '<json>'`. Use `--json` to receive the exact `automation-draft/v1` body shown by the Settings preview. Preview requires `workflow:read`; mutations require `workflow:write`.
+
+Activation preview returns the exact `requestRevision`. Pass it to `draft activate` to create a Run Approval, approve that request in Run Approvals, then repeat the identical command with `--approval-id`. Pause, resume, and revoke require the binding's current `--expected-revision` plus an operator reason.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1496,7 +1496,10 @@ Unified operator surface for scheduled deliverables, scheduled workflow definiti
 - **Operations telemetry** — Scheduler events emit bounded run telemetry with `agent=scheduler` for operations digest visibility
 - **Custom cron guardrail** — Cron schedules are visible and manually runnable, but automatic custom-cron due execution is deferred until a cron adapter is configured
 - **Automation draft compiler** — Natural recurring intent and structured hints compile into inactive `automation-draft/v1` previews with timezone-aware run examples, field provenance, standing scope, budgets, stop conditions, redaction, and exact blockers
-- **No activation side effect** — Preview, save, revise, clone, and delete operations never create scheduler definitions, reservations, runs, provider queues, approvals, or external actions
+- **Exact activation review** — Operators review the same Run Access vocabulary, current workflow/provider/tool/integration evidence, expiry, outputs, and budgets before critical human approval
+- **Immutable active versions** — Approval creates one `automation-version/v1` and compare-and-set binding; later draft edits cannot mutate active authority
+- **Durable due-window ownership** — Each manual or due run persists a stable claim before shared workflow admission, preventing duplicate provider launches across ticks and restarts
+- **Fail-closed lifecycle** — Pause, revoke, expiry, evidence drift, aggregate budget exhaustion, and repeated failure stop future claims without deleting history
 
 → [Full guide](features/recurring-work-scheduler.md) — API, CLI, execution model, and scheduler guardrails
 

--- a/docs/features/recurring-work-scheduler.md
+++ b/docs/features/recurring-work-scheduler.md
@@ -8,6 +8,7 @@ It currently surfaces:
 - workflow definitions with enabled non-manual schedules
 - workflow scheduled-snapshot outputs
 - queue intake monitors
+- immutable, operator-approved automation versions
 
 ## Operator Controls
 
@@ -43,7 +44,17 @@ Consequential values are never silently defaulted. Each field records its value,
 
 The standing-scope object separately lists reads, writes, sends, external targets, artifact destinations, integration and credential definition IDs, tools, and approval-required actions. Draft serialization removes URL credentials, query strings, fragments, and common inline secret assignments. Only safe integration identifiers are persisted; raw integration configuration and credential values are not accepted.
 
-Saved revisions remain inactive and immutable. Revision, clone, and delete operations touch only the bounded `drafts` collection in scheduler state. Activation is intentionally a separate future workflow.
+Saved revisions remain inactive and immutable. Revision, clone, and delete operations touch only the bounded `drafts` collection in scheduler state.
+
+## Automation Activation
+
+Activation is a separate exact-approval workflow. `automation-activation-preview/v1` binds the selected draft digest and revision to the current workflow version, provider support, tool and integration evidence, output destination, standing scope, per-run and aggregate budgets, expiry, and stop conditions. The returned `requestRevision` is a compare-and-set token. Any target or evidence change produces a different revision and invalidates the pending decision.
+
+The first activate call creates a critical Run Approval and returns `202`. After a freshly authenticated human approves that exact action in Run Approvals, retry the identical activation with its approval ID. Veritas then atomically creates an immutable `automation-version/v1` and mutable `automation-binding/v1`. Editing a draft never mutates an active version.
+
+Each due or manual execution first persists one `automation-run-claim/v1` for the exact version and due window. Duplicate ticks return the existing claim and do not dispatch again. Accepted runs enter the normal workflow admission controller with a stable automation idempotency key and an execution-tree root anchored to the immutable version. The saved tool scope is intersected with current workflow policy, and the normal launch, phase, provider, credential, approval, and admission controls may narrow or block it.
+
+Pause, revoke, expiry, workflow or integration drift, exhausted aggregate runs/cost/tokens/duration, and repeated launch failures stop future acceptance while preserving versions, claims, and scheduler events. A consequential action listed as approval-required still uses a per-run exact-action approval; it never widens the saved standing scope.
 
 ## CLI
 
@@ -62,6 +73,13 @@ vk scheduler draft show automation_ID --json
 vk scheduler draft revise automation_ID --intent "Every weekday at 8 AM create a support report" --request-id draft-revise --hints '{"timezone":"America/Chicago"}' --json
 vk scheduler draft clone automation_ID --request-id draft-clone --json
 vk scheduler draft delete automation_ID --confirm automation_ID --json
+vk scheduler draft activation-preview automation_ID --request-id activation-1 --revision 2 --json
+vk scheduler draft activate automation_ID --request-id activation-1 --expected-request-revision sha256:DIGEST --revision 2 --json
+vk scheduler draft activate automation_ID --request-id activation-1 --expected-request-revision sha256:DIGEST --revision 2 --approval-id runapproval_ID --json
+vk scheduler automation list --json
+vk scheduler automation pause automation_binding_ID --expected-revision 1 --reason "Maintenance window"
+vk scheduler automation resume automation_binding_ID --expected-revision 2 --reason "Maintenance complete"
+vk scheduler automation revoke automation_binding_ID --expected-revision 3 --reason "No longer authorized"
 ```
 
 Use `--json` on any command for automation-friendly output.
@@ -70,19 +88,25 @@ Use `--json` on any command for automation-friendly output.
 
 Mounted at `/api/scheduler`.
 
-| Method   | Path                                  | Description                     |
-| -------- | ------------------------------------- | ------------------------------- |
-| `GET`    | `/api/scheduler`                      | List scheduler items and events |
-| `GET`    | `/api/scheduler/items/:id`            | Read one scheduler item         |
-| `POST`   | `/api/scheduler/items/:id/run`        | Run one scheduler item now      |
-| `POST`   | `/api/scheduler/items/:id/pause`      | Pause one scheduler item        |
-| `POST`   | `/api/scheduler/items/:id/resume`     | Resume one scheduler item       |
-| `POST`   | `/api/scheduler/items/:id/validate`   | Validate one scheduler item     |
-| `POST`   | `/api/scheduler/due/run`              | Run all items due now           |
-| `POST`   | `/api/scheduler/drafts/preview`       | Compile without saving          |
-| `GET`    | `/api/scheduler/drafts`               | List latest inactive revisions  |
-| `POST`   | `/api/scheduler/drafts`               | Save an inactive draft          |
-| `GET`    | `/api/scheduler/drafts/:id`           | Read a draft revision           |
-| `POST`   | `/api/scheduler/drafts/:id/revisions` | Append an immutable revision    |
-| `POST`   | `/api/scheduler/drafts/:id/clone`     | Clone as another inactive draft |
-| `DELETE` | `/api/scheduler/drafts/:id`           | Delete all inactive revisions   |
+| Method   | Path                                           | Description                                    |
+| -------- | ---------------------------------------------- | ---------------------------------------------- |
+| `GET`    | `/api/scheduler`                               | List scheduler items and events                |
+| `GET`    | `/api/scheduler/items/:id`                     | Read one scheduler item                        |
+| `POST`   | `/api/scheduler/items/:id/run`                 | Run one scheduler item now                     |
+| `POST`   | `/api/scheduler/items/:id/pause`               | Pause one scheduler item                       |
+| `POST`   | `/api/scheduler/items/:id/resume`              | Resume one scheduler item                      |
+| `POST`   | `/api/scheduler/items/:id/validate`            | Validate one scheduler item                    |
+| `POST`   | `/api/scheduler/due/run`                       | Run all items due now                          |
+| `POST`   | `/api/scheduler/drafts/preview`                | Compile without saving                         |
+| `GET`    | `/api/scheduler/drafts`                        | List latest inactive revisions                 |
+| `POST`   | `/api/scheduler/drafts`                        | Save an inactive draft                         |
+| `GET`    | `/api/scheduler/drafts/:id`                    | Read a draft revision                          |
+| `POST`   | `/api/scheduler/drafts/:id/revisions`          | Append an immutable revision                   |
+| `POST`   | `/api/scheduler/drafts/:id/clone`              | Clone as another inactive draft                |
+| `DELETE` | `/api/scheduler/drafts/:id`                    | Delete all inactive revisions                  |
+| `POST`   | `/api/scheduler/drafts/:id/activation-preview` | Preview exact standing authority               |
+| `POST`   | `/api/scheduler/drafts/:id/activate`           | Request approval or activate the exact version |
+| `GET`    | `/api/scheduler/automations`                   | List versions, bindings, and recent claims     |
+| `POST`   | `/api/scheduler/automations/:bindingId/pause`  | Pause with compare-and-set                     |
+| `POST`   | `/api/scheduler/automations/:bindingId/resume` | Resume with compare-and-set                    |
+| `POST`   | `/api/scheduler/automations/:bindingId/revoke` | Permanently revoke with compare-and-set        |

--- a/server/src/__tests__/automation-activation-service.test.ts
+++ b/server/src/__tests__/automation-activation-service.test.ts
@@ -1,0 +1,388 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type {
+  AutomationDraftCompileInput,
+  RunApprovalRequest,
+  TaskTemplate,
+  WorkflowDefinition,
+} from '@veritas-kanban/shared';
+import { AutomationActivationService } from '../services/automation-activation-service.js';
+import { AutomationDraftService } from '../services/automation-draft-service.js';
+import { FileSchedulerStateRepository } from '../storage/scheduler-state-repository.js';
+
+describe('AutomationActivationService', () => {
+  let root: string;
+  let repository: FileSchedulerStateRepository;
+  let drafts: AutomationDraftService;
+  let workflow: WorkflowDefinition;
+  let approval: RunApprovalRequest;
+  let now: Date;
+  let savedWorkflow: WorkflowDefinition | undefined;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(process.cwd(), '.veritas-automation-activation-'));
+    repository = new FileSchedulerStateRepository(path.join(root, 'scheduler-state.json'));
+    now = new Date('2026-08-30T15:00:00.000Z');
+    workflow = workflowFixture();
+    savedWorkflow = undefined;
+    drafts = new AutomationDraftService({
+      stateRepository: repository,
+      now: () => now,
+      workflowExists: async (id) => id === workflow.id,
+      taskExists: async (id) => id === 'task-source',
+      templateExists: async () => false,
+      integrationReady: async (id) => id === 'teams-reviewed',
+      providerSupported: (id) => id === 'openclaw',
+      listSchedulerItems: async () => [],
+    });
+    approval = approvalFixture();
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('requires exact approval before atomically persisting an immutable version and binding', async () => {
+    const draft = await drafts.save(completeInput());
+    const service = activationService();
+    const preview = await service.preview(draft.id, 'activate-stable', draft.revision);
+
+    expect(preview).toMatchObject({
+      draftDigest: draft.digest,
+      workspaceId: 'workspace-1',
+      evidence: { workflowId: workflow.id, workflowVersion: 3, enforceable: true },
+      approval: { required: true, riskClass: 'critical' },
+    });
+    expect(preview.effectiveRunAccess).toMatchObject({
+      tools: ['support-read', 'work-product-write'],
+      integrations: ['teams-reviewed'],
+    });
+
+    const pending = await service.apply({
+      draftId: draft.id,
+      revision: draft.revision,
+      requestId: preview.requestId,
+      expectedRequestRevision: preview.requestRevision,
+    });
+    expect(pending).toMatchObject({ approvalId: approval.id, approvalStatus: 'pending' });
+    expect((await repository.read()).automationVersions).toEqual({});
+
+    approval = {
+      ...approval,
+      status: 'approved',
+      revision: 2,
+      resolution: {
+        decision: 'approved',
+        actor: { id: 'operator-1', type: 'user', workspaceId: 'workspace-1' },
+        decidedAt: '2026-08-30T15:01:00.000Z',
+      },
+    };
+    const activated = await service.apply({
+      draftId: draft.id,
+      revision: draft.revision,
+      requestId: preview.requestId,
+      expectedRequestRevision: preview.requestRevision,
+      approvalId: approval.id,
+    });
+
+    expect(activated.version).toMatchObject({
+      draftDigest: draft.digest,
+      workflowId: workflow.id,
+      workflowVersion: 3,
+      approval: { id: approval.id, revision: 2, approvedBy: 'operator-1' },
+    });
+    expect(activated.binding).toMatchObject({ status: 'active', acceptedRuns: 0, revision: 1 });
+
+    const replay = await service.apply({
+      draftId: draft.id,
+      revision: draft.revision,
+      requestId: preview.requestId,
+      expectedRequestRevision: preview.requestRevision,
+      approvalId: approval.id,
+    });
+    expect(replay.version?.id).toBe(activated.version?.id);
+    expect((await service.list()).versions).toHaveLength(1);
+  });
+
+  it('invalidates stale previews when workflow evidence changes', async () => {
+    const draft = await drafts.save(completeInput());
+    const service = activationService();
+    const preview = await service.preview(draft.id, 'activate-stale');
+    workflow = { ...workflow, version: 4 };
+
+    await expect(
+      service.apply({
+        draftId: draft.id,
+        requestId: preview.requestId,
+        expectedRequestRevision: preview.requestRevision,
+      })
+    ).rejects.toThrow(/preview is stale/i);
+  });
+
+  it('claims each due window once and blocks future ownership after pause or budget exhaustion', async () => {
+    const draft = await drafts.save(completeInput());
+    const service = activationService();
+    const preview = await service.preview(draft.id, 'activate-claims');
+    approval = {
+      ...approval,
+      status: 'approved',
+      revision: 2,
+      resolution: {
+        decision: 'approved',
+        actor: { id: 'operator-1', workspaceId: 'workspace-1' },
+        decidedAt: now.toISOString(),
+      },
+    };
+    const activated = await service.apply({
+      draftId: draft.id,
+      requestId: preview.requestId,
+      expectedRequestRevision: preview.requestRevision,
+      approvalId: approval.id,
+    });
+    const binding = activated.binding;
+    if (!binding) throw new Error('Expected binding');
+
+    const first = await service.claimRun(binding.id, 'manual-run', now);
+    const duplicate = await service.claimRun(binding.id, 'manual-run', now);
+    expect(first).toMatchObject({ replayed: false, claim: { status: 'accepted' } });
+    expect(duplicate).toMatchObject({ replayed: true, claim: { id: first.claim.id } });
+
+    const paused = await service.updateBinding(
+      binding.id,
+      first.binding.revision,
+      'paused',
+      'Operator pause.'
+    );
+    now = new Date('2026-08-30T15:02:00.000Z');
+    const blocked = await service.claimRun(paused.id, 'manual-run', now);
+    expect(blocked.claim).toMatchObject({
+      status: 'blocked',
+      reason: 'Automation binding is paused.',
+    });
+    expect(blocked.binding.status).toBe('blocked');
+  });
+
+  it('records consecutive failures idempotently and resets them after a completed run', async () => {
+    const draft = await drafts.save(completeInput());
+    const service = activationService();
+    const preview = await service.preview(draft.id, 'activate-retries');
+    approval = {
+      ...approval,
+      status: 'approved',
+      revision: 2,
+      resolution: {
+        decision: 'approved',
+        actor: { id: 'operator-1', workspaceId: 'workspace-1' },
+        decidedAt: now.toISOString(),
+      },
+    };
+    const activated = await service.apply({
+      draftId: draft.id,
+      requestId: preview.requestId,
+      expectedRequestRevision: preview.requestRevision,
+      approvalId: approval.id,
+    });
+    if (!activated.binding) throw new Error('Expected binding');
+
+    const failedClaim = await service.claimRun(activated.binding.id, 'manual-run', now);
+    await service.markRunStarted(failedClaim.claim.id, 'run-failed');
+    await service.markRunFailed(failedClaim.claim.id, 'Temporary provider failure.');
+    await service.markRunFailed(failedClaim.claim.id, 'Temporary provider failure.');
+    expect((await service.list()).bindings[0].failedRuns).toBe(1);
+
+    now = new Date('2026-08-30T15:01:00.000Z');
+    const completedClaim = await service.claimRun(activated.binding.id, 'manual-run', now);
+    await service.markRunStarted(completedClaim.claim.id, 'run-completed');
+    await service.markRunCompleted(completedClaim.claim.id, {
+      costUsd: 0.1,
+      tokens: 1_000,
+      durationMinutes: 2,
+    });
+    expect((await service.list()).bindings[0]).toMatchObject({
+      failedRuns: 0,
+      aggregateUsage: { runs: 2, costUsd: 0.1, tokens: 1_000, durationMinutes: 2 },
+    });
+  });
+
+  it('binds a task-template digest and persists its deterministic workflow only after approval', async () => {
+    const template = taskTemplateFixture();
+    const templateDrafts = new AutomationDraftService({
+      stateRepository: repository,
+      now: () => now,
+      workflowExists: async () => false,
+      taskExists: async (id) => id === 'task-source',
+      templateExists: async (id) => id === template.id,
+      integrationReady: async (id) => id === 'teams-reviewed',
+      providerSupported: (id) => id === 'openclaw',
+      listSchedulerItems: async () => [],
+    });
+    const input = completeInput();
+    input.hints = {
+      ...input.hints,
+      workflowId: undefined,
+      taskTemplateId: template.id,
+    };
+    const draft = await templateDrafts.save(input);
+    const service = activationService(templateDrafts, template);
+    const preview = await service.preview(draft.id, 'activate-template');
+    expect(preview.evidence.sourceTarget).toMatchObject({
+      kind: 'task-template',
+      id: template.id,
+      version: template.version,
+    });
+    expect(savedWorkflow).toBeUndefined();
+
+    approval = {
+      ...approval,
+      status: 'approved',
+      revision: 2,
+      resolution: {
+        decision: 'approved',
+        actor: { id: 'operator-1', workspaceId: 'workspace-1' },
+        decidedAt: now.toISOString(),
+      },
+    };
+    const result = await service.apply({
+      draftId: draft.id,
+      requestId: preview.requestId,
+      expectedRequestRevision: preview.requestRevision,
+      approvalId: approval.id,
+    });
+    expect(savedWorkflow).toMatchObject({
+      id: result.version?.workflowId,
+      agents: [expect.objectContaining({ provider: 'openclaw' })],
+    });
+    expect(result.version?.evidence.sourceTarget.digest).toBe(preview.evidence.sourceTarget.digest);
+  });
+
+  function activationService(
+    draftService: AutomationDraftService = drafts,
+    template: TaskTemplate | null = null
+  ): AutomationActivationService {
+    return new AutomationActivationService({
+      stateRepository: repository,
+      drafts: draftService,
+      workflows: {
+        loadWorkflow: async (id) =>
+          id === workflow.id ? workflow : savedWorkflow?.id === id ? savedWorkflow : null,
+        saveWorkflow: async (candidate) => {
+          savedWorkflow = candidate;
+        },
+      },
+      templates: { getTemplate: async (id) => (template?.id === id ? template : null) },
+      approvals: {
+        request: async (input) => ({
+          ...approval,
+          workspaceId: input.workspaceId ?? 'local',
+          taskId: input.taskId,
+          attemptId: input.attemptId,
+          provider: input.provider,
+          providerRequestId: input.providerRequestId,
+          evidenceRevision: input.evidenceRevision,
+        }),
+        get: async () => approval,
+      },
+      integrationEvidence: async (ids) => ids.map((id) => ({ id, ready: id === 'teams-reviewed' })),
+      toolPolicyEvidence: async () => ({
+        support: { allowed: ['support-read', 'work-product-write'], denied: [] },
+      }),
+      now: () => now,
+    });
+  }
+});
+
+function workflowFixture(): WorkflowDefinition {
+  return {
+    id: 'support-triage',
+    name: 'Support triage',
+    version: 3,
+    description: 'Review support queue.',
+    agents: [
+      {
+        id: 'triage-agent',
+        name: 'Triage agent',
+        role: 'support',
+        provider: 'openclaw',
+        description: 'Reviews support queue.',
+        tools: ['support-read', 'work-product-write'],
+      },
+    ],
+    steps: [
+      { id: 'triage', name: 'Triage', type: 'agent', agent: 'triage-agent', input: 'Review.' },
+    ],
+    variables: {},
+  };
+}
+
+function taskTemplateFixture(): TaskTemplate {
+  return {
+    id: 'template_support_triage',
+    name: 'Support triage',
+    description: 'Produce a bounded support triage report.',
+    version: 1,
+    taskDefaults: { type: 'automation', priority: 'medium', project: 'support' },
+    created: '2026-08-01T00:00:00.000Z',
+    updated: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+function completeInput(): AutomationDraftCompileInput {
+  return {
+    intent: 'Every weekday at 9 AM review the support queue and produce a triage report.',
+    requestId: 'draft-request',
+    requestedBy: 'operator-1',
+    hints: {
+      workspaceId: 'workspace-1',
+      sourceTaskId: 'task-source',
+      workflowId: 'support-triage',
+      provider: 'openclaw',
+      timezone: 'America/Chicago',
+      expiresAt: '2026-12-31T23:59:59.000Z',
+      overlapPolicy: 'forbid',
+      retry: { maxAttempts: 2, backoffMinutes: 15 },
+      outputDestination: 'work-products/triage',
+      expectedDeliverables: ['Triage report'],
+      standingScope: {
+        reads: ['support-queue'],
+        writes: ['work-products/triage'],
+        sends: [],
+        externalTargets: [],
+        artifactDestinations: ['work-products/triage'],
+        integrationIds: ['teams-reviewed'],
+        toolIds: ['support-read', 'work-product-write'],
+        credentialDefinitionIds: [],
+        approvalRequiredActions: ['write work product'],
+      },
+      perRunBudget: { maxRuns: 1, maxTokens: 100_000, maxDurationMinutes: 30 },
+      aggregateBudget: { maxRuns: 20, maxTokens: 2_000_000, maxDurationMinutes: 600 },
+      stopConditions: ['expiry reached', 'aggregate budget exhausted'],
+    },
+  };
+}
+
+function approvalFixture(): RunApprovalRequest {
+  return {
+    schemaVersion: 'run-approval/v1',
+    id: 'runapproval_Automation123456',
+    workspaceId: 'workspace-1',
+    taskId: 'task-source',
+    attemptId: 'activation-attempt',
+    provider: 'openclaw',
+    agentId: 'scheduler',
+    requestKind: 'approval',
+    actionClass: 'workflow',
+    action: 'Activate automation',
+    actionHash: 'a'.repeat(64),
+    resourceScope: [],
+    riskClass: 'critical',
+    evidenceRevision: `sha256:${'b'.repeat(64)}`,
+    providerRequestId: 'activate-stable',
+    mobileSafe: false,
+    status: 'pending',
+    revision: 1,
+    createdAt: '2026-08-30T15:00:00.000Z',
+    updatedAt: '2026-08-30T15:00:00.000Z',
+    expiresAt: '2026-08-30T15:15:00.000Z',
+  };
+}

--- a/server/src/__tests__/automation-activation-service.test.ts
+++ b/server/src/__tests__/automation-activation-service.test.ts
@@ -120,6 +120,18 @@ describe('AutomationActivationService', () => {
     ).rejects.toThrow(/preview is stale/i);
   });
 
+  it('rejects prototype property names before reading or writing automation maps', async () => {
+    const service = activationService();
+
+    await expect(service.getVersion('__proto__')).rejects.toThrow(/invalid automation version id/i);
+    await expect(
+      service.updateBinding('__proto__', 1, 'paused', 'Invalid target.')
+    ).rejects.toThrow(/invalid automation binding id/i);
+    await expect(service.claimRun('__proto__', 'manual-run', now)).rejects.toThrow(
+      /invalid automation binding id/i
+    );
+  });
+
   it('claims each due window once and blocks future ownership after pause or budget exhaustion', async () => {
     const draft = await drafts.save(completeInput());
     const service = activationService();

--- a/server/src/__tests__/scheduler-service.test.ts
+++ b/server/src/__tests__/scheduler-service.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import type { QueueMonitorSnapshot, WorkflowDefinition } from '@veritas-kanban/shared';
+import type {
+  AutomationBinding,
+  AutomationRunClaim,
+  AutomationVersion,
+  QueueMonitorSnapshot,
+  WorkflowDefinition,
+} from '@veritas-kanban/shared';
 import { SchedulerService } from '../services/scheduler-service.js';
 import {
   ScheduledDeliverablesService,
@@ -186,6 +192,83 @@ describe('SchedulerService', () => {
     );
   });
 
+  it('claims an immutable automation version before shared workflow admission', async () => {
+    const version = automationVersionFixture();
+    const binding = automationBindingFixture(version);
+    const claim = automationClaimFixture(version, binding);
+    const automationService = {
+      list: vi.fn(async () => ({
+        generatedAt: '2026-06-05T09:00:00.000Z',
+        versions: [version],
+        bindings: [binding],
+        recentClaims: [],
+      })),
+      claimRun: vi.fn(async () => ({ claim, version, binding, replayed: false })),
+      markRunStarted: vi.fn(async (_claimId, workflowRunId) => ({
+        ...claim,
+        status: 'started',
+        workflowRunId,
+      })),
+      markRunFailed: vi.fn(),
+      markRunCompleted: vi.fn(),
+      updateBinding: vi.fn(),
+    };
+    const workflowRunService = {
+      getRun: vi.fn(async () => null),
+      startRun: vi.fn(async () => ({
+        id: 'run_1780664400000_started',
+        workflowId: version.workflowId,
+        workflowVersion: version.workflowVersion,
+        status: 'running',
+        context: {},
+        startedAt: '2026-06-05T09:00:00.000Z',
+        steps: [],
+      })),
+    };
+    const service = new SchedulerService({
+      stateFile: path.join(testRoot, 'scheduler-state.json'),
+      deliverablesService,
+      workflowService,
+      workflowRunService: workflowRunService as never,
+      queueMonitorService: emptyQueueMonitorService() as never,
+      telemetryService: telemetry as never,
+      automationService: automationService as never,
+    });
+
+    const result = await service.runItem(
+      `automation:${binding.id}`,
+      'manual-run',
+      new Date('2026-06-05T09:00:00.000Z')
+    );
+
+    expect(automationService.claimRun).toHaveBeenCalledWith(
+      binding.id,
+      'manual-run',
+      new Date('2026-06-05T09:00:00.000Z')
+    );
+    expect(workflowRunService.startRun).toHaveBeenCalledWith(
+      version.workflowId,
+      version.sourceTaskId,
+      expect.objectContaining({ scheduler: expect.objectContaining({ trigger: 'manual-run' }) }),
+      expect.objectContaining({ scope: 'run' }),
+      expect.objectContaining({
+        automationVersionId: version.id,
+        bindingId: binding.id,
+        claimId: claim.id,
+        requestId: claim.requestId,
+        standingScope: version.standingScope,
+      })
+    );
+    expect(automationService.markRunStarted).toHaveBeenCalledWith(
+      claim.id,
+      'run_1780664400000_started'
+    );
+    expect(result.event).toMatchObject({
+      status: 'started',
+      sourceRunId: 'run_1780664400000_started',
+    });
+  });
+
   function schedulerService(): SchedulerService {
     return new SchedulerService({
       stateFile: path.join(testRoot, 'scheduler-state.json'),
@@ -299,5 +382,109 @@ function workflowDefinition(overrides: Partial<WorkflowDefinition> = {}): Workfl
     schedule: { mode: 'weekly', enabled: true, timezone: 'UTC' },
     outputTargets: [{ type: 'scheduled-snapshot', label: 'Snapshot', required: true }],
     ...overrides,
+  };
+}
+
+function automationVersionFixture(): AutomationVersion {
+  return {
+    schemaVersion: 'automation-version/v1',
+    id: 'automation_version_aaaaaaaaaaaaaaaaaaaaaaaa',
+    version: 1,
+    draftId: 'automation_bbbbbbbbbbbbbbbbbbbbbbbb',
+    draftRevision: 1,
+    draftDigest: `scrypt:${'c'.repeat(64)}`,
+    requestRevision: `sha256:${'d'.repeat(64)}`,
+    workspaceId: 'workspace-1',
+    sourceTaskId: 'task-source',
+    objective: 'Review support queue.',
+    workflowId: 'support-triage',
+    workflowVersion: 3,
+    provider: 'openclaw',
+    schedule: {
+      expression: '0 9 * * 1-5',
+      timezone: 'UTC',
+      expiresAt: '2026-12-31T23:59:59.000Z',
+      overlapPolicy: 'forbid',
+      retry: { maxAttempts: 2, backoffMinutes: 15 },
+      nextRunAt: '2026-06-05T09:00:00.000Z',
+    },
+    output: { destination: 'work-products/triage', expectedDeliverables: ['Triage report'] },
+    standingScope: {
+      reads: ['support-queue'],
+      writes: ['work-products/triage'],
+      sends: [],
+      externalTargets: [],
+      artifactDestinations: ['work-products/triage'],
+      integrationIds: [],
+      toolIds: ['support-read'],
+      credentialDefinitionIds: [],
+      approvalRequiredActions: [],
+    },
+    perRunBudget: { maxRuns: 1, maxTokens: 100_000, maxDurationMinutes: 30 },
+    aggregateBudget: { maxRuns: 20, maxTokens: 2_000_000, maxDurationMinutes: 600 },
+    stopConditions: ['expiry reached'],
+    evidence: {
+      sourceTarget: {
+        kind: 'workflow',
+        id: 'support-triage',
+        version: 3,
+        digest: `sha256:${'e'.repeat(64)}`,
+      },
+      workflowId: 'support-triage',
+      workflowVersion: 3,
+      workflowDigest: `sha256:${'e'.repeat(64)}`,
+      provider: 'openclaw',
+      providerEvidenceDigest: `sha256:${'f'.repeat(64)}`,
+      toolCatalogDigest: `sha256:${'1'.repeat(64)}`,
+      integrationEvidenceDigest: `sha256:${'2'.repeat(64)}`,
+      policyDigest: `sha256:${'3'.repeat(64)}`,
+      enforceable: true,
+      blockers: [],
+    },
+    approval: {
+      id: 'runapproval_Automation123456',
+      revision: 2,
+      actionHash: '4'.repeat(64),
+      approvedBy: 'operator-1',
+      approvedAt: '2026-06-05T08:55:00.000Z',
+    },
+    activatedAt: '2026-06-05T08:56:00.000Z',
+    digest: `sha256:${'5'.repeat(64)}`,
+  };
+}
+
+function automationBindingFixture(version: AutomationVersion): AutomationBinding {
+  return {
+    schemaVersion: 'automation-binding/v1',
+    id: 'automation_binding_aaaaaaaaaaaaaaaaaaaaaaaa',
+    revision: 1,
+    automationVersionId: version.id,
+    automationVersion: version.version,
+    status: 'active',
+    nextRunAt: version.schedule.nextRunAt,
+    acceptedRuns: 0,
+    failedRuns: 0,
+    aggregateUsage: { runs: 0, costUsd: 0, tokens: 0, durationMinutes: 0 },
+    statusReason: 'Active.',
+    createdAt: '2026-06-05T08:56:00.000Z',
+    updatedAt: '2026-06-05T08:56:00.000Z',
+  };
+}
+
+function automationClaimFixture(
+  version: AutomationVersion,
+  binding: AutomationBinding
+): AutomationRunClaim {
+  return {
+    schemaVersion: 'automation-run-claim/v1',
+    id: 'automation_claim_aaaaaaaaaaaaaaaaaaaaaaaa',
+    requestId: `automation:${version.id}:manual-run:2026-06-05T09:00:00.000Z`,
+    automationVersionId: version.id,
+    bindingId: binding.id,
+    dueWindow: '2026-06-05T09:00:00.000Z',
+    trigger: 'manual-run',
+    status: 'accepted',
+    createdAt: '2026-06-05T09:00:00.000Z',
+    updatedAt: '2026-06-05T09:00:00.000Z',
   };
 }

--- a/server/src/__tests__/scheduler-state-repository.test.ts
+++ b/server/src/__tests__/scheduler-state-repository.test.ts
@@ -168,4 +168,67 @@ describe('FileSchedulerStateRepository', () => {
     await persistDrafts({ automation_ffffffffffffffffffffffff: [draft] });
     await expect(repository.read()).rejects.toThrow(/conflicting identity or revision order/i);
   });
+
+  it('validates persisted automation version, binding, and claim collections', async () => {
+    const now = '2026-08-30T15:00:00.000Z';
+    const binding = {
+      schemaVersion: 'automation-binding/v1',
+      id: 'automation_binding_aaaaaaaaaaaaaaaaaaaaaaaa',
+      revision: 1,
+      automationVersionId: 'automation_version_bbbbbbbbbbbbbbbbbbbbbbbb',
+      automationVersion: 1,
+      status: 'active',
+      acceptedRuns: 0,
+      failedRuns: 0,
+      aggregateUsage: { runs: 0, costUsd: 0, tokens: 0, durationMinutes: 0 },
+      statusReason: 'Active.',
+      createdAt: now,
+      updatedAt: now,
+    };
+    const claim = {
+      schemaVersion: 'automation-run-claim/v1',
+      id: 'automation_claim_cccccccccccccccccccccccc',
+      requestId: 'request-1',
+      automationVersionId: binding.automationVersionId,
+      bindingId: binding.id,
+      dueWindow: now,
+      trigger: 'manual-run',
+      status: 'accepted',
+      createdAt: now,
+      updatedAt: now,
+    };
+    const persistAutomation = async (overrides: Record<string, unknown>): Promise<void> => {
+      await mkdir(path.dirname(stateFile), { recursive: true });
+      await writeFile(
+        stateFile,
+        JSON.stringify({ version: 1, items: {}, events: [], ...overrides }),
+        'utf8'
+      );
+    };
+
+    await persistAutomation({
+      automationBindings: { [binding.id]: binding },
+      automationClaims: Array(1_001).fill(claim),
+    });
+    await expect(repository.read()).resolves.toMatchObject({
+      automationBindings: { [binding.id]: binding },
+      automationClaims: expect.arrayContaining([claim]),
+    });
+    expect((await repository.read()).automationClaims).toHaveLength(1_000);
+
+    await persistAutomation({ automationVersions: null });
+    await expect(repository.read()).rejects.toThrow(/versions must be a record/i);
+    await persistAutomation({ automationBindings: [] });
+    await expect(repository.read()).rejects.toThrow(/bindings must be a record/i);
+    await persistAutomation({
+      automationVersions: Object.fromEntries(
+        Array.from({ length: 501 }, (_, index) => [`version-${index}`, {}])
+      ),
+    });
+    await expect(repository.read()).rejects.toThrow(/500-record limit/i);
+    await persistAutomation({ automationBindings: { wrong: binding } });
+    await expect(repository.read()).rejects.toThrow(/conflicting identity/i);
+    await persistAutomation({ automationClaims: {} });
+    await expect(repository.read()).rejects.toThrow(/claims must be an array/i);
+  });
 });

--- a/server/src/__tests__/scheduler-state-repository.test.ts
+++ b/server/src/__tests__/scheduler-state-repository.test.ts
@@ -44,6 +44,9 @@ describe('FileSchedulerStateRepository', () => {
       items: {},
       events: [],
       drafts: {},
+      automationVersions: {},
+      automationBindings: {},
+      automationClaims: [],
     });
     await Promise.all(
       ['one', 'two'].map((id) =>

--- a/server/src/__tests__/workflow-step-executor-codex.test.ts
+++ b/server/src/__tests__/workflow-step-executor-codex.test.ts
@@ -741,6 +741,48 @@ describe('WorkflowStepExecutor Codex integration', () => {
     expect(mockResumeThread).not.toHaveBeenCalled();
   });
 
+  it('intersects role tool policy with the immutable automation ceiling', () => {
+    const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
+    const applyCeiling = (
+      executor as unknown as {
+        applyAutomationToolCeiling: (
+          run: WorkflowRun,
+          current: { allowed?: string[]; denied?: string[] }
+        ) => { allowed?: string[]; denied?: string[] };
+      }
+    ).applyAutomationToolCeiling.bind(executor);
+    const automatedRun = {
+      automation: {
+        standingScope: { toolIds: ['tool-b', 'tool-a'] },
+      },
+    } as WorkflowRun;
+    const automation = automatedRun.automation;
+    if (!automation) throw new Error('Expected automation binding fixture.');
+
+    expect(applyCeiling(automatedRun, {})).toEqual({
+      allowed: ['tool-a', 'tool-b'],
+      denied: [],
+    });
+    expect(
+      applyCeiling(automatedRun, { allowed: ['tool-b', 'tool-c'], denied: ['tool-x'] })
+    ).toEqual({
+      allowed: ['tool-b'],
+      denied: ['tool-x'],
+    });
+    expect(
+      applyCeiling(
+        {
+          ...automatedRun,
+          automation: {
+            ...automation,
+            standingScope: { ...automation.standingScope, toolIds: [] },
+          },
+        },
+        {}
+      )
+    ).toEqual({ allowed: [], denied: ['*'] });
+  });
+
   it('records governance traces for workflow gate decisions', async () => {
     const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
     const step: WorkflowStep = {

--- a/server/src/routes/scheduler.ts
+++ b/server/src/routes/scheduler.ts
@@ -4,7 +4,11 @@ import { asyncHandler } from '../middleware/async-handler.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { ForbiddenError } from '../middleware/error-handler.js';
 import { getAutomationDraftService } from '../services/automation-draft-service.js';
+import { getAutomationActivationService } from '../services/automation-activation-service.js';
 import {
+  AutomationActivationApplyBodySchema,
+  AutomationActivationPreviewBodySchema,
+  AutomationBindingActionBodySchema,
   AutomationDraftCloneBodySchema,
   AutomationDraftCompileBodySchema,
   AutomationDraftDeleteQuerySchema,
@@ -68,6 +72,56 @@ router.get(
     });
   })
 );
+
+router.post(
+  '/drafts/:draftId/activation-preview',
+  asyncHandler(async (req, res) => {
+    const parsed = AutomationActivationPreviewBodySchema.parse(req.body);
+    res.json(
+      await getAutomationActivationService().preview(
+        String(req.params.draftId),
+        parsed.requestId,
+        parsed.revision
+      )
+    );
+  })
+);
+
+router.post(
+  '/drafts/:draftId/activate',
+  asyncHandler(async (req, res) => {
+    const parsed = AutomationActivationApplyBodySchema.parse(req.body);
+    const result = await getAutomationActivationService().apply({
+      draftId: String(req.params.draftId),
+      ...parsed,
+    });
+    res.status(result.version ? 201 : 202).json(result);
+  })
+);
+
+router.get(
+  '/automations',
+  asyncHandler(async (_req, res) => {
+    res.json(await getAutomationActivationService().list());
+  })
+);
+
+for (const action of ['pause', 'resume', 'revoke'] as const) {
+  router.post(
+    `/automations/:bindingId/${action}`,
+    asyncHandler(async (req, res) => {
+      const parsed = AutomationBindingActionBodySchema.parse(req.body);
+      res.json(
+        await getAutomationActivationService().updateBinding(
+          String(req.params.bindingId),
+          parsed.expectedRevision,
+          action === 'resume' ? 'active' : action === 'pause' ? 'paused' : 'revoked',
+          parsed.reason
+        )
+      );
+    })
+  );
+}
 
 router.get(
   '/drafts/:draftId',

--- a/server/src/schemas/automation-draft-schemas.ts
+++ b/server/src/schemas/automation-draft-schemas.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { AUTOMATION_DRAFT_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import {
+  AUTOMATION_BINDING_SCHEMA_VERSION,
+  AUTOMATION_DRAFT_SCHEMA_VERSION,
+  AUTOMATION_RUN_CLAIM_SCHEMA_VERSION,
+  AUTOMATION_VERSION_SCHEMA_VERSION,
+} from '@veritas-kanban/shared';
 
 const identifier = z.string().trim().min(1).max(200);
 const boundedStringList = z.array(z.string().trim().min(1).max(1000)).max(100);
@@ -176,4 +181,143 @@ export const AutomationDraftRevisionQuerySchema = z
 
 export const AutomationDraftDeleteQuerySchema = z
   .object({ confirm: z.string().regex(/^automation_[a-f0-9]{24}$/) })
+  .strict();
+
+const evidence = z
+  .object({
+    sourceTarget: z
+      .object({
+        kind: z.enum(['workflow', 'task-template']),
+        id: identifier,
+        version: z.number().int().min(0),
+        digest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+      })
+      .strict(),
+    workflowId: identifier,
+    workflowVersion: z.number().int().min(1),
+    workflowDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    provider: identifier,
+    providerEvidenceDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    toolCatalogDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    integrationEvidenceDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    policyDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    enforceable: z.boolean(),
+    blockers: boundedStringList,
+  })
+  .strict();
+
+const activeSchedule = z
+  .object({
+    expression: z.string().min(1).max(200),
+    timezone: z.string().min(1).max(100),
+    startAt: z.iso.datetime({ offset: true }).optional(),
+    expiresAt: z.iso.datetime({ offset: true }),
+    overlapPolicy: z.enum(['skip', 'queue-one', 'forbid']),
+    retry,
+    nextRunAt: z.iso.datetime({ offset: true }).optional(),
+  })
+  .strict();
+
+export const AutomationVersionSchema = z
+  .object({
+    schemaVersion: z.literal(AUTOMATION_VERSION_SCHEMA_VERSION),
+    id: z.string().regex(/^automation_version_[a-f0-9]{24}$/),
+    version: z.number().int().min(1),
+    draftId: z.string().regex(/^automation_[a-f0-9]{24}$/),
+    draftRevision: z.number().int().min(1).max(50),
+    draftDigest: z.string().regex(/^scrypt:[a-f0-9]{64}$/),
+    requestRevision: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    workspaceId: identifier,
+    sourceTaskId: identifier.optional(),
+    objective: z.string().min(1).max(10_000),
+    workflowId: identifier,
+    workflowVersion: z.number().int().min(1),
+    provider: identifier,
+    schedule: activeSchedule,
+    output: z
+      .object({ destination: z.string().min(1).max(1000), expectedDeliverables: boundedStringList })
+      .strict(),
+    standingScope,
+    perRunBudget: budget,
+    aggregateBudget: budget,
+    stopConditions: boundedStringList,
+    evidence,
+    approval: z
+      .object({
+        id: z.string().regex(/^runapproval_[A-Za-z0-9_-]{12,32}$/),
+        revision: z.number().int().min(1),
+        actionHash: z.string().regex(/^[a-f0-9]{64}$/),
+        approvedBy: identifier,
+        approvedAt: z.iso.datetime({ offset: true }),
+      })
+      .strict(),
+    activatedAt: z.iso.datetime({ offset: true }),
+    digest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  })
+  .strict();
+
+export const AutomationBindingSchema = z
+  .object({
+    schemaVersion: z.literal(AUTOMATION_BINDING_SCHEMA_VERSION),
+    id: z.string().regex(/^automation_binding_[a-f0-9]{24}$/),
+    revision: z.number().int().min(1),
+    automationVersionId: z.string().regex(/^automation_version_[a-f0-9]{24}$/),
+    automationVersion: z.number().int().min(1),
+    status: z.enum(['active', 'paused', 'revoked', 'expired', 'blocked']),
+    nextRunAt: z.iso.datetime({ offset: true }).optional(),
+    lastRunAt: z.iso.datetime({ offset: true }).optional(),
+    acceptedRuns: z.number().int().min(0),
+    failedRuns: z.number().int().min(0),
+    aggregateUsage: z
+      .object({
+        runs: z.number().int().min(0),
+        costUsd: z.number().min(0),
+        tokens: z.number().int().min(0),
+        durationMinutes: z.number().min(0),
+      })
+      .strict(),
+    statusReason: z.string().min(1).max(2000),
+    createdAt: z.iso.datetime({ offset: true }),
+    updatedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export const AutomationRunClaimSchema = z
+  .object({
+    schemaVersion: z.literal(AUTOMATION_RUN_CLAIM_SCHEMA_VERSION),
+    id: z.string().regex(/^automation_claim_[a-f0-9]{24}$/),
+    requestId: identifier,
+    automationVersionId: z.string().regex(/^automation_version_[a-f0-9]{24}$/),
+    bindingId: z.string().regex(/^automation_binding_[a-f0-9]{24}$/),
+    dueWindow: z.iso.datetime({ offset: true }),
+    trigger: z.enum(['due-run', 'manual-run']),
+    status: z.enum(['accepted', 'started', 'completed', 'blocked', 'failed']),
+    workflowRunId: identifier.optional(),
+    reason: z.string().min(1).max(2000).optional(),
+    createdAt: z.iso.datetime({ offset: true }),
+    updatedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export const AutomationActivationPreviewBodySchema = z
+  .object({
+    revision: z.number().int().min(1).max(50).optional(),
+    requestId: identifier,
+  })
+  .strict();
+
+export const AutomationActivationApplyBodySchema = AutomationActivationPreviewBodySchema.extend({
+  expectedRequestRevision: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  approvalId: z
+    .string()
+    .regex(/^runapproval_[A-Za-z0-9_-]{12,32}$/)
+    .optional(),
+  approvalTtlMs: z.number().int().min(1_000).max(86_400_000).optional(),
+}).strict();
+
+export const AutomationBindingActionBodySchema = z
+  .object({
+    expectedRevision: z.number().int().min(1),
+    reason: z.string().trim().min(1).max(2000),
+  })
   .strict();

--- a/server/src/services/automation-activation-service.ts
+++ b/server/src/services/automation-activation-service.ts
@@ -41,6 +41,8 @@ import { getStorage } from '../storage/index.js';
 const DEFAULT_APPROVAL_TTL_MS = 15 * 60_000;
 const MAX_CLAIMS = 1_000;
 const MAX_EVENTS = 200;
+const AUTOMATION_VERSION_ID_PATTERN = /^automation_version_[a-f0-9]{24}$/;
+const AUTOMATION_BINDING_ID_PATTERN = /^automation_binding_[a-f0-9]{24}$/;
 
 export interface AutomationActivationServiceOptions {
   stateRepository?: SchedulerStateRepository;
@@ -412,6 +414,7 @@ export class AutomationActivationService {
   }
 
   async getVersion(versionId: string): Promise<AutomationVersion> {
+    assertOpaqueId(versionId, AUTOMATION_VERSION_ID_PATTERN, 'automation version');
     const version = (await this.stateRepository.read()).automationVersions[versionId];
     if (!version) throw new NotFoundError(`Automation version ${versionId} not found.`);
     return version;
@@ -423,6 +426,7 @@ export class AutomationActivationService {
     status: Extract<AutomationBindingStatus, 'active' | 'paused' | 'revoked'>,
     reason: string
   ): Promise<AutomationBinding> {
+    assertOpaqueId(bindingId, AUTOMATION_BINDING_ID_PATTERN, 'automation binding');
     let result: AutomationBinding | undefined;
     await this.stateRepository.update((state) => {
       const current = state.automationBindings[bindingId];
@@ -443,7 +447,7 @@ export class AutomationActivationService {
         revision: current.revision + 1,
         updatedAt: this.now().toISOString(),
       };
-      state.automationBindings[bindingId] = result;
+      state.automationBindings[current.id] = result;
       state.events = [
         ...state.events,
         automationEvent(
@@ -464,6 +468,7 @@ export class AutomationActivationService {
     trigger: 'due-run' | 'manual-run',
     now = this.now()
   ): Promise<AutomationRunClaimResult> {
+    assertOpaqueId(bindingId, AUTOMATION_BINDING_ID_PATTERN, 'automation binding');
     const snapshot = await this.stateRepository.read();
     const snapshotBinding = snapshot.automationBindings[bindingId];
     if (!snapshotBinding) throw new NotFoundError(`Automation binding ${bindingId} not found.`);
@@ -541,7 +546,7 @@ export class AutomationActivationService {
           updatedAt: timestamp,
         };
       }
-      state.automationBindings[bindingId] = binding;
+      state.automationBindings[binding.id] = binding;
       state.automationClaims = [...state.automationClaims, claim].slice(-MAX_CLAIMS);
       result = { claim, version, binding, replayed: false };
       return state;
@@ -895,6 +900,10 @@ async function currentToolPolicyEvidence(roles: string[]): Promise<Record<string
 function required<T>(value: T | undefined, path: string): T {
   if (value === undefined) throw new ValidationError(`Automation field ${path} is unresolved.`);
   return value;
+}
+
+function assertOpaqueId(value: string, pattern: RegExp, label: string): void {
+  if (!pattern.test(value)) throw new ValidationError(`Invalid ${label} ID.`);
 }
 
 function minuteWindow(now: Date): string {

--- a/server/src/services/automation-activation-service.ts
+++ b/server/src/services/automation-activation-service.ts
@@ -1,0 +1,953 @@
+import { createHash } from 'node:crypto';
+import {
+  AUTOMATION_ACTIVATION_PREVIEW_SCHEMA_VERSION,
+  AUTOMATION_BINDING_SCHEMA_VERSION,
+  AUTOMATION_RUN_CLAIM_SCHEMA_VERSION,
+  AUTOMATION_VERSION_SCHEMA_VERSION,
+  EXECUTABLE_AGENT_PROVIDERS,
+  type AutomationActivationPreview,
+  type AutomationActivationResult,
+  type AutomationBinding,
+  type AutomationBindingStatus,
+  type AutomationDraft,
+  type AutomationRunClaim,
+  type AutomationVersion,
+  type AutomationVersionListResponse,
+  type ExecutableAgentProvider,
+  type RunApprovalRequest,
+  type TaskTemplate,
+  type WorkflowDefinition,
+} from '@veritas-kanban/shared';
+import { ConflictError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import {
+  FileSchedulerStateRepository,
+  type SchedulerStateRepository,
+} from '../storage/scheduler-state-repository.js';
+import { getCommunicationAdapterService } from './communication-adapter-service.js';
+import { getOutboundIntegrationService } from './outbound-integration-service.js';
+import {
+  AutomationDraftService,
+  getAutomationDraftService,
+  nextAutomationRunAt,
+} from './automation-draft-service.js';
+import {
+  getRunApprovalBrokerService,
+  type RunApprovalBrokerService,
+} from './run-approval-broker-service.js';
+import { getWorkflowService, type WorkflowService } from './workflow-service.js';
+import { getToolPolicyService } from './tool-policy-service.js';
+import { getStorage } from '../storage/index.js';
+
+const DEFAULT_APPROVAL_TTL_MS = 15 * 60_000;
+const MAX_CLAIMS = 1_000;
+const MAX_EVENTS = 200;
+
+export interface AutomationActivationServiceOptions {
+  stateRepository?: SchedulerStateRepository;
+  drafts?: Pick<AutomationDraftService, 'get'>;
+  workflows?: Pick<WorkflowService, 'loadWorkflow'> &
+    Partial<Pick<WorkflowService, 'saveWorkflow'>>;
+  templates?: { getTemplate(id: string): Promise<TaskTemplate | null> };
+  approvals?: Pick<RunApprovalBrokerService, 'request' | 'get'>;
+  integrationEvidence?: (
+    ids: string[]
+  ) => Promise<Array<{ id: string; ready: boolean; evidenceDigest?: string }>>;
+  toolPolicyEvidence?: (roles: string[]) => Promise<Record<string, unknown>>;
+  now?: () => Date;
+}
+
+export interface AutomationActivationApplyInput {
+  draftId: string;
+  revision?: number;
+  requestId: string;
+  expectedRequestRevision: string;
+  approvalId?: string;
+  approvalTtlMs?: number;
+}
+
+export interface AutomationRunClaimResult {
+  claim: AutomationRunClaim;
+  version: AutomationVersion;
+  binding: AutomationBinding;
+  replayed: boolean;
+}
+
+export class AutomationActivationService {
+  private readonly stateRepository: SchedulerStateRepository;
+  private readonly drafts: Pick<AutomationDraftService, 'get'>;
+  private readonly workflows: Pick<WorkflowService, 'loadWorkflow'> &
+    Partial<Pick<WorkflowService, 'saveWorkflow'>>;
+  private readonly templates: { getTemplate(id: string): Promise<TaskTemplate | null> };
+  private readonly approvals: Pick<RunApprovalBrokerService, 'request' | 'get'>;
+  private readonly integrationEvidence: (
+    ids: string[]
+  ) => Promise<Array<{ id: string; ready: boolean; evidenceDigest?: string }>>;
+  private readonly toolPolicyEvidence: (roles: string[]) => Promise<Record<string, unknown>>;
+  private readonly now: () => Date;
+
+  constructor(options: AutomationActivationServiceOptions = {}) {
+    this.stateRepository = options.stateRepository ?? new FileSchedulerStateRepository();
+    this.drafts = options.drafts ?? getAutomationDraftService();
+    this.workflows = options.workflows ?? getWorkflowService();
+    this.templates =
+      options.templates ??
+      ({
+        getTemplate: async (id: string) => getStorage().templates.getTemplate(id),
+      } satisfies AutomationActivationServiceOptions['templates']);
+    this.approvals = options.approvals ?? getRunApprovalBrokerService();
+    this.integrationEvidence = options.integrationEvidence ?? currentIntegrationEvidence;
+    this.toolPolicyEvidence = options.toolPolicyEvidence ?? currentToolPolicyEvidence;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async preview(
+    draftId: string,
+    requestId: string,
+    revision?: number
+  ): Promise<AutomationActivationPreview> {
+    const draft = await this.drafts.get(draftId, revision);
+    assertResolvedDraft(draft);
+    const provider = required(draft.execution.provider.value, 'execution.provider');
+    const { workflow, sourceTarget } = await this.resolveExecutionTarget(draft, provider);
+    const integrations = await this.integrationEvidence(
+      draft.standingScope.value?.integrationIds ?? []
+    );
+    const toolPolicies = await this.toolPolicyEvidence(
+      [...new Set(workflow.agents.map((agent) => agent.role))].sort()
+    );
+    const blockers = integrations
+      .filter((candidate) => !candidate.ready)
+      .map((candidate) => `Integration ${candidate.id} is unavailable or disabled.`);
+    if (!EXECUTABLE_AGENT_PROVIDERS.includes(provider as ExecutableAgentProvider)) {
+      blockers.push(`Provider ${provider} is not executable.`);
+    }
+    if (provider !== 'openclaw' && provider !== 'codex-sdk') {
+      blockers.push(`Provider ${provider} has no workflow execution adapter.`);
+    }
+    if (workflow.agents.some((agent) => agent.provider && agent.provider !== provider)) {
+      blockers.push('Workflow agent provider evidence conflicts with the requested provider.');
+    }
+
+    const schedule = {
+      expression: required(draft.schedule.expression.value, 'schedule.expression'),
+      timezone: required(draft.schedule.timezone.value, 'schedule.timezone'),
+      ...(draft.schedule.startAt.value ? { startAt: draft.schedule.startAt.value } : {}),
+      expiresAt: required(draft.schedule.expiresAt.value, 'schedule.expiresAt'),
+      overlapPolicy: required(draft.schedule.overlapPolicy.value, 'schedule.overlapPolicy'),
+      retry: required(draft.schedule.retry.value, 'schedule.retry'),
+      nextRunAt: nextAutomationRunAt(
+        required(draft.schedule.expression.value, 'schedule.expression'),
+        required(draft.schedule.timezone.value, 'schedule.timezone'),
+        this.now(),
+        draft.schedule.expiresAt.value
+      ),
+    };
+    const standingScope = required(draft.standingScope.value, 'standingScope');
+    const evidenceBase = {
+      sourceTarget,
+      workflowId: workflow.id,
+      workflowVersion: workflow.version,
+      workflowDigest: digest(workflow),
+      provider,
+      providerEvidenceDigest: digest({
+        provider,
+        executable: blockers.length === 0,
+        workflowAgents: workflow.agents.map((agent) => ({
+          id: agent.id,
+          provider: agent.provider,
+          command: agent.command,
+        })),
+      }),
+      toolCatalogDigest: digest({ requested: [...standingScope.toolIds].sort(), toolPolicies }),
+      integrationEvidenceDigest: digest(integrations),
+      policyDigest: digest({
+        workspaceId: draft.source.workspaceId.value,
+        standingScope,
+        perRunBudget: draft.perRunBudget.value,
+        aggregateBudget: draft.aggregateBudget.value,
+        output: draft.output,
+        stopConditions: draft.stopConditions.value,
+      }),
+      enforceable: blockers.length === 0,
+      blockers,
+    };
+    const base = {
+      schemaVersion: AUTOMATION_ACTIVATION_PREVIEW_SCHEMA_VERSION,
+      draftId: draft.id,
+      draftRevision: draft.revision,
+      draftDigest: draft.digest,
+      requestId,
+      workspaceId: required(draft.source.workspaceId.value, 'source.workspaceId'),
+      ...(draft.source.taskId.value ? { sourceTaskId: draft.source.taskId.value } : {}),
+      objective: required(draft.objective.value, 'objective'),
+      schedule,
+      output: {
+        destination: required(draft.output.destination.value, 'output.destination'),
+        expectedDeliverables: required(
+          draft.output.expectedDeliverables.value,
+          'output.expectedDeliverables'
+        ),
+      },
+      standingScope,
+      perRunBudget: required(draft.perRunBudget.value, 'perRunBudget'),
+      aggregateBudget: required(draft.aggregateBudget.value, 'aggregateBudget'),
+      stopConditions: required(draft.stopConditions.value, 'stopConditions'),
+      effectiveRunAccess: {
+        reads: [...standingScope.reads],
+        writes: [...standingScope.writes],
+        sends: [...standingScope.sends],
+        externalTargets: [...standingScope.externalTargets],
+        artifactDestinations: [...standingScope.artifactDestinations],
+        tools: [...standingScope.toolIds],
+        integrations: integrations.filter((candidate) => candidate.ready).map(({ id }) => id),
+        approvalRequiredActions: [...standingScope.approvalRequiredActions],
+      },
+      evidence: evidenceBase,
+      approval: {
+        required: true as const,
+        riskClass: 'critical' as const,
+        expiresInMs: DEFAULT_APPROVAL_TTL_MS,
+      },
+    };
+    return { ...base, requestRevision: digest(base) };
+  }
+
+  private async resolveExecutionTarget(
+    draft: AutomationDraft,
+    provider: string
+  ): Promise<{
+    workflow: WorkflowDefinition;
+    sourceTarget: AutomationActivationPreview['evidence']['sourceTarget'];
+  }> {
+    if (draft.execution.workflowId.value) {
+      const workflow = await this.workflows.loadWorkflow(draft.execution.workflowId.value);
+      if (!workflow) {
+        throw new NotFoundError(`Workflow ${draft.execution.workflowId.value} not found.`);
+      }
+      return {
+        workflow,
+        sourceTarget: {
+          kind: 'workflow',
+          id: workflow.id,
+          version: workflow.version,
+          digest: digest(workflow),
+        },
+      };
+    }
+    const templateId = required(draft.execution.taskTemplateId.value, 'execution.taskTemplateId');
+    const template = await this.templates.getTemplate(templateId);
+    if (!template) throw new NotFoundError(`Task template ${templateId} not found.`);
+    return {
+      workflow: taskTemplateWorkflow(template, provider, draft),
+      sourceTarget: {
+        kind: 'task-template',
+        id: template.id,
+        version: template.version,
+        digest: digest(template),
+      },
+    };
+  }
+
+  async apply(input: AutomationActivationApplyInput): Promise<AutomationActivationResult> {
+    const preview = await this.preview(input.draftId, input.requestId, input.revision);
+    if (preview.requestRevision !== input.expectedRequestRevision) {
+      throw new ConflictError('Automation activation preview is stale.', {
+        expectedRequestRevision: input.expectedRequestRevision,
+        currentRequestRevision: preview.requestRevision,
+      });
+    }
+    if (!preview.evidence.enforceable) {
+      throw new ValidationError(
+        `Automation activation is blocked: ${preview.evidence.blockers.join(' ')}`
+      );
+    }
+
+    const approval = await this.requestApproval(preview, input.approvalTtlMs);
+    if (!input.approvalId) {
+      return { preview, approvalId: approval.id, approvalStatus: 'pending' };
+    }
+    if (input.approvalId !== approval.id) {
+      throw new ConflictError('Approval does not match this exact automation activation.', {
+        expectedApprovalId: approval.id,
+        receivedApprovalId: input.approvalId,
+      });
+    }
+    const resolved = await this.approvals.get(input.approvalId, preview.workspaceId);
+    if (resolved.status !== 'approved' || !resolved.resolution) {
+      throw new ConflictError('Automation activation approval is not approved.', {
+        approvalId: resolved.id,
+        status: resolved.status,
+      });
+    }
+    const resolution = resolved.resolution;
+
+    if (preview.evidence.sourceTarget.kind === 'task-template') {
+      const draft = await this.drafts.get(preview.draftId, preview.draftRevision);
+      const { workflow } = await this.resolveExecutionTarget(draft, preview.evidence.provider);
+      if (digest(workflow) !== preview.evidence.workflowDigest) {
+        throw new ConflictError('Derived task-template workflow changed before activation.');
+      }
+      if (!this.workflows.saveWorkflow) {
+        throw new ValidationError('Task-template activation cannot persist its derived workflow.');
+      }
+      await this.workflows.saveWorkflow(workflow);
+    }
+
+    let version: AutomationVersion | undefined;
+    let binding: AutomationBinding | undefined;
+    await this.stateRepository.update((state) => {
+      const replay = Object.values(state.automationVersions).find(
+        (candidate) => candidate.requestRevision === preview.requestRevision
+      );
+      if (replay) {
+        version = replay;
+        binding = Object.values(state.automationBindings).find(
+          (candidate) => candidate.automationVersionId === replay.id
+        );
+        return state;
+      }
+      const now = this.now().toISOString();
+      const versionNumber =
+        Object.values(state.automationVersions).filter(
+          (candidate) => candidate.draftId === preview.draftId
+        ).length + 1;
+      const versionId = `automation_version_${hex(preview.requestRevision).slice(0, 24)}`;
+      const unsignedVersion = {
+        schemaVersion: AUTOMATION_VERSION_SCHEMA_VERSION,
+        id: versionId,
+        version: versionNumber,
+        draftId: preview.draftId,
+        draftRevision: preview.draftRevision,
+        draftDigest: preview.draftDigest,
+        requestRevision: preview.requestRevision,
+        workspaceId: preview.workspaceId,
+        ...(preview.sourceTaskId ? { sourceTaskId: preview.sourceTaskId } : {}),
+        objective: preview.objective,
+        workflowId: preview.evidence.workflowId,
+        workflowVersion: preview.evidence.workflowVersion,
+        provider: preview.evidence.provider,
+        schedule: preview.schedule,
+        output: preview.output,
+        standingScope: preview.standingScope,
+        perRunBudget: preview.perRunBudget,
+        aggregateBudget: preview.aggregateBudget,
+        stopConditions: preview.stopConditions,
+        evidence: preview.evidence,
+        approval: {
+          id: resolved.id,
+          revision: resolved.revision,
+          actionHash: resolved.actionHash,
+          approvedBy: resolution.actor.id,
+          approvedAt: resolution.decidedAt,
+        },
+        activatedAt: now,
+      };
+      version = { ...unsignedVersion, digest: digest(unsignedVersion) };
+      const bindingId = `automation_binding_${hex(digest(versionId)).slice(0, 24)}`;
+      const supersededEvents = Object.values(state.automationBindings).flatMap((candidate) => {
+        const candidateVersion = state.automationVersions[candidate.automationVersionId];
+        if (
+          candidateVersion?.draftId !== preview.draftId ||
+          candidate.status === 'revoked' ||
+          candidate.status === 'expired'
+        ) {
+          return [];
+        }
+        const revoked = {
+          ...candidate,
+          status: 'revoked' as const,
+          statusReason: `Superseded by immutable automation version ${versionId}.`,
+          revision: candidate.revision + 1,
+          updatedAt: now,
+        };
+        state.automationBindings[candidate.id] = revoked;
+        return [automationEvent(revoked, 'revoke', 'success', revoked.statusReason, now)];
+      });
+      binding = {
+        schemaVersion: AUTOMATION_BINDING_SCHEMA_VERSION,
+        id: bindingId,
+        revision: 1,
+        automationVersionId: versionId,
+        automationVersion: versionNumber,
+        status: 'active',
+        nextRunAt: preview.schedule.nextRunAt,
+        acceptedRuns: 0,
+        failedRuns: 0,
+        aggregateUsage: { runs: 0, costUsd: 0, tokens: 0, durationMinutes: 0 },
+        statusReason: 'Activated with exact human approval.',
+        createdAt: now,
+        updatedAt: now,
+      };
+      state.automationVersions[versionId] = version;
+      state.automationBindings[bindingId] = binding;
+      state.events = [
+        ...state.events,
+        ...supersededEvents,
+        automationEvent(
+          binding,
+          'activate',
+          'success',
+          'Immutable automation version activated.',
+          now
+        ),
+      ].slice(-MAX_EVENTS);
+      return state;
+    });
+    if (!version || !binding) throw new Error('Automation activation persistence failed.');
+    return { preview, approvalId: resolved.id, approvalStatus: 'approved', version, binding };
+  }
+
+  async list(): Promise<AutomationVersionListResponse> {
+    const state = await this.stateRepository.read();
+    return {
+      generatedAt: this.now().toISOString(),
+      versions: Object.values(state.automationVersions).sort((a, b) =>
+        b.activatedAt.localeCompare(a.activatedAt)
+      ),
+      bindings: Object.values(state.automationBindings).sort((a, b) =>
+        b.createdAt.localeCompare(a.createdAt)
+      ),
+      recentClaims: [...state.automationClaims].slice(-100).reverse(),
+    };
+  }
+
+  async getVersion(versionId: string): Promise<AutomationVersion> {
+    const version = (await this.stateRepository.read()).automationVersions[versionId];
+    if (!version) throw new NotFoundError(`Automation version ${versionId} not found.`);
+    return version;
+  }
+
+  async updateBinding(
+    bindingId: string,
+    expectedRevision: number,
+    status: Extract<AutomationBindingStatus, 'active' | 'paused' | 'revoked'>,
+    reason: string
+  ): Promise<AutomationBinding> {
+    let result: AutomationBinding | undefined;
+    await this.stateRepository.update((state) => {
+      const current = state.automationBindings[bindingId];
+      if (!current) throw new NotFoundError(`Automation binding ${bindingId} not found.`);
+      if (current.revision !== expectedRevision) {
+        throw new ConflictError('Automation binding compare-and-set was rejected.', {
+          expectedRevision,
+          currentRevision: current.revision,
+        });
+      }
+      if (current.status === 'revoked') {
+        throw new ConflictError('Revoked automation bindings cannot be resumed.');
+      }
+      result = {
+        ...current,
+        status,
+        statusReason: reason,
+        revision: current.revision + 1,
+        updatedAt: this.now().toISOString(),
+      };
+      state.automationBindings[bindingId] = result;
+      state.events = [
+        ...state.events,
+        automationEvent(
+          result,
+          status === 'active' ? 'resume' : status === 'paused' ? 'pause' : 'revoke',
+          'success',
+          reason,
+          result.updatedAt
+        ),
+      ].slice(-MAX_EVENTS);
+      return state;
+    });
+    return required(result, 'binding');
+  }
+
+  async claimRun(
+    bindingId: string,
+    trigger: 'due-run' | 'manual-run',
+    now = this.now()
+  ): Promise<AutomationRunClaimResult> {
+    const snapshot = await this.stateRepository.read();
+    const snapshotBinding = snapshot.automationBindings[bindingId];
+    if (!snapshotBinding) throw new NotFoundError(`Automation binding ${bindingId} not found.`);
+    const snapshotVersion = snapshot.automationVersions[snapshotBinding.automationVersionId];
+    if (!snapshotVersion) {
+      throw new NotFoundError(
+        `Automation version ${snapshotBinding.automationVersionId} not found.`
+      );
+    }
+    const driftBlocker = await this.runtimeDriftBlocker(snapshotVersion);
+    let result: AutomationRunClaimResult | undefined;
+    await this.stateRepository.update((state) => {
+      let binding = state.automationBindings[bindingId];
+      if (!binding) throw new NotFoundError(`Automation binding ${bindingId} not found.`);
+      const version = state.automationVersions[binding.automationVersionId];
+      if (!version)
+        throw new NotFoundError(`Automation version ${binding.automationVersionId} not found.`);
+      if (
+        binding.revision !== snapshotBinding.revision ||
+        version.digest !== snapshotVersion.digest
+      ) {
+        throw new ConflictError('Automation binding changed during run admission.', {
+          expectedBindingRevision: snapshotBinding.revision,
+          currentBindingRevision: binding.revision,
+        });
+      }
+      const dueWindow = trigger === 'due-run' ? binding.nextRunAt : minuteWindow(now);
+      if (!dueWindow) throw new ValidationError('Automation has no due run window.');
+      const requestId = `automation:${version.id}:${trigger}:${dueWindow}`;
+      const existing = state.automationClaims.find((claim) => claim.requestId === requestId);
+      if (existing) {
+        result = { claim: existing, version, binding, replayed: true };
+        return state;
+      }
+      const blocker = bindingBlocker(binding, version, now) ?? driftBlocker;
+      const claimId = `automation_claim_${hex(digest(requestId)).slice(0, 24)}`;
+      const timestamp = now.toISOString();
+      const claim: AutomationRunClaim = {
+        schemaVersion: AUTOMATION_RUN_CLAIM_SCHEMA_VERSION,
+        id: claimId,
+        requestId,
+        automationVersionId: version.id,
+        bindingId,
+        dueWindow,
+        trigger,
+        status: blocker ? 'blocked' : 'accepted',
+        ...(blocker ? { reason: blocker } : {}),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+      if (blocker) {
+        binding = {
+          ...binding,
+          status: Date.parse(version.schedule.expiresAt) <= now.getTime() ? 'expired' : 'blocked',
+          statusReason: blocker,
+          revision: binding.revision + 1,
+          updatedAt: timestamp,
+        };
+      } else {
+        binding = {
+          ...binding,
+          acceptedRuns: binding.acceptedRuns + 1,
+          aggregateUsage: {
+            ...binding.aggregateUsage,
+            runs: binding.aggregateUsage.runs + 1,
+          },
+          lastRunAt: timestamp,
+          nextRunAt: nextAutomationRunAt(
+            version.schedule.expression,
+            version.schedule.timezone,
+            now,
+            version.schedule.expiresAt
+          ),
+          revision: binding.revision + 1,
+          updatedAt: timestamp,
+        };
+      }
+      state.automationBindings[bindingId] = binding;
+      state.automationClaims = [...state.automationClaims, claim].slice(-MAX_CLAIMS);
+      result = { claim, version, binding, replayed: false };
+      return state;
+    });
+    return required(result, 'claim result');
+  }
+
+  private async runtimeDriftBlocker(version: AutomationVersion): Promise<string | undefined> {
+    if (version.evidence.sourceTarget.kind === 'task-template') {
+      const template = await this.templates.getTemplate(version.evidence.sourceTarget.id);
+      if (
+        !template ||
+        template.version !== version.evidence.sourceTarget.version ||
+        digest(template) !== version.evidence.sourceTarget.digest
+      ) {
+        return `Task template ${version.evidence.sourceTarget.id} changed after automation activation.`;
+      }
+    }
+    const workflow = await this.workflows.loadWorkflow(version.workflowId);
+    if (!workflow) return `Workflow ${version.workflowId} is unavailable.`;
+    if (
+      workflow.version !== version.workflowVersion ||
+      digest(workflow) !== version.evidence.workflowDigest
+    ) {
+      return `Workflow ${version.workflowId} changed after automation activation.`;
+    }
+    const integrations = await this.integrationEvidence(version.standingScope.integrationIds);
+    if (integrations.some((candidate) => !candidate.ready)) {
+      return 'One or more required integrations are unavailable or disabled.';
+    }
+    if (digest(integrations) !== version.evidence.integrationEvidenceDigest) {
+      return 'Required integration evidence changed after automation activation.';
+    }
+    const toolPolicies = await this.toolPolicyEvidence(
+      [...new Set(workflow.agents.map((agent) => agent.role))].sort()
+    );
+    if (
+      digest({ requested: [...version.standingScope.toolIds].sort(), toolPolicies }) !==
+      version.evidence.toolCatalogDigest
+    ) {
+      return 'Workflow tool policy changed after automation activation.';
+    }
+    if (
+      digest({
+        provider: version.provider,
+        executable: true,
+        workflowAgents: workflow.agents.map((agent) => ({
+          id: agent.id,
+          provider: agent.provider,
+          command: agent.command,
+        })),
+      }) !== version.evidence.providerEvidenceDigest
+    ) {
+      return 'Provider evidence changed after automation activation.';
+    }
+    if (!EXECUTABLE_AGENT_PROVIDERS.includes(version.provider as ExecutableAgentProvider)) {
+      return `Provider ${version.provider} is no longer executable.`;
+    }
+    return undefined;
+  }
+
+  async markRunStarted(claimId: string, workflowRunId: string): Promise<AutomationRunClaim> {
+    return this.updateClaim(claimId, 'started', { workflowRunId });
+  }
+
+  async markRunFailed(claimId: string, reason: string): Promise<AutomationRunClaim> {
+    return this.updateClaim(claimId, 'failed', { reason });
+  }
+
+  async markRunCompleted(
+    claimId: string,
+    usage: { costUsd: number; tokens: number; durationMinutes: number }
+  ): Promise<AutomationRunClaim> {
+    let result: AutomationRunClaim | undefined;
+    await this.stateRepository.update((state) => {
+      const index = state.automationClaims.findIndex((claim) => claim.id === claimId);
+      if (index < 0) throw new NotFoundError(`Automation run claim ${claimId} not found.`);
+      const current = state.automationClaims[index];
+      if (current.status === 'completed') {
+        result = current;
+        return state;
+      }
+      if (current.status !== 'started') {
+        throw new ConflictError('Only a started automation claim can complete.', {
+          claimId,
+          status: current.status,
+        });
+      }
+      result = { ...current, status: 'completed', updatedAt: this.now().toISOString() };
+      state.automationClaims[index] = result;
+      const binding = state.automationBindings[current.bindingId];
+      const version = binding ? state.automationVersions[binding.automationVersionId] : undefined;
+      if (binding && version) {
+        const aggregateUsage = {
+          runs: binding.aggregateUsage.runs,
+          costUsd: binding.aggregateUsage.costUsd + Math.max(0, usage.costUsd),
+          tokens: binding.aggregateUsage.tokens + Math.max(0, Math.trunc(usage.tokens)),
+          durationMinutes:
+            binding.aggregateUsage.durationMinutes + Math.max(0, usage.durationMinutes),
+        };
+        const exhaustion = aggregateBudgetBlocker(version, aggregateUsage);
+        state.automationBindings[binding.id] = {
+          ...binding,
+          aggregateUsage,
+          failedRuns: 0,
+          ...(exhaustion ? { status: 'blocked' as const, statusReason: exhaustion } : {}),
+          revision: binding.revision + 1,
+          updatedAt: this.now().toISOString(),
+        };
+      }
+      return state;
+    });
+    return required(result, 'claim');
+  }
+
+  private async updateClaim(
+    claimId: string,
+    status: Extract<AutomationRunClaim['status'], 'started' | 'failed'>,
+    update: Pick<AutomationRunClaim, 'workflowRunId' | 'reason'>
+  ): Promise<AutomationRunClaim> {
+    let result: AutomationRunClaim | undefined;
+    await this.stateRepository.update((state) => {
+      const index = state.automationClaims.findIndex((claim) => claim.id === claimId);
+      if (index < 0) throw new NotFoundError(`Automation run claim ${claimId} not found.`);
+      const current = state.automationClaims[index];
+      if (current.status === status) {
+        result = current;
+        return state;
+      }
+      if (
+        current.status !== 'accepted' &&
+        !(status === 'failed' && current.status === 'started') &&
+        current.status !== status
+      ) {
+        throw new ConflictError('Automation run claim is already terminal.', {
+          claimId,
+          status: current.status,
+        });
+      }
+      result = {
+        ...current,
+        status,
+        ...(update.workflowRunId ? { workflowRunId: update.workflowRunId } : {}),
+        ...(update.reason ? { reason: update.reason } : {}),
+        updatedAt: this.now().toISOString(),
+      };
+      state.automationClaims[index] = result;
+      if (status === 'failed') {
+        const binding = state.automationBindings[current.bindingId];
+        if (binding) {
+          const version = state.automationVersions[binding.automationVersionId];
+          const failedRuns = binding.failedRuns + 1;
+          const retryLimit = version?.schedule.retry.maxAttempts ?? 0;
+          state.automationBindings[current.bindingId] = {
+            ...binding,
+            failedRuns,
+            ...(failedRuns >= retryLimit
+              ? {
+                  status: 'blocked' as const,
+                  statusReason: `Retry limit reached: ${update.reason ?? 'launch failed'}`,
+                }
+              : {}),
+            revision: binding.revision + 1,
+            updatedAt: this.now().toISOString(),
+          };
+        }
+      }
+      return state;
+    });
+    return required(result, 'claim');
+  }
+
+  private async requestApproval(
+    preview: AutomationActivationPreview,
+    ttlMs?: number
+  ): Promise<RunApprovalRequest> {
+    const provider = preview.evidence.provider as ExecutableAgentProvider;
+    return this.approvals.request({
+      workspaceId: preview.workspaceId,
+      taskId: preview.sourceTaskId ?? preview.draftId,
+      attemptId: `activation-${hex(preview.requestRevision).slice(0, 24)}`,
+      provider,
+      agentId: 'scheduler',
+      requestKind: 'approval',
+      actionClass: 'workflow',
+      action: `Activate immutable automation ${preview.draftId} revision ${preview.draftRevision}`,
+      exactAction: preview,
+      details: 'Grants bounded standing authority until the exact version expires or is revoked.',
+      resourceScope: [
+        ...preview.standingScope.reads,
+        ...preview.standingScope.writes,
+        ...preview.standingScope.sends,
+        ...preview.standingScope.externalTargets,
+      ],
+      riskClass: 'critical',
+      policyReason: 'Recurring execution requires exact human approval of standing authority.',
+      evidenceRevision: preview.requestRevision,
+      providerRequestId: preview.requestId,
+      mobileSafe: false,
+      ttlMs: ttlMs ?? DEFAULT_APPROVAL_TTL_MS,
+    });
+  }
+}
+
+function assertResolvedDraft(draft: AutomationDraft): void {
+  if (!draft.validation.valid) {
+    throw new ValidationError('Automation draft is not valid for activation.', {
+      blockers: draft.validation.issues.filter((issue) => issue.severity === 'blocker'),
+    });
+  }
+}
+
+function taskTemplateWorkflow(
+  template: TaskTemplate,
+  provider: string,
+  draft: AutomationDraft
+): WorkflowDefinition {
+  const templateDigest = digest(template);
+  const workflowId = `automation-template-${hex(templateDigest).slice(0, 24)}`;
+  const objective = required(draft.objective.value, 'objective');
+  const destination = required(draft.output.destination.value, 'output.destination');
+  const tools = required(draft.standingScope.value, 'standingScope').toolIds;
+  return {
+    id: workflowId,
+    name: `Automation: ${template.name}`,
+    version: 1,
+    description: `Immutable workflow derived from task template ${template.id} version ${template.version}.`,
+    agents: [
+      {
+        id: 'automation-template-agent',
+        name: template.name,
+        role: 'orchestrator',
+        provider,
+        command: provider === 'codex-sdk' ? 'codex' : 'openclaw',
+        description: template.description ?? `Execute task template ${template.id}.`,
+        tools: [...tools],
+      },
+    ],
+    steps: [
+      {
+        id: 'execute-template',
+        name: template.name,
+        type: 'agent',
+        agent: 'automation-template-agent',
+        input: `${objective}\n\nApply task template ${template.id} version ${template.version}. Write the reviewed deliverables to ${destination}.`,
+        acceptance_criteria: required(
+          draft.output.expectedDeliverables.value,
+          'output.expectedDeliverables'
+        ),
+      },
+    ],
+    variables: {
+      automationTemplate: {
+        id: template.id,
+        version: template.version,
+        digest: templateDigest,
+      },
+    },
+    createdBy: 'automation-activation',
+    updatedBy: 'automation-activation',
+  };
+}
+
+function bindingBlocker(
+  binding: AutomationBinding,
+  version: AutomationVersion,
+  now: Date
+): string | undefined {
+  if (binding.status !== 'active') return `Automation binding is ${binding.status}.`;
+  if (Date.parse(version.schedule.expiresAt) <= now.getTime()) return 'Automation version expired.';
+  const budgetBlocker = aggregateBudgetBlocker(version, binding.aggregateUsage);
+  if (budgetBlocker) return budgetBlocker;
+  return undefined;
+}
+
+function aggregateBudgetBlocker(
+  version: AutomationVersion,
+  usage: AutomationBinding['aggregateUsage']
+): string | undefined {
+  if (usage.runs >= version.aggregateBudget.maxRuns) {
+    return 'Automation aggregate run budget is exhausted.';
+  }
+  if (
+    version.aggregateBudget.maxCostUsd !== undefined &&
+    usage.costUsd >= version.aggregateBudget.maxCostUsd
+  ) {
+    return 'Automation aggregate cost budget is exhausted.';
+  }
+  if (
+    version.aggregateBudget.maxTokens !== undefined &&
+    usage.tokens >= version.aggregateBudget.maxTokens
+  ) {
+    return 'Automation aggregate token budget is exhausted.';
+  }
+  if (
+    version.aggregateBudget.maxDurationMinutes !== undefined &&
+    usage.durationMinutes >= version.aggregateBudget.maxDurationMinutes
+  ) {
+    return 'Automation aggregate duration budget is exhausted.';
+  }
+  return undefined;
+}
+
+async function currentIntegrationEvidence(
+  ids: string[]
+): Promise<Array<{ id: string; ready: boolean; evidenceDigest?: string }>> {
+  if (ids.length === 0) return [];
+  const [endpoints, adapters] = await Promise.all([
+    getOutboundIntegrationService().listEndpoints(),
+    getCommunicationAdapterService().listAdapters(),
+  ]);
+  return [...new Set(ids)].sort().map((id) => {
+    const endpoint = endpoints.find((candidate) => candidate.id === id);
+    const adapter = adapters.find((candidate) => candidate.id === id);
+    return {
+      id,
+      ready: Boolean(endpoint?.enabled && endpoint.validation.valid) || Boolean(adapter?.enabled),
+      evidenceDigest: digest(
+        endpoint
+          ? {
+              id: endpoint.id,
+              type: endpoint.type,
+              enabled: endpoint.enabled,
+              validation: endpoint.validation,
+              updatedAt: endpoint.updatedAt,
+            }
+          : adapter
+            ? {
+                id: adapter.id,
+                kind: adapter.kind,
+                enabled: adapter.enabled,
+                deliveryMode: adapter.deliveryMode,
+                destinationType: adapter.destinationType,
+                updatedAt: adapter.updatedAt,
+              }
+            : { id, missing: true }
+      ),
+    };
+  });
+}
+
+async function currentToolPolicyEvidence(roles: string[]): Promise<Record<string, unknown>> {
+  const service = getToolPolicyService();
+  return Object.fromEntries(
+    await Promise.all(
+      roles.map(async (role) => [role, await service.getToolFilterForRole(role)] as const)
+    )
+  );
+}
+
+function required<T>(value: T | undefined, path: string): T {
+  if (value === undefined) throw new ValidationError(`Automation field ${path} is unresolved.`);
+  return value;
+}
+
+function minuteWindow(now: Date): string {
+  return new Date(Math.floor(now.getTime() / 60_000) * 60_000).toISOString();
+}
+
+function digest(value: unknown): string {
+  return `sha256:${createHash('sha256').update(stableJson(value)).digest('hex')}`;
+}
+
+function hex(value: string): string {
+  return value.replace(/^[^:]+:/, '');
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, candidate]) => candidate !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, candidate]) => `${JSON.stringify(key)}:${stableJson(candidate)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function automationEvent(
+  binding: AutomationBinding,
+  type: 'activate' | 'pause' | 'resume' | 'revoke',
+  status: 'success',
+  summary: string,
+  runAt: string
+) {
+  return {
+    id: `sched_evt_${hex(digest({ bindingId: binding.id, revision: binding.revision, type })).slice(0, 10)}`,
+    itemId: `automation:${binding.id}`,
+    sourceId: binding.id,
+    kind: 'automation' as const,
+    type,
+    status,
+    summary,
+    runAt,
+    nextRunAt: binding.nextRunAt,
+  };
+}
+
+let instance: AutomationActivationService | undefined;
+
+export function getAutomationActivationService(): AutomationActivationService {
+  instance ??= new AutomationActivationService();
+  return instance;
+}
+
+export function resetAutomationActivationServiceForTests(): void {
+  instance = undefined;
+}

--- a/server/src/services/automation-draft-service.ts
+++ b/server/src/services/automation-draft-service.ts
@@ -647,6 +647,24 @@ function parseCron(expression: string): ParsedCron | null {
   };
 }
 
+export function nextAutomationRunAt(
+  expression: string,
+  timezone: string,
+  after: Date,
+  expiresAt?: string
+): string | undefined {
+  const cron = parseCron(expression);
+  if (!cron || !isValidTimezone(timezone)) return undefined;
+  const parsedExpiry = expiresAt ? Date.parse(expiresAt) : Number.NaN;
+  return nextCronRuns(
+    cron,
+    timezone,
+    after,
+    1,
+    Number.isFinite(parsedExpiry) ? new Date(parsedExpiry) : undefined
+  )[0];
+}
+
 function parseCronField(value: string, min: number, max: number): CronMatcher | null {
   if (value === '*') return () => true;
   const step = value.match(/^\*\/(\d+)$/);

--- a/server/src/services/scheduler-service.ts
+++ b/server/src/services/scheduler-service.ts
@@ -10,6 +10,9 @@ import type {
   SchedulerRunStatus,
   SchedulerValidationIssue,
   SchedulerValidationResult,
+  AutomationBinding,
+  AutomationVersion,
+  AgentBudgetPolicy,
   QueueMonitorSnapshot,
   WorkflowDefinition,
   WorkflowSchedule,
@@ -42,6 +45,10 @@ import {
   getQueueIntakeMonitorService,
   type QueueIntakeMonitorService,
 } from './queue-intake-monitor-service.js';
+import {
+  AutomationActivationService,
+  getAutomationActivationService,
+} from './automation-activation-service.js';
 
 const log = createLogger('scheduler');
 const DEFAULT_MAX_ATTEMPTS = 3;
@@ -59,6 +66,7 @@ interface SchedulerServiceOptions {
   workflowAuthoringService?: WorkflowAuthoringService;
   queueMonitorService?: QueueIntakeMonitorService;
   telemetryService?: TelemetryService;
+  automationService?: AutomationActivationService;
 }
 
 export class SchedulerService {
@@ -69,6 +77,7 @@ export class SchedulerService {
   private readonly workflowAuthoringService: WorkflowAuthoringService;
   private readonly queueMonitorService: QueueIntakeMonitorService;
   private readonly telemetryService: TelemetryService;
+  private readonly automationService: AutomationActivationService;
   private state: SchedulerState | null = null;
   private runningDue = false;
   private readonly runningItems = new Set<string>();
@@ -83,6 +92,11 @@ export class SchedulerService {
       options.workflowAuthoringService ?? getWorkflowAuthoringService();
     this.queueMonitorService = options.queueMonitorService ?? getQueueIntakeMonitorService();
     this.telemetryService = options.telemetryService ?? getTelemetryService();
+    this.automationService =
+      options.automationService ??
+      (options.stateFile || options.stateRepository
+        ? new AutomationActivationService({ stateRepository: this.stateRepository })
+        : getAutomationActivationService());
   }
 
   async list(now = new Date()): Promise<SchedulerListResponse> {
@@ -145,7 +159,15 @@ export class SchedulerService {
       throw new ValidationError(`Scheduler item is already paused: ${itemId}`);
     }
 
-    if (item.kind === 'scheduled-deliverable') {
+    if (item.kind === 'automation') {
+      const binding = await this.automationService.updateBinding(
+        item.sourceId,
+        await this.bindingRevision(item.sourceId),
+        'paused',
+        'Paused by operator.'
+      );
+      void binding;
+    } else if (item.kind === 'scheduled-deliverable') {
       await this.deliverablesService.update(item.sourceId, { enabled: false });
     } else if (item.kind === 'queue-monitor') {
       await this.queueMonitorService.updateMonitor(item.sourceId, { enabled: false }, now);
@@ -169,7 +191,15 @@ export class SchedulerService {
       throw new ValidationError(`Scheduler item is already enabled: ${itemId}`);
     }
 
-    if (item.kind === 'scheduled-deliverable') {
+    if (item.kind === 'automation') {
+      const binding = await this.automationService.updateBinding(
+        item.sourceId,
+        await this.bindingRevision(item.sourceId),
+        'active',
+        'Resumed by operator.'
+      );
+      void binding;
+    } else if (item.kind === 'scheduled-deliverable') {
       await this.deliverablesService.update(item.sourceId, { enabled: true });
     } else if (item.kind === 'queue-monitor') {
       await this.queueMonitorService.updateMonitor(item.sourceId, { enabled: true }, now);
@@ -222,11 +252,13 @@ export class SchedulerService {
     const startedAt = Date.now();
     try {
       const result =
-        item.kind === 'scheduled-deliverable'
-          ? await this.runDeliverable(item, trigger, now, startedAt)
-          : item.kind === 'queue-monitor'
-            ? await this.runQueueMonitor(item, trigger, now, startedAt)
-            : await this.runWorkflow(item, trigger, now, startedAt);
+        item.kind === 'automation'
+          ? await this.runAutomation(item, trigger, now, startedAt)
+          : item.kind === 'scheduled-deliverable'
+            ? await this.runDeliverable(item, trigger, now, startedAt)
+            : item.kind === 'queue-monitor'
+              ? await this.runQueueMonitor(item, trigger, now, startedAt)
+              : await this.runWorkflow(item, trigger, now, startedAt);
       return result;
     } finally {
       this.runningItems.delete(itemId);
@@ -361,6 +393,89 @@ export class SchedulerService {
     return { item: await this.getItem(item.id, now), event };
   }
 
+  private async runAutomation(
+    item: SchedulerItem,
+    trigger: Extract<SchedulerEventType, 'manual-run' | 'due-run'>,
+    now: Date,
+    startedAt: number
+  ): Promise<SchedulerRunResult> {
+    const claimed = await this.automationService.claimRun(item.sourceId, trigger, now);
+    if (claimed.replayed) {
+      const event = await this.recordEvent({
+        item,
+        type: 'overlap',
+        status: 'skipped',
+        summary: `Automation due window already claimed: ${claimed.claim.id}`,
+        sourceRunId: claimed.claim.workflowRunId,
+        durationMs: Date.now() - startedAt,
+        now,
+        nextRunAt: claimed.binding.nextRunAt,
+      });
+      return { item: await this.getItem(item.id, now), event };
+    }
+    if (claimed.claim.status === 'blocked') {
+      const event = await this.recordEvent({
+        item,
+        type: trigger,
+        status: 'failed',
+        summary: 'Automation run was blocked before admission.',
+        error: claimed.claim.reason,
+        durationMs: Date.now() - startedAt,
+        now,
+        nextRunAt: claimed.binding.nextRunAt,
+      });
+      return { item: await this.getItem(item.id, now), event };
+    }
+
+    try {
+      const run = await this.workflowRunService.startRun(
+        claimed.version.workflowId,
+        claimed.version.sourceTaskId,
+        {
+          scheduler: { itemId: item.id, trigger, runAt: now.toISOString() },
+        },
+        automationBudgetPolicy(claimed.version),
+        {
+          automationVersionId: claimed.version.id,
+          automationVersion: claimed.version.version,
+          bindingId: claimed.binding.id,
+          claimId: claimed.claim.id,
+          requestId: claimed.claim.requestId,
+          workspaceId: claimed.version.workspaceId,
+          outputDestination: claimed.version.output.destination,
+          standingScope: claimed.version.standingScope,
+          evidenceDigest: claimed.version.digest,
+        }
+      );
+      await this.automationService.markRunStarted(claimed.claim.id, run.id);
+      const event = await this.recordEvent({
+        item,
+        type: trigger,
+        status: 'started',
+        summary: `Automation ${claimed.version.id} started workflow run ${run.id}.`,
+        sourceRunId: run.id,
+        durationMs: Date.now() - startedAt,
+        now,
+        nextRunAt: claimed.binding.nextRunAt,
+      });
+      return { item: await this.getItem(item.id, now), event };
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : 'Automation workflow launch failed.';
+      await this.automationService.markRunFailed(claimed.claim.id, reason);
+      const event = await this.recordEvent({
+        item,
+        type: trigger,
+        status: 'failed',
+        summary: 'Automation workflow launch failed after durable claim.',
+        error: reason,
+        durationMs: Date.now() - startedAt,
+        now,
+        nextRunAt: claimed.binding.nextRunAt,
+      });
+      return { item: await this.getItem(item.id, now), event };
+    }
+  }
+
   private async runQueueMonitor(
     item: SchedulerItem,
     trigger: Extract<SchedulerEventType, 'manual-run' | 'due-run'>,
@@ -398,10 +513,12 @@ export class SchedulerService {
 
   private async buildItems(now: Date): Promise<SchedulerItem[]> {
     await this.ensureLoaded();
-    const [deliverables, workflows, queueMonitors] = await Promise.all([
+    await this.reconcileAutomationRuns();
+    const [deliverables, workflows, queueMonitors, automations] = await Promise.all([
       this.deliverablesService.list(),
       this.workflowService.listWorkflows(),
       this.queueMonitorService.list(now),
+      this.automationService.list(),
     ]);
 
     const items = [
@@ -410,6 +527,9 @@ export class SchedulerService {
         .filter((workflow) => shouldExposeWorkflow(workflow))
         .map((workflow) => this.workflowItem(workflow, now)),
       ...queueMonitors.monitors.map((monitor) => this.queueMonitorItem(monitor)),
+      ...automations.bindings.map((binding) =>
+        this.automationItem(binding, automations.versions, now)
+      ),
     ];
 
     return items.sort((a, b) => {
@@ -418,6 +538,33 @@ export class SchedulerService {
       if (aNext !== bNext) return aNext - bNext;
       return a.name.localeCompare(b.name);
     });
+  }
+
+  private async reconcileAutomationRuns(): Promise<void> {
+    const automations = await this.automationService.list();
+    for (const claim of automations.recentClaims.filter(
+      (candidate) => candidate.status === 'started' && candidate.workflowRunId
+    )) {
+      const run = await this.workflowRunService.getRun(claim.workflowRunId as string);
+      if (!run || (run.status !== 'completed' && run.status !== 'failed')) continue;
+      if (run.status === 'failed') {
+        await this.automationService.markRunFailed(
+          claim.id,
+          run.error ?? 'Automation workflow run failed.'
+        );
+        continue;
+      }
+      await this.automationService.markRunCompleted(claim.id, {
+        costUsd: run.budget?.usage.costUsd ?? 0,
+        tokens: run.budget?.usage.totalTokens ?? 0,
+        durationMinutes: Math.max(
+          0,
+          ((run.completedAt ? Date.parse(run.completedAt) : Date.now()) -
+            Date.parse(run.startedAt)) /
+            60_000
+        ),
+      });
+    }
   }
 
   private deliverableItem(deliverable: Deliverable): SchedulerItem {
@@ -515,6 +662,68 @@ export class SchedulerService {
       retry: retryState(state),
       actions: baseActions(monitor.enabled),
     });
+  }
+
+  private automationItem(
+    binding: AutomationBinding,
+    versions: AutomationVersion[],
+    now: Date
+  ): SchedulerItem {
+    const version = versions.find((candidate) => candidate.id === binding.automationVersionId);
+    if (!version) throw new Error(`Automation version missing for binding ${binding.id}`);
+    const id = itemId('automation', binding.id);
+    const state = this.currentState().items[id] ?? {};
+    const expired = Date.parse(version.schedule.expiresAt) <= now.getTime();
+    const enabled = binding.status === 'active' && !expired;
+    return this.decorateItem({
+      id,
+      kind: 'automation',
+      provider: 'local-server',
+      sourceId: binding.id,
+      name: version.objective,
+      description: `Immutable automation ${version.id} version ${version.version}`,
+      enabled,
+      trigger: {
+        mode: 'custom',
+        description: `${version.schedule.expression} (${version.schedule.timezone})`,
+        cronExpr: version.schedule.expression,
+        timezone: version.schedule.timezone,
+        startAt: version.schedule.startAt,
+        endAt: version.schedule.expiresAt,
+        customDueRunnerSupported: true,
+      },
+      tags: ['automation', version.id],
+      nextRunAt: binding.nextRunAt,
+      lastRunAt: binding.lastRunAt ?? state.lastRunAt,
+      lastStatus: state.lastStatus,
+      lastSummary: state.lastSummary,
+      lastError: state.lastError,
+      sourceRunId: state.sourceRunId,
+      health:
+        expired || binding.status === 'blocked' || binding.status === 'revoked'
+          ? 'blocked'
+          : 'healthy',
+      healthSummary: expired ? 'Expired' : binding.statusReason,
+      retry: {
+        attempts: binding.failedRuns,
+        maxAttempts: version.schedule.retry.maxAttempts,
+        backoffMinutes: version.schedule.retry.backoffMinutes,
+      },
+      actions: {
+        canRun: enabled,
+        canPause: binding.status === 'active',
+        canResume: binding.status === 'paused',
+        canValidate: true,
+      },
+    });
+  }
+
+  private async bindingRevision(bindingId: string): Promise<number> {
+    const binding = (await this.automationService.list()).bindings.find(
+      (candidate) => candidate.id === bindingId
+    );
+    if (!binding) throw new NotFoundError(`Automation binding ${bindingId} not found.`);
+    return binding.revision;
   }
 
   private decorateItem(item: SchedulerItem): SchedulerItem {
@@ -796,6 +1005,25 @@ function queueMonitorStatus(status: QueueMonitorSnapshot['lastStatus']): Schedul
   if (status === 'started') return 'started';
   if (status === 'success') return 'success';
   return 'skipped';
+}
+
+function automationBudgetPolicy(version: AutomationVersion): AgentBudgetPolicy {
+  return {
+    enabled: true,
+    name: `Automation ${version.id} per-run budget`,
+    scope: 'run',
+    limits: {
+      totalTokens: version.perRunBudget.maxTokens,
+      costUsd: version.perRunBudget.maxCostUsd,
+      runtimeSeconds:
+        version.perRunBudget.maxDurationMinutes === undefined
+          ? undefined
+          : version.perRunBudget.maxDurationMinutes * 60,
+      retries: version.schedule.retry.maxAttempts,
+    },
+    hardAction: 'pause',
+    notes: `Bound to immutable automation version ${version.id}.`,
+  };
 }
 
 function isItemDue(item: SchedulerItem, cutoff: number): boolean {

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -28,6 +28,7 @@ import {
   type WorkflowPipelineRoleStatusPatch,
   type WorkflowSubagentRunStatus,
   type WorkflowSubagentTelemetry,
+  type WorkflowAutomationBinding,
   WORKFLOW_ADMISSION_SCHEMA_VERSION,
 } from '@veritas-kanban/shared';
 import type { WorkflowRun, StepRun, WorkflowDefinition, WorkflowStep } from '../types/workflow.js';
@@ -81,6 +82,7 @@ const RESERVED_CONTEXT_KEYS = new Set([
   '_retryContext',
   '_gateBlock',
   '_gateApproval',
+  'automation',
 ]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -402,14 +404,18 @@ export class WorkflowRunService {
   ): Promise<NonNullable<WorkflowRun['admission']>> {
     const admissionTaskId = this.rootAdmissionTaskId(run.id);
     const attemptId = admissionTaskId;
-    const workspaceId = this.workflowWorkspaceId(task);
-    const rootTaskId = run.taskId ?? admissionTaskId;
+    const workspaceId = run.automation?.workspaceId ?? this.workflowWorkspaceId(task);
+    const rootTaskId = run.taskId ?? run.automation?.bindingId ?? admissionTaskId;
     const executionTree: ExecutionTreeIdentity =
       run.executionTree ??
       ({
         schemaVersion: 'execution-tree-identity/v1',
         rootObjectiveId: `objective_${createHash('sha256')
-          .update(`${workspaceId}:${rootTaskId}:${run.id}`)
+          .update(
+            run.automation
+              ? `${workspaceId}:${run.automation.automationVersionId}`
+              : `${workspaceId}:${rootTaskId}:${run.id}`
+          )
           .digest('hex')
           .slice(0, 32)}`,
         nodeId: attemptId,
@@ -446,7 +452,9 @@ export class WorkflowRunService {
       hostId: this.admission.getExecutionHostId(),
       source: this.workflowAdmissionSource(run),
       workflowRunId: run.id,
-      idempotencyKey: `workflow-root:${run.id}`,
+      idempotencyKey: run.automation
+        ? `automation-root:${run.automation.requestId}`
+        : `workflow-root:${run.id}`,
       requested: {
         runSlots: 1,
         processSlots: 0,
@@ -1369,7 +1377,8 @@ export class WorkflowRunService {
     workflowId: string,
     taskId?: string,
     initialContext?: Record<string, unknown>,
-    runBudget?: AgentBudgetPolicy
+    runBudget?: AgentBudgetPolicy,
+    automation?: WorkflowAutomationBinding
   ): Promise<WorkflowRun> {
     const workflow = await this.workflowService.loadWorkflow(workflowId);
     if (!workflow) {
@@ -1425,6 +1434,7 @@ export class WorkflowRunService {
       workflowId: workflow.id,
       workflowVersion: workflow.version,
       taskId,
+      ...(automation ? { automation } : {}),
       status: 'pending',
       currentStep: workflow.steps[0]?.id,
       context: {
@@ -1433,6 +1443,8 @@ export class WorkflowRunService {
 
         // Custom initial context (from API caller)
         ...safeInitialContext,
+
+        ...(automation ? { automation } : {}),
 
         // Task payload (if provided)
         ...(task ? { task } : {}),

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -295,7 +295,10 @@ export class WorkflowStepExecutor {
     const prompt = this.renderTemplate(step.input || '', sessionContext);
 
     // Get tool policy filter for this agent role (#110)
-    const toolPolicyFilter = await this.getToolPolicyForAgent(agentDef);
+    const toolPolicyFilter = this.applyAutomationToolCeiling(
+      run,
+      await this.getToolPolicyForAgent(agentDef)
+    );
     const workingDirectory = this.expandPath(this.getWorkflowWorkingDirectory(run));
     const runtimeProvider = this.resolveWorkflowProvider(step, agentDef);
     const runtimeManifest = await this.resolveRuntimeManifest(step, agentDef, runtimeProvider);
@@ -2210,5 +2213,22 @@ export class WorkflowStepExecutor {
 
     const toolPolicyService = getToolPolicyService();
     return await toolPolicyService.getToolFilterForRole(agentDef.role);
+  }
+
+  private applyAutomationToolCeiling(
+    run: WorkflowRun,
+    current: { allowed?: string[]; denied?: string[] }
+  ): { allowed?: string[]; denied?: string[] } {
+    const ceiling = run.automation?.standingScope.toolIds;
+    if (!ceiling) return current;
+    const ceilingSet = new Set(ceiling);
+    const currentAllowed = current.allowed ?? ['*'];
+    const allowed = currentAllowed.includes('*')
+      ? [...ceilingSet]
+      : currentAllowed.filter((tool) => ceilingSet.has(tool));
+    return {
+      allowed: allowed.sort((left, right) => left.localeCompare(right)),
+      denied: [...new Set([...(current.denied ?? []), ...(ceiling.length === 0 ? ['*'] : [])])],
+    };
   }
 }

--- a/server/src/storage/scheduler-state-repository.ts
+++ b/server/src/storage/scheduler-state-repository.ts
@@ -1,17 +1,31 @@
 import { constants } from 'node:fs';
 import { lstat, mkdir, open } from 'node:fs/promises';
 import path from 'node:path';
-import type { AutomationDraft, SchedulerEvent, SchedulerRunStatus } from '@veritas-kanban/shared';
+import type {
+  AutomationBinding,
+  AutomationDraft,
+  AutomationRunClaim,
+  AutomationVersion,
+  SchedulerEvent,
+  SchedulerRunStatus,
+} from '@veritas-kanban/shared';
 import { withFileLock } from '../services/file-lock.js';
 import { getRuntimeDir } from '../utils/paths.js';
 import { ensureWithinBase } from '../utils/sanitize.js';
 import { atomicWriteFile } from './fs-helpers.js';
-import { AutomationDraftSchema } from '../schemas/automation-draft-schemas.js';
+import {
+  AutomationBindingSchema,
+  AutomationDraftSchema,
+  AutomationRunClaimSchema,
+  AutomationVersionSchema,
+} from '../schemas/automation-draft-schemas.js';
 
 const MAX_SCHEDULER_STATE_BYTES = 8 * 1024 * 1024;
 const MAX_EVENTS = 200;
 const MAX_AUTOMATION_DRAFTS = 200;
 const MAX_AUTOMATION_DRAFT_REVISIONS = 50;
+const MAX_AUTOMATION_VERSIONS = 500;
+const MAX_AUTOMATION_CLAIMS = 1_000;
 
 export interface SchedulerItemState {
   attempts?: number;
@@ -29,6 +43,9 @@ export interface SchedulerState {
   items: Record<string, SchedulerItemState>;
   events: SchedulerEvent[];
   drafts: Record<string, AutomationDraft[]>;
+  automationVersions: Record<string, AutomationVersion>;
+  automationBindings: Record<string, AutomationBinding>;
+  automationClaims: AutomationRunClaim[];
 }
 
 export interface SchedulerStateRepository {
@@ -37,7 +54,15 @@ export interface SchedulerStateRepository {
 }
 
 function emptyState(): SchedulerState {
-  return { version: 1, items: {}, events: [], drafts: {} };
+  return {
+    version: 1,
+    items: {},
+    events: [],
+    drafts: {},
+    automationVersions: {},
+    automationBindings: {},
+    automationClaims: [],
+  };
 }
 
 function normalizeState(parsed: Partial<SchedulerState>): SchedulerState {
@@ -46,7 +71,53 @@ function normalizeState(parsed: Partial<SchedulerState>): SchedulerState {
     items: parsed.items && typeof parsed.items === 'object' ? parsed.items : {},
     events: Array.isArray(parsed.events) ? parsed.events.slice(-MAX_EVENTS) : [],
     drafts: normalizeDrafts(parsed.drafts),
+    automationVersions: normalizeRecord(
+      parsed.automationVersions,
+      AutomationVersionSchema,
+      MAX_AUTOMATION_VERSIONS,
+      'versions'
+    ),
+    automationBindings: normalizeRecord(
+      parsed.automationBindings,
+      AutomationBindingSchema,
+      MAX_AUTOMATION_VERSIONS,
+      'bindings'
+    ),
+    automationClaims: normalizeClaims(parsed.automationClaims),
   };
+}
+
+function normalizeRecord<T>(
+  value: unknown,
+  schema: { parse(candidate: unknown): T },
+  limit: number,
+  label: string
+): Record<string, T> {
+  if (value === undefined) return {};
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Scheduler automation ${label} must be a record.`);
+  }
+  const entries = Object.entries(value);
+  if (entries.length > limit) {
+    throw new Error(`Scheduler automation ${label} exceed the ${limit}-record limit.`);
+  }
+  return Object.fromEntries(
+    entries.map(([id, candidate]) => {
+      const parsed = schema.parse(candidate) as T & { id?: string };
+      if (parsed.id !== id) {
+        throw new Error(`Scheduler automation ${label} entry ${id} has conflicting identity.`);
+      }
+      return [id, parsed];
+    })
+  );
+}
+
+function normalizeClaims(value: unknown): AutomationRunClaim[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error('Scheduler automation claims must be an array.');
+  return value
+    .slice(-MAX_AUTOMATION_CLAIMS)
+    .map((claim) => AutomationRunClaimSchema.parse(claim)) as AutomationRunClaim[];
 }
 
 function normalizeDrafts(value: unknown): Record<string, AutomationDraft[]> {

--- a/server/src/types/workflow.ts
+++ b/server/src/types/workflow.ts
@@ -206,6 +206,8 @@ export interface WorkflowRun {
   taskId?: string; // Optional task association
   admission?: import('@veritas-kanban/shared').WorkflowRootAdmissionBinding;
   executionTree?: import('@veritas-kanban/shared').ExecutionTreeIdentity;
+  /** Immutable recurring-work version and claim that owns this run. */
+  automation?: import('@veritas-kanban/shared').WorkflowAutomationBinding;
   status: WorkflowRunStatus;
   currentStep?: string; // Current step ID
   context: Record<string, unknown>; // Shared context across steps

--- a/shared/src/types/scheduler.types.ts
+++ b/shared/src/types/scheduler.types.ts
@@ -1,12 +1,13 @@
 import type { WorkflowScheduleMode } from './workflow.js';
 
 export type SchedulerDeliverableSchedule = 'daily' | 'weekly' | 'biweekly' | 'monthly' | 'custom';
-export type SchedulerItemKind = 'scheduled-deliverable' | 'workflow' | 'queue-monitor';
+export type SchedulerItemKind =
+  'scheduled-deliverable' | 'workflow' | 'queue-monitor' | 'automation';
 export type SchedulerItemProvider = 'local-server';
 export type SchedulerHealth = 'healthy' | 'warning' | 'paused' | 'blocked';
 export type SchedulerRunStatus = 'success' | 'failed' | 'skipped' | 'started';
 export type SchedulerEventType =
-  'due-run' | 'manual-run' | 'pause' | 'resume' | 'validate' | 'overlap';
+  'due-run' | 'manual-run' | 'pause' | 'resume' | 'revoke' | 'activate' | 'validate' | 'overlap';
 
 export interface SchedulerTrigger {
   mode: SchedulerDeliverableSchedule | WorkflowScheduleMode;
@@ -237,4 +238,173 @@ export interface AutomationDraftCompileInput {
 export interface AutomationDraftListResponse {
   generatedAt: string;
   drafts: AutomationDraft[];
+}
+
+export const AUTOMATION_ACTIVATION_PREVIEW_SCHEMA_VERSION =
+  'automation-activation-preview/v1' as const;
+export const AUTOMATION_VERSION_SCHEMA_VERSION = 'automation-version/v1' as const;
+export const AUTOMATION_BINDING_SCHEMA_VERSION = 'automation-binding/v1' as const;
+export const AUTOMATION_RUN_CLAIM_SCHEMA_VERSION = 'automation-run-claim/v1' as const;
+
+export type AutomationBindingStatus = 'active' | 'paused' | 'revoked' | 'expired' | 'blocked';
+export type AutomationRunClaimStatus = 'accepted' | 'started' | 'completed' | 'blocked' | 'failed';
+
+export interface AutomationActivationEvidence {
+  sourceTarget: {
+    kind: 'workflow' | 'task-template';
+    id: string;
+    version: number;
+    digest: string;
+  };
+  workflowId: string;
+  workflowVersion: number;
+  workflowDigest: string;
+  provider: string;
+  providerEvidenceDigest: string;
+  toolCatalogDigest: string;
+  integrationEvidenceDigest: string;
+  policyDigest: string;
+  enforceable: boolean;
+  blockers: string[];
+}
+
+export interface AutomationActivationPreview {
+  schemaVersion: typeof AUTOMATION_ACTIVATION_PREVIEW_SCHEMA_VERSION;
+  draftId: string;
+  draftRevision: number;
+  draftDigest: string;
+  requestId: string;
+  requestRevision: string;
+  workspaceId: string;
+  sourceTaskId?: string;
+  objective: string;
+  schedule: {
+    expression: string;
+    timezone: string;
+    startAt?: string;
+    expiresAt: string;
+    overlapPolicy: 'skip' | 'queue-one' | 'forbid';
+    retry: AutomationDraftRetryPosture;
+    nextRunAt?: string;
+  };
+  output: {
+    destination: string;
+    expectedDeliverables: string[];
+  };
+  standingScope: AutomationDraftStandingScope;
+  perRunBudget: AutomationDraftBudget;
+  aggregateBudget: AutomationDraftBudget;
+  stopConditions: string[];
+  effectiveRunAccess: {
+    reads: string[];
+    writes: string[];
+    sends: string[];
+    externalTargets: string[];
+    artifactDestinations: string[];
+    tools: string[];
+    integrations: string[];
+    approvalRequiredActions: string[];
+  };
+  evidence: AutomationActivationEvidence;
+  approval: {
+    required: true;
+    riskClass: 'critical';
+    expiresInMs: number;
+  };
+}
+
+export interface AutomationVersion {
+  schemaVersion: typeof AUTOMATION_VERSION_SCHEMA_VERSION;
+  id: string;
+  version: number;
+  draftId: string;
+  draftRevision: number;
+  draftDigest: string;
+  requestRevision: string;
+  workspaceId: string;
+  sourceTaskId?: string;
+  objective: string;
+  workflowId: string;
+  workflowVersion: number;
+  provider: string;
+  schedule: AutomationActivationPreview['schedule'];
+  output: AutomationActivationPreview['output'];
+  standingScope: AutomationDraftStandingScope;
+  perRunBudget: AutomationDraftBudget;
+  aggregateBudget: AutomationDraftBudget;
+  stopConditions: string[];
+  evidence: AutomationActivationEvidence;
+  approval: {
+    id: string;
+    revision: number;
+    actionHash: string;
+    approvedBy: string;
+    approvedAt: string;
+  };
+  activatedAt: string;
+  digest: string;
+}
+
+export interface AutomationBinding {
+  schemaVersion: typeof AUTOMATION_BINDING_SCHEMA_VERSION;
+  id: string;
+  revision: number;
+  automationVersionId: string;
+  automationVersion: number;
+  status: AutomationBindingStatus;
+  nextRunAt?: string;
+  lastRunAt?: string;
+  acceptedRuns: number;
+  failedRuns: number;
+  aggregateUsage: {
+    runs: number;
+    costUsd: number;
+    tokens: number;
+    durationMinutes: number;
+  };
+  statusReason: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AutomationRunClaim {
+  schemaVersion: typeof AUTOMATION_RUN_CLAIM_SCHEMA_VERSION;
+  id: string;
+  requestId: string;
+  automationVersionId: string;
+  bindingId: string;
+  dueWindow: string;
+  trigger: 'due-run' | 'manual-run';
+  status: AutomationRunClaimStatus;
+  workflowRunId?: string;
+  reason?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AutomationActivationResult {
+  preview: AutomationActivationPreview;
+  approvalId?: string;
+  approvalStatus?: 'pending' | 'approved';
+  version?: AutomationVersion;
+  binding?: AutomationBinding;
+}
+
+export interface AutomationVersionListResponse {
+  generatedAt: string;
+  versions: AutomationVersion[];
+  bindings: AutomationBinding[];
+  recentClaims: AutomationRunClaim[];
+}
+
+export interface WorkflowAutomationBinding {
+  automationVersionId: string;
+  automationVersion: number;
+  bindingId: string;
+  claimId: string;
+  requestId: string;
+  workspaceId: string;
+  outputDestination: string;
+  standingScope: AutomationDraftStandingScope;
+  evidenceDigest: string;
 }

--- a/shared/src/types/workflow.ts
+++ b/shared/src/types/workflow.ts
@@ -280,6 +280,8 @@ export interface WorkflowRun {
   taskId?: string; // Optional task association
   admission?: WorkflowRootAdmissionBinding;
   executionTree?: import('./execution-tree-budget.types.js').ExecutionTreeIdentity;
+  /** Immutable recurring-work version and claim that owns this run. */
+  automation?: import('./scheduler.types.js').WorkflowAutomationBinding;
   status: WorkflowRunStatus;
   currentStep?: string; // Current step ID
   context: Record<string, unknown>; // Shared context across steps

--- a/web/src/__tests__/api-scheduler.test.ts
+++ b/web/src/__tests__/api-scheduler.test.ts
@@ -22,6 +22,25 @@ describe('scheduler API', () => {
     await schedulerApi.listDrafts();
     await schedulerApi.previewDraft(draft);
     await schedulerApi.saveDraft(draft);
+    await schedulerApi.previewActivation({
+      draftId: 'draft/one',
+      revision: 2,
+      requestId: 'preview-1',
+    });
+    await schedulerApi.applyActivation({
+      draftId: 'draft/one',
+      revision: 2,
+      requestId: 'preview-1',
+      expectedRequestRevision: 'sha256:revision',
+      approvalId: 'approval-1',
+    });
+    await schedulerApi.applyActivation({
+      draftId: 'draft/two',
+      revision: 1,
+      requestId: 'preview-2',
+      expectedRequestRevision: 'sha256:revision-2',
+    });
+    await schedulerApi.listAutomations();
     await schedulerApi.runDue();
     await schedulerApi.runItem('item/one');
     await schedulerApi.pause('item/one');
@@ -33,6 +52,37 @@ describe('scheduler API', () => {
       ['/api/scheduler/drafts'],
       ['/api/scheduler/drafts/preview', { method: 'POST', body: JSON.stringify(draft) }],
       ['/api/scheduler/drafts', { method: 'POST', body: JSON.stringify(draft) }],
+      [
+        '/api/scheduler/drafts/draft%2Fone/activation-preview',
+        {
+          method: 'POST',
+          body: JSON.stringify({ revision: 2, requestId: 'preview-1' }),
+        },
+      ],
+      [
+        '/api/scheduler/drafts/draft%2Fone/activate',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            revision: 2,
+            requestId: 'preview-1',
+            expectedRequestRevision: 'sha256:revision',
+            approvalId: 'approval-1',
+          }),
+        },
+      ],
+      [
+        '/api/scheduler/drafts/draft%2Ftwo/activate',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            revision: 1,
+            requestId: 'preview-2',
+            expectedRequestRevision: 'sha256:revision-2',
+          }),
+        },
+      ],
+      ['/api/scheduler/automations'],
       ['/api/scheduler/due/run', { method: 'POST' }],
       ['/api/scheduler/items/item%2Fone/run', { method: 'POST' }],
       ['/api/scheduler/items/item%2Fone/pause', { method: 'POST' }],

--- a/web/src/__tests__/needs-attention-queue-mantine.test.tsx
+++ b/web/src/__tests__/needs-attention-queue-mantine.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   useAcknowledgeDriftAlert: vi.fn(),
   useActiveRuns: vi.fn(),
   useAgentHealthClassifications: vi.fn(),
+  useAutomations: vi.fn(),
   useDriftAlerts: vi.fn(),
   useFailedRuns: vi.fn(),
   useMarkNotificationDelivered: vi.fn(),
@@ -61,6 +62,10 @@ vi.mock('@/hooks/useNotifications', () => ({
 
 vi.mock('@/hooks/useSkillSecurity', () => ({
   useSkillRiskInventory: mocks.useSkillRiskInventory,
+}));
+
+vi.mock('@/hooks/useScheduler', () => ({
+  useAutomations: mocks.useAutomations,
 }));
 
 const tasks = [
@@ -300,6 +305,7 @@ function mockQueueData() {
   mocks.useTaskCost.mockReturnValue({ data: taskCost, isLoading: false });
   mocks.useActiveRuns.mockReturnValue({ data: activeRuns, isLoading: false });
   mocks.useRecentRuns.mockReturnValue({ data: [], isLoading: false });
+  mocks.useAutomations.mockReturnValue({ data: undefined, isLoading: false });
   mocks.useDriftAlerts.mockReturnValue({ data: driftAlerts, isLoading: false });
   mocks.usePendingAgentApprovals.mockReturnValue({ data: approvals, isLoading: false });
   mocks.useAgentHealthClassifications.mockReturnValue({
@@ -382,6 +388,107 @@ describe('needs attention queue', () => {
     expect(healthItem?.reason).toContain('3 run errors recorded');
   });
 
+  it('surfaces blocked automation versions with their exact reason', () => {
+    const items = buildNeedsAttentionItems(
+      {
+        automations: {
+          generatedAt: '2026-06-02T12:00:00Z',
+          versions: [
+            {
+              schemaVersion: 'automation-version/v1',
+              id: 'automation_version_aaaaaaaaaaaaaaaa',
+              version: 2,
+              draftId: 'automation_aaaaaaaaaaaaaaaaaaaaaaaa',
+              draftRevision: 3,
+              draftDigest: `sha256:${'a'.repeat(64)}`,
+              requestRevision: `sha256:${'b'.repeat(64)}`,
+              workspaceId: 'platform',
+              objective: 'Triage support queue',
+              workflowId: 'support-triage',
+              workflowVersion: 4,
+              provider: 'openclaw',
+              schedule: {
+                expression: '0 9 * * 1-5',
+                timezone: 'America/Chicago',
+                expiresAt: '2026-12-31T23:59:59Z',
+                overlapPolicy: 'forbid',
+                retry: { maxAttempts: 2, backoffMinutes: 15 },
+              },
+              output: { destination: 'work-products/triage', expectedDeliverables: [] },
+              standingScope: {
+                reads: [],
+                writes: [],
+                sends: [],
+                externalTargets: [],
+                artifactDestinations: [],
+                integrationIds: [],
+                toolIds: [],
+                credentialDefinitionIds: [],
+                approvalRequiredActions: [],
+              },
+              perRunBudget: { maxRuns: 1 },
+              aggregateBudget: { maxRuns: 20 },
+              stopConditions: [],
+              evidence: {
+                sourceTarget: {
+                  kind: 'workflow',
+                  id: 'support-triage',
+                  version: 4,
+                  digest: `sha256:${'c'.repeat(64)}`,
+                },
+                workflowId: 'support-triage',
+                workflowVersion: 4,
+                workflowDigest: `sha256:${'c'.repeat(64)}`,
+                provider: 'openclaw',
+                providerEvidenceDigest: `sha256:${'d'.repeat(64)}`,
+                toolCatalogDigest: `sha256:${'e'.repeat(64)}`,
+                integrationEvidenceDigest: `sha256:${'f'.repeat(64)}`,
+                policyDigest: `sha256:${'1'.repeat(64)}`,
+                enforceable: true,
+                blockers: [],
+              },
+              approval: {
+                id: 'runapproval_aaaaaaaaaaaaaaaa',
+                revision: 2,
+                actionHash: `sha256:${'2'.repeat(64)}`,
+                approvedBy: 'operator',
+                approvedAt: '2026-06-01T12:00:00Z',
+              },
+              activatedAt: '2026-06-01T12:00:00Z',
+              digest: `sha256:${'3'.repeat(64)}`,
+            },
+          ],
+          bindings: [
+            {
+              schemaVersion: 'automation-binding/v1',
+              id: 'automation_binding_aaaaaaaaaaaaaaaa',
+              revision: 5,
+              automationVersionId: 'automation_version_aaaaaaaaaaaaaaaa',
+              automationVersion: 2,
+              status: 'blocked',
+              acceptedRuns: 4,
+              failedRuns: 2,
+              aggregateUsage: { runs: 4, costUsd: 0, tokens: 0, durationMinutes: 0 },
+              statusReason: 'Provider evidence drifted after activation.',
+              createdAt: '2026-06-01T12:00:00Z',
+              updatedAt: '2026-06-02T11:00:00Z',
+            },
+          ],
+          recentClaims: [],
+        },
+        project: 'platform',
+      },
+      new Date('2026-06-02T12:00:00Z')
+    );
+
+    expect(items[0]).toMatchObject({
+      source: 'automation',
+      title: 'Triage support queue v2',
+      reason: 'Provider evidence drifted after activation.',
+      destinationLabel: 'automation:automation_version_aaaaaaaaaaaaaaaa',
+    });
+  });
+
   it('renders queue items through Mantine controls and opens task targets', async () => {
     const user = userEvent.setup();
     const onOpenTask = vi.fn();
@@ -444,6 +551,7 @@ describe('needs attention queue', () => {
     });
     mocks.useActiveRuns.mockReturnValue({ data: [], isLoading: false });
     mocks.useRecentRuns.mockReturnValue({ data: [], isLoading: false });
+    mocks.useAutomations.mockReturnValue({ data: undefined, isLoading: false });
     mocks.useDriftAlerts.mockReturnValue({ data: [], isLoading: false });
     mocks.usePendingAgentApprovals.mockReturnValue({ data: [], isLoading: false });
     mocks.useAgentHealthClassifications.mockReturnValue({

--- a/web/src/__tests__/scheduler-automation-drafts.test.tsx
+++ b/web/src/__tests__/scheduler-automation-drafts.test.tsx
@@ -230,10 +230,10 @@ function activationPreviewFixture(draft: AutomationDraft) {
       retry: { maxAttempts: 2, backoffMinutes: 15 },
     },
     output: { destination: 'work-products/triage', expectedDeliverables: ['Triage report'] },
-    standingScope: draft.standingScope.value!,
-    perRunBudget: draft.perRunBudget.value!,
-    aggregateBudget: draft.aggregateBudget.value!,
-    stopConditions: draft.stopConditions.value!,
+    standingScope: requiredValue(draft.standingScope.value),
+    perRunBudget: requiredValue(draft.perRunBudget.value),
+    aggregateBudget: requiredValue(draft.aggregateBudget.value),
+    stopConditions: requiredValue(draft.stopConditions.value),
     effectiveRunAccess: {
       reads: ['support-queue'],
       writes: ['work-products/triage'],
@@ -274,6 +274,11 @@ function resolved<T>(value: T) {
     confidence: 'high' as const,
     explanation: 'Explicit.',
   };
+}
+
+function requiredValue<T>(value: T | undefined): T {
+  if (value === undefined) throw new Error('Expected resolved fixture value.');
+  return value;
 }
 
 function missing(explanation: string) {

--- a/web/src/__tests__/scheduler-automation-drafts.test.tsx
+++ b/web/src/__tests__/scheduler-automation-drafts.test.tsx
@@ -9,6 +9,9 @@ const mocks = vi.hoisted(() => ({
   toast: vi.fn(),
   preview: vi.fn(),
   save: vi.fn(),
+  previewActivation: vi.fn(),
+  applyActivation: vi.fn(),
+  drafts: [] as AutomationDraft[],
 }));
 
 vi.mock('@/hooks/useIdentity', () => ({
@@ -29,9 +32,17 @@ vi.mock('@/hooks/useScheduler', () => ({
     },
     refetch: vi.fn(),
   }),
-  useAutomationDrafts: () => ({ data: { drafts: [] } }),
+  useAutomationDrafts: () => ({ data: { drafts: mocks.drafts } }),
   useAutomationDraftPreview: () => ({ mutateAsync: mocks.preview, isPending: false }),
   useAutomationDraftSave: () => ({ mutateAsync: mocks.save, isPending: false }),
+  useAutomationActivationPreview: () => ({
+    mutateAsync: mocks.previewActivation,
+    isPending: false,
+  }),
+  useAutomationActivationApply: () => ({
+    mutateAsync: mocks.applyActivation,
+    isPending: false,
+  }),
   useSchedulerRunDue: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useSchedulerRunItem: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useSchedulerPause: () => ({ mutateAsync: vi.fn(), isPending: false }),
@@ -46,6 +57,7 @@ describe('Scheduler automation draft authoring', () => {
     mocks.hasPermission.mockReturnValue(true);
     mocks.preview.mockResolvedValue(draftFixture());
     mocks.save.mockResolvedValue(draftFixture());
+    mocks.drafts.splice(0);
   });
 
   afterEach(() => {
@@ -74,6 +86,36 @@ describe('Scheduler automation draft authoring', () => {
     expect(mocks.save).not.toHaveBeenCalled();
     expect(await screen.findByText(/execution\.workflowId: Select a workflow/)).toBeDefined();
     expect(screen.getAllByText(/inactive/).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('reviews standing Run Access before requesting exact approval', async () => {
+    const draft = activatableDraftFixture();
+    mocks.drafts.push(draft);
+    mocks.previewActivation.mockResolvedValue(activationPreviewFixture(draft));
+    mocks.applyActivation.mockResolvedValue({
+      preview: activationPreviewFixture(draft),
+      approvalId: 'runapproval_Automation123456',
+      approvalStatus: 'pending',
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<SchedulerTab />);
+
+    await user.click(screen.getByRole('button', { name: 'Review Activation' }));
+    expect(mocks.previewActivation).toHaveBeenCalledWith({
+      draftId: draft.id,
+      revision: draft.revision,
+      requestId: `activation-ui-${draft.id}-${draft.revision}`,
+    });
+    expect(await screen.findByText(/Run Access ceiling: 2 tools/)).toBeDefined();
+
+    await user.click(screen.getByRole('button', { name: 'Request Exact Approval' }));
+    expect(mocks.applyActivation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draftId: draft.id,
+        expectedRequestRevision: `sha256:${'c'.repeat(64)}`,
+      })
+    );
+    expect(await screen.findByText(/Approve runapproval_Automation123456/)).toBeDefined();
   });
 });
 
@@ -129,6 +171,98 @@ function draftFixture(): AutomationDraft {
     inputDigest: `scrypt:${'b'.repeat(64)}`,
     createdAt: '2026-09-01T00:00:00.000Z',
     digest: `scrypt:${'a'.repeat(64)}`,
+  };
+}
+
+function activatableDraftFixture(): AutomationDraft {
+  const draft = draftFixture();
+  return {
+    ...draft,
+    id: 'automation_aaaaaaaaaaaaaaaaaaaaaaaa',
+    execution: {
+      workflowId: resolved('support-triage'),
+      taskTemplateId: missing('No template.'),
+      provider: resolved('openclaw'),
+    },
+    schedule: {
+      ...draft.schedule,
+      expiresAt: resolved('2026-12-31T23:59:59.000Z'),
+      overlapPolicy: resolved('forbid' as const),
+      retry: resolved({ maxAttempts: 2, backoffMinutes: 15 }),
+    },
+    output: {
+      destination: resolved('work-products/triage'),
+      expectedDeliverables: resolved(['Triage report']),
+    },
+    standingScope: resolved({
+      reads: ['support-queue'],
+      writes: ['work-products/triage'],
+      sends: [],
+      externalTargets: [],
+      artifactDestinations: ['work-products/triage'],
+      integrationIds: ['teams-reviewed'],
+      toolIds: ['support-read', 'work-product-write'],
+      credentialDefinitionIds: [],
+      approvalRequiredActions: ['write work product'],
+    }),
+    perRunBudget: resolved({ maxRuns: 1, maxTokens: 100_000 }),
+    aggregateBudget: resolved({ maxRuns: 20, maxTokens: 2_000_000 }),
+    stopConditions: resolved(['expiry reached']),
+    validation: { valid: true, issues: [] },
+  };
+}
+
+function activationPreviewFixture(draft: AutomationDraft) {
+  return {
+    schemaVersion: 'automation-activation-preview/v1' as const,
+    draftId: draft.id,
+    draftRevision: draft.revision,
+    draftDigest: draft.digest,
+    requestId: `activation-ui-${draft.id}-${draft.revision}`,
+    requestRevision: `sha256:${'c'.repeat(64)}`,
+    workspaceId: 'local',
+    objective: draft.objective.value ?? 'Triage',
+    schedule: {
+      expression: '0 9 * * 1-5',
+      timezone: 'America/Chicago',
+      expiresAt: '2026-12-31T23:59:59.000Z',
+      overlapPolicy: 'forbid' as const,
+      retry: { maxAttempts: 2, backoffMinutes: 15 },
+    },
+    output: { destination: 'work-products/triage', expectedDeliverables: ['Triage report'] },
+    standingScope: draft.standingScope.value!,
+    perRunBudget: draft.perRunBudget.value!,
+    aggregateBudget: draft.aggregateBudget.value!,
+    stopConditions: draft.stopConditions.value!,
+    effectiveRunAccess: {
+      reads: ['support-queue'],
+      writes: ['work-products/triage'],
+      sends: [],
+      externalTargets: [],
+      artifactDestinations: ['work-products/triage'],
+      tools: ['support-read', 'work-product-write'],
+      integrations: ['teams-reviewed'],
+      approvalRequiredActions: ['write work product'],
+    },
+    evidence: {
+      sourceTarget: {
+        kind: 'workflow' as const,
+        id: 'support-triage',
+        version: 3,
+        digest: `sha256:${'d'.repeat(64)}`,
+      },
+      workflowId: 'support-triage',
+      workflowVersion: 3,
+      workflowDigest: `sha256:${'d'.repeat(64)}`,
+      provider: 'openclaw',
+      providerEvidenceDigest: `sha256:${'e'.repeat(64)}`,
+      toolCatalogDigest: `sha256:${'f'.repeat(64)}`,
+      integrationEvidenceDigest: `sha256:${'1'.repeat(64)}`,
+      policyDigest: `sha256:${'2'.repeat(64)}`,
+      enforceable: true,
+      blockers: [],
+    },
+    approval: { required: true as const, riskClass: 'critical' as const, expiresInMs: 900_000 },
   };
 }
 

--- a/web/src/components/dashboard/NeedsAttentionQueue.tsx
+++ b/web/src/components/dashboard/NeedsAttentionQueue.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import type {
   AgentHealthClassification,
+  AutomationVersionListResponse,
   DriftAlert,
   SkillRiskInventoryItem,
   Task,
@@ -40,6 +41,7 @@ import {
 import { useTasks } from '@/hooks/useTasks';
 import { useActiveRuns, useRecentRuns, type WorkflowRun } from '@/hooks/useWorkflowStats';
 import { useSkillRiskInventory } from '@/hooks/useSkillSecurity';
+import { useAutomations } from '@/hooks/useScheduler';
 import { cn } from '@/lib/utils';
 
 const DISMISSED_STORAGE_KEY = 'veritas-needs-attention-dismissed-v1';
@@ -54,6 +56,7 @@ type NeedsAttentionSeverity = 'critical' | 'high' | 'medium' | 'low';
 
 type NeedsAttentionSource =
   | 'agent-health'
+  | 'automation'
   | 'approval'
   | 'blocked-task'
   | 'drift-alert'
@@ -97,6 +100,7 @@ export interface NeedsAttentionItem {
 export interface BuildNeedsAttentionInput {
   activeRuns?: WorkflowRun[];
   agentHealth?: AgentHealthClassification[];
+  automations?: AutomationVersionListResponse;
   approvals?: AgentApprovalRequest[];
   driftAlerts?: DriftAlert[];
   failedRuns?: FailedRunDetails[];
@@ -128,6 +132,7 @@ const SEVERITY_RANK: Record<NeedsAttentionSeverity, number> = {
 
 const SOURCE_LABELS: Record<NeedsAttentionSource, string> = {
   'agent-health': 'Agent health',
+  automation: 'Automation',
   approval: 'Approval',
   'blocked-task': 'Blocked task',
   'drift-alert': 'Drift',
@@ -143,6 +148,7 @@ const SOURCE_LABELS: Record<NeedsAttentionSource, string> = {
 
 const SOURCE_ICONS: Record<NeedsAttentionSource, typeof AlertTriangle> = {
   'agent-health': ShieldAlert,
+  automation: Workflow,
   approval: ShieldAlert,
   'blocked-task': AlertTriangle,
   'drift-alert': ShieldAlert,
@@ -281,6 +287,29 @@ export function buildNeedsAttentionItems(
   const items = new Map<string, NeedsAttentionItem>();
   const tasks = input.tasks ?? [];
   const taskById = new Map(tasks.map((task) => [task.id, task]));
+
+  for (const binding of input.automations?.bindings ?? []) {
+    if (binding.status !== 'blocked') continue;
+    const version = input.automations?.versions.find(
+      (candidate) => candidate.id === binding.automationVersionId
+    );
+    if (!version || !projectMatches(input.project, version.workspaceId)) continue;
+
+    addItem(items, {
+      id: `automation:${binding.id}`,
+      dedupeKey: `automation:${binding.id}:${binding.revision}:${binding.statusReason}`,
+      title: `${version.objective} v${version.version}`,
+      reason: binding.statusReason,
+      nextAction: 'Open automations',
+      severity: 'high',
+      source: 'automation',
+      sourceLabel: SOURCE_LABELS.automation,
+      timestamp: binding.updatedAt,
+      project: version.workspaceId,
+      destination: 'workflows',
+      destinationLabel: `automation:${version.id}`,
+    });
+  }
 
   for (const task of tasks) {
     if (!projectMatches(input.project, task.project)) continue;
@@ -544,17 +573,24 @@ export function buildNeedsAttentionItems(
     if (!projectMatches(input.project, project)) continue;
 
     const isBlocked = run.status === 'blocked';
+    const isFailedAutomation = run.status === 'failed' && Boolean(run.automation);
     const isStuckRunning =
       run.status === 'running' && ageMs(run.startedAt, now) >= STUCK_WORKFLOW_MS;
-    if (!isBlocked && !isStuckRunning) continue;
+    if (!isBlocked && !isFailedAutomation && !isStuckRunning) continue;
 
     addItem(items, {
       id: `stuck-workflow:${run.id}`,
       dedupeKey: `stuck-workflow:${run.id}:${run.status}:${run.currentStep ?? ''}`,
-      title: task?.title ?? `Workflow ${run.workflowId}`,
-      reason: isBlocked
-        ? `Workflow is blocked${run.currentStep ? ` at ${run.currentStep}` : ''}`
-        : `Workflow has been running for ${formatAge(run.startedAt, now)}`,
+      title:
+        task?.title ??
+        (run.automation
+          ? `Automation ${run.automation.automationVersionId}`
+          : `Workflow ${run.workflowId}`),
+      reason: isFailedAutomation
+        ? run.error || 'Automation workflow failed.'
+        : isBlocked
+          ? `Workflow is blocked${run.currentStep ? ` at ${run.currentStep}` : ''}`
+          : `Workflow has been running for ${formatAge(run.startedAt, now)}`,
       nextAction: task ? 'Open task' : 'Open workflows',
       severity: isBlocked ? 'high' : 'medium',
       source: 'stuck-workflow',
@@ -741,6 +777,7 @@ export function NeedsAttentionQueue({
   const { data: taskCost, isLoading: taskCostLoading } = useTaskCost(period, project, from, to);
   const { data: activeRuns = [], isLoading: activeRunsLoading } = useActiveRuns();
   const { data: recentRuns = [], isLoading: recentRunsLoading } = useRecentRuns();
+  const { data: automations, isLoading: automationsLoading } = useAutomations();
   const { data: driftAlerts = [], isLoading: driftLoading } = useDriftAlerts({
     acknowledged: false,
   });
@@ -759,6 +796,7 @@ export function NeedsAttentionQueue({
           activeRuns,
           agentHealth: agentHealthData?.classifications,
           approvals,
+          automations,
           driftAlerts,
           failedRuns,
           notifications,
@@ -774,6 +812,7 @@ export function NeedsAttentionQueue({
       activeRuns,
       agentHealthData?.classifications,
       approvals,
+      automations,
       driftAlerts,
       failedRuns,
       notifications,
@@ -821,6 +860,7 @@ export function NeedsAttentionQueue({
     failedRunsLoading ||
     taskCostLoading ||
     activeRunsLoading ||
+    automationsLoading ||
     recentRunsLoading ||
     driftLoading ||
     approvalsLoading ||

--- a/web/src/components/settings/tabs/SchedulerTab.tsx
+++ b/web/src/components/settings/tabs/SchedulerTab.tsx
@@ -16,6 +16,7 @@ import { CalendarClock, CheckCircle2, Pause, Play, RefreshCw, RotateCw } from 'l
 import type {
   AutomationDraft,
   AutomationDraftHints,
+  AutomationActivationPreview,
   SchedulerEvent,
   SchedulerItem,
   SchedulerRunStatus,
@@ -25,6 +26,8 @@ import {
   useAutomationDraftPreview,
   useAutomationDraftSave,
   useAutomationDrafts,
+  useAutomationActivationApply,
+  useAutomationActivationPreview,
   useScheduler,
   useSchedulerPause,
   useSchedulerResume,
@@ -44,9 +47,15 @@ export function SchedulerTab() {
   const drafts = useAutomationDrafts();
   const previewDraft = useAutomationDraftPreview();
   const saveDraft = useAutomationDraftSave();
+  const previewActivation = useAutomationActivationPreview();
+  const applyActivation = useAutomationActivationApply();
   const [intent, setIntent] = useState('');
   const [hintsJson, setHintsJson] = useState('{}');
   const [draftPreview, setDraftPreview] = useState<AutomationDraft | null>(null);
+  const [activationPreview, setActivationPreview] = useState<AutomationActivationPreview | null>(
+    null
+  );
+  const [activationApprovalId, setActivationApprovalId] = useState<string>();
   const [requestId] = useState(
     () => `automation-ui-${globalThis.crypto?.randomUUID?.() ?? Date.now().toString(36)}`
   );
@@ -88,6 +97,54 @@ export function SchedulerTab() {
     } catch (error) {
       toast({
         title: 'Automation draft failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const reviewActivation = async (draft: AutomationDraft) => {
+    try {
+      const preview = await previewActivation.mutateAsync({
+        draftId: draft.id,
+        revision: draft.revision,
+        requestId: `activation-ui-${draft.id}-${draft.revision}`,
+      });
+      setActivationPreview(preview);
+      setActivationApprovalId(undefined);
+      toast({ title: 'Standing authority preview compiled' });
+    } catch (error) {
+      toast({
+        title: 'Activation preview failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const requestOrApplyActivation = async () => {
+    if (!activationPreview) return;
+    try {
+      const result = await applyActivation.mutateAsync({
+        draftId: activationPreview.draftId,
+        revision: activationPreview.draftRevision,
+        requestId: activationPreview.requestId,
+        expectedRequestRevision: activationPreview.requestRevision,
+        approvalId: activationApprovalId,
+      });
+      if (result.version) {
+        setActivationApprovalId(undefined);
+        toast({ title: `Automation ${result.version.id} activated` });
+      } else {
+        setActivationApprovalId(result.approvalId);
+        toast({
+          title: 'Exact approval required',
+          description: `${result.approvalId} is available in Run Approvals.`,
+        });
+      }
+    } catch (error) {
+      toast({
+        title: activationApprovalId ? 'Activation failed' : 'Approval request failed',
         description: error instanceof Error ? error.message : 'Unknown error',
         variant: 'destructive',
       });
@@ -194,9 +251,56 @@ export function SchedulerTab() {
             Saved Inactive Drafts
           </Text>
           {drafts.data?.drafts.map((draft) => (
-            <AutomationDraftReview key={draft.id} draft={draft} compact />
+            <AutomationDraftReview
+              key={draft.id}
+              draft={draft}
+              compact
+              onReviewActivation={canWrite ? () => void reviewActivation(draft) : undefined}
+            />
           ))}
         </Stack>
+      )}
+
+      {activationPreview && (
+        <Alert
+          color={activationPreview.evidence.enforceable ? 'blue' : 'red'}
+          title={`Activation review · ${activationPreview.draftId}`}
+        >
+          <Stack gap="xs">
+            <Text size="xs">
+              {activationPreview.evidence.workflowId}@{activationPreview.evidence.workflowVersion} ·{' '}
+              {activationPreview.evidence.provider} · expires{' '}
+              {formatDate(activationPreview.schedule.expiresAt)}
+            </Text>
+            <Text size="xs">
+              Run Access ceiling: {activationPreview.effectiveRunAccess.tools.length} tools,{' '}
+              {activationPreview.effectiveRunAccess.integrations.length} integrations,{' '}
+              {activationPreview.effectiveRunAccess.externalTargets.length} external targets
+            </Text>
+            <Text size="xs" className="font-mono">
+              {activationPreview.requestRevision}
+            </Text>
+            {activationPreview.evidence.blockers.map((blocker) => (
+              <Text key={blocker} size="xs" c="red">
+                {blocker}
+              </Text>
+            ))}
+            <Group gap="xs">
+              <Button
+                size="xs"
+                disabled={!activationPreview.evidence.enforceable || applyActivation.isPending}
+                onClick={() => void requestOrApplyActivation()}
+              >
+                {activationApprovalId ? 'Activate Approved Version' : 'Request Exact Approval'}
+              </Button>
+              {activationApprovalId && (
+                <Text size="xs" c="dimmed">
+                  Approve {activationApprovalId} in Run Approvals, then activate this exact version.
+                </Text>
+              )}
+            </Group>
+          </Stack>
+        </Alert>
       )}
 
       {scheduler.data && (
@@ -241,7 +345,9 @@ export function SchedulerTab() {
                           ? 'Workflow'
                           : item.kind === 'queue-monitor'
                             ? 'Queue'
-                            : 'Deliverable'}
+                            : item.kind === 'automation'
+                              ? 'Automation'
+                              : 'Deliverable'}
                       </Badge>
                       <HealthBadge item={item} />
                     </Group>
@@ -349,9 +455,11 @@ export function SchedulerTab() {
 function AutomationDraftReview({
   draft,
   compact = false,
+  onReviewActivation,
 }: {
   draft: AutomationDraft;
   compact?: boolean;
+  onReviewActivation?: () => void;
 }) {
   const blockers = draft.validation.issues.filter((issue) => issue.severity === 'blocker');
   return (
@@ -370,9 +478,16 @@ function AutomationDraftReview({
           </Text>
         )}
         {blockers.length === 0 ? (
-          <Text size="xs">
-            No deterministic validation blockers. Activation still requires a separate review.
-          </Text>
+          <Group justify="space-between" align="center">
+            <Text size="xs">
+              No deterministic validation blockers. Activation still requires a separate review.
+            </Text>
+            {onReviewActivation && (
+              <Button size="xs" variant="light" onClick={onReviewActivation}>
+                Review Activation
+              </Button>
+            )}
+          </Group>
         ) : (
           <Stack gap={2}>
             {blockers.slice(0, compact ? 3 : undefined).map((issue) => (

--- a/web/src/components/task/AgentRunTimelinePanel.tsx
+++ b/web/src/components/task/AgentRunTimelinePanel.tsx
@@ -761,7 +761,9 @@ export function buildAgentRunTimelineEvents({
               : 'tool',
       source: 'derived',
       timestamp: workflowStartedAt(run),
-      title: `Workflow ${run.status}: ${run.workflowId}`,
+      title: run.automation
+        ? `Automation ${run.status}: ${run.automation.automationVersionId}`
+        : `Workflow ${run.status}: ${run.workflowId}`,
       detail: run.currentStep
         ? `Current step: ${run.currentStep}`
         : run.error || `${run.steps.length} step${run.steps.length === 1 ? '' : 's'}`,
@@ -775,6 +777,7 @@ export function buildAgentRunTimelineEvents({
         workflowVersion: run.workflowVersion,
         status: run.status,
         currentStep: run.currentStep,
+        automation: run.automation,
         context: run.context,
         steps: run.steps.map((step) => ({
           stepId: step.stepId,

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -818,7 +818,9 @@ export function TaskWorkView({
                 </Group>
                 <Text size="xs" c="dimmed" mt={4}>
                   {workflowRun
-                    ? `Workflow ${workflowRun.workflowId} v${workflowRun.workflowVersion}`
+                    ? workflowRun.automation
+                      ? `Automation ${workflowRun.automation.automationVersionId} · Workflow ${workflowRun.workflowId} v${workflowRun.workflowVersion}`
+                      : `Workflow ${workflowRun.workflowId} v${workflowRun.workflowVersion}`
                     : 'No workflow run has been recorded for this task.'}
                 </Text>
               </div>
@@ -848,6 +850,11 @@ export function TaskWorkView({
                   {workflowRun.currentStep && (
                     <Badge variant="light" color="blue">
                       {workflowRun.currentStep}
+                    </Badge>
+                  )}
+                  {workflowRun.automation && (
+                    <Badge variant="light" color="violet" className="font-mono">
+                      automation v{workflowRun.automation.automationVersion}
                     </Badge>
                   )}
                 </Group>

--- a/web/src/hooks/useScheduler.ts
+++ b/web/src/hooks/useScheduler.ts
@@ -3,6 +3,7 @@ import { api } from '@/lib/api';
 
 export const SCHEDULER_KEY = ['scheduler'] as const;
 export const AUTOMATION_DRAFTS_KEY = ['scheduler', 'drafts'] as const;
+export const AUTOMATIONS_KEY = ['scheduler', 'automations'] as const;
 
 export function useScheduler() {
   return useQuery({
@@ -28,6 +29,26 @@ export function useAutomationDraftSave() {
     mutationFn: api.scheduler.saveDraft,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: AUTOMATION_DRAFTS_KEY }),
   });
+}
+
+export function useAutomationActivationPreview() {
+  return useMutation({ mutationFn: api.scheduler.previewActivation });
+}
+
+export function useAutomationActivationApply() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: api.scheduler.applyActivation,
+    onSuccess: (result) => {
+      if (!result.version) return;
+      void queryClient.invalidateQueries({ queryKey: SCHEDULER_KEY });
+      void queryClient.invalidateQueries({ queryKey: AUTOMATIONS_KEY });
+    },
+  });
+}
+
+export function useAutomations() {
+  return useQuery({ queryKey: AUTOMATIONS_KEY, queryFn: api.scheduler.listAutomations });
 }
 
 export function useSchedulerRunDue() {

--- a/web/src/hooks/useWorkflowStats.ts
+++ b/web/src/hooks/useWorkflowStats.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api/helpers';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
+import type { WorkflowAutomationBinding } from '@veritas-kanban/shared';
 
 export type WorkflowPeriod = '24h' | '7d' | '30d';
 
@@ -11,6 +12,7 @@ export interface WorkflowRun {
   workflowId: string;
   workflowVersion: number;
   taskId?: string;
+  automation?: WorkflowAutomationBinding;
   status: WorkflowRunStatus;
   currentStep?: string;
   context?: Record<string, unknown>;

--- a/web/src/lib/api/scheduler.ts
+++ b/web/src/lib/api/scheduler.ts
@@ -2,6 +2,9 @@ import type {
   AutomationDraft,
   AutomationDraftHints,
   AutomationDraftListResponse,
+  AutomationActivationPreview,
+  AutomationActivationResult,
+  AutomationVersionListResponse,
   SchedulerDueRunResult,
   SchedulerListResponse,
   SchedulerRunResult,
@@ -30,6 +33,38 @@ export const schedulerApi = {
       method: 'POST',
       body: JSON.stringify(input),
     }),
+
+  previewActivation: (input: { draftId: string; revision: number; requestId: string }) =>
+    apiFetch<AutomationActivationPreview>(
+      `${API_BASE}/scheduler/drafts/${encodeURIComponent(input.draftId)}/activation-preview`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ revision: input.revision, requestId: input.requestId }),
+      }
+    ),
+
+  applyActivation: (input: {
+    draftId: string;
+    revision: number;
+    requestId: string;
+    expectedRequestRevision: string;
+    approvalId?: string;
+  }) =>
+    apiFetch<AutomationActivationResult>(
+      `${API_BASE}/scheduler/drafts/${encodeURIComponent(input.draftId)}/activate`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          revision: input.revision,
+          requestId: input.requestId,
+          expectedRequestRevision: input.expectedRequestRevision,
+          ...(input.approvalId ? { approvalId: input.approvalId } : {}),
+        }),
+      }
+    ),
+
+  listAutomations: () =>
+    apiFetch<AutomationVersionListResponse>(`${API_BASE}/scheduler/automations`),
 
   runDue: () =>
     apiFetch<SchedulerDueRunResult>(`${API_BASE}/scheduler/due/run`, {


### PR DESCRIPTION
## Summary

- add exact Run Access previews and critical human approval for immutable automation versions
- claim due windows durably before shared workflow admission and enforce versioned tool and budget ceilings
- expose activation, lifecycle controls, blockers, history, Task Work, Timeline, Needs Attention, API, CLI, and operator docs

## Verification

- shared, server, CLI, and web typechecks
- 27 focused server workflow and automation tests
- 8 focused scheduler and Needs Attention UI tests
- 3 focused CLI tests
- lint and permission-surface coverage
- critical-path coverage for server, web, and CLI: 1,620 tests passed and all ratchets passed

Closes #1253