### PR TITLE
feat: enforce provenance-aware file execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,11 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   reconstruction. A dangling handle becomes `interrupted` after restart
   because inherited pipes cannot be reattached safely. PTY, interactive stdin,
   and restart reattachment fail closed until their typed controls ship.
+- Explicit run-terminal executable, script, loader, config, archive, and
+  load-path inputs use `run-file-execution-approval-evidence/v1`. Bind exact
+  provenance or launch-baseline digests into the approval, require a critical
+  human-only decision for external or unknown bytes, and rehash immediately
+  before spawn. Unsupported indirect and tool transports fail closed.
 - File-backed Work Products use the exact manifest-bound `run-artifact` root
   exposed as `VERITAS_ARTIFACT_ROOT`. Register only completed relative files
   through the governed artifact service; never persist or expose the host root.

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1657,9 +1657,9 @@ Execution accepts a stable caller-owned request ID, an executable plus argument 
 }
 ```
 
-The first valid request returns `202` with `status: "approval-required"` and an exact-action run approval. Resolve that approval through `/api/v1/run-approvals/:approvalId/decision`, then retry the identical request. An approved retry returns `201` with `status: "started"` and the run-owned handle. Reusing `requestId` with a changed command returns `409`; retrying an already-started exact request returns the original handle.
+The first valid request returns `202` with `status: "approval-required"` and an exact-action run approval. Resolve that approval through `/api/v1/run-approvals/:approvalId/decision`, then retry the identical request. An approved retry returns `201` with `status: "started"` and the run-owned handle. Reusing `requestId` with a changed command or changed referenced-file evidence returns `409`; retrying an already-started exact request returns the original handle.
 
-The server, not the caller, supplies environment values and applies the active run's filesystem wrapper and network-egress environment. Commands are launched without a shell. Missing process authority, stale manifest or phase evidence, unenforceable required sandbox posture, cwd escape, credential-shaped arguments, unapproved environment names, and unsupported PTY mode fail closed before spawn.
+The server, not the caller, supplies environment values and applies the active run's filesystem wrapper and network-egress environment. Commands are launched without a shell. Supported direct executable, interpreter, loader, config, and archive paths are hashed and joined to exact provenance or launch-baseline evidence. External, downloaded, attachment, connector, stale, gap, or unknown executable bytes require a critical human-only approval and are rehashed immediately before spawn. Project policy can require human review or deny agent, command, and tool-created inputs, but cannot lower the external-source floor. Unsupported indirect execution and uncertified file identities return typed `409` blockers. See [Run File Execution Approval v1](architecture/RUN-FILE-EXECUTION-APPROVAL-V1.md).
 
 ---
 
@@ -2983,7 +2983,12 @@ Task create/update payloads may set reusable defaults under
 {
   "executionPolicy": {
     "commitPolicy": "forbidden",
-    "allowedSideEffects": [{ "kind": "filesystem-write", "scope": "." }]
+    "allowedSideEffects": [{ "kind": "filesystem-write", "scope": "." }],
+    "fileExecution": {
+      "agentCreated": "human-approval",
+      "commandCreated": "standard-approval",
+      "toolCreated": "deny"
+    }
   }
 }
 ```
@@ -2994,6 +2999,10 @@ does not authorize. Path scopes wider than the assigned worktree are clamped to
 the worktree, while disjoint path scopes are dropped. Generic task PATCH calls
 cannot set `attempt.taskEnvelope` or `attempt.completionResult`; only the
 launch and finalization services may persist those authoritative contracts.
+`fileExecution` accepts `standard-approval`, `human-approval`, or `deny` for
+agent, command, and tool-created inputs and is frozen into the task envelope.
+External, attachment, connector, downloaded, stale, gap, and unknown sources
+always retain the human-only floor.
 
 Before dispatch, the selected adapter renders the envelope through an immutable
 `provider-task-envelope-transport/v1` request. Built-in renderers exist for

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1225,6 +1225,12 @@ Reusable launch-time sandbox presets for provider execution guardrails.
   Code, and ACP stdio; Hermes and OpenClaw fail closed for credential-bound
   catalogs. Existing provider authentication and explicit environment
   passthrough are not mislabeled as brokered.
+- Run-owned terminal execution binds explicit executable, script, loader,
+  configuration, and archive inputs to provenance or launch-baseline digests.
+  External or unknown bytes require a critical human-only decision, project
+  policy governs other run-produced sources, and every reference is rehashed
+  immediately before spawn. Unsupported indirect and tool transports fail
+  closed rather than claiming incomplete enforcement.
 - Provider capability checks currently distinguish Codex CLI, Codex SDK,
   Codex app-server, Claude Code, ACP stdio harnesses, Hermes, and OpenClaw
   execution behavior. Gateway capability evidence is invalidated by provider

--- a/docs/architecture/RUN-FILE-EXECUTION-APPROVAL-V1.md
+++ b/docs/architecture/RUN-FILE-EXECUTION-APPROVAL-V1.md
@@ -1,0 +1,19 @@
+# Run File Execution Approval v1
+
+`run-file-execution-approval-evidence/v1` binds files referenced by a mediated command to the exact run approval that permits process creation. A filename is never approval evidence by itself.
+
+## Enforced path
+
+The provider-neutral run terminal normalizes direct worktree executables and supported interpreter, loader, configuration, archive, and load-path inputs. Each regular single-link file is resolved beneath the canonical worktree, hashed with SHA-256, and joined to its exact `run-file-provenance/v1` record or launch baseline. Symlinks, hard links, path escape, oversized inputs, provenance races, and ambiguous identities fail closed.
+
+The approval evidence binds workspace, task, root objective, execution node, run, attempt, workflow step, terminal request ID and digest, command ID, cwd-bound relative path, launch manifest, active phase, project policy, content digest, source class, provenance record and evidence digests, and the combined decision digest. The run terminal handle retains the combined evidence digest.
+
+Downloaded, connector-derived, attachment-derived, external, unknown, stale, or gap-backed executable inputs require a critical `human-only` approval. Agents, services, reviewer models, allowlists, retries, fallback, and prior path approvals cannot resolve that request. Agent, command, and tool-created inputs use the immutable task envelope's project policy: `standard-approval`, `human-approval`, or `deny`. External and unknown sources cannot be downgraded by project policy.
+
+After approval, the server reopens and rehashes every reference, re-resolves its provenance or launch baseline, and compares the complete evidence digest immediately before the synchronous spawn call. Changed bytes, source, phase, manifest, request, policy, or causal evidence invalidate the decision. The approval remains revisioned, expiring, interruption-aware, single-use, and exact to one stable request ID.
+
+## Supported and blocked forms
+
+The first enforcement release covers direct worktree executables; Node, Python, POSIX shell, Ruby, Perl, PowerShell, .NET, and Java archive script inputs; Node loaders and config inputs; and `tar` or `unzip` archive inputs when the path is explicit. Inline interpreter code, Python module dispatch, package-script dispatch, environment load paths, provider-native execution without certified command mediation, and MCP tools declaring `x-veritas-file-execution` return typed blockers. Veritas does not heuristically parse arbitrary shell language or claim downstream tool enforcement it cannot prove.
+
+This control is provenance and approval enforcement, not malware scanning, sandboxing, code review, or a claim that approved bytes are safe.

--- a/docs/architecture/RUN-FILE-PROVENANCE-V1.md
+++ b/docs/architecture/RUN-FILE-PROVENANCE-V1.md
@@ -31,4 +31,4 @@ Only `exact` is affirmative provenance evidence. The response includes a bounded
 
 The API exposes exact resolution and bounded attempt listing. `vk agent:file-provenance` mirrors exact resolution. The run timeline shows the newest records and gaps without polling beyond the existing live-run refresh path.
 
-The initial automatic producer integration covers governed File Work Product artifact registration. Providers and tools that cannot expose causal digest-bound file operations remain explicitly unsupported. General filesystem interception, certified link identity, and approval-policy enforcement are separate boundaries; they must not be inferred from this ledger.
+The initial automatic producer integration covers governed File Work Product artifact registration. Providers and tools that cannot expose causal digest-bound file operations remain explicitly unsupported. General filesystem interception is not inferred from this ledger. The provider-neutral run terminal now consumes exact ledger or launch-baseline evidence through [Run File Execution Approval v1](RUN-FILE-EXECUTION-APPROVAL-V1.md); unsupported indirect or tool transports return typed blockers.

--- a/docs/security.md
+++ b/docs/security.md
@@ -330,6 +330,15 @@ Required filesystem boundaries have no per-run bypass. Task-readiness
 an authorized advisory policy preset, and the evaluated policy plus launch
 decision are retained as governance evidence.
 
+Run-owned terminal commands also bind supported executable, script, loader,
+configuration, archive, and load-path inputs to exact file provenance or the
+launch baseline. External or unknown bytes require a fresh human-only approval;
+project policy may further require human review or deny run-produced inputs.
+Every referenced file is reopened, rehashed, and compared with the complete
+approval evidence immediately before spawn. Unsupported indirect execution and
+uncertified tool transports fail closed. See
+[Run File Execution Approval v1](architecture/RUN-FILE-EXECUTION-APPROVAL-V1.md).
+
 ### Credential broker core
 
 Credential definitions are stored separately from secret values. An admin can

--- a/docs/testing/critical-path-coverage.json
+++ b/docs/testing/critical-path-coverage.json
@@ -67,6 +67,7 @@
           "src/__tests__/routes/work-product-artifacts.test.ts",
           "src/__tests__/routes/v1-permission-guards.test.ts",
           "src/__tests__/run-launch-manifest-service.test.ts",
+          "src/__tests__/run-approval-broker-service.test.ts",
           "src/__tests__/run-file-provenance-service.test.ts",
           "src/__tests__/run-access-summary-service.test.ts",
           "src/__tests__/run-recovery-policy-service.test.ts",

