### PR TITLE
chore: upgrade Electron to 44

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.4.0",
-    "electron": "^43.4.1",
+    "electron": "^44.0.0",
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ importers:
         specifier: ^26.4.0
         version: 26.4.0
       electron:
-        specifier: ^43.4.1
-        version: 43.4.1
+        specifier: ^44.0.0
+        version: 44.1.1
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
@@ -2503,8 +2503,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.4.1:
-    resolution: {integrity: sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==}
+  electron@44.1.1:
+    resolution: {integrity: sha512-N2WCq2sbOkqQgvXJYx2lS6UiO8bF+Yr67trDnS6JKa2WxTCRQsAjGl57SUtdW9h6r5PlduBFjIhxhgd3dzv1hg==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -7468,7 +7468,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.4.1:
+  electron@44.1.1:
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0


### PR DESCRIPTION
## Summary

- upgrade the desktop runtime from Electron 43.4.1 to the Electron 44 line
- resolve the current compatible patch, Electron 44.1.1
- regenerate the pnpm lockfile from current `main`

## Compatibility review

- Veritas already requires macOS 14+, above Electron 44's macOS 13 floor
- desktop packaging targets only x64 and arm64
- Electron clipboard usage is main-process only
- the codebase does not use the removed login-item fields, retired ANGLE libraries, or affected `net.request` mode

## Verification

- shared workspace build plus 71 desktop tests
- desktop typecheck
- desktop production build and Electron artifact checks
- full root build
- unsigned macOS arm64 directory package
- packaged Veritas version 6.1.4 and Electron Framework version 44.1.1 read back from the app bundle
- `pnpm audit --prod --audit-level high`
- `git diff --check`

Supersedes #1306. Part of #1310.