### PR TITLE
fix: bind repository publication to managed worktrees

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -2,7 +2,7 @@
 cli/src/__tests__/snapshot.test.ts:generic-api-key:220
 
 # API documentation contains non-functional response examples.
-docs/API-REFERENCE.md:generic-api-key:991
+docs/API-REFERENCE.md:generic-api-key:1000
 docs/API-WORKFLOWS.md:generic-api-key:1460
 
 # Operator documentation uses placeholders in curl authentication examples.

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -447,6 +447,14 @@ manifest. The baseline source is recorded as `legacy-adopted`, not as original
 creation provenance. Local tracked and untracked changes are preserved and
 appear in cleanup preview.
 
+Branch and base names must pass Git's canonical branch validation. Pull-request
+creation is available only for an active manifest-backed worktree whose task,
+configured repository, origin, path, lease, branch, and base still match. A
+caller-supplied PR base may only repeat the manifest base. Veritas publishes the
+exact fully qualified task branch, requires a successful non-force push, and
+verifies the remote commit before creating or linking the pull request. Legacy
+worktrees must use the adoption endpoint first.
+
 Merge creates a detached integration worktree from the latest exact remote
 base, merges the task branch there, and pushes `HEAD` to the base without
 force. It never checks out, pulls, stages, commits, or otherwise changes the

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -451,9 +451,10 @@ Branch and base names must pass Git's canonical branch validation. Pull-request
 creation is available only for an active manifest-backed worktree whose task,
 configured repository, origin, path, lease, branch, and base still match. A
 caller-supplied PR base may only repeat the manifest base. Veritas publishes the
-exact fully qualified task branch, requires a successful non-force push, and
-verifies the remote commit before creating or linking the pull request. Legacy
-worktrees must use the adoption endpoint first.
+captured managed commit to the exact fully qualified task branch on the verified
+origin, requires a successful non-force push, and verifies the remote commit
+before creating or linking the pull request in that repository. Legacy worktrees
+must use the adoption endpoint first.
 
 Merge creates a detached integration worktree from the latest exact remote
 base, merges the task branch there, and pushes `HEAD` to the base without

--- a/docs/security.md
+++ b/docs/security.md
@@ -109,6 +109,15 @@ credential-redacted remote identity before any push. Integration uses a
 detached temporary worktree and a non-force push, so the configured primary
 checkout is not mutated.
 
+Git branch and base names are validated at the task and pull-request API
+boundaries and revalidated with Git before use. Pull-request publication and
+Git-backed diff/review operations resolve authority from the durable worktree
+manifest rather than mutable task paths. Publication holds the task manifest
+lock, rechecks repository, origin, path, branch, base, and lease ownership,
+pushes only the exact fully qualified task branch without force, and verifies
+the remote commit before creating or associating a pull request. Missing,
+legacy, removed, or mismatched worktree evidence fails closed.
+
 Repository-controlled execution is a separate trust boundary from worktree
 ownership. Before an executable provider launch, Veritas inventories recognized
 agent instructions, provider configuration, MCP servers, hooks, language-server

--- a/docs/security.md
+++ b/docs/security.md
@@ -114,9 +114,10 @@ boundaries and revalidated with Git before use. Pull-request publication and
 Git-backed diff/review operations resolve authority from the durable worktree
 manifest rather than mutable task paths. Publication holds the task manifest
 lock, rechecks repository, origin, path, branch, base, and lease ownership,
-pushes only the exact fully qualified task branch without force, and verifies
-the remote commit before creating or associating a pull request. Missing,
-legacy, removed, or mismatched worktree evidence fails closed.
+pushes the captured commit only to the exact fully qualified task branch on the
+verified origin without force, and binds pull-request lookup and creation to
+that same repository. Missing, legacy, removed, or mismatched worktree evidence
+fails closed.
 
 Repository-controlled execution is a separate trust boundary from worktree
 ownership. Before an executable provider launch, Veritas inventories recognized

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   body-parser@<2.3.0: 2.3.0
   brace-expansion@<5.0.9: 5.0.9
   esbuild@<0.28.1: 0.28.1
-  fast-uri@<3.1.5: 3.1.5
+  fast-uri@<3.1.6: 3.1.6
   form-data@<4.0.6: 4.0.6
   hono: '>=4.12.34'
   ip-address: '>=10.3.1'
@@ -2734,8 +2734,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6612,7 +6612,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7837,7 +7837,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ overrides:
   'body-parser@<2.3.0': 2.3.0
   'brace-expansion@<5.0.9': 5.0.9
   'esbuild@<0.28.1': 0.28.1
-  'fast-uri@<3.1.5': 3.1.5
+  'fast-uri@<3.1.6': 3.1.6
   'form-data@<4.0.6': 4.0.6
   hono: '>=4.12.34'
   ip-address: '>=10.3.1'

