### PR TITLE
chore: prepare Veritas Kanban 6.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.4] - 2026-09-02
+
+Veritas Kanban 6.1.4 is a focused security release that binds repository
+publication to the managed task worktree and its captured Git state.
+
+### Security
+
+- Validated task and pull-request branch inputs as canonical Git branch names.
+- Bound pull-request lookup, push, creation, and readback to the configured
+  repository, captured commit, exact head and base branches, and verified
+  origin.
+- Isolated publication transport from repository-controlled Git configuration
+  and rejected missing, stale, or mismatched publication authority.
+- Updated the `fast-uri` security override to patched version 3.1.6.
+
 ## [6.1.3] - 2026-08-30
 
 Veritas Kanban 6.1.3 adds governed file artifacts, provenance-aware execution,
@@ -2617,7 +2632,8 @@ Veritas Kanban is an AI-native project management board built for developers and
 
 _Built by [Digital Meld](https://digitalmeld.io) — AI-driven enterprise automation._
 
-[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v6.1.3...HEAD
+[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v6.1.4...HEAD
+[6.1.4]: https://github.com/BradGroux/veritas-kanban/compare/v6.1.3...v6.1.4
 [6.1.3]: https://github.com/BradGroux/veritas-kanban/compare/v6.1.2...v6.1.3
 [6.1.2]: https://github.com/BradGroux/veritas-kanban/compare/v6.1.1...v6.1.2
 [6.1.1]: https://github.com/BradGroux/veritas-kanban/compare/v6.1.0...v6.1.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-6.1.3-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-6.1.4-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/releases/v6.1.4.md
+++ b/docs/releases/v6.1.4.md
@@ -1,0 +1,32 @@
+Veritas Kanban 6.1.4 is a focused security release that prevents repository publication from escaping the managed task worktree and its captured Git state. It also updates `fast-uri` to the patched 3.1.6 release. There are no API or database schema changes.
+
+## What changed
+
+Pull-request publication now accepts only canonical Git branch names and requires durable authority for the exact task, managed worktree, repository, origin, branch, base, and captured commit. Pushes use the captured commit through an isolated Git transport, and pull-request lookup, creation, and readback stay bound to the configured repository.
+
+Publication fails closed when the managed-worktree evidence is absent, stale, or mismatched. Existing valid hierarchical branch names remain supported, and existing remote task branches may advance only by safe fast-forward.
+
+The existing `fast-uri` override now resolves to 3.1.6, which clears the high-severity production dependency audit threshold.
+
+## Install or upgrade
+
+Back up the complete stopped-writer workspace before upgrading and retain the backup until the new runtime is accepted.
+
+```bash
+brew update
+brew upgrade --cask bradgroux/tap/veritas-kanban
+```
+
+For a first installation:
+
+```bash
+brew install --cask bradgroux/tap/veritas-kanban
+```
+
+The Assets section provides signed and notarized macOS arm64 DMG and ZIP packages after the release workflow completes. Linux and Windows packages remain unsigned verification previews.
+
+## Compatibility and rollback
+
+The public REST API remains `v1`, and this release adds no database migration. Valid 6.1.3 workspaces remain compatible. Roll back by reinstalling the previous complete application bundle; do not mix package or bundled runtime versions.
+
+See the [changelog](https://github.com/BradGroux/veritas-kanban/blob/v6.1.4/CHANGELOG.md) for the concise change record.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/server/src/__tests__/docker-paths.test.ts
+++ b/server/src/__tests__/docker-paths.test.ts
@@ -8,6 +8,7 @@ const createFsPromisesMock = vi.hoisted(() => () => {
     cp: vi.fn().mockResolvedValue(undefined),
     lstat: vi.fn().mockResolvedValue({ isSymbolicLink: () => false }),
     mkdir: vi.fn().mockResolvedValue(undefined),
+    mkdtemp: vi.fn().mockResolvedValue('/tmp/veritas-test'),
     open: vi.fn().mockResolvedValue(undefined),
     readFile: vi.fn().mockResolvedValue(''),
     writeFile: vi.fn().mockResolvedValue(undefined),

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump all Veritas Kanban packages and the README badge to 6.1.4.
- Add the focused 6.1.4 security changelog and canonical GitHub release body.
- Keep the Docker path regression mock aligned with the managed publication filesystem boundary merged in #1308.

## Verification

- Workspace build passed.
- Workspace typecheck passed.
- Lint and the 458-warning budget passed.
- Workspace unit suites passed: server, web, CLI, and MCP.
- Production dependency audit passed the high-severity threshold with three moderate advisories remaining.
- CLI/MCP compatibility smoke passed its credential-free checks; the live write lane was skipped because no test API key was configured.
- Release format and `pnpm validate:release -- --version 6.1.4` passed with all build outputs present.

## Release scope

- No API or database schema changes.
- Apply `ci:full` for the final release matrix.
- The release tracker remains open until the tag, GitHub release, signed macOS assets, and Homebrew cask are verified.

Tracks #1307.
