### PR TITLE
chore: align CodeQL action revisions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: javascript-typescript
           build-mode: none
           queries: security-extended
       - name: Analyze JavaScript and TypeScript
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: '/language:javascript-typescript'
 

--- a/scripts/check-security-gates.mjs
+++ b/scripts/check-security-gates.mjs
@@ -54,11 +54,14 @@ export function findSecurityWorkflowViolations(content) {
   ) {
     violations.push('CodeQL job must grant only contents: read and security-events: write');
   }
-  if (
-    !/uses:\s*github\/codeql-action\/init@[0-9a-f]{40}\s+#\s*\S+/.test(codeqlJob) ||
-    !/uses:\s*github\/codeql-action\/analyze@[0-9a-f]{40}\s+#\s*\S+/.test(codeqlJob)
-  ) {
+  const codeqlInit =
+    /uses:\s*github\/codeql-action\/init@([0-9a-f]{40})\s+#\s*(\S+)/.exec(codeqlJob);
+  const codeqlAnalyze =
+    /uses:\s*github\/codeql-action\/analyze@([0-9a-f]{40})\s+#\s*(\S+)/.exec(codeqlJob);
+  if (!codeqlInit || !codeqlAnalyze) {
     violations.push('CodeQL init and analyze actions must both be present');
+  } else if (codeqlInit[1] !== codeqlAnalyze[1] || codeqlInit[2] !== codeqlAnalyze[2]) {
+    violations.push('CodeQL init and analyze actions must use the same pinned revision');
   }
 
   const gitleaksJob = yamlBlock(content, 'gitleaks', 2);

--- a/scripts/check-security-gates.test.mjs
+++ b/scripts/check-security-gates.test.mjs
@@ -6,10 +6,16 @@ import {
   findSecurityWorkflowViolations,
 } from './check-security-gates.mjs';
 
-const SHA = 'db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28';
+const SHA_4_37_8 = 'db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28';
+const SHA_4_37_9 = 'cdf488f595d80d6e07e03d4674febd5ab45fa938';
 
-test('accepts a least-privilege scheduled CodeQL and gitleaks workflow', () => {
-  const workflow = `
+function securityWorkflow({
+  initSha = SHA_4_37_8,
+  initVersion = 'v4.37.8',
+  analyzeSha = SHA_4_37_8,
+  analyzeVersion = 'v4.37.8',
+} = {}) {
+  return `
 name: Security Gates
 on:
   pull_request:
@@ -25,16 +31,18 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: github/codeql-action/init@${SHA} # v4.37.8
-      - uses: github/codeql-action/analyze@${SHA} # v4.37.8
+      - uses: github/codeql-action/init@${initSha} # ${initVersion}
+      - uses: github/codeql-action/analyze@${analyzeSha} # ${analyzeVersion}
   gitleaks:
     permissions:
       contents: read
     steps:
       - run: pnpm check:gitleaks
 `;
+}
 
-  assert.deepEqual(findSecurityWorkflowViolations(workflow), []);
+test('accepts a least-privilege scheduled CodeQL and gitleaks workflow', () => {
+  assert.deepEqual(findSecurityWorkflowViolations(securityWorkflow()), []);
 });
 
 test('rejects missing schedules, broad permissions, and incomplete gates', () => {
@@ -59,6 +67,19 @@ jobs:
       'runner context must not be used in job-level environment values',
       'gitleaks job must run pnpm check:gitleaks with contents: read permission',
     ]
+  );
+});
+
+test('rejects mixed CodeQL action revisions', () => {
+  assert.deepEqual(findSecurityWorkflowViolations(securityWorkflow({ analyzeSha: SHA_4_37_9 })), [
+    'CodeQL init and analyze actions must use the same pinned revision',
+  ]);
+});
+
+test('rejects mismatched CodeQL action version annotations', () => {
+  assert.deepEqual(
+    findSecurityWorkflowViolations(securityWorkflow({ analyzeVersion: 'v4.37.9' })),
+    ['CodeQL init and analyze actions must use the same pinned revision']
   );
 });
 


### PR DESCRIPTION
## Summary

- update CodeQL init and analyze to the same immutable v4.37.9 commit
- reject workflows that mix CodeQL SHAs or version annotations
- add focused regression coverage for both mismatch modes

## Why

Dependabot split the two action components into separate pull requests. Each branch failed because CodeQL loaded configuration from one action version and ran the other. This replaces them with one atomic update.

## Verification

- `node --test scripts/check-security-gates.test.mjs`
- `pnpm check:security-gates`
- `pnpm check:actions-pinned`
- `git diff --check`

Supersedes #1303 and #1304. Part of #1310.