--- a/server/src/__tests__/codex-review-service.test.ts
+++ b/server/src/__tests__/codex-review-service.test.ts
@@ -82,7 +82,20 @@ describe('CodexReviewService', () => {
     process.env.VK_API_URL = 'http://127.0.0.1:3001';
 
     try {
-      const service = new CodexReviewService();
+      const service = new CodexReviewService({
+        worktreeService: {
+          resolvePublicationAuthority: vi.fn().mockResolvedValue({
+            task: await mockGetTask('task_1'),
+            repoPath: '/tmp/repository',
+            worktreePath: '/tmp/review-worktree',
+            branch: 'feature/review',
+            baseBranch: 'main',
+            baseCommit: 'a'.repeat(40),
+            headCommit: 'b'.repeat(40),
+            manifestId: 'worktree_review',
+          }),
+        },
+      });
       await service.reviewTask({ taskId: 'task_1', save: false });
 
       const env = (

--- a/server/src/__tests__/diff-service.test.ts
+++ b/server/src/__tests__/diff-service.test.ts
@@ -133,22 +133,6 @@ describe('DiffService', () => {
     });
   });
 
-  describe('expandPath (private)', () => {
-    const expandPath = (p: string) => {
-      return (service as any).expandPath(p);
-    };
-
-    it('should expand ~ to HOME', () => {
-      const result = expandPath('~/projects/test');
-      expect(result).not.toContain('~');
-      expect(result).toContain('projects/test');
-    });
-
-    it('should not modify absolute paths', () => {
-      expect(expandPath('/usr/local/bin')).toBe('/usr/local/bin');
-    });
-  });
-
   describe('parseUnifiedDiff (private)', () => {
     const parseDiff = (output: string) => {
       return (service as any).parseUnifiedDiff(output);

--- a/server/src/__tests__/git-ref-schemas.test.ts
+++ b/server/src/__tests__/git-ref-schemas.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { GitBranchNameSchema } from '../schemas/git-ref-schemas.js';
+
+describe('GitBranchNameSchema', () => {
+  it.each(['feature/managed-worktree', 'release/6.1.4', 'main'])(
+    'accepts canonical branch %s',
+    (branch) => {
+      expect(GitBranchNameSchema.parse(branch)).toBe(branch);
+    }
+  );
+
+  it.each([
+    'HEAD:refs/heads/canary',
+    '-force-like-option',
+    'feature/../main',
+    'feature branch',
+    'refs/heads/main.lock',
+  ])('rejects noncanonical branch %s', (branch) => {
+    expect(() => GitBranchNameSchema.parse(branch)).toThrow();
+  });
+});

--- a/server/src/__tests__/git-ref-schemas.test.ts
+++ b/server/src/__tests__/git-ref-schemas.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { GitBranchNameSchema } from '../schemas/git-ref-schemas.js';
 
 describe('GitBranchNameSchema', () => {
-  it.each(['feature/managed-worktree', 'release/6.1.4', 'main'])(
+  it.each(['feature/managed-worktree', 'release/6.1.4', 'topic/a.b', 'main'])(
     'accepts canonical branch %s',
     (branch) => {
       expect(GitBranchNameSchema.parse(branch)).toBe(branch);
@@ -11,7 +11,11 @@ describe('GitBranchNameSchema', () => {
 
   it.each([
     'HEAD:refs/heads/canary',
+    '+HEAD:refs/heads/main',
     '-force-like-option',
+    '.hidden',
+    'topic/.hidden',
+    'topic.lock/next',
     'feature/../main',
     'feature branch',
     'refs/heads/main.lock',

--- a/server/src/__tests__/github-service-security.test.ts
+++ b/server/src/__tests__/github-service-security.test.ts
@@ -35,7 +35,10 @@ vi.mock('../services/task-service.js', () => ({
 }));
 
 import { GitHubService } from '../services/github-service.js';
-import { WorktreeService } from '../services/worktree-service.js';
+import {
+  WorktreeService,
+  type WorktreePublicationAuthority,
+} from '../services/worktree-service.js';
 import { FileWorktreeManifestRepository } from '../storage/worktree-manifest-repository.js';
 
 async function git(cwd: string, ...args: string[]): Promise<string> {
@@ -251,6 +254,54 @@ describe('GitHubService repository publication boundary', () => {
     expect((await fs.readFile(argsFile, 'utf8')).split('\n')).toEqual(
       expect.arrayContaining(['--base', 'main', '--head', 'feature/repository-publication'])
     );
+  });
+
+  it('binds publication to the captured commit and remote when mutable Git state drifts', async () => {
+    const { taskStore, configSource, worktreeService } = await prepareManagedBranch(true);
+    await installFakeGh();
+    const decoyRemotePath = path.join(root, 'decoy.git');
+    await fs.mkdir(decoyRemotePath, { recursive: true });
+    await git(decoyRemotePath, 'init', '--bare', '--initial-branch=main');
+    let capturedHead = '';
+    const authoritySource = {
+      resolvePublicationAuthority: (taskId: string) =>
+        worktreeService.resolvePublicationAuthority(taskId),
+      withPublicationAuthority: <T>(
+        taskId: string,
+        operation: (authority: WorktreePublicationAuthority) => Promise<T>
+      ) =>
+        worktreeService.withPublicationAuthority(taskId, async (authority) => {
+          capturedHead = authority.headCommit;
+          await fs.writeFile(path.join(authority.worktreePath, 'later-change.txt'), 'later\n');
+          await git(authority.worktreePath, 'add', 'later-change.txt');
+          await git(authority.worktreePath, 'commit', '-m', 'later change');
+          await git(authority.worktreePath, 'remote', 'set-url', 'origin', decoyRemotePath);
+          return operation(authority);
+        }),
+    };
+    const service = new GitHubService({
+      taskService: taskStore,
+      configService: configSource,
+      worktreeService: authoritySource,
+    });
+    vi.spyOn(service, 'checkGhCli').mockResolvedValue({
+      installed: true,
+      authenticated: true,
+      user: 'VeritasTest',
+    });
+    vi.spyOn(service, 'getPRForBranch').mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+    await service.createPR({ taskId: 'task_publication' });
+
+    expect(await git(remotePath, 'rev-parse', 'refs/heads/feature/repository-publication')).toBe(
+      capturedHead
+    );
+    expect(await git(fixtures.task!.git!.worktreePath!, 'rev-parse', 'HEAD')).not.toBe(
+      capturedHead
+    );
+    await expect(
+      git(decoyRemotePath, 'show-ref', '--verify', 'refs/heads/feature/repository-publication')
+    ).rejects.toThrow();
   });
 
   it('rejects a mismatched requested base before publication', async () => {

--- a/server/src/__tests__/github-service-security.test.ts
+++ b/server/src/__tests__/github-service-security.test.ts
@@ -73,6 +73,7 @@ describe('GitHubService repository publication boundary', () => {
     await git(primaryPath, 'add', 'README.md');
     await git(primaryPath, 'commit', '-m', 'baseline');
     await git(primaryPath, 'push', '-u', 'origin', 'main');
+    await git(primaryPath, 'remote', 'set-url', 'origin', `file://${remotePath}`);
 
     fixtures.config = {
       repos: [{ name: 'veritas', path: primaryPath, defaultBranch: 'main' }],
@@ -324,12 +325,6 @@ describe('GitHubService repository publication boundary', () => {
     const decoyRemotePath = path.join(root, 'decoy.git');
     await fs.mkdir(decoyRemotePath, { recursive: true });
     await git(decoyRemotePath, 'init', '--bare', '--initial-branch=main');
-    await git(
-      fixtures.task!.git!.worktreePath!,
-      'config',
-      'remote.veritas-publication-authority.pushurl',
-      decoyRemotePath
-    );
     let capturedHead = '';
     const authoritySource = {
       resolvePublicationAuthority: (taskId: string) =>
@@ -343,6 +338,18 @@ describe('GitHubService repository publication boundary', () => {
           await fs.writeFile(path.join(authority.worktreePath, 'later-change.txt'), 'later\n');
           await git(authority.worktreePath, 'add', 'later-change.txt');
           await git(authority.worktreePath, 'commit', '-m', 'later change');
+          await git(
+            authority.worktreePath,
+            'config',
+            'remote.veritas-publication-authority.pushurl',
+            decoyRemotePath
+          );
+          await git(
+            authority.worktreePath,
+            'config',
+            `url.file://${decoyRemotePath}.insteadOf`,
+            `file://${remotePath}`
+          );
           await git(authority.worktreePath, 'remote', 'set-url', 'origin', decoyRemotePath);
           return operation(authority);
         }),

--- a/server/src/__tests__/github-service-security.test.ts
+++ b/server/src/__tests__/github-service-security.test.ts
@@ -44,6 +44,7 @@ import {
 } from '../services/worktree-service.js';
 import { FileWorktreeManifestRepository } from '../storage/worktree-manifest-repository.js';
 import { errorHandler } from '../middleware/error-handler.js';
+import { writeRateLimit } from '../middleware/rate-limit.js';
 import { createGitHubPRHandler } from '../routes/github.js';
 import { taskAccess } from '../routes/v1/permissions.js';
 
@@ -306,7 +307,7 @@ describe('GitHubService repository publication boundary', () => {
       (req as AuthenticatedRequest).auth = { role: 'agent', isLocalhost: false };
       next();
     });
-    app.post('/api/v1/github/pr', taskAccess, createGitHubPRHandler(service));
+    app.post('/api/v1/github/pr', writeRateLimit, taskAccess, createGitHubPRHandler(service));
     app.use(errorHandler);
 
     const rejected = await request(app).post('/api/v1/github/pr').send({

--- a/server/src/__tests__/github-service-security.test.ts
+++ b/server/src/__tests__/github-service-security.test.ts
@@ -152,9 +152,7 @@ describe('GitHubService repository publication boundary', () => {
 
   it('derives only a credential-free GitHub repository slug from verified remotes', () => {
     expect(
-      githubRepositoryFromRemote(
-        'https://publication-token:secret-value@github.com/BradGroux/veritas-kanban.git'
-      )
+      githubRepositoryFromRemote('https://build-user@github.com/BradGroux/veritas-kanban.git')
     ).toBe('BradGroux/veritas-kanban');
     expect(githubRepositoryFromRemote('git@github.com:BradGroux/veritas-kanban.git')).toBe(
       'BradGroux/veritas-kanban'

--- a/server/src/__tests__/github-service-security.test.ts
+++ b/server/src/__tests__/github-service-security.test.ts
@@ -3,8 +3,11 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
+import express from 'express';
+import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AppConfig, Task } from '@veritas-kanban/shared';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
 
 const execFileAsync = promisify(execFile);
 const fixtures = vi.hoisted(() => ({
@@ -34,12 +37,15 @@ vi.mock('../services/task-service.js', () => ({
   },
 }));
 
-import { GitHubService } from '../services/github-service.js';
+import { GitHubService, githubRepositoryFromRemote } from '../services/github-service.js';
 import {
   WorktreeService,
   type WorktreePublicationAuthority,
 } from '../services/worktree-service.js';
 import { FileWorktreeManifestRepository } from '../storage/worktree-manifest-repository.js';
+import { errorHandler } from '../middleware/error-handler.js';
+import { createGitHubPRHandler } from '../routes/github.js';
+import { taskAccess } from '../routes/v1/permissions.js';
 
 async function git(cwd: string, ...args: string[]): Promise<string> {
   const result = await execFileAsync('git', args, { cwd });
@@ -143,6 +149,17 @@ describe('GitHubService repository publication boundary', () => {
     return { taskStore, configSource, worktreeService, manifestRepository };
   }
 
+  it('derives only a credential-free GitHub repository slug from verified remotes', () => {
+    expect(
+      githubRepositoryFromRemote(
+        'https://publication-token:secret-value@github.com/BradGroux/veritas-kanban.git'
+      )
+    ).toBe('BradGroux/veritas-kanban');
+    expect(githubRepositoryFromRemote('git@github.com:BradGroux/veritas-kanban.git')).toBe(
+      'BradGroux/veritas-kanban'
+    );
+  });
+
   async function prepareManagedBranch(
     remoteBehind = false
   ): Promise<ReturnType<typeof managedServices>> {
@@ -222,6 +239,7 @@ describe('GitHubService repository publication boundary', () => {
       taskService: taskStore,
       configService: configSource,
       worktreeService,
+      repositoryResolver: () => 'BradGroux/veritas-kanban',
     });
 
     await expect(service.createPR({ taskId: 'task_publication' })).rejects.toThrow(
@@ -236,6 +254,7 @@ describe('GitHubService repository publication boundary', () => {
       taskService: taskStore,
       configService: configSource,
       worktreeService,
+      repositoryResolver: () => 'BradGroux/veritas-kanban',
     });
     vi.spyOn(service, 'checkGhCli').mockResolvedValue({
       installed: true,
@@ -256,12 +275,61 @@ describe('GitHubService repository publication boundary', () => {
     );
   });
 
+  it('enforces the publication boundary for an authenticated agent task-write request', async () => {
+    const { taskStore, configSource, worktreeService } = await prepareManagedBranch(true);
+    await installFakeGh();
+    const service = new GitHubService({
+      taskService: taskStore,
+      configService: configSource,
+      worktreeService,
+      repositoryResolver: () => 'BradGroux/veritas-kanban',
+    });
+    vi.spyOn(service, 'checkGhCli').mockResolvedValue({
+      installed: true,
+      authenticated: true,
+      user: 'VeritasTest',
+    });
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as AuthenticatedRequest).auth = { role: 'agent', isLocalhost: false };
+      next();
+    });
+    app.post('/api/v1/github/pr', taskAccess, createGitHubPRHandler(service));
+    app.use(errorHandler);
+
+    const rejected = await request(app).post('/api/v1/github/pr').send({
+      taskId: 'task_publication',
+      targetBranch: 'HEAD:refs/heads/canary',
+    });
+    expect(rejected.status).toBe(400);
+    await expect(git(remotePath, 'show-ref', '--verify', 'refs/heads/canary')).rejects.toThrow();
+
+    const accepted = await request(app).post('/api/v1/github/pr').send({
+      taskId: 'task_publication',
+    });
+    expect(accepted.status).toBe(201);
+    expect(accepted.body).toEqual(
+      expect.objectContaining({
+        url: 'https://github.com/example/repo/pull/17',
+        headBranch: 'feature/repository-publication',
+        baseBranch: 'main',
+      })
+    );
+  });
+
   it('binds publication to the captured commit and remote when mutable Git state drifts', async () => {
     const { taskStore, configSource, worktreeService } = await prepareManagedBranch(true);
     await installFakeGh();
     const decoyRemotePath = path.join(root, 'decoy.git');
     await fs.mkdir(decoyRemotePath, { recursive: true });
     await git(decoyRemotePath, 'init', '--bare', '--initial-branch=main');
+    await git(
+      fixtures.task!.git!.worktreePath!,
+      'config',
+      'remote.veritas-publication-authority.pushurl',
+      decoyRemotePath
+    );
     let capturedHead = '';
     const authoritySource = {
       resolvePublicationAuthority: (taskId: string) =>
@@ -283,6 +351,7 @@ describe('GitHubService repository publication boundary', () => {
       taskService: taskStore,
       configService: configSource,
       worktreeService: authoritySource,
+      repositoryResolver: () => 'BradGroux/veritas-kanban',
     });
     vi.spyOn(service, 'checkGhCli').mockResolvedValue({
       installed: true,
@@ -310,6 +379,7 @@ describe('GitHubService repository publication boundary', () => {
       taskService: taskStore,
       configService: configSource,
       worktreeService,
+      repositoryResolver: () => 'BradGroux/veritas-kanban',
     });
 
     await expect(
@@ -387,6 +457,7 @@ describe('GitHubService repository publication boundary', () => {
       taskService: taskStore,
       configService: configSource,
       worktreeService,
+      repositoryResolver: () => 'BradGroux/veritas-kanban',
     });
     vi.spyOn(service, 'checkGhCli').mockResolvedValue({
       installed: true,

--- a/server/src/__tests__/github-service-security.test.ts
+++ b/server/src/__tests__/github-service-security.test.ts
@@ -52,6 +52,17 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
   return result.stdout.trim();
 }
 
+function requireTask(): Task {
+  if (!fixtures.task) throw new Error('task fixture is not initialized');
+  return fixtures.task;
+}
+
+function requireTaskGit(): NonNullable<Task['git']> {
+  const taskGit = requireTask().git;
+  if (!taskGit) throw new Error('task Git fixture is not initialized');
+  return taskGit;
+}
+
 describe('GitHubService repository publication boundary', () => {
   let root: string;
   let remotePath: string;
@@ -163,7 +174,7 @@ describe('GitHubService repository publication boundary', () => {
     remoteBehind = false
   ): Promise<ReturnType<typeof managedServices>> {
     fixtures.task = {
-      ...fixtures.task!,
+      ...requireTask(),
       git: {
         repo: 'veritas',
         branch: 'feature/repository-publication',
@@ -225,7 +236,7 @@ describe('GitHubService repository publication boundary', () => {
 
   it('rejects legacy task paths until the existing adoption flow records authority', async () => {
     fixtures.task = {
-      ...fixtures.task!,
+      ...requireTask(),
       git: {
         repo: 'veritas',
         branch: 'feature/legacy-publication',
@@ -263,7 +274,8 @@ describe('GitHubService repository publication boundary', () => {
     vi.spyOn(service, 'getPRForBranch').mockResolvedValueOnce(null).mockResolvedValueOnce(null);
 
     const result = await service.createPR({ taskId: 'task_publication' });
-    const worktreePath = fixtures.task!.git!.worktreePath!;
+    const worktreePath = requireTaskGit().worktreePath;
+    if (!worktreePath) throw new Error('managed worktree path was not recorded');
 
     expect(result.url).toBe('https://github.com/example/repo/pull/17');
     expect(await git(remotePath, 'rev-parse', 'refs/heads/feature/repository-publication')).toBe(
@@ -370,9 +382,9 @@ describe('GitHubService repository publication boundary', () => {
     expect(await git(remotePath, 'rev-parse', 'refs/heads/feature/repository-publication')).toBe(
       capturedHead
     );
-    expect(await git(fixtures.task!.git!.worktreePath!, 'rev-parse', 'HEAD')).not.toBe(
-      capturedHead
-    );
+    const worktreePath = requireTaskGit().worktreePath;
+    if (!worktreePath) throw new Error('managed worktree path was not recorded');
+    expect(await git(worktreePath, 'rev-parse', 'HEAD')).not.toBe(capturedHead);
     await expect(
       git(decoyRemotePath, 'show-ref', '--verify', 'refs/heads/feature/repository-publication')
     ).rejects.toThrow();
@@ -419,13 +431,15 @@ describe('GitHubService repository publication boundary', () => {
 
   it('rejects task allocation and origin drift', async () => {
     const { worktreeService } = await prepareManagedBranch();
-    const managedPath = fixtures.task!.git!.worktreePath!;
-    fixtures.task!.git!.worktreePath = primaryPath;
+    const taskGit = requireTaskGit();
+    const managedPath = taskGit.worktreePath;
+    if (!managedPath) throw new Error('managed worktree path was not recorded');
+    taskGit.worktreePath = primaryPath;
     await expect(worktreeService.resolvePublicationAuthority('task_publication')).rejects.toThrow(
       /allocation does not match/i
     );
 
-    fixtures.task!.git!.worktreePath = managedPath;
+    taskGit.worktreePath = managedPath;
     await git(primaryPath, 'remote', 'set-url', 'origin', path.join(root, 'other.git'));
     await expect(worktreeService.resolvePublicationAuthority('task_publication')).rejects.toThrow(
       /durable worktree manifest/i
@@ -434,7 +448,8 @@ describe('GitHubService repository publication boundary', () => {
 
   it('rejects actual branch drift and invalid legacy manifest refs', async () => {
     const { worktreeService, manifestRepository } = await prepareManagedBranch();
-    const managedPath = fixtures.task!.git!.worktreePath!;
+    const managedPath = requireTaskGit().worktreePath;
+    if (!managedPath) throw new Error('managed worktree path was not recorded');
     await git(managedPath, 'checkout', '-b', 'feature/unexpected');
     await expect(worktreeService.resolvePublicationAuthority('task_publication')).rejects.toThrow(
       /branch does not match/i

--- a/server/src/__tests__/github-service-security.test.ts
+++ b/server/src/__tests__/github-service-security.test.ts
@@ -104,6 +104,7 @@ describe('GitHubService repository publication boundary', () => {
     };
     configSource: { getConfig(): Promise<AppConfig> };
     worktreeService: WorktreeService;
+    manifestRepository: FileWorktreeManifestRepository;
   } {
     const taskStore = {
       async getTask(taskId: string): Promise<Task | null> {
@@ -127,15 +128,16 @@ describe('GitHubService repository publication boundary', () => {
         return structuredClone(fixtures.config);
       },
     };
+    const manifestRepository = new FileWorktreeManifestRepository({
+      manifestsDir: path.join(root, 'worktree-manifests'),
+    });
     const worktreeService = new WorktreeService({
       worktreesDir: path.join(root, 'worktrees'),
       taskService: taskStore,
       configService: configSource,
-      manifestRepository: new FileWorktreeManifestRepository({
-        manifestsDir: path.join(root, 'worktree-manifests'),
-      }),
+      manifestRepository,
     });
-    return { taskStore, configSource, worktreeService };
+    return { taskStore, configSource, worktreeService, manifestRepository };
   }
 
   async function prepareManagedBranch(
@@ -175,18 +177,53 @@ describe('GitHubService repository publication boundary', () => {
     return argsFile;
   }
 
-  it('rejects a refspec-shaped task branch before it mutates the remote', async () => {
-    const service = new GitHubService();
-    vi.spyOn(service, 'checkGhCli').mockResolvedValue({
-      installed: true,
-      authenticated: true,
-      user: 'VeritasTest',
+  it.each(['HEAD:refs/heads/canary', '+HEAD:refs/heads/main'])(
+    'rejects stored refspec-shaped branch %s before it mutates the remote',
+    async (hostileBranch) => {
+      const { taskStore, configSource, worktreeService, manifestRepository } =
+        await prepareManagedBranch();
+      const manifest = await manifestRepository.read('task_publication');
+      if (!manifest) throw new Error('managed manifest was not created');
+      await taskStore.updateTask('task_publication', {
+        git: { ...fixtures.task?.git, branch: hostileBranch },
+      });
+      await manifestRepository.save({ ...manifest, branch: hostileBranch });
+      const mainBefore = await git(remotePath, 'rev-parse', 'refs/heads/main');
+      const service = new GitHubService({
+        taskService: taskStore,
+        configService: configSource,
+        worktreeService,
+      });
+
+      await expect(service.createPR({ taskId: 'task_publication' })).rejects.toThrow(
+        /Invalid Git branch name/i
+      );
+
+      expect(await git(remotePath, 'rev-parse', 'refs/heads/main')).toBe(mainBefore);
+      await expect(git(remotePath, 'show-ref', '--verify', 'refs/heads/canary')).rejects.toThrow();
+    }
+  );
+
+  it('rejects legacy task paths until the existing adoption flow records authority', async () => {
+    fixtures.task = {
+      ...fixtures.task!,
+      git: {
+        repo: 'veritas',
+        branch: 'feature/legacy-publication',
+        baseBranch: 'main',
+        worktreePath: primaryPath,
+      },
+    };
+    const { taskStore, configSource, worktreeService } = managedServices();
+    const service = new GitHubService({
+      taskService: taskStore,
+      configService: configSource,
+      worktreeService,
     });
-    vi.spyOn(service, 'getPRForBranch').mockResolvedValue(null);
 
-    await service.createPR({ taskId: 'task_publication' }).catch(() => undefined);
-
-    await expect(git(remotePath, 'show-ref', '--verify', 'refs/heads/canary')).rejects.toThrow();
+    await expect(service.createPR({ taskId: 'task_publication' })).rejects.toThrow(
+      /requires an active managed worktree/i
+    );
   });
 
   it('publishes only the exact managed branch to a throwaway bare remote', async () => {
@@ -266,6 +303,26 @@ describe('GitHubService repository publication boundary', () => {
     await git(primaryPath, 'remote', 'set-url', 'origin', path.join(root, 'other.git'));
     await expect(worktreeService.resolvePublicationAuthority('task_publication')).rejects.toThrow(
       /durable worktree manifest/i
+    );
+  });
+
+  it('rejects actual branch drift and invalid legacy manifest refs', async () => {
+    const { worktreeService, manifestRepository } = await prepareManagedBranch();
+    const managedPath = fixtures.task!.git!.worktreePath!;
+    await git(managedPath, 'checkout', '-b', 'feature/unexpected');
+    await expect(worktreeService.resolvePublicationAuthority('task_publication')).rejects.toThrow(
+      /branch does not match/i
+    );
+
+    await git(managedPath, 'checkout', 'feature/repository-publication');
+    const manifest = await manifestRepository.read('task_publication');
+    if (!manifest) throw new Error('managed manifest was not created');
+    await manifestRepository.save({
+      ...manifest,
+      base: { ...manifest.base, branch: 'main:refs/heads/canary' },
+    });
+    await expect(worktreeService.previewCleanup('task_publication')).rejects.toThrow(
+      /Invalid Git branch name/i
     );
   });
 

--- a/server/src/__tests__/github-service-security.test.ts
+++ b/server/src/__tests__/github-service-security.test.ts
@@ -1,0 +1,293 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppConfig, Task } from '@veritas-kanban/shared';
+
+const execFileAsync = promisify(execFile);
+const fixtures = vi.hoisted(() => ({
+  config: undefined as AppConfig | undefined,
+  task: undefined as Task | undefined,
+}));
+
+vi.mock('../services/config-service.js', () => ({
+  ConfigService: class MockConfigService {
+    async getConfig(): Promise<AppConfig> {
+      if (!fixtures.config) throw new Error('config fixture is not initialized');
+      return structuredClone(fixtures.config);
+    }
+  },
+}));
+
+vi.mock('../services/task-service.js', () => ({
+  TaskService: class MockTaskService {
+    async getTask(taskId: string): Promise<Task | null> {
+      return fixtures.task?.id === taskId ? structuredClone(fixtures.task) : null;
+    }
+
+    async updateTask(): Promise<Task> {
+      if (!fixtures.task) throw new Error('task fixture is not initialized');
+      return structuredClone(fixtures.task);
+    }
+  },
+}));
+
+import { GitHubService } from '../services/github-service.js';
+import { WorktreeService } from '../services/worktree-service.js';
+import { FileWorktreeManifestRepository } from '../storage/worktree-manifest-repository.js';
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const result = await execFileAsync('git', args, { cwd });
+  return result.stdout.trim();
+}
+
+describe('GitHubService repository publication boundary', () => {
+  let root: string;
+  let remotePath: string;
+  let primaryPath: string;
+  let originalPath: string | undefined;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-github-service-'));
+    remotePath = path.join(root, 'remote.git');
+    primaryPath = path.join(root, 'primary');
+    originalPath = process.env.PATH;
+
+    await fs.mkdir(remotePath, { recursive: true });
+    await git(remotePath, 'init', '--bare', '--initial-branch=main');
+    await git(root, 'clone', remotePath, primaryPath);
+    await git(primaryPath, 'config', 'user.name', 'Veritas Test');
+    await git(primaryPath, 'config', 'user.email', 'veritas@example.test');
+    await fs.writeFile(path.join(primaryPath, 'README.md'), 'baseline\n');
+    await git(primaryPath, 'add', 'README.md');
+    await git(primaryPath, 'commit', '-m', 'baseline');
+    await git(primaryPath, 'push', '-u', 'origin', 'main');
+
+    fixtures.config = {
+      repos: [{ name: 'veritas', path: primaryPath, defaultBranch: 'main' }],
+      agents: [],
+      defaultAgent: 'codex',
+    };
+    fixtures.task = {
+      id: 'task_publication',
+      title: 'Repository publication boundary',
+      description: '',
+      type: 'code',
+      status: 'todo',
+      priority: 'high',
+      created: '2026-09-02T12:00:00.000Z',
+      updated: '2026-09-02T12:00:00.000Z',
+      git: {
+        repo: 'veritas',
+        branch: 'HEAD:refs/heads/canary',
+        baseBranch: 'main',
+        worktreePath: primaryPath,
+      },
+    };
+  });
+
+  afterEach(async () => {
+    fixtures.config = undefined;
+    fixtures.task = undefined;
+    process.env.PATH = originalPath;
+    delete process.env.GH_ARGS_FILE;
+    delete process.env.GH_LIST_JSON;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  function managedServices(): {
+    taskStore: {
+      getTask(taskId: string): Promise<Task | null>;
+      updateTask(taskId: string, update: Partial<Task>): Promise<Task | null>;
+    };
+    configSource: { getConfig(): Promise<AppConfig> };
+    worktreeService: WorktreeService;
+  } {
+    const taskStore = {
+      async getTask(taskId: string): Promise<Task | null> {
+        return fixtures.task?.id === taskId ? structuredClone(fixtures.task) : null;
+      },
+      async updateTask(taskId: string, update: Partial<Task>): Promise<Task | null> {
+        if (!fixtures.task || fixtures.task.id !== taskId) return null;
+        fixtures.task = {
+          ...fixtures.task,
+          ...structuredClone(update),
+          git: update.git
+            ? ({ ...fixtures.task.git, ...structuredClone(update.git) } as Task['git'])
+            : fixtures.task.git,
+        };
+        return structuredClone(fixtures.task);
+      },
+    };
+    const configSource = {
+      async getConfig(): Promise<AppConfig> {
+        if (!fixtures.config) throw new Error('config fixture is not initialized');
+        return structuredClone(fixtures.config);
+      },
+    };
+    const worktreeService = new WorktreeService({
+      worktreesDir: path.join(root, 'worktrees'),
+      taskService: taskStore,
+      configService: configSource,
+      manifestRepository: new FileWorktreeManifestRepository({
+        manifestsDir: path.join(root, 'worktree-manifests'),
+      }),
+    });
+    return { taskStore, configSource, worktreeService };
+  }
+
+  async function prepareManagedBranch(
+    remoteBehind = false
+  ): Promise<ReturnType<typeof managedServices>> {
+    fixtures.task = {
+      ...fixtures.task!,
+      git: {
+        repo: 'veritas',
+        branch: 'feature/repository-publication',
+        baseBranch: 'main',
+      },
+    };
+    const services = managedServices();
+    const info = await services.worktreeService.createWorktree('task_publication');
+    if (remoteBehind) {
+      await git(info.path, 'push', '-u', 'origin', 'feature/repository-publication');
+    }
+    await fs.writeFile(path.join(info.path, 'change.txt'), 'managed change\n');
+    await git(info.path, 'add', 'change.txt');
+    await git(info.path, 'commit', '-m', 'managed change');
+    return services;
+  }
+
+  async function installFakeGh(): Promise<string> {
+    const binDir = path.join(root, 'bin');
+    const argsFile = path.join(root, 'gh-args.txt');
+    const ghPath = path.join(binDir, 'gh');
+    await fs.mkdir(binDir, { recursive: true });
+    await fs.writeFile(
+      ghPath,
+      '#!/bin/sh\nif [ "$1" = "repo" ] && [ "$2" = "view" ]; then\n  printf \'%s\\n\' \'{"nameWithOwner":"BradGroux/veritas-kanban"}\'\n  exit 0\nfi\nif [ "$1" = "pr" ] && [ "$2" = "list" ]; then\n  printf \'%s\\n\' "$GH_LIST_JSON"\n  exit 0\nfi\nprintf \'%s\\n\' "$@" > "$GH_ARGS_FILE"\nprintf \'https://github.com/example/repo/pull/17\\n\'\n'
+    );
+    await fs.chmod(ghPath, 0o755);
+    process.env.PATH = `${binDir}:${originalPath ?? ''}`;
+    process.env.GH_ARGS_FILE = argsFile;
+    return argsFile;
+  }
+
+  it('rejects a refspec-shaped task branch before it mutates the remote', async () => {
+    const service = new GitHubService();
+    vi.spyOn(service, 'checkGhCli').mockResolvedValue({
+      installed: true,
+      authenticated: true,
+      user: 'VeritasTest',
+    });
+    vi.spyOn(service, 'getPRForBranch').mockResolvedValue(null);
+
+    await service.createPR({ taskId: 'task_publication' }).catch(() => undefined);
+
+    await expect(git(remotePath, 'show-ref', '--verify', 'refs/heads/canary')).rejects.toThrow();
+  });
+
+  it('publishes only the exact managed branch to a throwaway bare remote', async () => {
+    const { taskStore, configSource, worktreeService } = await prepareManagedBranch(true);
+    const argsFile = await installFakeGh();
+    const service = new GitHubService({
+      taskService: taskStore,
+      configService: configSource,
+      worktreeService,
+    });
+    vi.spyOn(service, 'checkGhCli').mockResolvedValue({
+      installed: true,
+      authenticated: true,
+      user: 'VeritasTest',
+    });
+    vi.spyOn(service, 'getPRForBranch').mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+    const result = await service.createPR({ taskId: 'task_publication' });
+    const worktreePath = fixtures.task!.git!.worktreePath!;
+
+    expect(result.url).toBe('https://github.com/example/repo/pull/17');
+    expect(await git(remotePath, 'rev-parse', 'refs/heads/feature/repository-publication')).toBe(
+      await git(worktreePath, 'rev-parse', 'HEAD')
+    );
+    expect((await fs.readFile(argsFile, 'utf8')).split('\n')).toEqual(
+      expect.arrayContaining(['--base', 'main', '--head', 'feature/repository-publication'])
+    );
+  });
+
+  it('rejects a mismatched requested base before publication', async () => {
+    const { taskStore, configSource, worktreeService } = await prepareManagedBranch();
+    const service = new GitHubService({
+      taskService: taskStore,
+      configService: configSource,
+      worktreeService,
+    });
+
+    await expect(
+      service.createPR({ taskId: 'task_publication', targetBranch: 'release/other' })
+    ).rejects.toThrow(/does not match the managed worktree/i);
+    await expect(
+      git(remotePath, 'show-ref', '--verify', 'refs/heads/feature/repository-publication')
+    ).rejects.toThrow();
+  });
+
+  it('does not adopt a same-named PR from a fork repository', async () => {
+    const argsFile = await installFakeGh();
+    process.env.GH_LIST_JSON = JSON.stringify([
+      {
+        url: 'https://github.com/BradGroux/veritas-kanban/pull/99',
+        number: 99,
+        title: 'Fork branch',
+        state: 'OPEN',
+        isDraft: false,
+        headRefName: 'feature/repository-publication',
+        baseRefName: 'main',
+        headRepository: { nameWithOwner: 'someone-else/veritas-kanban' },
+      },
+    ]);
+    const service = new GitHubService();
+
+    await expect(
+      service.getPRForBranch(primaryPath, 'feature/repository-publication', 'main')
+    ).resolves.toBeNull();
+    await expect(fs.readFile(argsFile, 'utf8')).rejects.toThrow();
+  });
+
+  it('rejects task allocation and origin drift', async () => {
+    const { worktreeService } = await prepareManagedBranch();
+    const managedPath = fixtures.task!.git!.worktreePath!;
+    fixtures.task!.git!.worktreePath = primaryPath;
+    await expect(worktreeService.resolvePublicationAuthority('task_publication')).rejects.toThrow(
+      /allocation does not match/i
+    );
+
+    fixtures.task!.git!.worktreePath = managedPath;
+    await git(primaryPath, 'remote', 'set-url', 'origin', path.join(root, 'other.git'));
+    await expect(worktreeService.resolvePublicationAuthority('task_publication')).rejects.toThrow(
+      /durable worktree manifest/i
+    );
+  });
+
+  it('stops before PR creation when the explicit push fails', async () => {
+    const { taskStore, configSource, worktreeService } = await prepareManagedBranch();
+    const hookPath = path.join(remotePath, 'hooks', 'pre-receive');
+    await fs.writeFile(hookPath, '#!/bin/sh\nexit 1\n');
+    await fs.chmod(hookPath, 0o755);
+    const argsFile = await installFakeGh();
+    const service = new GitHubService({
+      taskService: taskStore,
+      configService: configSource,
+      worktreeService,
+    });
+    vi.spyOn(service, 'checkGhCli').mockResolvedValue({
+      installed: true,
+      authenticated: true,
+      user: 'VeritasTest',
+    });
+    vi.spyOn(service, 'getPRForBranch').mockResolvedValue(null);
+
+    await expect(service.createPR({ taskId: 'task_publication' })).rejects.toThrow();
+    await expect(fs.readFile(argsFile, 'utf8')).rejects.toThrow();
+  });
+});

--- a/server/src/__tests__/routes/github-codex-cloud.test.ts
+++ b/server/src/__tests__/routes/github-codex-cloud.test.ts
@@ -75,4 +75,17 @@ describe('GitHub Codex Cloud routes', () => {
     expect(response.status).toBe(400);
     expect(mockGithubService.delegateToCodexCloud).not.toHaveBeenCalled();
   });
+
+  it.each(['HEAD:refs/heads/canary', '-force-like-option'])(
+    'rejects invalid PR target branch %s at the route boundary',
+    async (targetBranch) => {
+      const response = await request(app).post('/api/github/pr').send({
+        taskId: 'task_123',
+        targetBranch,
+      });
+
+      expect(response.status).toBe(400);
+      expect(mockGithubService.createPR).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/server/src/__tests__/routes/tasks-coverage.test.ts
+++ b/server/src/__tests__/routes/tasks-coverage.test.ts
@@ -330,6 +330,18 @@ describe('Tasks Routes (actual module)', () => {
       expect(mockTaskService.updateTask).not.toHaveBeenCalled();
     });
 
+    it.each(['HEAD:refs/heads/canary', '+HEAD:refs/heads/main', '-force-like-option'])(
+      'rejects invalid task branch %s at the route boundary',
+      async (branch) => {
+        const res = await request(app)
+          .patch('/api/tasks/t1')
+          .send({ git: { repo: 'veritas', branch, baseBranch: 'main' } });
+
+        expect(res.status).toBe(400);
+        expect(mockTaskService.updateTask).not.toHaveBeenCalled();
+      }
+    );
+
     it('rejects generic PATCH attempts that mutate authoritative run contracts', async () => {
       for (const field of ['taskEnvelope', 'completionResult']) {
         const res = await request(app)

--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -52,6 +52,10 @@ function runGuard(handler: AccessGuard, req: AuthenticatedRequest) {
 }
 
 describe('v1 REST permission guard presets', () => {
+  it('allows the agent role through the task-write guard used by GitHub PR routes', () => {
+    expect(runGuard(taskAccess, mockRequest('POST', '/pr', 'agent')).next).toHaveBeenCalled();
+  });
+
   it('allows admission inspection but reserves future mutations for administrators', () => {
     expect(
       runGuard(admissionAccess, mockRequest('GET', '/', 'agent', ['agent:read'])).next

--- a/server/src/routes/github.ts
+++ b/server/src/routes/github.ts
@@ -4,6 +4,7 @@ import { GitHubService } from '../services/github-service.js';
 import { getGitHubSyncService } from '../services/github-sync-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { ValidationError } from '../middleware/error-handler.js';
+import { GitBranchNameSchema } from '../schemas/git-ref-schemas.js';
 
 const router: RouterType = Router();
 const githubService = new GitHubService();
@@ -14,7 +15,7 @@ const createPRSchema = z.object({
   taskId: z.string().min(1),
   title: z.string().optional(),
   body: z.string().optional(),
-  targetBranch: z.string().optional(),
+  targetBranch: GitBranchNameSchema.optional(),
   draft: z.boolean().optional(),
 });
 

--- a/server/src/routes/github.ts
+++ b/server/src/routes/github.ts
@@ -1,4 +1,4 @@
-import { Router, type Router as RouterType } from 'express';
+import { Router, type RequestHandler, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { GitHubService } from '../services/github-service.js';
 import { getGitHubSyncService } from '../services/github-sync-service.js';
@@ -46,10 +46,10 @@ router.get(
   })
 );
 
-// POST /api/github/pr - Create a PR for a task
-router.post(
-  '/pr',
-  asyncHandler(async (req, res) => {
+export function createGitHubPRHandler(
+  service: Pick<GitHubService, 'createPR'> = githubService
+): RequestHandler {
+  return asyncHandler(async (req, res) => {
     let input;
     try {
       input = createPRSchema.parse(req.body);
@@ -59,10 +59,13 @@ router.post(
       }
       throw error;
     }
-    const pr = await githubService.createPR(input);
+    const pr = await service.createPR(input);
     res.status(201).json(pr);
-  })
-);
+  });
+}
+
+// POST /api/github/pr - Create a PR for a task
+router.post('/pr', createGitHubPRHandler());
 
 // POST /api/github/pr/:taskId/open - Open PR in browser
 router.post(

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -25,6 +25,7 @@ import { actorFromRequest, assertFreshRevision, setRevisionHeaders } from '../ut
 import type { TaskIdentityDiagnostics } from '../services/task-identity-diagnostics.js';
 import { TaskExecutionPolicySchema } from '../schemas/task-envelope-schemas.js';
 import { ReorderTasksBodySchema } from '../schemas/task-mutation-schemas.js';
+import { GitBranchNameSchema } from '../schemas/git-ref-schemas.js';
 
 const router: RouterType = Router();
 const taskService = getTaskService();
@@ -85,8 +86,8 @@ const createTaskSchema = z.object({
 const gitSchema = z
   .object({
     repo: z.string().optional(),
-    branch: z.string().optional(),
-    baseBranch: z.string().optional(),
+    branch: GitBranchNameSchema.optional(),
+    baseBranch: GitBranchNameSchema.optional(),
     worktreePath: z.string().optional(),
   })
   .optional();

--- a/server/src/schemas/git-ref-schemas.ts
+++ b/server/src/schemas/git-ref-schemas.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export function isCanonicalGitBranchName(value: string): boolean {
+  const hasForbiddenControl = [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x20 || code === 0x7f;
+  });
+  return (
+    value.length > 0 &&
+    value.length <= 240 &&
+    value === value.trim() &&
+    value !== '@' &&
+    !value.startsWith('-') &&
+    !value.startsWith('/') &&
+    !value.endsWith('/') &&
+    !value.endsWith('.') &&
+    !value.endsWith('.lock') &&
+    !value.includes('..') &&
+    !value.includes('//') &&
+    !value.includes('@{') &&
+    !hasForbiddenControl &&
+    !/[~^:?*[\\]/.test(value)
+  );
+}
+
+export const GitBranchNameSchema = z
+  .string()
+  .min(1)
+  .max(240)
+  .refine(isCanonicalGitBranchName, 'Invalid Git branch name');

--- a/server/src/schemas/git-ref-schemas.ts
+++ b/server/src/schemas/git-ref-schemas.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { z } from 'zod';
 
 export function isCanonicalGitBranchName(value: string): boolean {
@@ -5,7 +6,7 @@ export function isCanonicalGitBranchName(value: string): boolean {
     const code = character.charCodeAt(0);
     return code <= 0x20 || code === 0x7f;
   });
-  return (
+  const passesStructuralChecks =
     value.length > 0 &&
     value.length <= 240 &&
     value === value.trim() &&
@@ -19,7 +20,14 @@ export function isCanonicalGitBranchName(value: string): boolean {
     !value.includes('//') &&
     !value.includes('@{') &&
     !hasForbiddenControl &&
-    !/[~^:?*[\\]/.test(value)
+    !/[~^:?*[\\]/.test(value);
+  if (!passesStructuralChecks) return false;
+
+  return (
+    spawnSync('git', ['check-ref-format', '--branch', value], {
+      stdio: 'ignore',
+      timeout: 2_000,
+    }).status === 0
   );
 }
 

--- a/server/src/services/codex-review-service.ts
+++ b/server/src/services/codex-review-service.ts
@@ -1,6 +1,7 @@
 import { simpleGit } from 'simple-git';
 import { nanoid } from 'nanoid';
 import { TaskService } from './task-service.js';
+import { WorktreeService } from './worktree-service.js';
 import type { ReviewComment, ReviewDecision, Task } from '@veritas-kanban/shared';
 import { buildSafeCodexEnv } from '../utils/codex-env.js';
 
@@ -30,24 +31,23 @@ export interface CodexReviewResult {
 }
 
 export class CodexReviewService {
-  private taskService: TaskService;
+  private readonly taskService: TaskService;
+  private readonly worktreeService: Pick<WorktreeService, 'resolvePublicationAuthority'>;
 
-  constructor() {
+  constructor(
+    options: {
+      worktreeService?: Pick<WorktreeService, 'resolvePublicationAuthority'>;
+    } = {}
+  ) {
     this.taskService = new TaskService();
-  }
-
-  private expandPath(p: string): string {
-    return p.replace(/^~/, process.env.HOME || '');
+    this.worktreeService = options.worktreeService ?? new WorktreeService();
   }
 
   async reviewTask(input: CodexReviewInput): Promise<CodexReviewResult> {
-    const task = await this.taskService.getTask(input.taskId);
-    if (!task) throw new Error('Task not found');
-    if (!task.git?.worktreePath) throw new Error('Task must have an active worktree to review');
-
-    const worktreePath = this.expandPath(task.git.worktreePath);
-    const baseBranch = task.git.baseBranch || 'main';
-    const diff = await simpleGit(worktreePath).diff([baseBranch]);
+    const authority = await this.worktreeService.resolvePublicationAuthority(input.taskId);
+    const task = authority.task;
+    const worktreePath = authority.worktreePath;
+    const diff = await simpleGit(worktreePath).diff([authority.baseCommit]);
     if (!diff.trim()) throw new Error('Task branch has no diff to review');
 
     const prompt = this.buildReviewPrompt(task, diff, input.instructions);

--- a/server/src/services/diff-service.ts
+++ b/server/src/services/diff-service.ts
@@ -1,5 +1,5 @@
 import { simpleGit } from 'simple-git';
-import { TaskService } from './task-service.js';
+import { WorktreeService } from './worktree-service.js';
 import { createLogger } from '../lib/logger.js';
 const log = createLogger('diff-service');
 
@@ -43,14 +43,14 @@ export interface DiffSummary {
 }
 
 export class DiffService {
-  private taskService: TaskService;
+  private readonly worktreeService: Pick<WorktreeService, 'resolvePublicationAuthority'>;
 
-  constructor() {
-    this.taskService = new TaskService();
-  }
-
-  private expandPath(p: string): string {
-    return p.replace(/^~/, process.env.HOME || '');
+  constructor(
+    options: {
+      worktreeService?: Pick<WorktreeService, 'resolvePublicationAuthority'>;
+    } = {}
+  ) {
+    this.worktreeService = options.worktreeService ?? new WorktreeService();
   }
 
   private getLanguageFromPath(filePath: string): string {
@@ -95,19 +95,11 @@ export class DiffService {
   }
 
   async getDiffSummary(taskId: string): Promise<DiffSummary> {
-    const task = await this.taskService.getTask(taskId);
-    if (!task?.git?.worktreePath) {
-      throw new Error('Task does not have an active worktree');
-    }
-
-    const worktreePath = this.expandPath(task.git.worktreePath);
-    const git = simpleGit(worktreePath);
-
-    // Get diff against base branch
-    const baseBranch = task.git.baseBranch || 'main';
+    const authority = await this.worktreeService.resolvePublicationAuthority(taskId);
+    const git = simpleGit(authority.worktreePath);
 
     // Get list of changed files with stats
-    const diffStat = await git.diffSummary([baseBranch]);
+    const diffStat = await git.diffSummary([authority.baseCommit]);
 
     const files: FileChange[] = diffStat.files.map((file) => {
       const additions = 'insertions' in file ? file.insertions : 0;
@@ -137,20 +129,14 @@ export class DiffService {
   }
 
   async getFileDiff(taskId: string, filePath: string): Promise<FileDiff> {
-    const task = await this.taskService.getTask(taskId);
-    if (!task?.git?.worktreePath) {
-      throw new Error('Task does not have an active worktree');
-    }
-
-    const worktreePath = this.expandPath(task.git.worktreePath);
-    const git = simpleGit(worktreePath);
-    const baseBranch = task.git.baseBranch || 'main';
+    const authority = await this.worktreeService.resolvePublicationAuthority(taskId);
+    const git = simpleGit(authority.worktreePath);
 
     // Get unified diff for the file
-    const diffOutput = await git.diff([baseBranch, '--', filePath]);
+    const diffOutput = await git.diff([authority.baseCommit, '--', filePath]);
 
     // Get file stats
-    const diffStat = await git.diffSummary([baseBranch, '--', filePath]);
+    const diffStat = await git.diffSummary([authority.baseCommit, '--', filePath]);
     const fileStat = diffStat.files[0];
 
     // Parse the unified diff

--- a/server/src/services/github-service.ts
+++ b/server/src/services/github-service.ts
@@ -3,10 +3,10 @@ import { promisify } from 'util';
 import { nanoid } from 'nanoid';
 import { ConfigService } from './config-service.js';
 import { TaskService } from './task-service.js';
+import { WorktreeService, type WorktreePublicationAuthority } from './worktree-service.js';
 import { getBreaker } from './circuit-registry.js';
 import type { AgentType, Task } from '@veritas-kanban/shared';
-import { createLogger } from '../lib/logger.js';
-const log = createLogger('github-service');
+import { ConflictError } from '../middleware/error-handler.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -27,6 +27,28 @@ export interface PRInfo {
   draft: boolean;
   headBranch: string;
   baseBranch: string;
+}
+
+interface GitHubTaskStore {
+  getTask(taskId: string): Promise<Task | null>;
+  updateTask(
+    taskId: string,
+    update: Parameters<TaskService['updateTask']>[1]
+  ): Promise<Task | null>;
+}
+
+interface GitHubConfigSource {
+  getConfig(): ReturnType<ConfigService['getConfig']>;
+}
+
+interface PublicationAuthoritySource {
+  resolvePublicationAuthority(taskId: string): Promise<WorktreePublicationAuthority>;
+}
+
+export interface GitHubServiceOptions {
+  taskService?: GitHubTaskStore;
+  configService?: GitHubConfigSource;
+  worktreeService?: PublicationAuthoritySource;
 }
 
 export type CodexCloudTarget = 'issue' | 'issue-comment' | 'pr-comment';
@@ -50,12 +72,19 @@ export interface CodexCloudDelegationResult {
 }
 
 export class GitHubService {
-  private configService: ConfigService;
-  private taskService: TaskService;
+  private readonly configService: GitHubConfigSource;
+  private readonly taskService: GitHubTaskStore;
+  private readonly worktreeService: PublicationAuthoritySource;
 
-  constructor() {
-    this.configService = new ConfigService();
-    this.taskService = new TaskService();
+  constructor(options: GitHubServiceOptions = {}) {
+    this.configService = options.configService ?? new ConfigService();
+    this.taskService = options.taskService ?? new TaskService();
+    this.worktreeService =
+      options.worktreeService ??
+      new WorktreeService({
+        taskService: this.taskService,
+        configService: this.configService,
+      });
   }
 
   private expandPath(p: string): string {
@@ -104,24 +133,53 @@ export class GitHubService {
   /**
    * Check if a PR already exists for the branch
    */
-  async getPRForBranch(repoPath: string, branch: string): Promise<PRInfo | null> {
+  async getPRForBranch(
+    repoPath: string,
+    branch: string,
+    baseBranch: string
+  ): Promise<PRInfo | null> {
     const ghBreaker = getBreaker('github');
     try {
+      const expectedHeadRepository = await this.getRepoNameWithOwner(repoPath);
       const { stdout } = await ghBreaker.execute(() =>
         execFileAsync(
           'gh',
           [
             'pr',
-            'view',
+            'list',
+            '--head',
             branch,
+            '--base',
+            baseBranch,
+            '--state',
+            'all',
+            '--limit',
+            '1',
             '--json',
-            'url,number,title,state,isDraft,headRefName,baseRefName',
+            'url,number,title,state,isDraft,headRefName,baseRefName,headRepository',
           ],
           { cwd: repoPath }
         )
       );
 
-      const data = JSON.parse(stdout);
+      const data = (
+        JSON.parse(stdout) as Array<{
+          url: string;
+          number: number;
+          title: string;
+          state: string;
+          isDraft: boolean;
+          headRefName: string;
+          baseRefName: string;
+          headRepository?: { nameWithOwner?: string };
+        }>
+      ).find(
+        (candidate) =>
+          candidate.headRefName === branch &&
+          candidate.baseRefName === baseBranch &&
+          candidate.headRepository?.nameWithOwner === expectedHeadRepository
+      );
+      if (!data) return null;
       return {
         url: data.url,
         number: data.number,
@@ -250,27 +308,16 @@ export class GitHubService {
    * Create a GitHub PR for a task
    */
   async createPR(input: CreatePRInput): Promise<PRInfo> {
-    const task = await this.taskService.getTask(input.taskId);
-    if (!task) {
-      throw new Error('Task not found');
+    let authority = await this.worktreeService.resolvePublicationAuthority(input.taskId);
+    let task = authority.task;
+    const requestedTarget = input.targetBranch ?? authority.baseBranch;
+    if (requestedTarget !== authority.baseBranch) {
+      throw new ConflictError('The requested PR base does not match the managed worktree.', {
+        taskId: input.taskId,
+        requestedBase: requestedTarget,
+        authorizedBase: authority.baseBranch,
+      });
     }
-
-    if (!task.git?.repo || !task.git?.branch) {
-      throw new Error('Task must have a repository and branch configured');
-    }
-
-    // Get repo config
-    const config = await this.configService.getConfig();
-    const repoConfig = config.repos.find(
-      (r: { name: string; path: string; defaultBranch: string; devServer?: any }) =>
-        r.name === task.git!.repo
-    );
-    if (!repoConfig) {
-      throw new Error(`Repository "${task.git.repo}" not found in config`);
-    }
-
-    const repoPath = this.expandPath(repoConfig.path);
-    const workingDir = task.git.worktreePath || repoPath;
 
     // Check if gh CLI is ready
     const ghStatus = await this.checkGhCli();
@@ -282,7 +329,11 @@ export class GitHubService {
     }
 
     // Check if PR already exists
-    const existingPR = await this.getPRForBranch(repoPath, task.git.branch);
+    const existingPR = await this.getPRForBranch(
+      authority.repoPath,
+      authority.branch,
+      authority.baseBranch
+    );
     if (existingPR) {
       // Update task with PR link
       await this.taskService.updateTask(input.taskId, {
@@ -295,20 +346,57 @@ export class GitHubService {
       return existingPR;
     }
 
-    // Push branch first to ensure it exists on remote
-    try {
-      await execFileAsync('git', ['push', '-u', 'origin', task.git.branch], { cwd: workingDir });
-    } catch (error: any) {
-      // Ignore if already pushed
-      if (!error.message?.includes('Everything up-to-date')) {
-        log.warn('Push warning:', error.message);
+    // Re-resolve immediately before publication so task or worktree drift fails closed.
+    authority = await this.worktreeService.resolvePublicationAuthority(input.taskId);
+    task = authority.task;
+    if (requestedTarget !== authority.baseBranch) {
+      throw new ConflictError('The managed PR base changed before publication.', {
+        taskId: input.taskId,
+        requestedBase: requestedTarget,
+        authorizedBase: authority.baseBranch,
+      });
+    }
+    const headRef = `refs/heads/${authority.branch}`;
+    const { stdout: existingRemoteOutput } = await execFileAsync(
+      'git',
+      ['ls-remote', '--heads', 'origin', headRef],
+      { cwd: authority.worktreePath }
+    );
+    const existingRemoteHead = existingRemoteOutput.trim().split(/\s+/)[0];
+    if (existingRemoteHead && existingRemoteHead !== authority.headCommit) {
+      try {
+        await execFileAsync(
+          'git',
+          ['merge-base', '--is-ancestor', existingRemoteHead, authority.headCommit],
+          { cwd: authority.worktreePath }
+        );
+      } catch {
+        throw new ConflictError('The remote branch is not an ancestor of the managed HEAD.', {
+          taskId: input.taskId,
+          manifestId: authority.manifestId,
+        });
       }
+    }
+    await execFileAsync('git', ['push', '-u', 'origin', `${headRef}:${headRef}`], {
+      cwd: authority.worktreePath,
+    });
+    const { stdout: remoteHeadOutput } = await execFileAsync(
+      'git',
+      ['ls-remote', '--exit-code', 'origin', headRef],
+      { cwd: authority.worktreePath }
+    );
+    const remoteHead = remoteHeadOutput.trim().split(/\s+/)[0];
+    if (remoteHead !== authority.headCommit) {
+      throw new ConflictError('The published remote branch does not match the managed worktree.', {
+        taskId: input.taskId,
+        manifestId: authority.manifestId,
+      });
     }
 
     // Build PR title and body
     const prTitle = input.title || task.title;
     const prBody = input.body || this.buildPRBody(task);
-    const targetBranch = input.targetBranch || task.git.baseBranch || 'main';
+    const targetBranch = authority.baseBranch;
 
     // Create the PR using execFile (no shell — safe from injection)
     const ghArgs = [
@@ -321,7 +409,7 @@ export class GitHubService {
       '--base',
       targetBranch,
       '--head',
-      task.git.branch,
+      authority.branch,
     ];
 
     if (input.draft) {
@@ -331,7 +419,7 @@ export class GitHubService {
     const ghBreaker = getBreaker('github');
     try {
       const { stdout } = await ghBreaker.execute(() =>
-        execFileAsync('gh', ghArgs, { cwd: repoPath })
+        execFileAsync('gh', ghArgs, { cwd: authority.repoPath })
       );
       const prUrl = stdout.trim();
 
@@ -350,13 +438,13 @@ export class GitHubService {
 
       // Fetch full PR info
       return (
-        (await this.getPRForBranch(repoPath, task.git.branch)) || {
+        (await this.getPRForBranch(authority.repoPath, authority.branch, authority.baseBranch)) || {
           url: prUrl,
           number: prNumber,
           title: prTitle,
           state: 'OPEN',
           draft: input.draft || false,
-          headBranch: task.git.branch,
+          headBranch: authority.branch,
           baseBranch: targetBranch,
         }
       );

--- a/server/src/services/github-service.ts
+++ b/server/src/services/github-service.ts
@@ -140,17 +140,20 @@ export class GitHubService {
   async getPRForBranch(
     repoPath: string,
     branch: string,
-    baseBranch: string
+    baseBranch: string,
+    expectedHeadRepository?: string
   ): Promise<PRInfo | null> {
     const ghBreaker = getBreaker('github');
     try {
-      const expectedHeadRepository = await this.getRepoNameWithOwner(repoPath);
+      const headRepository = expectedHeadRepository ?? (await this.getRepoNameWithOwner(repoPath));
+      const repoArgs = expectedHeadRepository ? ['--repo', expectedHeadRepository] : [];
       const { stdout } = await ghBreaker.execute(() =>
         execFileAsync(
           'gh',
           [
             'pr',
             'list',
+            ...repoArgs,
             '--head',
             branch,
             '--base',
@@ -181,7 +184,7 @@ export class GitHubService {
         (candidate) =>
           candidate.headRefName === branch &&
           candidate.baseRefName === baseBranch &&
-          candidate.headRepository?.nameWithOwner === expectedHeadRepository
+          candidate.headRepository?.nameWithOwner === headRepository
       );
       if (!matchingPR) return null;
       return {
@@ -312,8 +315,7 @@ export class GitHubService {
    * Create a GitHub PR for a task
    */
   async createPR(input: CreatePRInput): Promise<PRInfo> {
-    let authority = await this.worktreeService.resolvePublicationAuthority(input.taskId);
-    let task = authority.task;
+    const authority = await this.worktreeService.resolvePublicationAuthority(input.taskId);
     const requestedTarget = input.targetBranch ?? authority.baseBranch;
     if (requestedTarget !== authority.baseBranch) {
       throw new ConflictError('The requested PR base does not match the managed worktree.', {
@@ -332,136 +334,171 @@ export class GitHubService {
       throw new Error('GitHub CLI is not authenticated. Run: gh auth login');
     }
 
-    // Check if PR already exists
-    const existingPR = await this.getPRForBranch(
-      authority.repoPath,
-      authority.branch,
-      authority.baseBranch
-    );
-    if (existingPR) {
-      // Update task with PR link
-      await this.taskService.updateTask(input.taskId, {
-        git: {
-          ...task.git,
-          prUrl: existingPR.url,
-          prNumber: existingPR.number,
-        },
-      });
-      return existingPR;
-    }
+    // Hold the task's manifest lock through lookup, publication, PR creation, and association.
+    return this.worktreeService.withPublicationAuthority(input.taskId, async (currentAuthority) => {
+      if (requestedTarget !== currentAuthority.baseBranch) {
+        throw new ConflictError('The managed PR base changed before publication.', {
+          taskId: input.taskId,
+          requestedBase: requestedTarget,
+          authorizedBase: currentAuthority.baseBranch,
+        });
+      }
+      const expectedRepository = await this.getRepoNameWithOwnerForRemote(
+        currentAuthority.repoPath,
+        currentAuthority.originUrl
+      );
+      const match = await this.getPRForBranch(
+        currentAuthority.repoPath,
+        currentAuthority.branch,
+        currentAuthority.baseBranch,
+        expectedRepository
+      );
+      if (match) {
+        await this.associatePR(input.taskId, currentAuthority, match.url, match.number);
+        return match;
+      }
 
-    // Hold the task's manifest lock while re-resolving and publishing the exact authority.
-    authority = await this.worktreeService.withPublicationAuthority(
-      input.taskId,
-      async (currentAuthority) => {
-        if (requestedTarget !== currentAuthority.baseBranch) {
-          throw new ConflictError('The managed PR base changed before publication.', {
+      const publicationRemote = 'veritas-publication-authority';
+      const publicationRemoteEnv = 'VERITAS_PUBLICATION_REMOTE_URL';
+      const publicationEnvironment = {
+        ...process.env,
+        [publicationRemoteEnv]: currentAuthority.originUrl,
+      };
+      const remoteConfig = `--config-env=remote.${publicationRemote}.url=${publicationRemoteEnv}`;
+      const headRef = `refs/heads/${currentAuthority.branch}`;
+      const { stdout: existingRemoteOutput } = await execFileAsync(
+        'git',
+        [remoteConfig, 'ls-remote', '--heads', publicationRemote, headRef],
+        { cwd: currentAuthority.worktreePath, env: publicationEnvironment }
+      );
+      const existingRemoteHead = existingRemoteOutput.trim().split(/\s+/)[0];
+      if (existingRemoteHead && existingRemoteHead !== currentAuthority.headCommit) {
+        try {
+          await execFileAsync(
+            'git',
+            ['merge-base', '--is-ancestor', existingRemoteHead, currentAuthority.headCommit],
+            { cwd: currentAuthority.worktreePath }
+          );
+        } catch {
+          throw new ConflictError('The remote branch is not an ancestor of the managed HEAD.', {
             taskId: input.taskId,
-            requestedBase: requestedTarget,
-            authorizedBase: currentAuthority.baseBranch,
+            manifestId: currentAuthority.manifestId,
           });
         }
-        const headRef = `refs/heads/${currentAuthority.branch}`;
-        const { stdout: existingRemoteOutput } = await execFileAsync(
-          'git',
-          ['ls-remote', '--heads', 'origin', headRef],
-          { cwd: currentAuthority.worktreePath }
-        );
-        const existingRemoteHead = existingRemoteOutput.trim().split(/\s+/)[0];
-        if (existingRemoteHead && existingRemoteHead !== currentAuthority.headCommit) {
-          try {
-            await execFileAsync(
-              'git',
-              ['merge-base', '--is-ancestor', existingRemoteHead, currentAuthority.headCommit],
-              { cwd: currentAuthority.worktreePath }
-            );
-          } catch {
-            throw new ConflictError('The remote branch is not an ancestor of the managed HEAD.', {
-              taskId: input.taskId,
-              manifestId: currentAuthority.manifestId,
-            });
-          }
-        }
-        await execFileAsync('git', ['push', '-u', 'origin', `${headRef}:${headRef}`], {
-          cwd: currentAuthority.worktreePath,
-        });
-        const { stdout: remoteHeadOutput } = await execFileAsync(
-          'git',
-          ['ls-remote', '--exit-code', 'origin', headRef],
-          { cwd: currentAuthority.worktreePath }
-        );
-        const remoteHead = remoteHeadOutput.trim().split(/\s+/)[0];
-        if (remoteHead !== currentAuthority.headCommit) {
-          throw new ConflictError(
-            'The published remote branch does not match the managed worktree.',
-            {
-              taskId: input.taskId,
-              manifestId: currentAuthority.manifestId,
-            }
-          );
-        }
-        return currentAuthority;
       }
-    );
-    task = authority.task;
-
-    // Build PR title and body
-    const prTitle = input.title || task.title;
-    const prBody = input.body || this.buildPRBody(task);
-    const targetBranch = authority.baseBranch;
-
-    // Create the PR using execFile (no shell — safe from injection)
-    const ghArgs = [
-      'pr',
-      'create',
-      '--title',
-      prTitle,
-      '--body',
-      prBody,
-      '--base',
-      targetBranch,
-      '--head',
-      authority.branch,
-    ];
-
-    if (input.draft) {
-      ghArgs.push('--draft');
-    }
-
-    const ghBreaker = getBreaker('github');
-    try {
-      const { stdout } = await ghBreaker.execute(() =>
-        execFileAsync('gh', ghArgs, { cwd: authority.repoPath })
+      await execFileAsync(
+        'git',
+        [remoteConfig, 'push', publicationRemote, `${currentAuthority.headCommit}:${headRef}`],
+        {
+          cwd: currentAuthority.worktreePath,
+          env: publicationEnvironment,
+        }
       );
-      const prUrl = stdout.trim();
+      const { stdout: remoteHeadOutput } = await execFileAsync(
+        'git',
+        [remoteConfig, 'ls-remote', '--exit-code', publicationRemote, headRef],
+        { cwd: currentAuthority.worktreePath, env: publicationEnvironment }
+      );
+      const remoteHead = remoteHeadOutput.trim().split(/\s+/)[0];
+      if (remoteHead !== currentAuthority.headCommit) {
+        throw new ConflictError(
+          'The published remote branch does not match the managed worktree.',
+          {
+            taskId: input.taskId,
+            manifestId: currentAuthority.manifestId,
+          }
+        );
+      }
+      const task = currentAuthority.task;
+      const prTitle = input.title || task.title;
+      const prBody = input.body || this.buildPRBody(task);
+      const ghArgs = [
+        'pr',
+        'create',
+        '--title',
+        prTitle,
+        '--body',
+        prBody,
+        '--base',
+        currentAuthority.baseBranch,
+        '--head',
+        currentAuthority.branch,
+        '--repo',
+        expectedRepository,
+      ];
 
-      // Extract PR number from URL
+      if (input.draft) {
+        ghArgs.push('--draft');
+      }
+
+      const ghBreaker = getBreaker('github');
+      let prUrl: string;
+      try {
+        const { stdout } = await ghBreaker.execute(() =>
+          execFileAsync('gh', ghArgs, { cwd: currentAuthority.repoPath })
+        );
+        prUrl = stdout.trim();
+      } catch (error: any) {
+        throw new Error(`Failed to create PR: ${error.message}`, { cause: error });
+      }
+
       const prNumberMatch = prUrl.match(/\/pull\/(\d+)/);
       const prNumber = prNumberMatch ? parseInt(prNumberMatch[1], 10) : 0;
+      await this.associatePR(input.taskId, currentAuthority, prUrl, prNumber);
 
-      // Update task with PR link
-      await this.taskService.updateTask(input.taskId, {
-        git: {
-          ...task.git,
-          prUrl,
-          prNumber,
-        },
-      });
-
-      // Fetch full PR info
       return (
-        (await this.getPRForBranch(authority.repoPath, authority.branch, authority.baseBranch)) || {
+        (await this.getPRForBranch(
+          currentAuthority.repoPath,
+          currentAuthority.branch,
+          currentAuthority.baseBranch,
+          expectedRepository
+        )) || {
           url: prUrl,
           number: prNumber,
           title: prTitle,
           state: 'OPEN',
           draft: input.draft || false,
-          headBranch: authority.branch,
-          baseBranch: targetBranch,
+          headBranch: currentAuthority.branch,
+          baseBranch: currentAuthority.baseBranch,
         }
       );
-    } catch (error: any) {
-      throw new Error(`Failed to create PR: ${error.message}`, { cause: error });
+    });
+  }
+
+  private async associatePR(
+    taskId: string,
+    authority: WorktreePublicationAuthority,
+    prUrl: string,
+    prNumber: number
+  ): Promise<void> {
+    const currentTask = await this.taskService.getTask(taskId);
+    const currentGit = currentTask?.git;
+    const authorizedGit = authority.task.git;
+    if (
+      !currentTask ||
+      !currentGit ||
+      !authorizedGit ||
+      currentGit.repo !== authorizedGit.repo ||
+      currentGit.branch !== authority.branch ||
+      currentGit.baseBranch !== authority.baseBranch ||
+      currentGit.worktreePath !== authorizedGit.worktreePath ||
+      currentGit.worktreeManifestId !== authority.manifestId ||
+      currentGit.worktreeLeaseId !== authorizedGit.worktreeLeaseId ||
+      (currentGit.prUrl !== undefined && currentGit.prUrl !== prUrl) ||
+      (currentGit.prNumber !== undefined && currentGit.prNumber !== prNumber)
+    ) {
+      throw new ConflictError('The task publication authority changed before PR association.', {
+        taskId,
+        manifestId: authority.manifestId,
+      });
+    }
+
+    const updated = await this.taskService.updateTask(taskId, {
+      expectedRevision: currentTask.revision ?? 1,
+      git: { prUrl, prNumber },
+    });
+    if (!updated) {
+      throw new ConflictError('The task disappeared before PR association.', { taskId });
     }
   }
 
@@ -543,6 +580,27 @@ export class GitHubService {
     const match = remote?.match(/github\.com[:/](.+?\/.+?)(?:\.git)?$/);
     if (match?.[1]) return match[1];
     throw new Error('Could not determine GitHub owner/repo for Codex Cloud delegation');
+  }
+
+  private async getRepoNameWithOwnerForRemote(
+    repoPath: string,
+    remoteUrl: string
+  ): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['repo', 'view', remoteUrl, '--json', 'nameWithOwner'],
+        { cwd: repoPath }
+      );
+      const parsed = JSON.parse(stdout) as { nameWithOwner?: string };
+      if (parsed.nameWithOwner) return parsed.nameWithOwner;
+    } catch {
+      // Fall back to parsing the already verified remote URL.
+    }
+
+    const match = remoteUrl.match(/github\.com[:/](.+?\/.+?)(?:\.git)?$/);
+    if (match?.[1]) return match[1];
+    throw new Error('Could not determine GitHub owner/repo from the managed repository remote');
   }
 
   private async getIssueInfo(

--- a/server/src/services/github-service.ts
+++ b/server/src/services/github-service.ts
@@ -43,6 +43,10 @@ interface GitHubConfigSource {
 
 interface PublicationAuthoritySource {
   resolvePublicationAuthority(taskId: string): Promise<WorktreePublicationAuthority>;
+  withPublicationAuthority<T>(
+    taskId: string,
+    operation: (authority: WorktreePublicationAuthority) => Promise<T>
+  ): Promise<T>;
 }
 
 export interface GitHubServiceOptions {
@@ -162,7 +166,7 @@ export class GitHubService {
         )
       );
 
-      const data = (
+      const matchingPR = (
         JSON.parse(stdout) as Array<{
           url: string;
           number: number;
@@ -179,15 +183,15 @@ export class GitHubService {
           candidate.baseRefName === baseBranch &&
           candidate.headRepository?.nameWithOwner === expectedHeadRepository
       );
-      if (!data) return null;
+      if (!matchingPR) return null;
       return {
-        url: data.url,
-        number: data.number,
-        title: data.title,
-        state: data.state,
-        draft: data.isDraft,
-        headBranch: data.headRefName,
-        baseBranch: data.baseRefName,
+        url: matchingPR.url,
+        number: matchingPR.number,
+        title: matchingPR.title,
+        state: matchingPR.state,
+        draft: matchingPR.isDraft,
+        headBranch: matchingPR.headRefName,
+        baseBranch: matchingPR.baseRefName,
       };
     } catch {
       // Intentionally silent: no PR exists for this branch
@@ -346,52 +350,60 @@ export class GitHubService {
       return existingPR;
     }
 
-    // Re-resolve immediately before publication so task or worktree drift fails closed.
-    authority = await this.worktreeService.resolvePublicationAuthority(input.taskId);
-    task = authority.task;
-    if (requestedTarget !== authority.baseBranch) {
-      throw new ConflictError('The managed PR base changed before publication.', {
-        taskId: input.taskId,
-        requestedBase: requestedTarget,
-        authorizedBase: authority.baseBranch,
-      });
-    }
-    const headRef = `refs/heads/${authority.branch}`;
-    const { stdout: existingRemoteOutput } = await execFileAsync(
-      'git',
-      ['ls-remote', '--heads', 'origin', headRef],
-      { cwd: authority.worktreePath }
-    );
-    const existingRemoteHead = existingRemoteOutput.trim().split(/\s+/)[0];
-    if (existingRemoteHead && existingRemoteHead !== authority.headCommit) {
-      try {
-        await execFileAsync(
+    // Hold the task's manifest lock while re-resolving and publishing the exact authority.
+    authority = await this.worktreeService.withPublicationAuthority(
+      input.taskId,
+      async (currentAuthority) => {
+        if (requestedTarget !== currentAuthority.baseBranch) {
+          throw new ConflictError('The managed PR base changed before publication.', {
+            taskId: input.taskId,
+            requestedBase: requestedTarget,
+            authorizedBase: currentAuthority.baseBranch,
+          });
+        }
+        const headRef = `refs/heads/${currentAuthority.branch}`;
+        const { stdout: existingRemoteOutput } = await execFileAsync(
           'git',
-          ['merge-base', '--is-ancestor', existingRemoteHead, authority.headCommit],
-          { cwd: authority.worktreePath }
+          ['ls-remote', '--heads', 'origin', headRef],
+          { cwd: currentAuthority.worktreePath }
         );
-      } catch {
-        throw new ConflictError('The remote branch is not an ancestor of the managed HEAD.', {
-          taskId: input.taskId,
-          manifestId: authority.manifestId,
+        const existingRemoteHead = existingRemoteOutput.trim().split(/\s+/)[0];
+        if (existingRemoteHead && existingRemoteHead !== currentAuthority.headCommit) {
+          try {
+            await execFileAsync(
+              'git',
+              ['merge-base', '--is-ancestor', existingRemoteHead, currentAuthority.headCommit],
+              { cwd: currentAuthority.worktreePath }
+            );
+          } catch {
+            throw new ConflictError('The remote branch is not an ancestor of the managed HEAD.', {
+              taskId: input.taskId,
+              manifestId: currentAuthority.manifestId,
+            });
+          }
+        }
+        await execFileAsync('git', ['push', '-u', 'origin', `${headRef}:${headRef}`], {
+          cwd: currentAuthority.worktreePath,
         });
+        const { stdout: remoteHeadOutput } = await execFileAsync(
+          'git',
+          ['ls-remote', '--exit-code', 'origin', headRef],
+          { cwd: currentAuthority.worktreePath }
+        );
+        const remoteHead = remoteHeadOutput.trim().split(/\s+/)[0];
+        if (remoteHead !== currentAuthority.headCommit) {
+          throw new ConflictError(
+            'The published remote branch does not match the managed worktree.',
+            {
+              taskId: input.taskId,
+              manifestId: currentAuthority.manifestId,
+            }
+          );
+        }
+        return currentAuthority;
       }
-    }
-    await execFileAsync('git', ['push', '-u', 'origin', `${headRef}:${headRef}`], {
-      cwd: authority.worktreePath,
-    });
-    const { stdout: remoteHeadOutput } = await execFileAsync(
-      'git',
-      ['ls-remote', '--exit-code', 'origin', headRef],
-      { cwd: authority.worktreePath }
     );
-    const remoteHead = remoteHeadOutput.trim().split(/\s+/)[0];
-    if (remoteHead !== authority.headCommit) {
-      throw new ConflictError('The published remote branch does not match the managed worktree.', {
-        taskId: input.taskId,
-        manifestId: authority.manifestId,
-      });
-    }
+    task = authority.task;
 
     // Build PR title and body
     const prTitle = input.title || task.title;

--- a/server/src/services/github-service.ts
+++ b/server/src/services/github-service.ts
@@ -1,4 +1,6 @@
 import { exec, execFile } from 'child_process';
+import os from 'node:os';
+import path from 'node:path';
 import { URL } from 'node:url';
 import { promisify } from 'util';
 import { nanoid } from 'nanoid';
@@ -8,6 +10,7 @@ import { WorktreeService, type WorktreePublicationAuthority } from './worktree-s
 import { getBreaker } from './circuit-registry.js';
 import type { AgentType, Task } from '@veritas-kanban/shared';
 import { ConflictError } from '../middleware/error-handler.js';
+import { mkdtemp, rm } from '../storage/fs-helpers.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -367,61 +370,7 @@ export class GitHubService {
         });
       }
       const expectedRepository = this.repositoryResolver(currentAuthority.originUrl);
-
-      const publicationRemote = `veritas-publication-${nanoid(12)}`;
-      const publicationRemoteEnv = 'VERITAS_PUBLICATION_REMOTE_URL';
-      const publicationEnvironment = {
-        ...process.env,
-        [publicationRemoteEnv]: currentAuthority.originUrl,
-      };
-      const remoteConfig = [
-        `--config-env=remote.${publicationRemote}.url=${publicationRemoteEnv}`,
-        `--config-env=remote.${publicationRemote}.pushurl=${publicationRemoteEnv}`,
-      ];
-      const headRef = `refs/heads/${currentAuthority.branch}`;
-      const { stdout: existingRemoteOutput } = await execFileAsync(
-        'git',
-        [...remoteConfig, 'ls-remote', '--heads', publicationRemote, headRef],
-        { cwd: currentAuthority.worktreePath, env: publicationEnvironment }
-      );
-      const existingRemoteHead = existingRemoteOutput.trim().split(/\s+/)[0];
-      if (existingRemoteHead && existingRemoteHead !== currentAuthority.headCommit) {
-        try {
-          await execFileAsync(
-            'git',
-            ['merge-base', '--is-ancestor', existingRemoteHead, currentAuthority.headCommit],
-            { cwd: currentAuthority.worktreePath }
-          );
-        } catch {
-          throw new ConflictError('The remote branch is not an ancestor of the managed HEAD.', {
-            taskId: input.taskId,
-            manifestId: currentAuthority.manifestId,
-          });
-        }
-      }
-      await execFileAsync(
-        'git',
-        [...remoteConfig, 'push', publicationRemote, `${currentAuthority.headCommit}:${headRef}`],
-        {
-          cwd: currentAuthority.worktreePath,
-          env: publicationEnvironment,
-        }
-      );
-      const { stdout: remoteHeadOutput } = await execFileAsync(
-        'git',
-        [...remoteConfig, 'ls-remote', '--exit-code', publicationRemote, headRef],
-        { cwd: currentAuthority.worktreePath, env: publicationEnvironment }
-      );
-      const remoteHead = remoteHeadOutput.trim().split(/\s+/)[0];
-      if (remoteHead !== currentAuthority.headCommit) {
-        throw new ConflictError(
-          'The published remote branch does not match the managed worktree.',
-          {
-            taskId: input.taskId,
-            manifestId: currentAuthority.manifestId,
-          }
-        );
-      }
+      await this.publishManagedCommit(input.taskId, currentAuthority);
       const match = await this.getPRForBranch(
         currentAuthority.repoPath,
         currentAuthority.branch,
@@ -486,6 +435,83 @@ export class GitHubService {
         }
       );
     });
+  }
+
+  private async publishManagedCommit(
+    taskId: string,
+    authority: WorktreePublicationAuthority
+  ): Promise<void> {
+    const isolatedGitDir = await mkdtemp(path.join(os.tmpdir(), 'veritas-publication-'));
+    const publicationRemote = `veritas-publication-${nanoid(12)}`;
+    const publicationRemoteEnv = 'VERITAS_PUBLICATION_REMOTE_URL';
+    const publicationEnvironment = { ...process.env };
+    for (const name of Object.keys(publicationEnvironment)) {
+      if (
+        name === 'GIT_CONFIG_PARAMETERS' ||
+        name === 'GIT_CONFIG_COUNT' ||
+        /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(name)
+      ) {
+        delete publicationEnvironment[name];
+      }
+    }
+    Object.assign(publicationEnvironment, {
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_CONFIG_SYSTEM: '/dev/null',
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_ALTERNATE_OBJECT_DIRECTORIES: authority.gitObjectDirectory,
+      [publicationRemoteEnv]: authority.originUrl,
+    });
+    const remoteConfig = [
+      `--config-env=remote.${publicationRemote}.url=${publicationRemoteEnv}`,
+      `--config-env=remote.${publicationRemote}.pushurl=${publicationRemoteEnv}`,
+    ];
+    const isolatedGitArgs = [`--git-dir=${isolatedGitDir}`, ...remoteConfig];
+    const headRef = `refs/heads/${authority.branch}`;
+
+    try {
+      await execFileAsync('git', ['init', '--bare', isolatedGitDir], {
+        env: publicationEnvironment,
+      });
+      const { stdout: existingRemoteOutput } = await execFileAsync(
+        'git',
+        [...isolatedGitArgs, 'ls-remote', '--heads', publicationRemote, headRef],
+        { env: publicationEnvironment }
+      );
+      const existingRemoteHead = existingRemoteOutput.trim().split(/\s+/)[0];
+      if (existingRemoteHead && existingRemoteHead !== authority.headCommit) {
+        try {
+          await execFileAsync(
+            'git',
+            ['merge-base', '--is-ancestor', existingRemoteHead, authority.headCommit],
+            { cwd: authority.worktreePath }
+          );
+        } catch {
+          throw new ConflictError('The remote branch is not an ancestor of the managed HEAD.', {
+            taskId,
+            manifestId: authority.manifestId,
+          });
+        }
+      }
+      await execFileAsync(
+        'git',
+        [...isolatedGitArgs, 'push', publicationRemote, `${authority.headCommit}:${headRef}`],
+        { env: publicationEnvironment }
+      );
+      const { stdout: remoteHeadOutput } = await execFileAsync(
+        'git',
+        [...isolatedGitArgs, 'ls-remote', '--exit-code', publicationRemote, headRef],
+        { env: publicationEnvironment }
+      );
+      const remoteHead = remoteHeadOutput.trim().split(/\s+/)[0];
+      if (remoteHead !== authority.headCommit) {
+        throw new ConflictError(
+          'The published remote branch does not match the managed worktree.',
+          { taskId, manifestId: authority.manifestId }
+        );
+      }
+    } finally {
+      await rm(isolatedGitDir, { recursive: true, force: true }).catch(() => {});
+    }
   }
 
   private async associatePR(

--- a/server/src/services/github-service.ts
+++ b/server/src/services/github-service.ts
@@ -1,4 +1,5 @@
 import { exec, execFile } from 'child_process';
+import { URL } from 'node:url';
 import { promisify } from 'util';
 import { nanoid } from 'nanoid';
 import { ConfigService } from './config-service.js';
@@ -10,6 +11,25 @@ import { ConflictError } from '../middleware/error-handler.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
+
+export function githubRepositoryFromRemote(remoteUrl: string): string {
+  let repositoryPath: string | undefined;
+  try {
+    const parsed = new URL(remoteUrl);
+    if (parsed.hostname.toLowerCase() === 'github.com') {
+      repositoryPath = parsed.pathname;
+    }
+  } catch {
+    const scpMatch = remoteUrl.match(/^(?:[^@/]+@)?github\.com:(.+)$/i);
+    repositoryPath = scpMatch?.[1];
+  }
+
+  const repository = repositoryPath?.replace(/^\/+/, '').replace(/\.git$/, '');
+  if (repository && /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    return repository;
+  }
+  throw new Error('Could not determine GitHub owner/repo from the managed repository remote');
+}
 
 export interface CreatePRInput {
   taskId: string;
@@ -53,6 +73,7 @@ export interface GitHubServiceOptions {
   taskService?: GitHubTaskStore;
   configService?: GitHubConfigSource;
   worktreeService?: PublicationAuthoritySource;
+  repositoryResolver?: (remoteUrl: string) => string;
 }
 
 export type CodexCloudTarget = 'issue' | 'issue-comment' | 'pr-comment';
@@ -79,6 +100,7 @@ export class GitHubService {
   private readonly configService: GitHubConfigSource;
   private readonly taskService: GitHubTaskStore;
   private readonly worktreeService: PublicationAuthoritySource;
+  private readonly repositoryResolver: (remoteUrl: string) => string;
 
   constructor(options: GitHubServiceOptions = {}) {
     this.configService = options.configService ?? new ConfigService();
@@ -89,6 +111,7 @@ export class GitHubService {
         taskService: this.taskService,
         configService: this.configService,
       });
+    this.repositoryResolver = options.repositoryResolver ?? githubRepositoryFromRemote;
   }
 
   private expandPath(p: string): string {
@@ -343,32 +366,22 @@ export class GitHubService {
           authorizedBase: currentAuthority.baseBranch,
         });
       }
-      const expectedRepository = await this.getRepoNameWithOwnerForRemote(
-        currentAuthority.repoPath,
-        currentAuthority.originUrl
-      );
-      const match = await this.getPRForBranch(
-        currentAuthority.repoPath,
-        currentAuthority.branch,
-        currentAuthority.baseBranch,
-        expectedRepository
-      );
-      if (match) {
-        await this.associatePR(input.taskId, currentAuthority, match.url, match.number);
-        return match;
-      }
+      const expectedRepository = this.repositoryResolver(currentAuthority.originUrl);
 
-      const publicationRemote = 'veritas-publication-authority';
+      const publicationRemote = `veritas-publication-${nanoid(12)}`;
       const publicationRemoteEnv = 'VERITAS_PUBLICATION_REMOTE_URL';
       const publicationEnvironment = {
         ...process.env,
         [publicationRemoteEnv]: currentAuthority.originUrl,
       };
-      const remoteConfig = `--config-env=remote.${publicationRemote}.url=${publicationRemoteEnv}`;
+      const remoteConfig = [
+        `--config-env=remote.${publicationRemote}.url=${publicationRemoteEnv}`,
+        `--config-env=remote.${publicationRemote}.pushurl=${publicationRemoteEnv}`,
+      ];
       const headRef = `refs/heads/${currentAuthority.branch}`;
       const { stdout: existingRemoteOutput } = await execFileAsync(
         'git',
-        [remoteConfig, 'ls-remote', '--heads', publicationRemote, headRef],
+        [...remoteConfig, 'ls-remote', '--heads', publicationRemote, headRef],
         { cwd: currentAuthority.worktreePath, env: publicationEnvironment }
       );
       const existingRemoteHead = existingRemoteOutput.trim().split(/\s+/)[0];
@@ -388,7 +401,7 @@ export class GitHubService {
       }
       await execFileAsync(
         'git',
-        [remoteConfig, 'push', publicationRemote, `${currentAuthority.headCommit}:${headRef}`],
+        [...remoteConfig, 'push', publicationRemote, `${currentAuthority.headCommit}:${headRef}`],
         {
           cwd: currentAuthority.worktreePath,
           env: publicationEnvironment,
@@ -396,7 +409,7 @@ export class GitHubService {
       );
       const { stdout: remoteHeadOutput } = await execFileAsync(
         'git',
-        [remoteConfig, 'ls-remote', '--exit-code', publicationRemote, headRef],
+        [...remoteConfig, 'ls-remote', '--exit-code', publicationRemote, headRef],
         { cwd: currentAuthority.worktreePath, env: publicationEnvironment }
       );
       const remoteHead = remoteHeadOutput.trim().split(/\s+/)[0];
@@ -408,6 +421,16 @@ export class GitHubService {
             manifestId: currentAuthority.manifestId,
           }
         );
+      }
+      const match = await this.getPRForBranch(
+        currentAuthority.repoPath,
+        currentAuthority.branch,
+        currentAuthority.baseBranch,
+        expectedRepository
+      );
+      if (match) {
+        await this.associatePR(input.taskId, currentAuthority, match.url, match.number);
+        return match;
       }
       const task = currentAuthority.task;
       const prTitle = input.title || task.title;
@@ -580,27 +603,6 @@ export class GitHubService {
     const match = remote?.match(/github\.com[:/](.+?\/.+?)(?:\.git)?$/);
     if (match?.[1]) return match[1];
     throw new Error('Could not determine GitHub owner/repo for Codex Cloud delegation');
-  }
-
-  private async getRepoNameWithOwnerForRemote(
-    repoPath: string,
-    remoteUrl: string
-  ): Promise<string> {
-    try {
-      const { stdout } = await execFileAsync(
-        'gh',
-        ['repo', 'view', remoteUrl, '--json', 'nameWithOwner'],
-        { cwd: repoPath }
-      );
-      const parsed = JSON.parse(stdout) as { nameWithOwner?: string };
-      if (parsed.nameWithOwner) return parsed.nameWithOwner;
-    } catch {
-      // Fall back to parsing the already verified remote URL.
-    }
-
-    const match = remoteUrl.match(/github\.com[:/](.+?\/.+?)(?:\.git)?$/);
-    if (match?.[1]) return match[1];
-    throw new Error('Could not determine GitHub owner/repo from the managed repository remote');
   }
 
   private async getIssueInfo(

--- a/server/src/services/worktree-service.ts
+++ b/server/src/services/worktree-service.ts
@@ -176,12 +176,14 @@ export class DefaultWorktreeGitRunner implements WorktreeGitRunner {
 
 interface RepoContext {
   rootPath: string;
+  originUrl: string;
   identity: WorktreeRepositoryIdentity;
 }
 
 export interface WorktreePublicationAuthority {
   task: Task;
   repoPath: string;
+  originUrl: string;
   worktreePath: string;
   branch: string;
   baseBranch: string;
@@ -1502,6 +1504,7 @@ export class WorktreeService {
       .catch(() => 'origin-unavailable');
     return {
       rootPath,
+      originUrl: origin,
       identity: {
         name: repoName,
         rootPath,
@@ -1593,6 +1596,7 @@ export class WorktreeService {
     return {
       task: structuredClone(task),
       repoPath: repo.rootPath,
+      originUrl: repo.originUrl,
       worktreePath: canonicalPath,
       branch: manifest.branch,
       baseBranch: manifest.base.branch,
@@ -1607,7 +1611,11 @@ export class WorktreeService {
     manifest: WorktreeManifest
   ): Promise<RepoContext> {
     if (!task?.git?.repo) {
-      return { rootPath: manifest.repository.rootPath, identity: manifest.repository };
+      return {
+        rootPath: manifest.repository.rootPath,
+        originUrl: 'origin-unavailable',
+        identity: manifest.repository,
+      };
     }
     const current = await this.getRepoContext(task.git.repo);
     if (

--- a/server/src/services/worktree-service.ts
+++ b/server/src/services/worktree-service.ts
@@ -619,9 +619,16 @@ export class WorktreeService {
   }
 
   async resolvePublicationAuthority(taskId: string): Promise<WorktreePublicationAuthority> {
+    return this.withPublicationAuthority(taskId, async (authority) => authority);
+  }
+
+  async withPublicationAuthority<T>(
+    taskId: string,
+    operation: (authority: WorktreePublicationAuthority) => Promise<T>
+  ): Promise<T> {
     validatePathSegment(taskId);
-    return this.manifests.withTaskLock(taskId, () =>
-      this.resolvePublicationAuthorityLocked(taskId)
+    return this.manifests.withTaskLock(taskId, async () =>
+      operation(await this.resolvePublicationAuthorityLocked(taskId))
     );
   }
 
@@ -1241,6 +1248,11 @@ export class WorktreeService {
     task: Task | null,
     manifest: WorktreeManifest
   ): Promise<WorktreeCleanupPreview> {
+    await this.validateRefNames(
+      manifest.repository.rootPath,
+      manifest.branch,
+      manifest.base.branch
+    );
     const blockedReasons: WorktreeCleanupReason[] = [];
     const checkedAt = this.now().toISOString();
     const add = (code: WorktreeCleanupReasonCode, message: string, overrideable: boolean): void => {

--- a/server/src/services/worktree-service.ts
+++ b/server/src/services/worktree-service.ts
@@ -184,6 +184,7 @@ export interface WorktreePublicationAuthority {
   task: Task;
   repoPath: string;
   originUrl: string;
+  gitObjectDirectory: string;
   worktreePath: string;
   branch: string;
   baseBranch: string;
@@ -1597,6 +1598,7 @@ export class WorktreeService {
       task: structuredClone(task),
       repoPath: repo.rootPath,
       originUrl: repo.originUrl,
+      gitObjectDirectory: path.join(repo.identity.commonGitDir, 'objects'),
       worktreePath: canonicalPath,
       branch: manifest.branch,
       baseBranch: manifest.base.branch,

--- a/server/src/services/worktree-service.ts
+++ b/server/src/services/worktree-service.ts
@@ -179,6 +179,17 @@ interface RepoContext {
   identity: WorktreeRepositoryIdentity;
 }
 
+export interface WorktreePublicationAuthority {
+  task: Task;
+  repoPath: string;
+  worktreePath: string;
+  branch: string;
+  baseBranch: string;
+  baseCommit: string;
+  headCommit: string;
+  manifestId: string;
+}
+
 export interface WorktreeServiceOptions {
   worktreesDir?: string;
   taskService?: WorktreeTaskStore;
@@ -357,6 +368,7 @@ export class WorktreeService {
         );
       }
       const repo = await this.getRepoContext(task.git.repo);
+      await this.validateRefNames(repo.rootPath, task.git.branch, task.git.baseBranch);
       return this.manifests.withAllocationLock(repo.identity.commonGitDir, async () => {
         const existing = await this.manifests.read(taskId);
         if (existing && existing.lifecycle.cleanup !== 'removed') {
@@ -606,6 +618,13 @@ export class WorktreeService {
     return this.buildWorktreeInfo(taskId, task, manifest);
   }
 
+  async resolvePublicationAuthority(taskId: string): Promise<WorktreePublicationAuthority> {
+    validatePathSegment(taskId);
+    return this.manifests.withTaskLock(taskId, () =>
+      this.resolvePublicationAuthorityLocked(taskId)
+    );
+  }
+
   async previewCleanup(taskId: string): Promise<WorktreeCleanupPreview> {
     const task = await this.taskService.getTask(taskId);
     const manifest = await this.requireActiveManifest(taskId);
@@ -717,6 +736,7 @@ export class WorktreeService {
       this.assertNoActiveRun(task);
       let manifest = await this.requireActiveManifest(taskId);
       const repo = await this.getRepoContext(task.git.repo);
+      await this.validateRefNames(repo.rootPath, task.git.branch, task.git.baseBranch);
       this.assertManifestOwnership(manifest, task, repo);
       this.assertNoCompetingLease(task, manifest);
       await this.assertWorktreeIdentity(manifest);
@@ -771,6 +791,7 @@ export class WorktreeService {
       this.assertNoActiveRun(task);
       let manifest = await this.requireActiveManifest(taskId);
       const repo = await this.getRepoContext(task.git.repo);
+      await this.validateRefNames(repo.rootPath, task.git.branch, task.git.baseBranch);
       this.assertManifestOwnership(manifest, task, repo);
       this.assertNoCompetingLease(task, manifest);
       const sourceExists = await fileExists(manifest.path);
@@ -1182,11 +1203,7 @@ export class WorktreeService {
       });
     }
     const status = await simpleGit(manifest.path).status(['--untracked-files=all']);
-    const comparisonBase =
-      (await this.tryResolveCommit(
-        manifest.repository.rootPath,
-        `refs/remotes/origin/${manifest.base.branch}^{commit}`
-      )) ?? manifest.base.commit;
+    const comparisonBase = manifest.base.commit;
     const counts = await this.git.run(manifest.path, [
       'rev-list',
       '--left-right',
@@ -1482,6 +1499,97 @@ export class WorktreeService {
     };
   }
 
+  private async resolvePublicationAuthorityLocked(
+    taskId: string
+  ): Promise<WorktreePublicationAuthority> {
+    const task = await this.requireCodeTask(taskId);
+    const manifest = await this.manifests.read(taskId);
+    if (!manifest || manifest.lifecycle.cleanup === 'removed') {
+      throw new ConflictError('PR publication requires an active managed worktree.', {
+        taskId,
+        remediation: 'Create or adopt the task worktree before publishing it.',
+      });
+    }
+    const repo = await this.getRepoContext(task.git.repo);
+    await this.validateRefNames(repo.rootPath, manifest.branch, manifest.base.branch);
+    this.assertManifestOwnership(manifest, task, repo);
+
+    if (manifest.lifecycle.creation !== 'ready') {
+      throw new ConflictError('The worktree is not ready for repository publication.', {
+        taskId,
+        manifestId: manifest.id,
+        creation: manifest.lifecycle.creation,
+      });
+    }
+    if (!['active', 'blocked'].includes(manifest.lifecycle.cleanup)) {
+      throw new ConflictError('The worktree is not active for repository publication.', {
+        taskId,
+        manifestId: manifest.id,
+        cleanup: manifest.lifecycle.cleanup,
+      });
+    }
+    if (
+      task.git.worktreeManifestId !== manifest.id ||
+      task.git.worktreeLeaseId !== manifest.lease.id ||
+      task.git.worktreePath !== manifest.path
+    ) {
+      throw new ConflictError('The task allocation does not match the durable worktree manifest.', {
+        taskId,
+        manifestId: manifest.id,
+        remediation: 'Reconcile or adopt the task worktree before publishing it.',
+      });
+    }
+    if (!(await fileExists(manifest.path))) {
+      throw new ConflictError('The managed worktree path is missing.', {
+        taskId,
+        manifestId: manifest.id,
+      });
+    }
+
+    const canonicalPath = await realpath(manifest.path);
+    await this.assertPathRepositoryIdentity(canonicalPath, repo.identity);
+    const actualBranch = await this.currentBranch(canonicalPath);
+    if (actualBranch !== manifest.branch) {
+      throw new ConflictError('The worktree branch does not match its publication authority.', {
+        taskId,
+        expected: manifest.branch,
+        actual: actualBranch,
+      });
+    }
+
+    const registered = parseWorktreeList(
+      (await this.git.run(repo.rootPath, ['worktree', 'list', '--porcelain'])).stdout
+    );
+    const exactRegistration = await Promise.all(
+      registered.map(async (worktree) => ({
+        ...worktree,
+        canonicalPath: await realpath(worktree.path).catch(() => path.resolve(worktree.path)),
+      }))
+    ).then((worktrees) =>
+      worktrees.find(
+        (worktree) =>
+          worktree.canonicalPath === canonicalPath && worktree.branch === manifest.branch
+      )
+    );
+    if (!exactRegistration) {
+      throw new ConflictError('The publication path is not the task-owned Git worktree.', {
+        taskId,
+        manifestId: manifest.id,
+      });
+    }
+
+    return {
+      task: structuredClone(task),
+      repoPath: repo.rootPath,
+      worktreePath: canonicalPath,
+      branch: manifest.branch,
+      baseBranch: manifest.base.branch,
+      baseCommit: manifest.base.commit,
+      headCommit: await this.resolveCommit(canonicalPath, 'HEAD^{commit}'),
+      manifestId: manifest.id,
+    };
+  }
+
   private async repoContextForManifest(
     task: Task | null,
     manifest: WorktreeManifest
@@ -1562,6 +1670,8 @@ export class WorktreeService {
   private assertManifestOwnership(manifest: WorktreeManifest, task: Task, repo: RepoContext): void {
     if (
       manifest.taskId !== task.id ||
+      manifest.repository.name !== task.git?.repo ||
+      manifest.repository.rootPath !== repo.rootPath ||
       manifest.branch !== task.git?.branch ||
       manifest.base.branch !== task.git?.baseBranch ||
       manifest.repository.commonGitDir !== repo.identity.commonGitDir ||

--- a/server/src/storage/fs-helpers.ts
+++ b/server/src/storage/fs-helpers.ts
@@ -18,6 +18,7 @@ import {
   copyFile as copyFileAsync,
   cp as cpAsync,
   lstat as lstatAsync,
+  mkdtemp as mkdtempAsync,
   mkdir as mkdirAsync,
   open as openAsync,
   readFile as readFileAsync,
@@ -77,6 +78,7 @@ export const createWriteStream = fs.createWriteStream;
 // ---------------------------------------------------------------------------
 
 export const mkdir = mkdirAsync;
+export const mkdtemp = mkdtempAsync;
 export const open = openAsync;
 export { access };
 export const appendFile = appendFileAsync;


### PR DESCRIPTION
## Summary

- Validate task and PR branch inputs as canonical Git branch names.
- Require durable managed-worktree authority before PR publication and Git-backed diff/review operations.
- Bind PR lookup, push, creation, and readback to the configured repository, captured commit, exact head/base branches, and verified origin.
- Stop PR creation when publication evidence is missing, mismatched, or the push fails.
- Refresh the existing `fast-uri` security override to patched version 3.1.6 after the upstream advisory update.

## Verification

- 143 focused server tests passed across publication, worktree, route, permission, diff, and review paths.
- Server typecheck passed.
- Touched-file lint passed with no errors.
- Service filesystem boundary check passed.
- Production dependency audit passes the high-severity threshold.
- Gitleaks and the exact-suppression policy check pass.
- Independent fix verification found the affected boundary closed.

## Compatibility

- Valid hierarchical feature and release branches remain supported.
- Existing remote task branches can advance only by safe fast-forward.
- Legacy worktrees must use the existing adoption flow before publication.

Part of #1307.
