### PR TITLE
fix: preserve diagnostics ampersand in macOS Help menu

### DIFF
--- a/desktop/src/main/__tests__/menu.test.ts
+++ b/desktop/src/main/__tests__/menu.test.ts
@@ -150,7 +150,7 @@ describe('desktop native menu', () => {
       const helpMenu = template.find((item) => item.role === 'help');
       const helpItems = Array.isArray(helpMenu?.submenu) ? helpMenu.submenu : [];
       const productHelp = helpItems.find((item) => item.label === 'Veritas Kanban Help');
-      const onboarding = helpItems.find((item) => item.label === 'Show Setup & Diagnostics');
+      const onboarding = helpItems.find((item) => item.label === 'Show Setup && Diagnostics');
 
       expect(productHelp?.enabled).not.toBe(false);
       expect(onboarding?.enabled).toBe(true);

--- a/desktop/src/main/menu.ts
+++ b/desktop/src/main/menu.ts
@@ -50,7 +50,7 @@ export function createDesktopMenuTemplate(
               },
               {
                 ...command('open-onboarding'),
-                label: 'Show Setup & Diagnostics',
+                label: 'Show Setup && Diagnostics',
               },
             ],
           },


### PR DESCRIPTION
## Summary

- escape the Help menu ampersand for Electron native rendering
- keep focused template coverage on the escaped source label and dispatch

Closes #1291

## Verification

- focused desktop menu tests: 8/8
- desktop typecheck and build
- workspace production build
- unsigned macOS directory package
- macOS accessibility tree exposes `Show Setup & Diagnostics` and activating it dispatches successfully