--- a/server/src/__tests__/__snapshots__/provider-task-envelope-renderer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/provider-task-envelope-renderer.test.ts.snap
@@ -6,7 +6,7 @@ exports[`provider task-envelope renderers > renders a callback-free Claude Code 
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:ef4bde56bd2a3ab7f14ab2fcbfe034092ea8dfae37927adc11ba2bfce3f06f86\`
+- Digest: \`sha256:8e7a438fdc0475439622eee6dc2e00879466d807b6f1eddd7fe8da4160b3bc64\`
 - Provider: \`claude-code\`
 - Adapter: \`claude-code\`
 - Runtime manifest: \`sha256:88e24bd4e81c1188c99ba752fa246b15e2cbe1610d8c7ebeb435a983e66dc348\`
@@ -97,7 +97,7 @@ exports[`provider task-envelope renderers > renders a callback-free Codex CLI tr
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:0655dd8724d872681c78ded660e839f8fc4e15aad3028a64196b807c73f987e5\`
+- Digest: \`sha256:e12e89c8ebe506051d179c44fd53893ea8624b7ea44f3a11de888adf35b0145e\`
 - Provider: \`codex-cli\`
 - Adapter: \`codex-cli\`
 - Runtime manifest: \`sha256:d8ad6b2c4913ff3b21f6ce902b77cb362401ef86f32aa4f3f28cbbd9d88082c9\`
@@ -185,7 +185,7 @@ exports[`provider task-envelope renderers > renders a callback-free Codex SDK tr
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:9e8bd5c917431107ec21f6f4836b1f9f7077f4a2201cf6afb031d5eeec657920\`
+- Digest: \`sha256:a9aa614dee26324078c21a97e8821292b9b7fc1f42ec80db3320e3d440c20f8f\`
 - Provider: \`codex-sdk\`
 - Adapter: \`codex-sdk\`
 - Runtime manifest: \`sha256:a0d6c0f07b4c24419c37b4526f183951db10d5c6ec9bf3451f2daa1ef7cf368a\`
@@ -274,7 +274,7 @@ exports[`provider task-envelope renderers > renders a callback-free Codex app-se
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:6c2fa8ebc32e978a3a8fda910471429b26e93be9afe346311d0a80c97680658a\`
+- Digest: \`sha256:752997c167a25a9ec8781076a8e8c093d6b9f1fdf269c18797f346bfdb1de341\`
 - Provider: \`codex-app-server\`
 - Adapter: \`codex-app-server\`
 - Runtime manifest: \`sha256:d5a32f42bfe25fc1a2d4e93a35b31f1cded947bfbf24041b8fd96ebd86c299a3\`
@@ -365,7 +365,7 @@ exports[`provider task-envelope renderers > renders a callback-free Hermes scrip
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:f4943d64435f9a418eb648d3a309ffa22cf7bf488db3cfac471e6a779beb29a5\`
+- Digest: \`sha256:61f6a557435b2ec3fabc10cf9ef6a190b8bb882910fe6ada1855597b8b119215\`
 - Provider: \`hermes-cli\`
 - Adapter: \`hermes-cli\`
 - Runtime manifest: \`sha256:105fc11b1236086a7d0181f73ac7201e519ef667c27ad7f7b71d44a28ee4360c\`
@@ -456,7 +456,7 @@ exports[`provider task-envelope renderers > renders an OpenClaw callback transpo
 ## Transport
 
 - Envelope: \`task-envelope/v1\`
-- Digest: \`sha256:43adb348cbb7ad4322b6b4ff1ca9a24091ddb7319a4e690602efe34e5caafbfd\`
+- Digest: \`sha256:6fb7e306ba5d86aa966cc32814ac2ae33915b7c55c68a8455171ff6a7a795c0f\`
 - Provider: \`openclaw\`
 - Adapter: \`openclaw\`
 - Runtime manifest: \`sha256:be3844c45a6aef384fb2c6d8dd0e15365b9cd06170272607396278beb052db68\`

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -246,6 +246,7 @@ import type { WorkspaceExecutionTrustService } from '../services/workspace-execu
 import type { AdmissionControlService } from '../services/admission-control-service.js';
 import type { RunTerminalService } from '../services/run-terminal-service.js';
 import type { WorkspaceCheckpointService } from '../services/workspace-checkpoint-service.js';
+import type { RunFileExecutionPolicyService } from '../services/run-file-execution-policy-service.js';
 import type { RunLaunchCompiler } from '../services/run-launch-compiler.js';
 
 const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'codex');
@@ -294,7 +295,11 @@ function testableService(
   workspaceCheckpoints: Pick<
     WorkspaceCheckpointService,
     'captureBoundary'
-  > = testWorkspaceCheckpoints()
+  > = testWorkspaceCheckpoints(),
+  runFileExecutionPolicy: Pick<
+    RunFileExecutionPolicyService,
+    'evaluate' | 'revalidate'
+  > = testRunFileExecutionPolicy()
 ): TestableClawdbotAgentService {
   const completionEvidence = testCompletionEvidence();
   const taskEnvelopes = new TaskEnvelopeService(completionEvidence);
@@ -327,10 +332,45 @@ function testableService(
     testReflectionExtractionJobs(),
     undefined,
     runTerminals,
-    workspaceCheckpoints
+    workspaceCheckpoints,
+    runFileExecutionPolicy
   ) as unknown as TestableClawdbotAgentService;
   service.logsDir = tmpDir;
   return service;
+}
+
+function testRunFileExecutionPolicy(): Pick<
+  RunFileExecutionPolicyService,
+  'evaluate' | 'revalidate'
+> {
+  return {
+    evaluate: vi.fn(async (input) => ({
+      schemaVersion: 'run-file-execution-approval-evidence/v1',
+      workspaceId: input.workspaceId,
+      taskId: input.taskId,
+      rootObjectiveId: input.rootObjectiveId,
+      executionNodeId: input.executionNodeId,
+      runId: input.runId,
+      attemptId: input.attemptId,
+      workflowStepId: input.workflowStepId,
+      terminalRequestId: input.request.requestId,
+      terminalRequestDigest: `sha256:${'d'.repeat(64)}`,
+      commandId: 'cmd_test',
+      launchManifestDigest: input.launchManifestDigest,
+      phaseEvidenceDigest: input.phaseEvidenceDigest,
+      policy: {
+        schemaVersion: 'run-file-execution-policy/v1',
+        agentCreated: 'standard-approval',
+        commandCreated: 'standard-approval',
+        toolCreated: 'standard-approval',
+      },
+      references: [],
+      decision: 'standard-approval',
+      reasonCode: 'no-referenced-files',
+      digest: `sha256:${'e'.repeat(64)}`,
+    })),
+    revalidate: vi.fn(async () => undefined),
+  };
 }
 
 function testWorkspaceCheckpoints(): Pick<WorkspaceCheckpointService, 'captureBoundary'> {
@@ -3579,6 +3619,8 @@ describe('ClawdbotAgentService Codex providers', () => {
         evidenceRevision: input.evidenceRevision,
         providerRequestId: input.providerRequestId,
         mobileSafe: input.mobileSafe ?? false,
+        decisionAuthority: input.decisionAuthority,
+        fileExecution: input.fileExecution,
         status: approvalStatus,
         revision: approvalStatus === 'approved' ? 2 : 1,
         createdAt: '2026-07-25T12:00:00.000Z',
@@ -3670,7 +3712,14 @@ describe('ClawdbotAgentService Codex providers', () => {
         attemptId: active.attemptId,
         providerRequestId: request.requestId,
         riskClass: 'high',
-        exactAction: request,
+        exactAction: {
+          request,
+          fileExecution: expect.objectContaining({
+            schemaVersion: 'run-file-execution-approval-evidence/v1',
+            terminalRequestId: request.requestId,
+            decision: 'standard-approval',
+          }),
+        },
       })
     );
 
@@ -3695,6 +3744,8 @@ describe('ClawdbotAgentService Codex providers', () => {
         launchManifestDigest: active.runLaunchManifest.digest,
         worktreeRoot: tmpDir,
         allowedCommands: [process.execPath],
+        fileExecutionEvidenceDigest: `sha256:${'e'.repeat(64)}`,
+        beforeSpawn: expect.any(Function),
         wrap: expect.any(Function),
       }),
       request

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -3637,6 +3637,29 @@ describe('ClawdbotAgentService Codex providers', () => {
       }),
       cancelAttempt: vi.fn(async () => []),
     } as unknown as RunApprovalBrokerService;
+    const runFileExecutionPolicy = testRunFileExecutionPolicy();
+    const evaluateFileExecution = vi
+      .mocked(runFileExecutionPolicy.evaluate)
+      .getMockImplementation();
+    if (!evaluateFileExecution) throw new Error('File execution policy fixture is incomplete.');
+    vi.mocked(runFileExecutionPolicy.evaluate).mockImplementation(async (input) => ({
+      ...(await evaluateFileExecution(input)),
+      references: [
+        {
+          kind: 'direct-executable',
+          root: 'worktree',
+          relativePath: 'bin/tool',
+          contentSha256: `sha256:${'1'.repeat(64)}`,
+          byteSize: 42,
+          source: 'repository-baseline',
+          provenanceStatus: 'launch-baseline',
+          provenanceRecordId: null,
+          provenanceRecordDigest: null,
+          provenanceEvidenceDigest: `sha256:${'2'.repeat(64)}`,
+          decision: 'standard-approval',
+        },
+      ],
+    }));
     const service = testableService(
       tmpDir,
       undefined,
@@ -3646,7 +3669,9 @@ describe('ClawdbotAgentService Codex providers', () => {
       undefined,
       undefined,
       undefined,
-      runTerminals
+      runTerminals,
+      undefined,
+      runFileExecutionPolicy
     );
     const active = await service.startAgent(task.id, 'codex');
     const request = {
@@ -3688,7 +3713,10 @@ describe('ClawdbotAgentService Codex providers', () => {
         restartReattachment: 'unsupported' as const,
       },
     };
-    vi.mocked(runTerminals.execute).mockResolvedValue(handle);
+    vi.mocked(runTerminals.execute).mockImplementation(async (context) => {
+      await context.beforeSpawn();
+      return handle;
+    });
 
     await expect(
       service.executeRunTerminal(task.id, active.attemptId, {
@@ -3698,6 +3726,34 @@ describe('ClawdbotAgentService Codex providers', () => {
       })
     ).rejects.toThrow('Credential-shaped values are not allowed');
     expect(approvalRequest).not.toHaveBeenCalled();
+
+    vi.mocked(runFileExecutionPolicy.evaluate).mockImplementationOnce(async (input) => ({
+      ...(await evaluateFileExecution(input)),
+      decision: 'deny',
+      reasonCode: 'project-policy-deny',
+    }));
+    await expect(
+      service.executeRunTerminal(task.id, active.attemptId, {
+        ...request,
+        requestId: 'terminal-denied-file-request',
+      })
+    ).rejects.toThrow('Project policy denies execution');
+
+    const pendingAgent = (
+      service as unknown as {
+        activePendingAgent(taskId: string): { executionTree?: ExecutionTreeIdentity } | undefined;
+      }
+    ).activePendingAgent(task.id);
+    if (!pendingAgent?.executionTree) throw new Error('Active execution tree fixture is missing.');
+    const executionTree = pendingAgent.executionTree;
+    delete pendingAgent.executionTree;
+    await expect(
+      service.executeRunTerminal(task.id, active.attemptId, {
+        ...request,
+        requestId: 'terminal-missing-execution-tree-request',
+      })
+    ).rejects.toThrow('no durable execution-tree identity');
+    pendingAgent.executionTree = executionTree;
 
     await expect(
       service.executeRunTerminal(task.id, active.attemptId, request)
@@ -3751,14 +3807,32 @@ describe('ClawdbotAgentService Codex providers', () => {
       request
     );
 
+    const bindPhaseApproval = vi.spyOn(
+      service as unknown as {
+        bindPhaseApproval(...args: unknown[]): Promise<unknown>;
+      },
+      'bindPhaseApproval'
+    );
+    bindPhaseApproval
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ evidenceDigest: `sha256:${'3'.repeat(64)}` });
+    await expect(
+      service.executeRunTerminal(task.id, active.attemptId, {
+        ...request,
+        requestId: 'terminal-phase-drift-request',
+      })
+    ).rejects.toThrow('phase evidence changed after approval');
+    bindPhaseApproval.mockRestore();
+
     let resolveLaunch: (() => void) | undefined;
     let launchSettled = false;
     const launchGate = new Promise<void>((resolve) => {
       resolveLaunch = resolve;
     });
-    vi.mocked(runTerminals.execute).mockImplementationOnce(async (_context, input) => {
+    vi.mocked(runTerminals.execute).mockImplementationOnce(async (context, input) => {
       await launchGate;
       launchSettled = true;
+      await context.beforeSpawn();
       return {
         ...handle,
         id: 'terminal_finalization_race',
@@ -3773,8 +3847,10 @@ describe('ClawdbotAgentService Codex providers', () => {
       ...request,
       requestId: 'terminal-finalization-race',
     };
+    const launchesBeforeRace = vi.mocked(runTerminals.execute).mock.calls.length;
     const racingExecution = service.executeRunTerminal(task.id, active.attemptId, racingRequest);
-    await waitFor(() => expect(runTerminals.execute).toHaveBeenCalledTimes(2));
+    const racingOutcome = expect(racingExecution).rejects.toThrow('raced with run finalization');
+    await waitFor(() => expect(runTerminals.execute).toHaveBeenCalledTimes(launchesBeforeRace + 1));
     const originalProviderComplete = ProviderCompletionService.prototype.complete;
     let resolveProviderCompletion: (() => void) | undefined;
     const providerCompletion = new Promise<void>((resolve) => {
@@ -3795,10 +3871,7 @@ describe('ClawdbotAgentService Codex providers', () => {
       expect(runTerminals.cleanupAttempt).not.toHaveBeenCalled();
 
       resolveLaunch?.();
-      await expect(racingExecution).resolves.toMatchObject({
-        status: 'started',
-        handle: { id: 'terminal_finalization_race' },
-      });
+      await racingOutcome;
       await stopping;
       expect(runTerminals.cleanupAttempt).toHaveBeenCalledOnce();
     } finally {

--- a/server/src/__tests__/run-approval-broker-service.test.ts
+++ b/server/src/__tests__/run-approval-broker-service.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../services/run-approval-broker-service.js';
 import type { RunEventJournalService } from '../services/run-event-journal-service.js';
 import type { RunPhaseAuthorityService } from '../services/run-phase-authority-service.js';
+import { calculateRunFileExecutionEvidenceDigest } from '../utils/run-file-execution-digest.js';
 
 class InMemoryRunApprovalRepository implements RunApprovalRepository {
   readonly requests = new Map<string, RunApprovalRequest>();
@@ -167,6 +168,55 @@ describe('RunApprovalBrokerService', () => {
         })
       )
     ).rejects.toMatchObject({ statusCode: 409, code: 'CONFLICT' });
+  });
+
+  it('persists only digest-valid run file execution evidence', async () => {
+    const fixture = service();
+    const material = {
+      schemaVersion: 'run-file-execution-approval-evidence/v1' as const,
+      workspaceId: 'local',
+      taskId: 'task_approval_fixture',
+      rootObjectiveId: 'objective_1',
+      executionNodeId: 'node_1',
+      runId: 'attempt_approval_fixture',
+      attemptId: 'attempt_approval_fixture',
+      workflowStepId: null,
+      terminalRequestId: 'provider-request-file-evidence',
+      terminalRequestDigest: `sha256:${'1'.repeat(64)}`,
+      commandId: 'cmd_fixture',
+      launchManifestDigest: `sha256:${'2'.repeat(64)}`,
+      phaseEvidenceDigest: null,
+      policy: {
+        schemaVersion: 'run-file-execution-policy/v1' as const,
+        agentCreated: 'standard-approval' as const,
+        commandCreated: 'standard-approval' as const,
+        toolCreated: 'standard-approval' as const,
+      },
+      references: [],
+      decision: 'standard-approval' as const,
+      reasonCode: 'no-referenced-files' as const,
+    };
+    const fileExecution = {
+      ...material,
+      digest: calculateRunFileExecutionEvidenceDigest(material),
+    };
+
+    await expect(
+      fixture.broker.request(
+        requestInput({
+          providerRequestId: 'provider-request-file-evidence',
+          fileExecution,
+        })
+      )
+    ).resolves.toMatchObject({ fileExecution });
+    await expect(
+      fixture.broker.request(
+        requestInput({
+          providerRequestId: 'provider-request-invalid-file-evidence',
+          fileExecution: { ...fileExecution, digest: `sha256:${'f'.repeat(64)}` },
+        })
+      )
+    ).rejects.toMatchObject({ statusCode: 400, code: 'VALIDATION_ERROR' });
   });
 
   it('deduplicates concurrent provider retries and binds authorization metadata', async () => {
@@ -406,6 +456,42 @@ describe('RunApprovalBrokerService', () => {
         },
       },
     });
+  });
+
+  it('prevents agents and services from resolving a human-only approval', async () => {
+    const now = new Date('2026-08-30T12:00:00.000Z');
+    const fixture = service(new InMemoryRunApprovalRepository(), () => now);
+    const pending = await fixture.broker.request(
+      requestInput({
+        providerRequestId: 'provider-request-human-only',
+        riskClass: 'critical',
+        decisionAuthority: 'human-only',
+      })
+    );
+    const decision = {
+      decision: 'approved' as const,
+      expectedRevision: pending.revision,
+      expectedActionHash: pending.actionHash,
+    };
+
+    await expect(
+      fixture.broker.decide(pending.id, decision, {
+        id: 'reviewer-model',
+        type: 'agent',
+        authMethod: 'service-token',
+        authenticatedAt: '2026-08-30T11:59:30.000Z',
+        workspaceId: 'local',
+      })
+    ).rejects.toMatchObject({ statusCode: 403, code: 'FORBIDDEN' });
+    await expect(
+      fixture.broker.decide(pending.id, decision, {
+        id: 'human-reviewer',
+        type: 'user',
+        authMethod: 'session',
+        authenticatedAt: '2026-08-30T11:59:30.000Z',
+        workspaceId: 'local',
+      })
+    ).resolves.toMatchObject({ status: 'approved', decisionAuthority: 'human-only' });
   });
 
   it('expires stale requests and cancels every pending request for an interrupted attempt', async () => {

--- a/server/src/__tests__/run-approval-broker-service.test.ts
+++ b/server/src/__tests__/run-approval-broker-service.test.ts
@@ -19,6 +19,7 @@ import {
 import type { RunEventJournalService } from '../services/run-event-journal-service.js';
 import type { RunPhaseAuthorityService } from '../services/run-phase-authority-service.js';
 import { calculateRunFileExecutionEvidenceDigest } from '../utils/run-file-execution-digest.js';
+import { RunApprovalRequestSchema } from '../schemas/run-approval-schemas.js';
 
 class InMemoryRunApprovalRepository implements RunApprovalRepository {
   readonly requests = new Map<string, RunApprovalRequest>();
@@ -201,14 +202,19 @@ describe('RunApprovalBrokerService', () => {
       digest: calculateRunFileExecutionEvidenceDigest(material),
     };
 
-    await expect(
-      fixture.broker.request(
-        requestInput({
-          providerRequestId: 'provider-request-file-evidence',
-          fileExecution,
-        })
-      )
-    ).resolves.toMatchObject({ fileExecution });
+    const persisted = await fixture.broker.request(
+      requestInput({
+        providerRequestId: 'provider-request-file-evidence',
+        fileExecution,
+      })
+    );
+    expect(persisted).toMatchObject({ fileExecution });
+    expect(() =>
+      RunApprovalRequestSchema.parse({
+        ...persisted,
+        fileExecution: { ...fileExecution, digest: `sha256:${'f'.repeat(64)}` },
+      })
+    ).toThrow();
     await expect(
       fixture.broker.request(
         requestInput({

--- a/server/src/__tests__/run-file-execution-policy-service.test.ts
+++ b/server/src/__tests__/run-file-execution-policy-service.test.ts
@@ -1,0 +1,227 @@
+import { mkdtemp, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  RunFileProvenanceApprovalEvidence,
+  RunFileProvenanceQuery,
+  RunFileProvenanceResponse,
+  RunFileProvenanceSource,
+} from '@veritas-kanban/shared';
+import {
+  RunFileExecutionPolicyService,
+  type RunFileExecutionEvaluationInput,
+} from '../services/run-file-execution-policy-service.js';
+
+const roots: string[] = [];
+const digest = (character: string) => `sha256:${character.repeat(64)}`;
+
+afterEach(async () => {
+  const { rm } = await import('node:fs/promises');
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(sourceByPath: Record<string, RunFileProvenanceSource> = {}) {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'vk-file-execution-'));
+  roots.push(root);
+  const provenance = {
+    approvalEvidence: vi.fn(async (query: RunFileProvenanceQuery) => {
+      const source = sourceByPath[query.relativePath];
+      return {
+        schemaVersion: 'run-file-provenance-approval-evidence/v1',
+        status: source ? 'exact' : 'unknown',
+        query,
+        currentRecordId: source ? `record_${query.relativePath.replaceAll('/', '_')}` : null,
+        currentRecordDigest: source ? digest('b') : null,
+        chainDigests: source ? [digest('b')] : [],
+        gapCodes: [],
+        generatedAt: '2026-08-30T12:00:00.000Z',
+        digest: source ? digest('c') : digest('d'),
+      } satisfies RunFileProvenanceApprovalEvidence;
+    }),
+    resolve: vi.fn(async (query: RunFileProvenanceQuery) => {
+      const source = sourceByPath[query.relativePath];
+      return {
+        schemaVersion: 'run-file-provenance-response/v1',
+        status: source ? 'exact' : 'unknown',
+        query,
+        current: source
+          ? {
+              id: `record_${query.relativePath.replaceAll('/', '_')}`,
+              digest: digest('b'),
+              source,
+            }
+          : null,
+        chain: [],
+        gaps: [],
+        generatedAt: '2026-08-30T12:00:00.000Z',
+      } as RunFileProvenanceResponse;
+    }),
+  };
+  const git = vi.fn(() => ({
+    raw: vi.fn(async () => 'same-object\n'),
+  }));
+  const service = new RunFileExecutionPolicyService({ provenance, git });
+  return { root, provenance, git, service };
+}
+
+function input(root: string, command: string, args: string[]): RunFileExecutionEvaluationInput {
+  return {
+    workspaceId: 'workspace_1',
+    taskId: 'task_1',
+    rootObjectiveId: 'objective_1',
+    executionNodeId: 'node_1',
+    runId: 'run_1',
+    attemptId: 'attempt_1',
+    workflowStepId: null,
+    launchManifestDigest: digest('a'),
+    phaseEvidenceDigest: digest('e'),
+    worktreeRoot: root,
+    baseline: {
+      capturedAt: '2026-08-30T11:00:00.000Z',
+      headSha: 'f'.repeat(40),
+      dirty: false,
+      files: [],
+    },
+    request: {
+      requestId: 'terminal-request-1',
+      command,
+      args,
+      mode: 'pipe',
+      startMode: 'background',
+      environmentKeys: [],
+    },
+  };
+}
+
+describe('RunFileExecutionPolicyService', () => {
+  it('binds an unchanged baseline interpreter script without raising the human-only floor', async () => {
+    const { root, service } = await fixture();
+    await writeFile(path.join(root, 'script.mjs'), 'console.log("baseline")');
+
+    const evidence = await service.evaluate(input(root, process.execPath, ['script.mjs']));
+
+    expect(evidence).toMatchObject({
+      schemaVersion: 'run-file-execution-approval-evidence/v1',
+      decision: 'standard-approval',
+      reasonCode: 'baseline-only',
+      references: [
+        {
+          kind: 'interpreter-script',
+          relativePath: 'script.mjs',
+          source: 'repository-baseline',
+          provenanceStatus: 'launch-baseline',
+          decision: 'standard-approval',
+        },
+      ],
+    });
+    expect(evidence.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it('requires a human decision for downloaded bytes and binds loaders and scripts separately', async () => {
+    const { root, service } = await fixture({
+      'loader.mjs': 'downloaded-external',
+      'script.mjs': 'agent-created',
+    });
+    await writeFile(path.join(root, 'loader.mjs'), 'export {};');
+    await writeFile(path.join(root, 'script.mjs'), 'console.log("run")');
+
+    const evidence = await service.evaluate(
+      input(root, process.execPath, ['--loader', './loader.mjs', './script.mjs'])
+    );
+
+    expect(evidence).toMatchObject({
+      decision: 'human-approval',
+      reasonCode: 'external-or-unknown-file',
+    });
+    expect(evidence.references).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'loader-input',
+          source: 'downloaded-external',
+          decision: 'human-approval',
+        }),
+        expect.objectContaining({
+          kind: 'interpreter-script',
+          source: 'agent-created',
+          decision: 'standard-approval',
+        }),
+      ])
+    );
+  });
+
+  it('enforces a project denial for tool-created executable inputs', async () => {
+    const { root, service } = await fixture({ 'task.py': 'tool-created' });
+    await writeFile(path.join(root, 'task.py'), 'print("run")');
+
+    const evidence = await service.evaluate({
+      ...input(root, 'python3', ['task.py']),
+      policy: {
+        schemaVersion: 'run-file-execution-policy/v1',
+        agentCreated: 'standard-approval',
+        commandCreated: 'standard-approval',
+        toolCreated: 'deny',
+      },
+    });
+
+    expect(evidence).toMatchObject({
+      decision: 'deny',
+      reasonCode: 'project-policy-deny',
+      references: [{ source: 'tool-created', decision: 'deny' }],
+    });
+  });
+
+  it('rejects digest drift when referenced bytes change after approval', async () => {
+    const { root, service } = await fixture({ 'script.mjs': 'agent-created' });
+    const script = path.join(root, 'script.mjs');
+    await writeFile(script, 'console.log("approved")');
+    const evaluation = input(root, process.execPath, ['script.mjs']);
+    const evidence = await service.evaluate(evaluation);
+
+    await writeFile(script, 'console.log("replaced")');
+
+    await expect(service.revalidate(evaluation, evidence)).rejects.toMatchObject({
+      statusCode: 409,
+      details: expect.objectContaining({ code: 'run-file-execution-evidence-drift' }),
+    });
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'fails closed for symlinked execution inputs',
+    async () => {
+      const { root, service } = await fixture();
+      await writeFile(path.join(root, 'target.mjs'), 'console.log("target")');
+      await symlink('target.mjs', path.join(root, 'script.mjs'));
+
+      await expect(
+        service.evaluate(input(root, process.execPath, ['script.mjs']))
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        details: expect.objectContaining({ code: 'run-file-execution-unsupported-identity' }),
+      });
+    }
+  );
+
+  it('returns a typed blocker for indirect execution the adapter cannot certify', async () => {
+    const { root, service } = await fixture();
+
+    await expect(
+      service.evaluate(input(root, process.execPath, ['-e', 'import("./run-produced.mjs")']))
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      details: expect.objectContaining({ code: 'run-file-execution-unsupported-indirect' }),
+    });
+    await expect(
+      service.evaluate({
+        ...input(root, 'python3', ['task.py']),
+        request: {
+          ...input(root, 'python3', ['task.py']).request,
+          environmentKeys: ['PYTHONPATH'],
+        },
+      })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      details: expect.objectContaining({ kind: 'environment-load-path' }),
+    });
+  });
+});

--- a/server/src/__tests__/run-terminal-service.test.ts
+++ b/server/src/__tests__/run-terminal-service.test.ts
@@ -207,6 +207,26 @@ describe('RunTerminalService', () => {
     expect(service.list(context.workspaceId, context.taskId, context.attemptId)).toEqual([]);
   });
 
+  it('runs the exact file identity guard immediately before spawning', async () => {
+    const { service, context, events } = await fixture();
+    const beforeSpawn = vi.fn(async () => {
+      throw new Error('referenced bytes changed');
+    });
+
+    await expect(
+      service.execute(
+        {
+          ...context,
+          fileExecutionEvidenceDigest: `sha256:${'f'.repeat(64)}`,
+          beforeSpawn,
+        },
+        request('process.exit(0)')
+      )
+    ).rejects.toThrow('referenced bytes changed');
+    expect(beforeSpawn).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([]);
+  });
+
   it('does not report a durable completion when terminal evidence cannot be persisted', async () => {
     const { context } = await fixture();
     let appendCount = 0;

--- a/server/src/__tests__/task-envelope-service.test.ts
+++ b/server/src/__tests__/task-envelope-service.test.ts
@@ -296,6 +296,34 @@ describe('TaskEnvelopeService', () => {
     expect(resolveTaskCommitPolicy({})).toBe('allowed');
   });
 
+  it('freezes the project file execution policy into the task envelope', async () => {
+    expect(
+      TaskExecutionPolicySchema.safeParse({ fileExecution: { agentCreated: 'automatic' } }).success
+    ).toBe(false);
+    const result = await new TaskEnvelopeService(evidenceSource).build({
+      task: task(),
+      attemptId: 'attempt_file_execution_policy',
+      createdAt,
+      worktreePath: '/tmp/veritas-kanban-task',
+      providerRuntimeManifest: providerRuntimeManifestFixture(),
+      commitPolicy: 'allowed',
+      executionPolicy: {
+        fileExecution: {
+          agentCreated: 'human-approval',
+          toolCreated: 'deny',
+        },
+      },
+    });
+
+    expect(result.fileExecutionPolicy).toEqual({
+      schemaVersion: 'run-file-execution-policy/v1',
+      agentCreated: 'human-approval',
+      commandCreated: 'standard-approval',
+      toolCreated: 'deny',
+    });
+    expect(verifyTaskEnvelopeDigest(result)).toBe(true);
+  });
+
   it('rejects contradictory commit and side-effect/output policy', async () => {
     const service = new TaskEnvelopeService(evidenceSource);
     const base = {

--- a/server/src/__tests__/tool-control-plane-service.test.ts
+++ b/server/src/__tests__/tool-control-plane-service.test.ts
@@ -204,9 +204,7 @@ function fixture(
     now: () => new Date('2026-07-24T12:00:00.000Z'),
     environment: options.environment ?? {},
     ...(options.phaseAuthority ? { phaseAuthority: options.phaseAuthority } : {}),
-    ...(options.dependencyExecution
-      ? { dependencyExecution: options.dependencyExecution }
-      : {}),
+    ...(options.dependencyExecution ? { dependencyExecution: options.dependencyExecution } : {}),
   });
   return { service, open, requests, append, requestApproval };
 }
@@ -243,6 +241,44 @@ async function catalog(
 }
 
 describe('ToolControlPlaneService', () => {
+  it('fails closed when a tool declares file execution without a certified transport', async () => {
+    const { service, requests } = fixture({
+      tools: [
+        {
+          name: 'execute_file',
+          inputSchema: {
+            type: 'object',
+            properties: { path: { type: 'string' } },
+            required: ['path'],
+            additionalProperties: false,
+            'x-veritas-file-execution': { pathArguments: ['/path'] },
+          },
+        },
+      ],
+    });
+    await catalog(service);
+
+    await expect(
+      service.invoke(
+        {
+          taskId: 'task-tools',
+          attemptId: 'attempt-tools',
+          serverId: 'fixture',
+          tool: 'execute_file',
+          arguments: { path: 'run-produced.sh' },
+          operationId: 'file-execution-tool-call',
+        },
+        'agent-a'
+      )
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      details: expect.objectContaining({
+        code: 'run-file-execution-unsupported-tool-transport',
+      }),
+    });
+    expect(requests.some((request) => request.method === 'tools/call')).toBe(false);
+  });
+
   it('reports discovery and invocation through scoped dependency circuits', async () => {
     const registry = new DependencyCircuitRegistryService({
       repository: new InMemoryDependencyCircuitStateRepository(),

--- a/server/src/schemas/run-approval-schemas.ts
+++ b/server/src/schemas/run-approval-schemas.ts
@@ -5,17 +5,84 @@ import {
   RUN_APPROVAL_ACTION_CLASSES,
   RUN_APPROVAL_SCHEMA_VERSION,
   PHASE_NAMES,
+  RUN_FILE_EXECUTION_EVIDENCE_SCHEMA_VERSION,
+  RUN_FILE_EXECUTION_POLICY_DECISIONS,
+  RUN_FILE_EXECUTION_POLICY_SCHEMA_VERSION,
+  RUN_FILE_EXECUTION_REFERENCE_KINDS,
   type RunApprovalActor,
   type RunApprovalDecisionInput,
   type RunApprovalRequest,
   type RunApprovalResolution,
   type RunEventJsonValue,
 } from '@veritas-kanban/shared';
+import { verifyRunFileExecutionEvidenceDigest } from '../utils/run-file-execution-digest.js';
 
 const IdentifierSchema = z.string().trim().min(1).max(240);
 const IsoTimestampSchema = z.string().datetime();
 const DigestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
 const PhaseScopeSchema = z.string().trim().min(1).max(2_048);
+const RunFileExecutionPolicySchema = z
+  .object({
+    schemaVersion: z.literal(RUN_FILE_EXECUTION_POLICY_SCHEMA_VERSION),
+    agentCreated: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS),
+    commandCreated: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS),
+    toolCreated: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS),
+  })
+  .strict();
+const RunFileExecutionReferenceSchema = z
+  .object({
+    kind: z.enum(RUN_FILE_EXECUTION_REFERENCE_KINDS),
+    root: z.enum(['worktree', 'run-artifact']),
+    relativePath: z.string().trim().min(1).max(2_000),
+    contentSha256: DigestSchema,
+    byteSize: z.number().int().nonnegative(),
+    source: z.enum([
+      'repository-baseline',
+      'agent-created',
+      'command-created',
+      'tool-created',
+      'attachment-derived',
+      'connector-derived',
+      'downloaded-external',
+      'operator-provided',
+      'unknown',
+    ]),
+    provenanceStatus: z.enum(['exact', 'stale', 'unknown', 'gap', 'launch-baseline']),
+    provenanceRecordId: IdentifierSchema.nullable(),
+    provenanceRecordDigest: DigestSchema.nullable(),
+    provenanceEvidenceDigest: DigestSchema,
+    decision: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS),
+  })
+  .strict();
+const RunFileExecutionEvidenceSchema = z
+  .object({
+    schemaVersion: z.literal(RUN_FILE_EXECUTION_EVIDENCE_SCHEMA_VERSION),
+    workspaceId: IdentifierSchema,
+    taskId: IdentifierSchema,
+    rootObjectiveId: IdentifierSchema,
+    executionNodeId: IdentifierSchema,
+    runId: IdentifierSchema,
+    attemptId: IdentifierSchema,
+    workflowStepId: IdentifierSchema.nullable(),
+    terminalRequestId: IdentifierSchema,
+    terminalRequestDigest: DigestSchema,
+    commandId: IdentifierSchema,
+    launchManifestDigest: DigestSchema,
+    phaseEvidenceDigest: DigestSchema.nullable(),
+    policy: RunFileExecutionPolicySchema,
+    references: z.array(RunFileExecutionReferenceSchema).max(16),
+    decision: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS),
+    reasonCode: z.enum([
+      'no-referenced-files',
+      'baseline-only',
+      'run-produced-file',
+      'external-or-unknown-file',
+      'project-policy-deny',
+      'unsupported-file-identity',
+    ]),
+    digest: DigestSchema,
+  })
+  .strict();
 const ApprovalPhaseIdentitySchema = z.discriminatedUnion('mode', [
   z.object({ mode: z.literal('legacy'), phase: z.literal('legacy') }).strict(),
   z
@@ -75,7 +142,7 @@ export const RunApprovalRequestSchema: z.ZodType<RunApprovalRequest> = z
     action: z.string().trim().min(1).max(2_000),
     actionHash: z.string().regex(/^[a-f0-9]{64}$/),
     details: z.string().trim().min(1).max(8_000).optional(),
-    resourceScope: z.array(z.string().trim().min(1).max(2_048)).max(100),
+    resourceScope: z.array(z.string().trim().min(1).max(2_048)).max(256),
     workingDirectory: z.string().trim().min(1).max(4_096).optional(),
     riskClass: z.enum(['low', 'medium', 'high', 'critical']),
     policyReason: z.string().trim().min(1).max(2_000).optional(),
@@ -85,6 +152,8 @@ export const RunApprovalRequestSchema: z.ZodType<RunApprovalRequest> = z
     turnId: IdentifierSchema.optional(),
     itemId: IdentifierSchema.optional(),
     mobileSafe: z.boolean(),
+    decisionAuthority: z.literal('human-only').optional(),
+    fileExecution: RunFileExecutionEvidenceSchema.optional(),
     phase: z
       .object({
         evidenceDigest: DigestSchema,
@@ -142,6 +211,13 @@ export const RunApprovalRequestSchema: z.ZodType<RunApprovalRequest> = z
         code: 'custom',
         path: ['expiresAt'],
         message: 'Approval expiry must be after creation.',
+      });
+    }
+    if (request.fileExecution && !verifyRunFileExecutionEvidenceDigest(request.fileExecution)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['fileExecution', 'digest'],
+        message: 'Run file execution evidence digest is invalid.',
       });
     }
   });

--- a/server/src/schemas/run-terminal-schemas.ts
+++ b/server/src/schemas/run-terminal-schemas.ts
@@ -112,6 +112,10 @@ export const RunTerminalHandleSchema = z
     launchManifestDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
     requestId: terminalIdentifierSchema,
     requestDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    fileExecutionEvidenceDigest: z
+      .string()
+      .regex(/^sha256:[a-f0-9]{64}$/)
+      .optional(),
     mode: z.enum(RUN_TERMINAL_MODES),
     startMode: z.enum(RUN_TERMINAL_START_MODES),
     state: z.enum(RUN_TERMINAL_STATES),

--- a/server/src/schemas/task-envelope-schemas.ts
+++ b/server/src/schemas/task-envelope-schemas.ts
@@ -13,6 +13,8 @@ import {
   TASK_SIDE_EFFECT_KINDS,
   TASK_TERMINAL_SOURCES,
   TASK_VERIFICATION_STATUSES,
+  RUN_FILE_EXECUTION_POLICY_DECISIONS,
+  RUN_FILE_EXECUTION_POLICY_SCHEMA_VERSION,
   type CompletionResult,
   type TaskEnvelope,
 } from '@veritas-kanban/shared';
@@ -53,6 +55,14 @@ export const TaskExecutionPolicySchema = z
     commitPolicy: TaskCommitPolicySchema.optional(),
     allowedSideEffects: z.array(TaskAllowedSideEffectSchema).max(32).optional(),
     expectedOutputs: z.array(TaskExpectedOutputSchema).max(64).optional(),
+    fileExecution: z
+      .object({
+        agentCreated: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS).optional(),
+        commandCreated: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS).optional(),
+        toolCreated: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 
@@ -146,6 +156,15 @@ export const TaskEnvelopeSchema = z
     commitPolicy: TaskCommitPolicySchema,
     allowedSideEffects: z.array(TaskAllowedSideEffectSchema).max(32),
     expectedOutputs: z.array(TaskExpectedOutputSchema).max(64),
+    fileExecutionPolicy: z
+      .object({
+        schemaVersion: z.literal(RUN_FILE_EXECUTION_POLICY_SCHEMA_VERSION),
+        agentCreated: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS),
+        commandCreated: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS),
+        toolCreated: z.enum(RUN_FILE_EXECUTION_POLICY_DECISIONS),
+      })
+      .strict()
+      .optional(),
     verificationGates: z
       .array(
         z

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -8913,13 +8913,17 @@ export class ClawdbotAgentService {
     };
   }
 
+  private activePendingAgent(taskId: string): PendingAgent | undefined {
+    return pendingAgents.get(taskId);
+  }
+
   async executeRunTerminal(
     taskId: string,
     attemptId: string,
     inputRequest: RunTerminalExecuteRequest
   ): Promise<RunTerminalExecutionResult> {
     const request = RunTerminalExecuteRequestSchema.parse(inputRequest);
-    const pending = pendingAgents.get(taskId);
+    const pending = this.activePendingAgent(taskId);
     if (!pending || pending.attemptId !== attemptId) {
       throw new NotFoundError('Active run terminal scope not found.');
     }

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -203,6 +203,11 @@ import {
   type RunEventJournalService,
 } from './run-event-journal-service.js';
 import { getRunTerminalService, type RunTerminalService } from './run-terminal-service.js';
+import {
+  getRunFileExecutionPolicyService,
+  type RunFileExecutionEvaluationInput,
+  type RunFileExecutionPolicyService,
+} from './run-file-execution-policy-service.js';
 import { type ProviderMappedRunEvent } from './provider-run-event-mappers.js';
 import {
   AgentProviderAdapterRegistry,
@@ -636,6 +641,7 @@ export class ClawdbotAgentService {
     RunTerminalService,
     'execute' | 'list' | 'cleanupAttempt' | 'reconcileAttempt'
   >;
+  private runFileExecutionPolicy: Pick<RunFileExecutionPolicyService, 'evaluate' | 'revalidate'>;
   private workspaceCheckpoints: Pick<WorkspaceCheckpointService, 'captureBoundary'>;
   private logsDir: string;
 
@@ -690,7 +696,11 @@ export class ClawdbotAgentService {
     workspaceCheckpoints: Pick<
       WorkspaceCheckpointService,
       'captureBoundary'
-    > = getWorkspaceCheckpointService()
+    > = getWorkspaceCheckpointService(),
+    runFileExecutionPolicy: Pick<
+      RunFileExecutionPolicyService,
+      'evaluate' | 'revalidate'
+    > = getRunFileExecutionPolicyService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -724,6 +734,7 @@ export class ClawdbotAgentService {
     this.dependencyExecution = dependencyExecution;
     this.runTerminals = runTerminals;
     this.workspaceCheckpoints = workspaceCheckpoints;
+    this.runFileExecutionPolicy = runFileExecutionPolicy;
     this.workspaceExecutionTrust = workspaceExecutionTrust;
     this.phaseAuthority = phaseAuthority;
     this.phaseTransitions = phaseTransitions;
@@ -8963,7 +8974,10 @@ export class ClawdbotAgentService {
       .filter((reference) =>
         pending.runLaunchManifest.runtime.credentialReferences.includes(reference)
       );
-    const phase = await this.bindPhaseApproval(taskId, attemptId, pending.runLaunchManifest, [
+    const phaseRequirements: Array<{
+      dimension: PhaseAuthorityDimension;
+      requestedScopes: string[];
+    }> = [
       { dimension: 'filesystem.read', requestedScopes: ['<workspace>'] },
       { dimension: 'command.execute', requestedScopes: [commandClass] },
       ...(commandClass === 'inspect'
@@ -8990,7 +9004,51 @@ export class ClawdbotAgentService {
             },
           ]
         : []),
-    ]);
+    ];
+    const phase = await this.bindPhaseApproval(
+      taskId,
+      attemptId,
+      pending.runLaunchManifest,
+      phaseRequirements
+    );
+    if (!pending.executionTree) {
+      throw new ConflictError('Run terminal execution has no durable execution-tree identity.', {
+        taskId,
+        attemptId,
+        code: 'run-file-execution-tree-missing',
+      });
+    }
+    const fileExecutionInput: RunFileExecutionEvaluationInput = {
+      workspaceId: pending.taskEnvelope.workspace.workspaceId,
+      taskId,
+      rootObjectiveId: pending.executionTree.rootObjectiveId,
+      executionNodeId: pending.executionTree.nodeId,
+      runId: attemptId,
+      attemptId,
+      workflowStepId:
+        pending.executionTree.edge === 'workflow-step' ? pending.executionTree.nodeId : null,
+      launchManifestDigest: pending.runLaunchManifest.digest,
+      phaseEvidenceDigest: phase?.evidenceDigest ?? null,
+      worktreeRoot,
+      baseline: pending.taskEnvelope.workspace.baseline,
+      request,
+      ...(pending.taskEnvelope.fileExecutionPolicy
+        ? { policy: pending.taskEnvelope.fileExecutionPolicy }
+        : {}),
+    };
+    const fileExecution = await this.runFileExecutionPolicy.evaluate(fileExecutionInput);
+    if (fileExecution.decision === 'deny') {
+      throw new ForbiddenError(
+        'Project policy denies execution of a referenced run-produced file.',
+        {
+          taskId,
+          attemptId,
+          evidenceDigest: fileExecution.digest,
+          reasonCode: fileExecution.reasonCode,
+        }
+      );
+    }
+    const humanFileApproval = fileExecution.decision === 'human-approval';
     const requestedApproval = await this.approvalBroker.request({
       workspaceId: pending.taskEnvelope.workspace.workspaceId,
       taskId,
@@ -9001,19 +9059,36 @@ export class ClawdbotAgentService {
       requestKind: 'approval',
       actionClass: 'shell',
       action: `Execute ${request.command}`,
-      details: this.redactTraceText(JSON.stringify(request.args)).slice(0, 4_000),
+      details: this.redactTraceText(
+        JSON.stringify({
+          args: request.args,
+          fileExecution: fileExecution.references.map((reference) => ({
+            kind: reference.kind,
+            path: reference.relativePath,
+            source: reference.source,
+            digest: reference.contentSha256,
+            decision: reference.decision,
+          })),
+        })
+      ).slice(0, 8_000),
       resourceScope: [
         `command:${commandClass}`,
         `cwd:${request.cwd ?? '.'}`,
         ...request.environmentKeys.map((key) => `env:${key}`),
+        ...fileExecution.references.map(
+          (reference) => `file:${reference.source}:${reference.contentSha256}`
+        ),
       ],
       workingDirectory: request.cwd ?? '.',
-      riskClass: 'high',
-      policyReason:
-        'A provider-neutral terminal child requires exact operator approval before launch.',
+      riskClass: humanFileApproval ? 'critical' : 'high',
+      policyReason: humanFileApproval
+        ? 'External, unknown, or project-governed run-produced bytes require a fresh human decision before execution.'
+        : 'A provider-neutral terminal child requires exact operator approval before launch.',
       evidenceRevision: pending.runLaunchManifest.digest,
       mobileSafe: false,
-      exactAction: request,
+      exactAction: { request, fileExecution },
+      fileExecution,
+      ...(humanFileApproval ? { decisionAuthority: 'human-only' as const } : {}),
       ...(phase ? { phase } : {}),
     });
     const approval = await this.approvalBroker.get(
@@ -9050,6 +9125,31 @@ export class ClawdbotAgentService {
         worktreeRoot,
         environment: approvedEnvironment,
         allowedCommands: [request.command],
+        fileExecutionEvidenceDigest: fileExecution.digest,
+        beforeSpawn: async () => {
+          await this.assertPendingManifestSnapshotForAttempt(taskId, attemptId);
+          if (pendingAgents.get(taskId) !== pending || finalizingAgents.has(pending)) {
+            throw new ConflictError('Run terminal execution raced with run finalization.', {
+              taskId,
+              attemptId,
+            });
+          }
+          const currentPhase = await this.bindPhaseApproval(
+            taskId,
+            attemptId,
+            pending.runLaunchManifest,
+            phaseRequirements
+          );
+          if (JSON.stringify(currentPhase) !== JSON.stringify(phase)) {
+            throw new ConflictError('Run terminal phase evidence changed after approval.', {
+              taskId,
+              attemptId,
+              expectedPhaseEvidenceDigest: phase?.evidenceDigest,
+              currentPhaseEvidenceDigest: currentPhase?.evidenceDigest,
+            });
+          }
+          await this.runFileExecutionPolicy.revalidate(fileExecutionInput, fileExecution);
+        },
         wrap: (command, args, cwd) => {
           const launch = this.filesystemSandboxLaunch(pending, command, args, cwd);
           return {

--- a/server/src/services/run-approval-broker-service.ts
+++ b/server/src/services/run-approval-broker-service.ts
@@ -10,6 +10,7 @@ import {
   type RunApprovalRequestKind,
   type RunApprovalPhaseBinding,
   type RunApprovalRiskClass,
+  type RunFileExecutionApprovalEvidence,
   type RunEventJsonValue,
 } from '@veritas-kanban/shared';
 import { redactString } from '../lib/redact.js';
@@ -27,6 +28,7 @@ import { getStorage, getStorageTypeFromEnv } from '../storage/index.js';
 import { broadcastRunApprovalChange } from './broadcast-service.js';
 import { RunEventJournalService } from './run-event-journal-service.js';
 import type { RunPhaseAuthorityService } from './run-phase-authority-service.js';
+import { verifyRunFileExecutionEvidenceDigest } from '../utils/run-file-execution-digest.js';
 
 const DEFAULT_APPROVAL_TTL_MS = 5 * 60 * 1_000;
 const MIN_APPROVAL_TTL_MS = 1_000;
@@ -60,6 +62,8 @@ export interface CreateRunApprovalRequestInput {
   turnId?: string;
   itemId?: string;
   mobileSafe?: boolean;
+  decisionAuthority?: 'human-only';
+  fileExecution?: RunFileExecutionApprovalEvidence;
   phase?: RunApprovalPhaseBinding;
   ttlMs?: number;
 }
@@ -107,6 +111,9 @@ export class RunApprovalBrokerService {
   }
 
   async request(input: CreateRunApprovalRequestInput): Promise<RunApprovalRequest> {
+    if (input.fileExecution && !verifyRunFileExecutionEvidenceDigest(input.fileExecution)) {
+      throw new ValidationError('Run file execution approval evidence digest is invalid.');
+    }
     const workspaceId = input.workspaceId?.trim() || 'local';
     const exactAction = canonicalizeExactAction(input.exactAction);
     const actionHash = sha256(
@@ -128,6 +135,8 @@ export class RunApprovalBrokerService {
           policyReason: input.policyReason,
           evidenceRevision: input.evidenceRevision,
           mobileSafe: input.mobileSafe ?? false,
+          decisionAuthority: input.decisionAuthority,
+          fileExecution: input.fileExecution,
           phase: input.phase,
           exactAction,
         })
@@ -177,6 +186,8 @@ export class RunApprovalBrokerService {
       turnId: input.turnId,
       itemId: input.itemId,
       mobileSafe: input.mobileSafe ?? false,
+      decisionAuthority: input.decisionAuthority,
+      fileExecution: input.fileExecution,
       phase: input.phase,
       status: 'pending',
       revision: 1,
@@ -252,6 +263,13 @@ export class RunApprovalBrokerService {
           maximumAgeMs: MAX_PRIVILEGED_AUTH_AGE_MS,
         }
       );
+    }
+    if (current.decisionAuthority === 'human-only' && actor.type !== 'user') {
+      throw new ForbiddenError('This approval requires a human user decision.', {
+        approvalId: current.id,
+        decisionAuthority: current.decisionAuthority,
+        actorType: actor.type ?? 'unknown',
+      });
     }
     if (actor.clientMode === 'mobile-pwa' && !current.mobileSafe) {
       throw new ForbiddenError('This approval is not marked mobile-safe.', {
@@ -431,6 +449,22 @@ export class RunApprovalBrokerService {
         policyReason: request.policyReason,
         evidenceRevision: request.evidenceRevision,
         mobileSafe: request.mobileSafe,
+        decisionAuthority: request.decisionAuthority,
+        fileExecution: request.fileExecution
+          ? {
+              digest: request.fileExecution.digest,
+              decision: request.fileExecution.decision,
+              reasonCode: request.fileExecution.reasonCode,
+              references: request.fileExecution.references.map((reference) => ({
+                kind: reference.kind,
+                relativePath: reference.relativePath,
+                source: reference.source,
+                contentSha256: reference.contentSha256,
+                provenanceRecordId: reference.provenanceRecordId,
+                provenanceRecordDigest: reference.provenanceRecordDigest,
+              })),
+            }
+          : undefined,
         status: request.status,
         revision: request.revision,
         expiresAt: request.expiresAt,

--- a/server/src/services/run-file-execution-policy-service.ts
+++ b/server/src/services/run-file-execution-policy-service.ts
@@ -1,0 +1,555 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { simpleGit, type SimpleGit } from 'simple-git';
+import {
+  DEFAULT_RUN_FILE_EXECUTION_PROJECT_POLICY,
+  RUN_FILE_EXECUTION_EVIDENCE_SCHEMA_VERSION,
+  type RunFileExecutionApprovalEvidence,
+  type RunFileExecutionProjectPolicy,
+  type RunFileExecutionReferenceEvidence,
+  type RunFileExecutionReferenceKind,
+  type RunFileProvenanceSource,
+  type RunTerminalExecuteRequest,
+  type TaskLaunchBaseline,
+} from '@veritas-kanban/shared';
+import { ConflictError } from '../middleware/error-handler.js';
+import { lstat, open, realpath } from '../storage/fs-helpers.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import { calculateRunFileExecutionEvidenceDigest } from '../utils/run-file-execution-digest.js';
+import {
+  getRunFileProvenanceService,
+  type RunFileProvenanceService,
+} from './run-file-provenance-service.js';
+import { digestTerminalRequest, runTerminalCommandId } from './run-terminal-service.js';
+
+const MAX_REFERENCES = 16;
+const MAX_REFERENCED_FILE_BYTES = 512 * 1024 * 1024;
+const EXTERNAL_SOURCES = new Set<RunFileProvenanceSource>([
+  'attachment-derived',
+  'connector-derived',
+  'downloaded-external',
+  'unknown',
+]);
+
+export interface RunFileExecutionEvaluationInput {
+  workspaceId: string;
+  taskId: string;
+  rootObjectiveId: string;
+  executionNodeId: string;
+  runId: string;
+  attemptId: string;
+  workflowStepId: string | null;
+  launchManifestDigest: string;
+  phaseEvidenceDigest: string | null;
+  worktreeRoot: string;
+  baseline: TaskLaunchBaseline;
+  request: RunTerminalExecuteRequest;
+  policy?: RunFileExecutionProjectPolicy;
+}
+
+interface FileSnapshot {
+  relativePath: string;
+  sha256: string;
+  byteSize: number;
+}
+
+interface ReferenceCandidate {
+  kind: RunFileExecutionReferenceKind;
+  value: string;
+}
+
+export interface RunFileExecutionPolicyServiceOptions {
+  provenance?: Pick<RunFileProvenanceService, 'approvalEvidence' | 'resolve'>;
+  git?: (cwd: string) => Pick<SimpleGit, 'raw'>;
+}
+
+export class RunFileExecutionPolicyService {
+  private readonly provenance: Pick<RunFileProvenanceService, 'approvalEvidence' | 'resolve'>;
+  private readonly git: (cwd: string) => Pick<SimpleGit, 'raw'>;
+
+  constructor(options: RunFileExecutionPolicyServiceOptions = {}) {
+    this.provenance = options.provenance ?? getRunFileProvenanceService();
+    this.git = options.git ?? ((cwd) => simpleGit({ baseDir: cwd, maxConcurrentProcesses: 1 }));
+  }
+
+  async evaluate(
+    input: RunFileExecutionEvaluationInput
+  ): Promise<RunFileExecutionApprovalEvidence> {
+    const policy = input.policy ?? DEFAULT_RUN_FILE_EXECUTION_PROJECT_POLICY;
+    assertSupportedInvocation(input.request);
+    const canonicalRoot = await realpath(path.resolve(input.worktreeRoot));
+    const requestedCwd = path.resolve(canonicalRoot, input.request.cwd ?? '.');
+    ensureWithinBase(canonicalRoot, requestedCwd);
+    const canonicalCwd = await realpath(requestedCwd);
+    ensureWithinBase(canonicalRoot, canonicalCwd);
+    const candidates = referenceCandidates(input.request);
+    if (candidates.length > MAX_REFERENCES) {
+      throw new ConflictError('Run file execution reference count exceeds its safety bound.', {
+        code: 'run-file-execution-reference-limit',
+        maximum: MAX_REFERENCES,
+      });
+    }
+
+    const references: RunFileExecutionReferenceEvidence[] = [];
+    const seen = new Set<string>();
+    for (const candidate of candidates) {
+      const snapshot = await snapshotCandidate(canonicalRoot, canonicalCwd, candidate);
+      if (!snapshot) continue;
+      const identity = `${candidate.kind}\0${snapshot.relativePath}`;
+      if (seen.has(identity)) continue;
+      seen.add(identity);
+      references.push(await this.referenceEvidence(input, policy, candidate.kind, snapshot));
+    }
+    references.sort(
+      (left, right) =>
+        left.relativePath.localeCompare(right.relativePath) || left.kind.localeCompare(right.kind)
+    );
+
+    const decision = references.some((reference) => reference.decision === 'deny')
+      ? 'deny'
+      : references.some((reference) => reference.decision === 'human-approval')
+        ? 'human-approval'
+        : 'standard-approval';
+    const reasonCode =
+      references.length === 0
+        ? 'no-referenced-files'
+        : decision === 'deny'
+          ? 'project-policy-deny'
+          : references.some((reference) => EXTERNAL_SOURCES.has(reference.source))
+            ? 'external-or-unknown-file'
+            : references.some((reference) => reference.provenanceStatus === 'exact')
+              ? 'run-produced-file'
+              : 'baseline-only';
+    const material = {
+      schemaVersion: RUN_FILE_EXECUTION_EVIDENCE_SCHEMA_VERSION,
+      workspaceId: input.workspaceId,
+      taskId: input.taskId,
+      rootObjectiveId: input.rootObjectiveId,
+      executionNodeId: input.executionNodeId,
+      runId: input.runId,
+      attemptId: input.attemptId,
+      workflowStepId: input.workflowStepId,
+      terminalRequestId: input.request.requestId,
+      terminalRequestDigest: digestTerminalRequest(input.request),
+      commandId: runTerminalCommandId(input.request.command, input.request.args),
+      launchManifestDigest: input.launchManifestDigest,
+      phaseEvidenceDigest: input.phaseEvidenceDigest,
+      policy,
+      references,
+      decision,
+      reasonCode,
+    } satisfies Omit<RunFileExecutionApprovalEvidence, 'digest'>;
+    return { ...material, digest: calculateRunFileExecutionEvidenceDigest(material) };
+  }
+
+  async revalidate(
+    input: RunFileExecutionEvaluationInput,
+    expected: RunFileExecutionApprovalEvidence
+  ): Promise<void> {
+    const current = await this.evaluate(input);
+    if (current.digest !== expected.digest) {
+      throw new ConflictError('Referenced file identity changed after approval.', {
+        code: 'run-file-execution-evidence-drift',
+        expectedEvidenceDigest: expected.digest,
+        currentEvidenceDigest: current.digest,
+        terminalRequestId: input.request.requestId,
+      });
+    }
+  }
+
+  private async referenceEvidence(
+    input: RunFileExecutionEvaluationInput,
+    policy: RunFileExecutionProjectPolicy,
+    kind: RunFileExecutionReferenceKind,
+    snapshot: FileSnapshot
+  ): Promise<RunFileExecutionReferenceEvidence> {
+    const provenance = await this.provenance.approvalEvidence({
+      workspaceId: input.workspaceId,
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+      root: 'worktree',
+      relativePath: snapshot.relativePath,
+      sha256: snapshot.sha256,
+    });
+    if (provenance.status === 'exact' && provenance.currentRecordId) {
+      const resolved = await this.exactRecord(input, snapshot.relativePath, snapshot.sha256);
+      if (
+        resolved.current?.id !== provenance.currentRecordId ||
+        resolved.current?.digest !== provenance.currentRecordDigest
+      ) {
+        throw new ConflictError('File provenance changed during approval evaluation.', {
+          code: 'run-file-execution-provenance-race',
+          relativePath: snapshot.relativePath,
+        });
+      }
+      const source = resolved.current.source;
+      return {
+        kind,
+        root: 'worktree',
+        relativePath: snapshot.relativePath,
+        contentSha256: snapshot.sha256,
+        byteSize: snapshot.byteSize,
+        source,
+        provenanceStatus: 'exact',
+        provenanceRecordId: provenance.currentRecordId,
+        provenanceRecordDigest: provenance.currentRecordDigest,
+        provenanceEvidenceDigest: provenance.digest,
+        decision: decisionForSource(source, policy),
+      };
+    }
+
+    const launchSource = await this.launchBaselineSource(input, snapshot);
+    if (launchSource) {
+      return {
+        kind,
+        root: 'worktree',
+        relativePath: snapshot.relativePath,
+        contentSha256: snapshot.sha256,
+        byteSize: snapshot.byteSize,
+        source: launchSource,
+        provenanceStatus: 'launch-baseline',
+        provenanceRecordId: null,
+        provenanceRecordDigest: null,
+        provenanceEvidenceDigest: digest({
+          status: 'launch-baseline',
+          source: launchSource,
+          headSha: input.baseline.headSha,
+          relativePath: snapshot.relativePath,
+          sha256: snapshot.sha256,
+        }),
+        decision: 'standard-approval',
+      };
+    }
+
+    return {
+      kind,
+      root: 'worktree',
+      relativePath: snapshot.relativePath,
+      contentSha256: snapshot.sha256,
+      byteSize: snapshot.byteSize,
+      source: 'unknown',
+      provenanceStatus: provenance.status,
+      provenanceRecordId: provenance.currentRecordId,
+      provenanceRecordDigest: provenance.currentRecordDigest,
+      provenanceEvidenceDigest: provenance.digest,
+      decision: 'human-approval',
+    };
+  }
+
+  private async exactRecord(
+    input: RunFileExecutionEvaluationInput,
+    relativePath: string,
+    sha256: string
+  ) {
+    const resolved = await this.provenance.resolve({
+      workspaceId: input.workspaceId,
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+      root: 'worktree',
+      relativePath,
+      sha256,
+    });
+    if (resolved.status !== 'exact' || !resolved.current) {
+      throw new ConflictError('File provenance changed during approval evaluation.', {
+        code: 'run-file-execution-provenance-race',
+        relativePath,
+      });
+    }
+    return resolved;
+  }
+
+  private async launchBaselineSource(
+    input: RunFileExecutionEvaluationInput,
+    snapshot: FileSnapshot
+  ): Promise<'repository-baseline' | 'operator-provided' | null> {
+    const captured = input.baseline.files.find((file) => file.path === snapshot.relativePath);
+    if (captured?.worktreeSha256 === snapshot.sha256.slice('sha256:'.length)) {
+      return 'operator-provided';
+    }
+    if (captured) return null;
+    if (!/^[a-f0-9]{40,64}$/.test(input.baseline.headSha)) return null;
+    try {
+      const git = this.git(input.worktreeRoot);
+      const worktreeObject = await git.raw(['hash-object', '--', snapshot.relativePath]);
+      const baselineObject = await git.raw([
+        'rev-parse',
+        `${input.baseline.headSha}:${snapshot.relativePath}`,
+      ]);
+      return worktreeObject.trim() === baselineObject.trim() ? 'repository-baseline' : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function decisionForSource(
+  source: RunFileProvenanceSource,
+  policy: RunFileExecutionProjectPolicy
+): RunFileExecutionReferenceEvidence['decision'] {
+  if (EXTERNAL_SOURCES.has(source)) return 'human-approval';
+  if (source === 'agent-created') return policy.agentCreated;
+  if (source === 'command-created') return policy.commandCreated;
+  if (source === 'tool-created') return policy.toolCreated;
+  return 'standard-approval';
+}
+
+function referenceCandidates(request: RunTerminalExecuteRequest): ReferenceCandidate[] {
+  const candidates: ReferenceCandidate[] = [];
+  if (pathLike(request.command)) {
+    candidates.push({ kind: 'direct-executable', value: request.command });
+  }
+  const executable = path
+    .basename(request.command)
+    .toLowerCase()
+    .replace(/\.exe$/, '');
+  if (executable === 'node') {
+    candidates.push(...nodeReferences(request.args));
+  } else if (executable === 'bun') {
+    if (['run', 'test', 'install', 'add', 'remove', 'x'].includes(request.args[0] ?? '')) {
+      candidates.push({ kind: 'configuration-input', value: 'package.json' });
+    } else {
+      candidates.push(...nodeReferences(request.args));
+    }
+  } else if (executable === 'deno') {
+    const denoArgs = request.args[0] === 'run' ? request.args.slice(1) : request.args;
+    candidates.push(...nodeReferences(denoArgs));
+  } else if (/^python(?:\d+(?:\.\d+)*)?$/.test(executable)) {
+    candidates.push(...positionalScript(request.args, ['-c', '-m'], ['-W', '-X']));
+  } else if (['bash', 'sh', 'zsh', 'dash', 'ruby', 'perl'].includes(executable)) {
+    candidates.push(...positionalScript(request.args, ['-c', '-e'], []));
+  } else if (['pwsh', 'powershell'].includes(executable)) {
+    const file = optionValue(request.args, ['-file']);
+    if (file) candidates.push({ kind: 'interpreter-script', value: file });
+  } else if (executable === 'java') {
+    const archive = optionValue(request.args, ['-jar']);
+    if (archive) candidates.push({ kind: 'archive-input', value: archive });
+  } else if (executable === 'dotnet') {
+    const script = request.args.find((argument) => !argument.startsWith('-'));
+    if (script?.toLowerCase().endsWith('.dll')) {
+      candidates.push({ kind: 'interpreter-script', value: script });
+    }
+  } else if (
+    ['npm', 'pnpm', 'yarn'].includes(executable) &&
+    packageCommandUsesConfig(request.args)
+  ) {
+    candidates.push({ kind: 'configuration-input', value: 'package.json' });
+  } else if (executable === 'unzip') {
+    const archive = request.args.find((argument) => !argument.startsWith('-'));
+    if (archive) candidates.push({ kind: 'archive-input', value: archive });
+  } else if (executable === 'tar') {
+    const archive = optionValue(request.args, ['-f', '--file']);
+    if (archive) candidates.push({ kind: 'archive-input', value: archive });
+  }
+  return candidates;
+}
+
+function assertSupportedInvocation(request: RunTerminalExecuteRequest): void {
+  const loadPathEnvironment = request.environmentKeys.find((key) =>
+    [
+      'NODE_PATH',
+      'PYTHONPATH',
+      'RUBYLIB',
+      'PERL5LIB',
+      'LD_LIBRARY_PATH',
+      'DYLD_LIBRARY_PATH',
+    ].includes(key)
+  );
+  if (loadPathEnvironment) {
+    throw unsupportedIndirect('environment-load-path', loadPathEnvironment);
+  }
+  const executable = path
+    .basename(request.command)
+    .toLowerCase()
+    .replace(/\.exe$/, '');
+  if (['node', 'bun', 'deno'].includes(executable)) {
+    const inline = request.args.find((argument) =>
+      ['-e', '--eval', '-p', '--print'].includes(argument)
+    );
+    if (inline) throw unsupportedIndirect('inline-interpreter', inline);
+  }
+  if (/^python(?:\d+(?:\.\d+)*)?$/.test(executable)) {
+    const indirect = request.args.find((argument) => ['-c', '-m'].includes(argument));
+    if (indirect) throw unsupportedIndirect('python-indirect', indirect);
+  }
+  if (['bash', 'sh', 'zsh', 'dash', 'ruby', 'perl'].includes(executable)) {
+    const inline = request.args.find((argument) => ['-c', '-e'].includes(argument));
+    if (inline) throw unsupportedIndirect('inline-shell-or-interpreter', inline);
+  }
+  if (['npm', 'pnpm', 'yarn'].includes(executable) && packageCommandUsesConfig(request.args)) {
+    throw unsupportedIndirect('package-script-dispatch', executable);
+  }
+  if (executable === 'bun' && ['run', 'test', 'x'].includes(request.args[0] ?? '')) {
+    throw unsupportedIndirect('package-script-dispatch', executable);
+  }
+}
+
+function nodeReferences(args: string[]): ReferenceCandidate[] {
+  const candidates: ReferenceCandidate[] = [];
+  for (const [names, kind] of [
+    [['-r', '--require', '--import', '--loader'], 'loader-input'],
+    [['--config', '--env-file'], 'configuration-input'],
+  ] as const) {
+    for (const name of names) {
+      const value = optionValue(args, [name]);
+      if (value) candidates.push({ kind, value });
+    }
+  }
+  if (args.some((argument) => ['-e', '--eval', '-p', '--print'].includes(argument))) {
+    return candidates;
+  }
+  const consumed = new Set<number>();
+  for (let index = 0; index < args.length; index += 1) {
+    if (
+      ['-r', '--require', '--import', '--loader', '--config', '--env-file'].includes(args[index])
+    ) {
+      consumed.add(index);
+      consumed.add(index + 1);
+    }
+  }
+  const script = args.find((argument, index) => !consumed.has(index) && !argument.startsWith('-'));
+  if (script) candidates.push({ kind: 'interpreter-script', value: script });
+  return candidates;
+}
+
+function positionalScript(
+  args: string[],
+  inlineFlags: string[],
+  valueFlags: string[]
+): ReferenceCandidate[] {
+  if (args.some((argument) => inlineFlags.includes(argument))) return [];
+  const consumed = new Set<number>();
+  for (let index = 0; index < args.length; index += 1) {
+    if (valueFlags.includes(args[index])) {
+      consumed.add(index);
+      consumed.add(index + 1);
+    }
+  }
+  const script = args.find((argument, index) => !consumed.has(index) && !argument.startsWith('-'));
+  return script ? [{ kind: 'interpreter-script', value: script }] : [];
+}
+
+function optionValue(args: string[], names: readonly string[]): string | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (names.includes(argument)) return args[index + 1];
+    for (const name of names) {
+      if (argument.startsWith(`${name}=`)) return argument.slice(name.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function packageCommandUsesConfig(args: string[]): boolean {
+  if (args.some((argument) => ['--version', '-v', '--help', '-h'].includes(argument))) return false;
+  const command = args.find((argument) => !argument.startsWith('-'))?.toLowerCase();
+  if (!command) return false;
+  return !['config', 'help', 'list', 'view', 'why', 'outdated'].includes(command);
+}
+
+async function snapshotCandidate(
+  canonicalRoot: string,
+  canonicalCwd: string,
+  candidate: ReferenceCandidate
+): Promise<FileSnapshot | null> {
+  if (!candidate.value || candidate.value.includes('\0') || candidate.value.startsWith('file:')) {
+    throw unsupportedIdentity(candidate);
+  }
+  const absolutePath = path.resolve(canonicalCwd, candidate.value);
+  try {
+    ensureWithinBase(canonicalRoot, absolutePath);
+  } catch {
+    if (candidate.kind === 'direct-executable' && path.isAbsolute(candidate.value)) return null;
+    throw unsupportedIdentity(candidate);
+  }
+  let before;
+  try {
+    before = await lstat(absolutePath);
+  } catch {
+    if (candidate.kind === 'direct-executable' && !pathLike(candidate.value)) return null;
+    throw unsupportedIdentity(candidate);
+  }
+  if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1) {
+    throw unsupportedIdentity(candidate);
+  }
+  if (before.size > MAX_REFERENCED_FILE_BYTES) {
+    throw new ConflictError('Referenced execution input exceeds its hashing bound.', {
+      code: 'run-file-execution-file-too-large',
+      kind: candidate.kind,
+      maximumBytes: MAX_REFERENCED_FILE_BYTES,
+    });
+  }
+  const canonicalPath = await realpath(absolutePath);
+  ensureWithinBase(canonicalRoot, canonicalPath);
+  const handle = await open(absolutePath, 'r');
+  try {
+    const opened = await handle.stat();
+    if (!opened.isFile() || opened.nlink !== 1 || opened.size !== before.size) {
+      throw unsupportedIdentity(candidate);
+    }
+    const hash = createHash('sha256');
+    for await (const chunk of handle.createReadStream({ autoClose: false })) hash.update(chunk);
+    const after = await lstat(absolutePath);
+    const afterCanonical = await realpath(absolutePath);
+    if (
+      after.isSymbolicLink() ||
+      after.nlink !== 1 ||
+      after.dev !== opened.dev ||
+      after.ino !== opened.ino ||
+      after.size !== opened.size ||
+      afterCanonical !== canonicalPath
+    ) {
+      throw unsupportedIdentity(candidate);
+    }
+    return {
+      relativePath: path.relative(canonicalRoot, canonicalPath).split(path.sep).join('/'),
+      sha256: `sha256:${hash.digest('hex')}`,
+      byteSize: opened.size,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+function unsupportedIdentity(candidate: ReferenceCandidate): ConflictError {
+  return new ConflictError('Referenced execution input identity cannot be certified.', {
+    code: 'run-file-execution-unsupported-identity',
+    kind: candidate.kind,
+  });
+}
+
+function unsupportedIndirect(kind: string, control: string): ConflictError {
+  return new ConflictError('Indirect file execution cannot be certified by this runtime.', {
+    code: 'run-file-execution-unsupported-indirect',
+    kind,
+    control,
+    remediation:
+      'Use an explicit direct executable, interpreter script, loader, archive, or config path.',
+  });
+}
+
+function pathLike(value: string): boolean {
+  return path.isAbsolute(value) || value.startsWith('.') || /[\\/]/.test(value);
+}
+
+function digest(value: unknown): string {
+  return `sha256:${createHash('sha256').update(stableJson(value)).digest('hex')}`;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, child]) => child !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stableJson(child)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+let runFileExecutionPolicyService: RunFileExecutionPolicyService | undefined;
+
+export function getRunFileExecutionPolicyService(): RunFileExecutionPolicyService {
+  runFileExecutionPolicyService ??= new RunFileExecutionPolicyService();
+  return runFileExecutionPolicyService;
+}

--- a/server/src/services/run-terminal-service.ts
+++ b/server/src/services/run-terminal-service.ts
@@ -63,6 +63,9 @@ export interface RunTerminalLaunchContext {
   worktreeRoot: string;
   environment: Record<string, string>;
   allowedCommands: string[];
+  fileExecutionEvidenceDigest?: string;
+  /** Revalidates exact referenced bytes immediately before the synchronous spawn call. */
+  beforeSpawn?: () => Promise<void>;
   wrap?: (
     command: string,
     args: string[],
@@ -217,7 +220,7 @@ export class RunTerminalService {
     }
     if (!context.allowedCommands.includes(request.command)) {
       throw new ConflictError('Terminal command is not approved by the run launch manifest.', {
-        commandId: commandId(request.command, request.args),
+        commandId: runTerminalCommandId(request.command, request.args),
       });
     }
     assertNoCredentialArguments(request.command, request.args);
@@ -235,6 +238,7 @@ export class RunTerminalService {
       ...selectEnvironment(context.environment, request.environmentKeys),
       ...launch.environment,
     };
+    await context.beforeSpawn?.();
     const id = `terminal_${nanoid(18)}`;
     const startedAt = this.now().toISOString();
     const child = spawn(launch.command, launch.args, {
@@ -257,10 +261,13 @@ export class RunTerminalService {
       launchManifestDigest: context.launchManifestDigest,
       requestId: request.requestId,
       requestDigest,
+      ...(context.fileExecutionEvidenceDigest
+        ? { fileExecutionEvidenceDigest: context.fileExecutionEvidenceDigest }
+        : {}),
       mode: request.mode,
       startMode: request.startMode,
       state: child.pid ? 'running' : 'starting',
-      commandId: commandId(request.command, request.args),
+      commandId: runTerminalCommandId(request.command, request.args),
       ...(child.pid
         ? {
             processId: child.pid,
@@ -940,6 +947,12 @@ function normalizeContext(input: RunTerminalLaunchContext): RunTerminalLaunchCon
   if (!/^sha256:[a-f0-9]{64}$/.test(launchManifestDigest)) {
     throw new ValidationError('Run terminal launch manifest digest is invalid.');
   }
+  if (
+    input.fileExecutionEvidenceDigest &&
+    !/^sha256:[a-f0-9]{64}$/.test(input.fileExecutionEvidenceDigest)
+  ) {
+    throw new ValidationError('Run terminal file execution evidence digest is invalid.');
+  }
   const worktreeRoot = path.resolve(required(input.worktreeRoot, 'worktreeRoot'));
   const allowedCommands = [...new Set(input.allowedCommands.map((command) => command.trim()))]
     .filter(Boolean)
@@ -955,6 +968,10 @@ function normalizeContext(input: RunTerminalLaunchContext): RunTerminalLaunchCon
     worktreeRoot,
     environment: { ...input.environment },
     allowedCommands,
+    ...(input.fileExecutionEvidenceDigest
+      ? { fileExecutionEvidenceDigest: input.fileExecutionEvidenceDigest }
+      : {}),
+    ...(input.beforeSpawn ? { beforeSpawn: input.beforeSpawn } : {}),
     ...(input.wrap ? { wrap: input.wrap } : {}),
   };
 }
@@ -1005,14 +1022,14 @@ function assertNoCredentialArguments(command: string, args: string[]): void {
   }
 }
 
-function commandId(command: string, args: string[]): string {
+export function runTerminalCommandId(command: string, args: string[]): string {
   return `cmd_${createHash('sha256')
     .update(JSON.stringify([command, args]))
     .digest('base64url')
     .slice(0, 24)}`;
 }
 
-function digestTerminalRequest(request: RunTerminalExecuteRequest): string {
+export function digestTerminalRequest(request: RunTerminalExecuteRequest): string {
   return `sha256:${createHash('sha256')
     .update(
       JSON.stringify({
@@ -1101,6 +1118,7 @@ function assertSamePersistedHandleIdentity(
     current.launchManifestDigest,
     current.requestId,
     current.requestDigest,
+    current.fileExecutionEvidenceDigest,
     current.mode,
     current.commandId,
     current.processId,
@@ -1116,6 +1134,7 @@ function assertSamePersistedHandleIdentity(
     next.launchManifestDigest,
     next.requestId,
     next.requestDigest,
+    next.fileExecutionEvidenceDigest,
     next.mode,
     next.commandId,
     next.processId,

--- a/server/src/services/task-envelope-service.ts
+++ b/server/src/services/task-envelope-service.ts
@@ -16,6 +16,7 @@ import {
   type TaskEnvelope,
   type TaskEvidenceRequirement,
   type TaskExecutionPolicy,
+  DEFAULT_RUN_FILE_EXECUTION_PROJECT_POLICY,
   type TaskExpectedOutput,
   type TaskLaunchBaseline,
   type TaskLaunchBaselineFile,
@@ -344,6 +345,10 @@ export class TaskEnvelopeService {
       commitPolicy: input.commitPolicy,
       allowedSideEffects: buildAllowedSideEffects(input),
       expectedOutputs: buildExpectedOutputs(input),
+      fileExecutionPolicy: {
+        ...DEFAULT_RUN_FILE_EXECUTION_PROJECT_POLICY,
+        ...input.executionPolicy?.fileExecution,
+      },
       verificationGates: (input.task.verificationSteps ?? []).slice(0, 256).map((step) => ({
         id: step.id,
         description: step.description,

--- a/server/src/services/tool-control-plane-service.ts
+++ b/server/src/services/tool-control-plane-service.ts
@@ -497,6 +497,18 @@ export class ToolControlPlaneService {
         errors: validateArguments.errors,
       });
     }
+    if (tool.inputSchema['x-veritas-file-execution']) {
+      throw new ConflictError(
+        'This mediated tool declares file execution that its transport cannot certify.',
+        {
+          code: 'run-file-execution-unsupported-tool-transport',
+          serverId: entry.serverId,
+          tool: tool.name,
+          remediation:
+            'Use the run-terminal path or a future tool adapter that can bind provenance and revalidate bytes before execution.',
+        }
+      );
+    }
     const definition = await this.getCatalogDefinition(entry);
     const credentialBound = (entry.credentialBindings?.length ?? 0) > 0;
     const credentialAction = credentialBound

--- a/server/src/utils/run-file-execution-digest.ts
+++ b/server/src/utils/run-file-execution-digest.ts
@@ -1,0 +1,15 @@
+import type { RunFileExecutionApprovalEvidence } from '@veritas-kanban/shared';
+import { digestRunLaunchValue } from './run-launch-manifest-digest.js';
+
+export function calculateRunFileExecutionEvidenceDigest(
+  evidence: RunFileExecutionApprovalEvidence | Omit<RunFileExecutionApprovalEvidence, 'digest'>
+): string {
+  const { digest: _digest, ...material } = evidence as RunFileExecutionApprovalEvidence;
+  return digestRunLaunchValue(material);
+}
+
+export function verifyRunFileExecutionEvidenceDigest(
+  evidence: RunFileExecutionApprovalEvidence
+): boolean {
+  return evidence.digest === calculateRunFileExecutionEvidenceDigest(evidence);
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -65,6 +65,7 @@ export * from './run-event.types.js';
 export * from './progress-watchdog.types.js';
 export * from './run-output-artifact.types.js';
 export * from './run-file-provenance.types.js';
+export * from './run-file-execution.types.js';
 export * from './dependency-circuit.types.js';
 export * from './run-terminal.types.js';
 export * from './run-recovery.types.js';

--- a/shared/src/types/run-approval.types.ts
+++ b/shared/src/types/run-approval.types.ts
@@ -60,6 +60,10 @@ export interface RunApprovalRequest {
   turnId?: string;
   itemId?: string;
   mobileSafe: boolean;
+  /** Present when an approval may only be resolved by a freshly authenticated human user. */
+  decisionAuthority?: 'human-only';
+  /** Bounded digest-bound evidence for run-produced file execution. */
+  fileExecution?: import('./run-file-execution.types.js').RunFileExecutionApprovalEvidence;
   /** Present when approval authority is constrained by an active run phase. */
   phase?: import('./phase-capability.types.js').RunApprovalPhaseBinding;
   status: RunApprovalStatus;

--- a/shared/src/types/run-file-execution.types.ts
+++ b/shared/src/types/run-file-execution.types.ts
@@ -1,0 +1,81 @@
+import type {
+  RunFileProvenanceResponse,
+  RunFileProvenanceRoot,
+  RunFileProvenanceSource,
+} from './run-file-provenance.types.js';
+
+export const RUN_FILE_EXECUTION_POLICY_SCHEMA_VERSION = 'run-file-execution-policy/v1' as const;
+export const RUN_FILE_EXECUTION_EVIDENCE_SCHEMA_VERSION =
+  'run-file-execution-approval-evidence/v1' as const;
+
+export const RUN_FILE_EXECUTION_POLICY_DECISIONS = [
+  'standard-approval',
+  'human-approval',
+  'deny',
+] as const;
+export const RUN_FILE_EXECUTION_REFERENCE_KINDS = [
+  'direct-executable',
+  'interpreter-script',
+  'loader-input',
+  'archive-input',
+  'configuration-input',
+  'load-path',
+] as const;
+
+export type RunFileExecutionPolicyDecision = (typeof RUN_FILE_EXECUTION_POLICY_DECISIONS)[number];
+export type RunFileExecutionReferenceKind = (typeof RUN_FILE_EXECUTION_REFERENCE_KINDS)[number];
+
+export interface RunFileExecutionProjectPolicy {
+  schemaVersion: typeof RUN_FILE_EXECUTION_POLICY_SCHEMA_VERSION;
+  agentCreated: RunFileExecutionPolicyDecision;
+  commandCreated: RunFileExecutionPolicyDecision;
+  toolCreated: RunFileExecutionPolicyDecision;
+}
+
+export interface RunFileExecutionReferenceEvidence {
+  kind: RunFileExecutionReferenceKind;
+  root: RunFileProvenanceRoot;
+  relativePath: string;
+  contentSha256: string;
+  byteSize: number;
+  source: RunFileProvenanceSource;
+  provenanceStatus: RunFileProvenanceResponse['status'] | 'launch-baseline';
+  provenanceRecordId: string | null;
+  provenanceRecordDigest: string | null;
+  provenanceEvidenceDigest: string;
+  decision: RunFileExecutionPolicyDecision;
+}
+
+export interface RunFileExecutionApprovalEvidence {
+  schemaVersion: typeof RUN_FILE_EXECUTION_EVIDENCE_SCHEMA_VERSION;
+  workspaceId: string;
+  taskId: string;
+  rootObjectiveId: string;
+  executionNodeId: string;
+  runId: string;
+  attemptId: string;
+  workflowStepId: string | null;
+  terminalRequestId: string;
+  terminalRequestDigest: string;
+  commandId: string;
+  launchManifestDigest: string;
+  phaseEvidenceDigest: string | null;
+  policy: RunFileExecutionProjectPolicy;
+  references: RunFileExecutionReferenceEvidence[];
+  decision: RunFileExecutionPolicyDecision;
+  reasonCode:
+    | 'no-referenced-files'
+    | 'baseline-only'
+    | 'run-produced-file'
+    | 'external-or-unknown-file'
+    | 'project-policy-deny'
+    | 'unsupported-file-identity';
+  digest: string;
+}
+
+export const DEFAULT_RUN_FILE_EXECUTION_PROJECT_POLICY: RunFileExecutionProjectPolicy = {
+  schemaVersion: RUN_FILE_EXECUTION_POLICY_SCHEMA_VERSION,
+  agentCreated: 'standard-approval',
+  commandCreated: 'standard-approval',
+  toolCreated: 'standard-approval',
+};

--- a/shared/src/types/run-terminal.types.ts
+++ b/shared/src/types/run-terminal.types.ts
@@ -59,6 +59,8 @@ export interface RunTerminalHandle {
   launchManifestDigest: string;
   requestId: string;
   requestDigest: string;
+  /** Exact run-file execution evidence revalidated immediately before spawn. */
+  fileExecutionEvidenceDigest?: string;
   mode: RunTerminalMode;
   startMode: RunTerminalStartMode;
   state: RunTerminalState;

--- a/shared/src/types/task-envelope.types.ts
+++ b/shared/src/types/task-envelope.types.ts
@@ -9,6 +9,13 @@ export interface TaskExecutionPolicy {
   commitPolicy?: TaskCommitPolicy;
   allowedSideEffects?: TaskAllowedSideEffect[];
   expectedOutputs?: TaskExpectedOutput[];
+  /** Optional project policy for agent, command, and tool-created executable inputs. */
+  fileExecution?: Partial<
+    Pick<
+      import('./run-file-execution.types.js').RunFileExecutionProjectPolicy,
+      'agentCreated' | 'commandCreated' | 'toolCreated'
+    >
+  >;
 }
 
 export const TASK_COMPLETION_STATUSES = [
@@ -191,6 +198,8 @@ export interface TaskEnvelope {
   commitPolicy: TaskCommitPolicy;
   allowedSideEffects: TaskAllowedSideEffect[];
   expectedOutputs: TaskExpectedOutput[];
+  /** Resolved immutable policy for files referenced by mediated execution. */
+  fileExecutionPolicy?: import('./run-file-execution.types.js').RunFileExecutionProjectPolicy;
   verificationGates: TaskVerificationGate[];
   launchManifest: TaskLaunchManifestReference;
   completionContract: TaskCompletionContract;


### PR DESCRIPTION
## Summary

- bind explicit executable, script, loader, config, and archive inputs to exact provenance or the launch baseline
- require critical human-only approval for external or unknown bytes and revalidate file, phase, and manifest evidence immediately before spawn
- freeze project policy for other run-produced sources and return typed blockers for unsupported indirect and tool transports
- add bounded approval audit evidence and operator documentation

## Verification

- 77 focused server policy, approval, terminal, task-envelope, tool, and provider integration tests
- shared build and server typecheck
- focused ESLint and formatting
- security artifact, immutable action, tracked-ignore, and delivery guidance commit hooks

Closes #1255