### PR TITLE
fix: make board drag moves atomic

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -2,7 +2,7 @@
 cli/src/__tests__/snapshot.test.ts:generic-api-key:220
 
 # API documentation contains non-functional response examples.
-docs/API-REFERENCE.md:generic-api-key:1000
+docs/API-REFERENCE.md:generic-api-key:1043
 docs/API-WORKFLOWS.md:generic-api-key:1460
 
 # Operator documentation uses placeholders in curl authentication examples.

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -339,6 +339,49 @@ POST /api/tasks/reorder
 
 **Body**: `{ "taskIds": ["TASK-003", "TASK-001", "TASK-002"] }`
 
+### Move Task on the Board
+
+```
+POST /api/tasks/:id/move
+```
+
+Atomically changes a task's column and destination order. Send the revision from
+the loaded task with `If-Match` and a UUID `operationId`; retrying the same
+operation is idempotent and returns `replayed: true` without another task write.
+
+**Headers**:
+
+```http
+If-Match: "task:TASK-001:4"
+```
+
+**Body**:
+
+```json
+{
+  "operationId": "c570c646-2982-4f74-82fb-6b7da81ab58b",
+  "sourceStatus": "todo",
+  "sourcePosition": 0,
+  "destinationStatus": "blocked",
+  "destinationIndex": 1
+}
+```
+
+**Response** `200`:
+
+```json
+{
+  "task": { "id": "TASK-001", "status": "blocked", "revision": 5 },
+  "operationId": "c570c646-2982-4f74-82fb-6b7da81ab58b",
+  "orderedTaskIds": ["TASK-004", "TASK-001", "TASK-007"],
+  "replayed": false
+}
+```
+
+A stale revision or source state returns `409 CONFLICT` with the current task in
+`details.current`. Reusing an operation ID with different move input also
+returns `409 CONFLICT`.
+
 ### Bulk Update
 
 ```

--- a/e2e/board-drag-atomic.spec.ts
+++ b/e2e/board-drag-atomic.spec.ts
@@ -1,0 +1,470 @@
+import { expect, test } from '@playwright/test';
+import { bypassAuth, cleanupRoutes, deleteTask, seedTestTask, unwrapApiData } from './helpers/auth';
+
+const API_BASE = process.env.API_BASE_URL || 'http://127.0.0.1:3001';
+
+test.describe('Atomic board drag', () => {
+  const taskIds: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    await bypassAuth(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await Promise.all(taskIds.splice(0).map((taskId) => deleteTask(page, taskId).catch(() => {})));
+    await cleanupRoutes(page);
+  });
+
+  for (const theme of ['dark', 'light'] as const)
+    test(`keeps the pending projection and commits one revisioned move in ${theme} theme`, async ({
+      page,
+    }) => {
+      const rightRailOpen = theme === 'dark';
+      await page.addInitScript(
+        ({ selectedTheme, openRightRail }) => {
+          window.localStorage.setItem('veritas-kanban-theme', selectedTheme);
+          window.localStorage.setItem('veritas.desktop.rightRailOpen', String(openRightRail));
+          Object.defineProperty(window, 'veritasDesktop', {
+            configurable: true,
+            value: {
+              onMenuCommand: () => () => undefined,
+              toggleWindowMaximize: async () => ({ maximized: false }),
+            },
+          });
+        },
+        { selectedTheme: theme, openRightRail: rightRailOpen }
+      );
+      await page.route('**/api/settings/features', async (route) => {
+        const response = await route.fetch();
+        const body = (await response.json()) as Record<string, unknown>;
+        const data = (body.data ?? body) as Record<string, unknown>;
+        data.board = {
+          ...(data.board as Record<string, unknown>),
+          showDashboard: true,
+        };
+        await route.fulfill({
+          status: response.status(),
+          contentType: 'application/json',
+          body: JSON.stringify(body),
+        });
+      });
+      const destination = await seedTestTask(page, {
+        title: 'Atomic drag destination',
+        status: 'blocked',
+      });
+      const moving = await seedTestTask(page, {
+        title: 'Atomic drag source',
+        status: 'todo',
+      });
+      const pendingPeer = await seedTestTask(page, {
+        title: 'Atomic drag pending peer',
+        status: 'todo',
+      });
+      const destinationId = destination.id as string;
+      const movingId = moving.id as string;
+      const pendingPeerId = pendingPeer.id as string;
+      taskIds.push(destinationId, movingId, pendingPeerId);
+
+      let releaseMove!: () => void;
+      const moveRelease = new Promise<void>((resolve) => {
+        releaseMove = resolve;
+      });
+      let markMoveSeen!: () => void;
+      const moveSeen = new Promise<void>((resolve) => {
+        markMoveSeen = resolve;
+      });
+      const mutationRequests: Array<{ method: string; pathname: string }> = [];
+      let moveOperationId: string | undefined;
+      page.on('request', (request) => {
+        const url = new URL(request.url());
+        if (url.pathname.startsWith('/api/tasks')) {
+          mutationRequests.push({ method: request.method(), pathname: url.pathname });
+          if (url.pathname === `/api/tasks/${movingId}/move`) {
+            moveOperationId = (request.postDataJSON() as { operationId?: string }).operationId;
+          }
+        }
+      });
+      await page.route(`**/api/tasks/${movingId}/move`, async (route) => {
+        markMoveSeen();
+        await moveRelease;
+        await route.fallback();
+      });
+
+      await page.setViewportSize({ width: 1280, height: 720 });
+      await page.goto('/');
+      const source = page.locator(`[data-task-id="${movingId}"]`);
+      const destinationCard = page.locator(`[data-task-id="${destinationId}"]`);
+      const blocked = page.getByRole('region', { name: 'Blocked' });
+      await expect(source).toBeVisible();
+      await expect(destinationCard).toBeVisible();
+      await expect(blocked).toBeVisible();
+      await expect(page.locator('html')).toHaveAttribute('data-client', 'desktop');
+      if (rightRailOpen) await expect(page.getByLabel('Board right sidebar')).toBeVisible();
+      else await expect(page.getByLabel('Board right sidebar')).toHaveCount(0);
+      await expect(page.getByLabel('Board dashboard')).toBeAttached();
+      await page.waitForTimeout(500);
+
+      const sourceBox = await source.boundingBox();
+      const destinationBox = await destinationCard.boundingBox();
+      expect(sourceBox).not.toBeNull();
+      expect(destinationBox).not.toBeNull();
+      const countBefore = {
+        todo: Number(
+          await page
+            .getByRole('region', { name: 'To Do' })
+            .locator('span[aria-live="polite"]')
+            .textContent()
+        ),
+        blocked: Number(await blocked.locator('span[aria-live="polite"]').textContent()),
+      };
+      const geometryBefore = await page.evaluate(() => ({
+        documentHeight: document.documentElement.scrollHeight,
+        scrollY: window.scrollY,
+        board: document
+          .querySelector('[aria-label^="Kanban board"]')
+          ?.getBoundingClientRect()
+          .toJSON(),
+        grid: document
+          .querySelector('[aria-label="Kanban columns"]')
+          ?.getBoundingClientRect()
+          .toJSON(),
+        dashboard: document
+          .querySelector('[aria-label="Board dashboard"]')
+          ?.getBoundingClientRect()
+          .toJSON(),
+      }));
+      expect(geometryBefore.dashboard?.top).toBeGreaterThanOrEqual(
+        geometryBefore.board?.bottom ?? 0
+      );
+
+      await page.mouse.move(sourceBox!.x + sourceBox!.width / 2, sourceBox!.y + 18);
+      await page.mouse.down();
+      await page.mouse.move(sourceBox!.x + sourceBox!.width / 2 + 12, sourceBox!.y + 30, {
+        steps: 3,
+      });
+      await page.mouse.move(destinationBox!.x + destinationBox!.width / 2, destinationBox!.y + 18, {
+        steps: 8,
+      });
+
+      const overlay = page.locator('[data-board-drag-overlay]');
+      await expect(overlay).toHaveCount(1);
+      const overlayBox = await overlay.boundingBox();
+      expect(overlayBox).not.toBeNull();
+      expect(Math.abs(overlayBox!.width - sourceBox!.width)).toBeLessThanOrEqual(1);
+      expect(Math.abs(overlayBox!.height - sourceBox!.height)).toBeLessThanOrEqual(1);
+      const overlayColors = await overlay.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return { backgroundColor: style.backgroundColor, color: style.color };
+      });
+      expect(await overlay.evaluate((element) => element.classList.contains('bg-card'))).toBe(true);
+      if (theme === 'dark') expect(overlayColors.backgroundColor).not.toBe('rgb(255, 255, 255)');
+
+      const geometryDuring = await page.evaluate(() => ({
+        documentHeight: document.documentElement.scrollHeight,
+        scrollY: window.scrollY,
+        board: document
+          .querySelector('[aria-label^="Kanban board"]')
+          ?.getBoundingClientRect()
+          .toJSON(),
+        grid: document
+          .querySelector('[aria-label="Kanban columns"]')
+          ?.getBoundingClientRect()
+          .toJSON(),
+        dashboard: document
+          .querySelector('[aria-label="Board dashboard"]')
+          ?.getBoundingClientRect()
+          .toJSON(),
+      }));
+      expect(geometryDuring).toEqual(geometryBefore);
+      await expect(page.getByLabel('Search tasks')).toBeVisible();
+
+      await page.mouse.up();
+      await moveSeen;
+      await expect(blocked.locator(`[data-task-id="${movingId}"]`)).toBeVisible();
+      await expect(page.locator('[data-board-drag-overlay]')).toHaveCount(0);
+      await expect(page.getByText(/Atomic drag source moved to Blocked/)).toHaveCount(0);
+
+      const pendingPeerCard = page.locator(`[data-task-id="${pendingPeerId}"]`);
+      const pendingPeerBox = await pendingPeerCard.boundingBox();
+      expect(pendingPeerBox).not.toBeNull();
+      await page.mouse.move(pendingPeerBox!.x + pendingPeerBox!.width / 2, pendingPeerBox!.y + 18);
+      await page.mouse.down();
+      await page.mouse.move(destinationBox!.x + destinationBox!.width / 2, destinationBox!.y + 18, {
+        steps: 8,
+      });
+      await page.mouse.up();
+      await expect(page.locator('[data-board-drag-overlay]')).toHaveCount(0);
+      expect(
+        mutationRequests.filter(
+          (request) => request.pathname === `/api/tasks/${pendingPeerId}/move`
+        )
+      ).toHaveLength(0);
+
+      releaseMove();
+      await expect
+        .poll(async () => {
+          const response = await page.request.get(`${API_BASE}/api/tasks/${movingId}`);
+          const body = unwrapApiData<Record<string, unknown>>(await response.json());
+          return {
+            status: body.status,
+            revision: body.revision,
+            hasPosition: typeof body.position === 'number',
+          };
+        })
+        .toEqual({ status: 'blocked', revision: 2, hasPosition: true });
+
+      await expect(page.getByText('Task changed elsewhere')).toHaveCount(0);
+      await expect(page.getByText('Move not saved')).toHaveCount(0);
+      await expect(page.getByText(/Atomic drag source moved to Blocked/)).toHaveCount(1);
+      await expect(page.locator(`[data-task-id="${movingId}"]`)).toHaveCount(1);
+      expect(
+        Number(
+          await page
+            .getByRole('region', { name: 'To Do' })
+            .locator('span[aria-live="polite"]')
+            .textContent()
+        )
+      ).toBe(countBefore.todo - 1);
+      expect(Number(await blocked.locator('span[aria-live="polite"]').textContent())).toBe(
+        countBefore.blocked + 1
+      );
+      if (rightRailOpen) {
+        await expect(
+          page
+            .getByLabel('Board right sidebar')
+            .getByRole('button', { name: /→ blockedAtomic drag source/ })
+            .first()
+        ).toBeVisible();
+      }
+      await expect
+        .poll(async () => {
+          const response = await page.request.get(
+            `${API_BASE}/api/activity?taskId=${movingId}&limit=50`
+          );
+          const activities = unwrapApiData<Array<{ details?: { operationId?: string } }>>(
+            await response.json()
+          );
+          return activities.filter((activity) => activity.details?.operationId === moveOperationId)
+            .length;
+        })
+        .toBe(1);
+      const moveMutations = mutationRequests.filter((request) => request.method !== 'GET');
+      expect(moveMutations).toEqual([{ method: 'POST', pathname: `/api/tasks/${movingId}/move` }]);
+
+      await page.reload();
+      await expect(
+        page.getByRole('region', { name: 'Blocked' }).locator(`[data-task-id="${movingId}"]`)
+      ).toBeVisible();
+    });
+
+  test('rejects a genuinely stale pointer move without partial status state', async ({ page }) => {
+    const moving = await seedTestTask(page, {
+      title: 'Atomic stale drag source',
+      status: 'todo',
+    });
+    const movingId = moving.id as string;
+    taskIds.push(movingId);
+    let injectedConflict = false;
+    await page.route(`**/api/tasks/${movingId}/move`, async (route) => {
+      if (!injectedConflict) {
+        injectedConflict = true;
+        const response = await page.request.patch(`${API_BASE}/api/tasks/${movingId}`, {
+          headers: { 'If-Match': `"task:${movingId}:1"` },
+          data: { title: 'Atomic stale drag source updated' },
+        });
+        expect(response.ok()).toBe(true);
+      }
+      await route.fallback();
+    });
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/');
+    const source = page.locator(`[data-task-id="${movingId}"]`);
+    const blocked = page.getByRole('region', { name: 'Blocked' });
+    await expect(source).toBeVisible();
+    const sourceBox = await source.boundingBox();
+    const blockedBox = await blocked.boundingBox();
+    expect(sourceBox).not.toBeNull();
+    expect(blockedBox).not.toBeNull();
+
+    await page.mouse.move(sourceBox!.x + sourceBox!.width / 2, sourceBox!.y + 18);
+    await page.mouse.down();
+    await page.mouse.move(sourceBox!.x + sourceBox!.width / 2 + 12, sourceBox!.y + 30);
+    await page.mouse.move(blockedBox!.x + blockedBox!.width / 2, blockedBox!.y + 90, {
+      steps: 8,
+    });
+    await page.mouse.up();
+
+    await expect(page.getByText('Move not saved')).toBeVisible();
+    await expect(
+      page.getByRole('region', { name: 'To Do' }).locator(`[data-task-id="${movingId}"]`)
+    ).toBeVisible();
+    await expect(blocked.locator(`[data-task-id="${movingId}"]`)).toHaveCount(0);
+    await expect
+      .poll(async () => {
+        const response = await page.request.get(`${API_BASE}/api/tasks/${movingId}`);
+        const body = unwrapApiData<Record<string, unknown>>(await response.json());
+        return { status: body.status, revision: body.revision, title: body.title };
+      })
+      .toEqual({ status: 'todo', revision: 2, title: 'Atomic stale drag source updated' });
+  });
+
+  test('routes a keyboard column move through the same move endpoint', async ({ page }) => {
+    const moving = await seedTestTask(page, {
+      title: 'Atomic keyboard source',
+      status: 'todo',
+    });
+    const movingId = moving.id as string;
+    taskIds.push(movingId);
+    const moveRequests: string[] = [];
+    page.on('request', (request) => {
+      if (
+        request.method() === 'POST' &&
+        new URL(request.url()).pathname === `/api/tasks/${movingId}/move`
+      ) {
+        moveRequests.push(request.url());
+      }
+    });
+
+    await page.goto('/');
+    await page.getByLabel('Search tasks').fill('Atomic keyboard source');
+    await page.getByLabel('Search tasks').blur();
+    await page.keyboard.press('j');
+    await page.keyboard.press('3');
+
+    await expect(
+      page.getByRole('region', { name: 'Blocked' }).locator(`[data-task-id="${movingId}"]`)
+    ).toBeVisible();
+    await expect
+      .poll(async () => {
+        const response = await page.request.get(`${API_BASE}/api/tasks/${movingId}`);
+        return unwrapApiData<Record<string, unknown>>(await response.json()).status;
+      })
+      .toBe('blocked');
+    expect(moveRequests).toHaveLength(1);
+    await expect(page.getByText(/Task Atomic keyboard source moved to Blocked/)).toHaveCount(1);
+  });
+
+  test('handles cancel, an empty column, and same-column ordering through real sensors', async ({
+    page,
+  }) => {
+    const moving = await seedTestTask(page, {
+      title: 'Atomic matrix moving',
+      status: 'todo',
+      position: 0,
+    });
+    const withinFirst = await seedTestTask(page, {
+      title: 'Atomic matrix within first',
+      status: 'todo',
+      position: 1,
+    });
+    const withinSecond = await seedTestTask(page, {
+      title: 'Atomic matrix within second',
+      status: 'todo',
+      position: 2,
+    });
+    const movingId = moving.id as string;
+    const withinFirstId = withinFirst.id as string;
+    const withinSecondId = withinSecond.id as string;
+    taskIds.push(movingId, withinFirstId, withinSecondId);
+
+    const moveRequests: Array<{
+      taskId: string;
+      destinationStatus: string;
+      destinationIndex: number;
+    }> = [];
+    page.on('request', (request) => {
+      const match = new URL(request.url()).pathname.match(/^\/api\/tasks\/([^/]+)\/move$/);
+      if (request.method() !== 'POST' || !match) return;
+      const payload = request.postDataJSON() as {
+        destinationStatus: string;
+        destinationIndex: number;
+      };
+      moveRequests.push({ taskId: match[1], ...payload });
+    });
+
+    await page.goto('/');
+    await page.getByLabel('Search tasks').fill('Atomic matrix');
+    await page.getByLabel('Search tasks').blur();
+    const movingCard = page.locator(`[data-task-id="${movingId}"]`);
+    const blocked = page.getByRole('region', { name: 'Blocked' });
+    await expect(movingCard).toBeVisible();
+    await expect(blocked.locator('[data-task-id]')).toHaveCount(0);
+
+    const movingBox = await movingCard.boundingBox();
+    const blockedBox = await blocked.boundingBox();
+    expect(movingBox).not.toBeNull();
+    expect(blockedBox).not.toBeNull();
+    await page.mouse.move(movingBox!.x + movingBox!.width / 2, movingBox!.y + 18);
+    await page.mouse.down();
+    await page.mouse.move(blockedBox!.x + blockedBox!.width / 2, blockedBox!.y + 90, {
+      steps: 8,
+    });
+    await expect(page.locator('[data-board-drag-overlay]')).toHaveCount(1);
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
+
+    await expect(page.locator('[data-board-drag-overlay]')).toHaveCount(0);
+    await expect(
+      page.getByRole('region', { name: 'To Do' }).locator(`[data-task-id="${movingId}"]`)
+    ).toBeVisible();
+    expect(moveRequests).toHaveLength(0);
+
+    const canceledBox = await movingCard.boundingBox();
+    expect(canceledBox).not.toBeNull();
+    await page.mouse.move(canceledBox!.x + canceledBox!.width / 2, canceledBox!.y + 18);
+    await page.mouse.down();
+    await page.mouse.move(blockedBox!.x + blockedBox!.width / 2, blockedBox!.y + 90, {
+      steps: 8,
+    });
+    await page.mouse.up();
+    await expect(blocked.locator(`[data-task-id="${movingId}"]`)).toBeVisible();
+    expect(moveRequests).toHaveLength(1);
+    expect(moveRequests[0]).toMatchObject({
+      taskId: movingId,
+      destinationStatus: 'blocked',
+      destinationIndex: 0,
+    });
+    await expect
+      .poll(async () => {
+        const response = await page.request.get(`${API_BASE}/api/tasks/${movingId}`);
+        return unwrapApiData<Record<string, unknown>>(await response.json()).status;
+      })
+      .toBe('blocked');
+    await expect(page.getByText(/Atomic matrix moving moved to Blocked/)).toHaveCount(1);
+
+    const todoCards = page.getByRole('region', { name: 'To Do' }).locator('[data-task-id]');
+    const beforeWithinOrder = await todoCards.evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute('data-task-id')).filter(Boolean)
+    );
+    expect(beforeWithinOrder).toHaveLength(2);
+    const targetWithinId = beforeWithinOrder[0] as string;
+    const sourceWithinId = beforeWithinOrder[1] as string;
+    const secondCard = page.locator(`[data-task-id="${sourceWithinId}"]`);
+    await secondCard.focus();
+    await page.keyboard.press('Space');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('Space');
+
+    await expect.poll(() => moveRequests.length).toBe(2);
+    expect(moveRequests[1]).toMatchObject({
+      taskId: sourceWithinId,
+      destinationStatus: 'todo',
+    });
+    expect(moveRequests[1].destinationIndex).toBeGreaterThanOrEqual(0);
+    const visibleTodoOrder = await page
+      .getByRole('region', { name: 'To Do' })
+      .locator('[data-task-id]')
+      .evaluateAll((elements) => elements.map((element) => element.getAttribute('data-task-id')));
+    expect(visibleTodoOrder.indexOf(sourceWithinId)).toBeLessThan(
+      visibleTodoOrder.indexOf(targetWithinId)
+    );
+    await expect
+      .poll(async () => {
+        const response = await page.request.get(`${API_BASE}/api/tasks/${sourceWithinId}`);
+        const task = unwrapApiData<Record<string, unknown>>(await response.json());
+        return { status: task.status, hasPosition: typeof task.position === 'number' };
+      })
+      .toEqual({ status: 'todo', hasPosition: true });
+  });
+});

--- a/server/src/__tests__/activity-service.test.ts
+++ b/server/src/__tests__/activity-service.test.ts
@@ -89,6 +89,21 @@ describe('ActivityService', () => {
       expect(activities[0].taskTitle).toBe('Second');
       expect(activities[1].taskTitle).toBe('First');
     });
+
+    it('logs an idempotent operation once under concurrent retries', async () => {
+      const operationId = '00000000-0000-4000-8000-000000000111';
+      const results = await Promise.all([
+        service.logActivityOnce(operationId, 'status_changed', 'task_1', 'Task', {
+          status: 'blocked',
+        }),
+        service.logActivityOnce(operationId, 'status_changed', 'task_1', 'Task', {
+          status: 'blocked',
+        }),
+      ]);
+
+      expect(results.map((result) => result.created).sort()).toEqual([false, true]);
+      expect(await service.getActivities(10, { taskId: 'task_1' })).toHaveLength(1);
+    });
   });
 
   describe('getActivities', () => {

--- a/server/src/__tests__/broadcast-service.test.ts
+++ b/server/src/__tests__/broadcast-service.test.ts
@@ -176,12 +176,37 @@ describe('BroadcastService', () => {
       wss.addClient(1);
       initBroadcast(asWebSocketServer(wss));
 
-      const types = ['created', 'updated', 'deleted', 'archived', 'restored', 'reordered'] as const;
+      const types = [
+        'created',
+        'updated',
+        'deleted',
+        'archived',
+        'restored',
+        'reordered',
+        'moved',
+      ] as const;
       for (const type of types) {
         broadcastTaskChange(type);
       }
 
-      expect(wss.sentMessages).toHaveLength(6);
+      expect(wss.sentMessages).toHaveLength(7);
+    });
+
+    it('includes the originating operation ID on board move events', () => {
+      const wss = createMockWss();
+      wss.addClient(1);
+      initBroadcast(asWebSocketServer(wss));
+
+      broadcastTaskChange('moved', 'task_456', undefined, {
+        operationId: '00000000-0000-4000-8000-000000000013',
+      });
+
+      expect(JSON.parse(wss.sentMessages[0])).toMatchObject({
+        type: 'task:changed',
+        changeType: 'moved',
+        taskId: 'task_456',
+        operationId: '00000000-0000-4000-8000-000000000013',
+      });
     });
 
     it('should filter task events by client workspace', () => {

--- a/server/src/__tests__/routes/tasks-coverage.test.ts
+++ b/server/src/__tests__/routes/tasks-coverage.test.ts
@@ -13,6 +13,8 @@ const {
   mockBlockingService,
   mockActivityService,
   mockBacklogService,
+  mockBroadcastTaskChange,
+  mockSyncTaskStatusToGitHub,
 } = vi.hoisted(() => ({
   mockTaskService: {
     listTasks: vi.fn(),
@@ -22,6 +24,17 @@ const {
     deleteTask: vi.fn(),
     archiveTask: vi.fn(),
     reorderTasks: vi.fn(),
+    moveTask: vi.fn(),
+    reconcileBoardMoveTelemetry: vi.fn().mockResolvedValue(true),
+    markBoardMoveAuditComplete: vi.fn().mockImplementation((id: string, operationId: string) =>
+      Promise.resolve({
+        id,
+        lastBoardMove: {
+          operationId,
+          auditCompletedAt: '2026-08-01T10:00:01.000Z',
+        },
+      })
+    ),
     getIdentityScanSources: vi.fn().mockReturnValue([]),
   },
   mockWorktreeService: {
@@ -41,6 +54,7 @@ const {
   },
   mockActivityService: {
     logActivity: vi.fn().mockResolvedValue(undefined),
+    logActivityOnce: vi.fn().mockResolvedValue({ activity: {}, created: true }),
   },
   mockBacklogService: {
     getTaskIdentityDiagnostics: vi
@@ -49,6 +63,8 @@ const {
     getBacklogCount: vi.fn().mockResolvedValue(0),
     demoteToBacklog: vi.fn(),
   },
+  mockBroadcastTaskChange: vi.fn(),
+  mockSyncTaskStatusToGitHub: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../services/task-service.js', () => ({
@@ -77,7 +93,11 @@ vi.mock('../../services/backlog-service.js', () => ({
 }));
 
 vi.mock('../../services/broadcast-service.js', () => ({
-  broadcastTaskChange: vi.fn(),
+  broadcastTaskChange: mockBroadcastTaskChange,
+}));
+
+vi.mock('../../services/github-sync-service.js', () => ({
+  getGitHubSyncService: () => ({ syncTaskStatusToGitHub: mockSyncTaskStatusToGitHub }),
 }));
 
 vi.mock('../../services/attachment-service.js', () => ({
@@ -138,6 +158,41 @@ describe('Tasks Routes (actual module)', () => {
       expect(res.body).toEqual([]);
     });
 
+    it('repairs the durable audit receipt when a board is loaded after restart', async () => {
+      const task = {
+        id: 't1',
+        title: 'Moved task',
+        status: 'blocked',
+        position: 0,
+        created: '2025-01-01',
+        updated: '2025-01-02',
+        updatedBy: 'user:test',
+        lastBoardMove: {
+          operationId: '00000000-0000-4000-8000-000000000013',
+          sourceStatus: 'todo',
+          sourcePosition: null,
+          destinationStatus: 'blocked',
+          destinationIndex: 0,
+          completedAt: '2025-01-02',
+        },
+      };
+      const secondTask = {
+        ...task,
+        id: 't2',
+        title: 'Second moved task',
+      };
+      mockTaskService.listTasks.mockResolvedValue([task, secondTask]);
+
+      const res = await request(app).get('/api/tasks');
+
+      expect(res.status).toBe(200);
+      await vi.waitFor(() => {
+        expect(mockTaskService.reconcileBoardMoveTelemetry).toHaveBeenCalledWith(task);
+        expect(mockTaskService.reconcileBoardMoveTelemetry).toHaveBeenCalledWith(secondTask);
+        expect(mockActivityService.logActivityOnce).toHaveBeenCalledTimes(2);
+      });
+    });
+
     it('should expose duplicate identity diagnostics as a response header', async () => {
       mockTaskService.listTasks.mockResolvedValue([]);
       mockBacklogService.getTaskIdentityDiagnostics.mockResolvedValueOnce({
@@ -192,6 +247,190 @@ describe('Tasks Routes (actual module)', () => {
     it('should reject missing orderedIds', async () => {
       const res = await request(app).post('/api/tasks/reorder').send({});
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/tasks/:id/move', () => {
+    it('does not overwrite a prior durable receipt while audit repair is unavailable', async () => {
+      mockTaskService.getTask.mockResolvedValue({
+        id: 't1',
+        title: 'Task',
+        status: 'blocked',
+        position: 0,
+        revision: 2,
+        lastBoardMove: {
+          operationId: '00000000-0000-4000-8000-000000000010',
+          sourceStatus: 'todo',
+          sourcePosition: null,
+          destinationStatus: 'blocked',
+          destinationIndex: 0,
+          completedAt: '2026-08-01T10:00:00.000Z',
+        },
+      });
+      mockActivityService.logActivityOnce.mockRejectedValueOnce(new Error('activity unavailable'));
+
+      const res = await request(app)
+        .post('/api/tasks/t1/move')
+        .set('If-Match', '"task:t1:2"')
+        .send({
+          operationId: '00000000-0000-4000-8000-000000000011',
+          sourceStatus: 'blocked',
+          sourcePosition: 0,
+          destinationStatus: 'done',
+          destinationIndex: 0,
+        });
+
+      expect(res.status).toBe(500);
+      expect(mockTaskService.moveTask).not.toHaveBeenCalled();
+    });
+
+    it('passes revision and operation identity to one move command', async () => {
+      const task = {
+        id: 't1',
+        title: 'Task',
+        status: 'todo',
+        position: 0,
+        revision: 4,
+      };
+      mockTaskService.getTask.mockResolvedValue(task);
+      mockTaskService.moveTask.mockResolvedValue({
+        task: { ...task, status: 'blocked', position: 0.5, revision: 5 },
+        operationId: '00000000-0000-4000-8000-000000000010',
+        orderedTaskIds: ['b1', 't1', 'b2'],
+        replayed: false,
+      });
+
+      const res = await request(app)
+        .post('/api/tasks/t1/move')
+        .set('If-Match', '"task:t1:4"')
+        .send({
+          operationId: '00000000-0000-4000-8000-000000000010',
+          sourceStatus: 'todo',
+          sourcePosition: 0,
+          destinationStatus: 'blocked',
+          destinationIndex: 1,
+        });
+
+      expect(res.status).toBe(200);
+      expect(mockTaskService.moveTask).toHaveBeenCalledWith(
+        't1',
+        expect.objectContaining({
+          operationId: '00000000-0000-4000-8000-000000000010',
+          expectedRevision: 4,
+          updatedBy: 'system:unknown',
+        })
+      );
+      expect(mockActivityService.logActivityOnce).toHaveBeenCalledOnce();
+      expect(mockActivityService.logActivityOnce.mock.invocationCallOrder[0]).toBeLessThan(
+        mockBroadcastTaskChange.mock.invocationCallOrder[0]
+      );
+      expect(res.body).toMatchObject({ replayed: false, task: { revision: 5 } });
+    });
+
+    it('allows an already committed operation to replay with its original revision', async () => {
+      const task = {
+        id: 't1',
+        title: 'Task',
+        status: 'blocked',
+        position: 0.5,
+        revision: 5,
+        github: { owner: 'BradGroux', repo: 'veritas-kanban', issue: 1302 },
+        lastBoardMove: {
+          operationId: '00000000-0000-4000-8000-000000000010',
+          sourceStatus: 'todo',
+          sourcePosition: 0,
+          destinationStatus: 'blocked',
+          destinationIndex: 1,
+          completedAt: '2026-08-01T10:00:00.000Z',
+        },
+      };
+      mockTaskService.getTask.mockResolvedValue(task);
+      mockTaskService.moveTask.mockResolvedValue({
+        task,
+        operationId: '00000000-0000-4000-8000-000000000010',
+        orderedTaskIds: ['b1', 't1', 'b2'],
+        replayed: true,
+      });
+      mockActivityService.logActivityOnce.mockResolvedValueOnce({ activity: {}, created: false });
+
+      const res = await request(app)
+        .post('/api/tasks/t1/move')
+        .set('If-Match', '"task:t1:4"')
+        .send({
+          operationId: '00000000-0000-4000-8000-000000000010',
+          sourceStatus: 'todo',
+          sourcePosition: 0,
+          destinationStatus: 'blocked',
+          destinationIndex: 1,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.replayed).toBe(true);
+      expect(mockActivityService.logActivityOnce).toHaveBeenCalledOnce();
+      expect(mockActivityService.logActivityOnce).toHaveBeenCalledWith(
+        '00000000-0000-4000-8000-000000000010',
+        'status_changed',
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ from: 'todo', status: 'blocked' }),
+        undefined,
+        'system:unknown'
+      );
+      expect(mockBroadcastTaskChange).not.toHaveBeenCalled();
+      expect(mockSyncTaskStatusToGitHub).toHaveBeenCalledWith(task);
+    });
+
+    it('returns the committed move when activity persistence is temporarily unavailable', async () => {
+      const task = { id: 't1', title: 'Task', status: 'todo', revision: 1 };
+      const moved = {
+        ...task,
+        status: 'blocked',
+        position: 0,
+        boardRank: 'v1:0/1',
+        revision: 2,
+        lastBoardMove: {
+          operationId: '00000000-0000-4000-8000-000000000011',
+          sourceStatus: 'todo',
+          sourcePosition: null,
+          destinationStatus: 'blocked',
+          destinationIndex: 0,
+          completedAt: '2026-08-01T10:00:00.000Z',
+        },
+      };
+      mockTaskService.getTask.mockResolvedValue(task);
+      mockTaskService.moveTask.mockResolvedValue({
+        task: moved,
+        operationId: '00000000-0000-4000-8000-000000000011',
+        orderedTaskIds: ['t1'],
+        replayed: false,
+      });
+      mockActivityService.logActivityOnce.mockRejectedValueOnce(new Error('activity unavailable'));
+
+      const res = await request(app)
+        .post('/api/tasks/t1/move')
+        .set('If-Match', '"task:t1:1"')
+        .send({
+          operationId: '00000000-0000-4000-8000-000000000011',
+          sourceStatus: 'todo',
+          sourcePosition: null,
+          destinationStatus: 'blocked',
+          destinationIndex: 0,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ task: moved, replayed: false });
+      await vi.waitFor(() => {
+        expect(mockActivityService.logActivityOnce).toHaveBeenCalledTimes(2);
+      });
+      expect(mockBroadcastTaskChange).toHaveBeenCalledWith('moved', 't1', undefined, {
+        operationId: '00000000-0000-4000-8000-000000000011',
+      });
+      expect(mockBroadcastTaskChange).toHaveBeenCalledWith('updated', 't1', undefined, {
+        operationId: '00000000-0000-4000-8000-000000000011',
+      });
+      expect(
+        mockBroadcastTaskChange.mock.calls.filter(([changeType]) => changeType === 'moved')
+      ).toHaveLength(1);
     });
   });
 

--- a/server/src/__tests__/task-move.test.ts
+++ b/server/src/__tests__/task-move.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { sortTasksByBoardPosition } from '@veritas-kanban/shared';
+import { TaskService } from '../services/task-service.js';
+import { TelemetryService } from '../services/telemetry-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../storage/sqlite/test-helpers.js';
+
+interface Fixture {
+  service: TaskService;
+  telemetry: TelemetryService;
+  root: string;
+  sqlite?: TestSqliteDatabase;
+}
+
+const fixtures: Fixture[] = [];
+
+async function createFixture(storageType: 'file' | 'sqlite'): Promise<Fixture> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), `veritas-task-move-${storageType}-`));
+  const sqlite = storageType === 'sqlite' ? createTestSqliteDatabase() : undefined;
+  const telemetry =
+    storageType === 'sqlite'
+      ? new TelemetryService({
+          storageType: 'sqlite',
+          sqliteConnectionOptions: { databasePath: sqlite?.databasePath },
+          config: { enabled: true },
+        })
+      : new TelemetryService({
+          telemetryDir: path.join(root, 'telemetry'),
+          config: { enabled: true },
+        });
+  const fixture: Fixture = {
+    root,
+    sqlite,
+    telemetry,
+    service: new TaskService({
+      storageType,
+      sqliteDatabase: sqlite?.database,
+      tasksDir: path.join(root, 'tasks', 'active'),
+      archiveDir: path.join(root, 'tasks', 'archive'),
+      telemetryService: telemetry,
+    }),
+  };
+  fixtures.push(fixture);
+  return fixture;
+}
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await Promise.all(
+    fixtures.splice(0).map(async ({ service, telemetry, sqlite, root }) => {
+      service.dispose();
+      telemetry.dispose();
+      sqlite?.cleanup();
+      await fs.rm(root, { recursive: true, force: true });
+    })
+  );
+});
+
+describe.each(['file', 'sqlite'] as const)('TaskService board move (%s)', (storageType) => {
+  it('commits status and destination order in one task revision', async () => {
+    const { service } = await createFixture(storageType);
+    const moving = await service.createTask({ title: 'Moving task' });
+    const first = await service.createTask({ title: 'First blocked task', status: 'blocked' });
+    const second = await service.createTask({ title: 'Second blocked task', status: 'blocked' });
+    const movingPositioned = await service.updateTask(moving.id, { position: 0 });
+    const firstPositioned = await service.updateTask(first.id, { position: 0 });
+    const secondPositioned = await service.updateTask(second.id, { position: 1 });
+
+    const result = await service.moveTask(moving.id, {
+      operationId: '00000000-0000-4000-8000-000000000001',
+      expectedRevision: movingPositioned?.revision ?? 1,
+      sourceStatus: 'todo',
+      sourcePosition: 0,
+      destinationStatus: 'blocked',
+      destinationIndex: 1,
+      updatedBy: 'user:test',
+    });
+
+    expect(result).toMatchObject({
+      replayed: false,
+      operationId: '00000000-0000-4000-8000-000000000001',
+      orderedTaskIds: [first.id, moving.id, second.id],
+      task: {
+        id: moving.id,
+        status: 'blocked',
+        position: 0.5,
+        revision: (movingPositioned?.revision ?? 1) + 1,
+      },
+    });
+    expect((await service.getTask(first.id))?.revision).toBe(firstPositioned?.revision);
+    expect((await service.getTask(second.id))?.revision).toBe(secondPositioned?.revision);
+  });
+
+  it('replays one operation without another write and rejects a genuinely stale move', async () => {
+    const { service } = await createFixture(storageType);
+    const moving = await service.createTask({ title: 'Moving task' });
+    await service.createTask({ title: 'Blocked task', status: 'blocked' });
+    const request = {
+      operationId: '00000000-0000-4000-8000-000000000002',
+      expectedRevision: moving.revision ?? 1,
+      sourceStatus: 'todo',
+      sourcePosition: null,
+      destinationStatus: 'blocked',
+      destinationIndex: 0,
+      updatedBy: 'user:test',
+    } as const;
+
+    const first = await service.moveTask(moving.id, request);
+    const replay = await service.moveTask(moving.id, request);
+
+    expect(first?.replayed).toBe(false);
+    expect(replay?.replayed).toBe(true);
+    expect(replay?.task.revision).toBe(first?.task.revision);
+
+    await expect(
+      service.moveTask(moving.id, {
+        ...request,
+        operationId: '00000000-0000-4000-8000-000000000003',
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+    expect(await service.getTask(moving.id)).toMatchObject({
+      status: 'blocked',
+      revision: first?.task.revision,
+    });
+  });
+
+  it('keeps a committed move successful and repairs telemetry on explicit replay', async () => {
+    const { service, telemetry } = await createFixture(storageType);
+    const moving = await service.createTask({ title: 'Moving task' });
+    const request = {
+      operationId: '00000000-0000-4000-8000-000000000007',
+      expectedRevision: moving.revision ?? 1,
+      sourceStatus: 'todo',
+      sourcePosition: null,
+      destinationStatus: 'blocked',
+      destinationIndex: 0,
+      updatedBy: 'user:test',
+    } as const;
+    const emit = vi.spyOn(telemetry, 'emit').mockRejectedValue(new Error('disk unavailable'));
+
+    await expect(service.moveTask(moving.id, request)).resolves.toMatchObject({ replayed: false });
+    expect(await service.getTask(moving.id)).toMatchObject({ status: 'blocked', revision: 2 });
+    await expect(
+      service.moveTask(moving.id, {
+        ...request,
+        operationId: '00000000-0000-4000-8000-000000000014',
+        expectedRevision: 2,
+        sourceStatus: 'blocked',
+        sourcePosition: 0,
+        destinationStatus: 'todo',
+      })
+    ).rejects.toMatchObject({ code: 'INTERNAL_ERROR' });
+
+    emit.mockRestore();
+    const replay = await service.moveTask(moving.id, request);
+    const statusEvents = (await telemetry.getTaskEvents(moving.id)).filter(
+      (event) =>
+        event.type === 'task.status_changed' &&
+        'operationId' in event &&
+        event.operationId === request.operationId
+    );
+
+    expect(replay?.replayed).toBe(true);
+    expect(statusEvents).toHaveLength(1);
+    const completed = await service.markBoardMoveAuditComplete(moving.id, request.operationId);
+    expect(completed).toMatchObject({
+      revision: 2,
+      lastBoardMove: {
+        operationId: request.operationId,
+        auditCompletedAt: expect.any(String),
+      },
+    });
+    expect(await service.getTask(moving.id)).toMatchObject({
+      revision: 2,
+      lastBoardMove: { auditCompletedAt: expect.any(String) },
+    });
+  });
+
+  it('serializes rapid duplicate submissions of the same operation', async () => {
+    const { service } = await createFixture(storageType);
+    const moving = await service.createTask({ title: 'Moving task' });
+    const request = {
+      operationId: '00000000-0000-4000-8000-000000000004',
+      expectedRevision: moving.revision ?? 1,
+      sourceStatus: 'todo',
+      sourcePosition: null,
+      destinationStatus: 'blocked',
+      destinationIndex: 0,
+      updatedBy: 'user:test',
+    } as const;
+
+    const results = await Promise.all([
+      service.moveTask(moving.id, request),
+      service.moveTask(moving.id, request),
+    ]);
+
+    expect(results.map((result) => result?.replayed).sort()).toEqual([false, true]);
+    expect((await service.getTask(moving.id))?.revision).toBe((moving.revision ?? 1) + 1);
+  });
+
+  it('commits only one of two distinct rapid operations from the same source revision', async () => {
+    const { service } = await createFixture(storageType);
+    const moving = await service.createTask({ title: 'Moving task' });
+    const request = {
+      expectedRevision: moving.revision ?? 1,
+      sourceStatus: 'todo',
+      sourcePosition: null,
+      destinationStatus: 'blocked',
+      destinationIndex: 0,
+      updatedBy: 'user:test',
+    } as const;
+
+    const results = await Promise.allSettled([
+      service.moveTask(moving.id, {
+        ...request,
+        operationId: '00000000-0000-4000-8000-000000000008',
+      }),
+      service.moveTask(moving.id, {
+        ...request,
+        operationId: '00000000-0000-4000-8000-000000000009',
+      }),
+    ]);
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect(results.find((result) => result.status === 'rejected')).toMatchObject({
+      reason: { code: 'CONFLICT' },
+    });
+    expect(await service.getTask(moving.id)).toMatchObject({ status: 'blocked', revision: 2 });
+  });
+
+  it('persists the requested order between legacy unpositioned tasks', async () => {
+    const { service } = await createFixture(storageType);
+    const moving = await service.createTask({ title: 'Moving task' });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T10:00:00.000Z'));
+    const older = await service.createTask({ title: 'Older blocked task', status: 'blocked' });
+    vi.setSystemTime(new Date('2026-08-01T10:00:01.000Z'));
+    const newer = await service.createTask({ title: 'Newer blocked task', status: 'blocked' });
+    vi.useRealTimers();
+
+    const result = await service.moveTask(moving.id, {
+      operationId: '00000000-0000-4000-8000-000000000005',
+      expectedRevision: moving.revision ?? 1,
+      sourceStatus: 'todo',
+      sourcePosition: null,
+      destinationStatus: 'blocked',
+      destinationIndex: 1,
+      updatedBy: 'user:test',
+    });
+
+    expect(result?.orderedTaskIds).toEqual([newer.id, moving.id, older.id]);
+    expect(
+      (
+        await service.moveTask(moving.id, {
+          operationId: '00000000-0000-4000-8000-000000000005',
+          expectedRevision: moving.revision ?? 1,
+          sourceStatus: 'todo',
+          sourcePosition: null,
+          destinationStatus: 'blocked',
+          destinationIndex: 1,
+          updatedBy: 'user:test',
+        })
+      )?.orderedTaskIds
+    ).toEqual([newer.id, moving.id, older.id]);
+    const persistedNewer = await service.getTask(newer.id);
+    const persistedOlder = await service.getTask(older.id);
+    expect(persistedNewer?.position).toBeUndefined();
+    expect(persistedNewer?.revision).toBe(newer.revision);
+    expect(persistedOlder?.position).toBeUndefined();
+    expect(persistedOlder?.revision).toBe(older.revision);
+  });
+
+  it('persists insertion between tasks with the same legacy position', async () => {
+    const { service } = await createFixture(storageType);
+    const moving = await service.createTask({ title: 'Moving task' });
+    const left = await service.createTask({ title: 'Equal position A', status: 'blocked' });
+    const right = await service.createTask({ title: 'Equal position B', status: 'blocked' });
+    await service.updateTask(left.id, { position: 0 });
+    await service.updateTask(right.id, { position: 0 });
+    const equalNeighbors = sortTasksByBoardPosition(
+      (await service.listTasks()).filter((task) => task.status === 'blocked')
+    );
+
+    const result = await service.moveTask(moving.id, {
+      operationId: '00000000-0000-4000-8000-000000000012',
+      expectedRevision: moving.revision ?? 1,
+      sourceStatus: 'todo',
+      sourcePosition: null,
+      destinationStatus: 'blocked',
+      destinationIndex: 1,
+      updatedBy: 'user:test',
+    });
+
+    const persisted = sortTasksByBoardPosition(
+      (await service.listTasks()).filter((task) => task.status === 'blocked')
+    );
+    const expectedOrder = [equalNeighbors[0].id, moving.id, equalNeighbors[1].id];
+    expect(result?.orderedTaskIds).toEqual(expectedOrder);
+    expect(persisted.map((task) => task.id)).toEqual(expectedOrder);
+  });
+
+  it('serializes position writers before resolving destination neighbors', async () => {
+    const { service } = await createFixture(storageType);
+    const moving = await service.createTask({ title: 'Moving task' });
+    const first = await service.createTask({ title: 'First blocked task', status: 'blocked' });
+    const second = await service.createTask({ title: 'Second blocked task', status: 'blocked' });
+    await service.updateTask(first.id, { position: 0 });
+    await service.updateTask(second.id, { position: 1 });
+
+    const positionWrite = service.updateTask(first.id, { position: 2 });
+    const move = service.moveTask(moving.id, {
+      operationId: '00000000-0000-4000-8000-000000000006',
+      expectedRevision: moving.revision ?? 1,
+      sourceStatus: 'todo',
+      sourcePosition: null,
+      destinationStatus: 'blocked',
+      destinationIndex: 1,
+      updatedBy: 'user:test',
+    });
+    await positionWrite;
+    const result = await move;
+
+    expect(result?.orderedTaskIds).toEqual([second.id, moving.id, first.id]);
+    expect(result?.task.position).toBe(1.5);
+  });
+
+  it('uses exact ranks through repeated insertions without rewriting neighbors', async () => {
+    const { service } = await createFixture(storageType);
+    const movingTasks = await Promise.all(
+      Array.from({ length: 64 }, (_, index) =>
+        service.createTask({ title: `Moving task ${index + 1}` })
+      )
+    );
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T10:00:00.000Z'));
+    const older = await service.createTask({ title: 'Older blocked task', status: 'blocked' });
+    vi.setSystemTime(new Date('2026-08-01T10:00:01.000Z'));
+    const newer = await service.createTask({ title: 'Newer blocked task', status: 'blocked' });
+    vi.useRealTimers();
+
+    for (const [index, moving] of movingTasks.entries()) {
+      await expect(
+        service.moveTask(moving.id, {
+          operationId: `00000000-0000-4000-8000-${String(index + 100).padStart(12, '0')}`,
+          expectedRevision: moving.revision ?? 1,
+          sourceStatus: 'todo',
+          sourcePosition: null,
+          destinationStatus: 'blocked',
+          destinationIndex: 1,
+          updatedBy: 'user:test',
+        })
+      ).resolves.toMatchObject({ replayed: false });
+    }
+
+    const ordered = sortTasksByBoardPosition(
+      (await service.listTasks()).filter((task) => task.status === 'blocked')
+    );
+    expect(ordered.map((task) => task.id)).toEqual([
+      newer.id,
+      ...movingTasks.map((task) => task.id).reverse(),
+      older.id,
+    ]);
+    expect(ordered.filter((task) => task.boardRank?.startsWith('v1:'))).toHaveLength(64);
+    const persistedNewer = await service.getTask(newer.id);
+    const persistedOlder = await service.getTask(older.id);
+    expect(persistedNewer?.position).toBeUndefined();
+    expect(persistedNewer?.revision).toBe(newer.revision);
+    expect(persistedOlder?.position).toBeUndefined();
+    expect(persistedOlder?.revision).toBe(older.revision);
+  });
+
+  it('reloads the persisted status and exact order from storage', async () => {
+    const fixture = await createFixture(storageType);
+    const first = await fixture.service.createTask({ title: 'First blocked', status: 'blocked' });
+    const moving = await fixture.service.createTask({ title: 'Moving task' });
+    await fixture.service.moveTask(moving.id, {
+      operationId: '00000000-0000-4000-8000-000000000010',
+      expectedRevision: moving.revision ?? 1,
+      sourceStatus: 'todo',
+      sourcePosition: null,
+      destinationStatus: 'blocked',
+      destinationIndex: 0,
+      updatedBy: 'user:test',
+    });
+
+    fixture.service.dispose();
+    fixture.service = new TaskService({
+      storageType,
+      sqliteDatabase: fixture.sqlite?.database,
+      tasksDir: path.join(fixture.root, 'tasks', 'active'),
+      archiveDir: path.join(fixture.root, 'tasks', 'archive'),
+      telemetryService: fixture.telemetry,
+    });
+
+    const reloaded = sortTasksByBoardPosition(
+      (await fixture.service.listTasks()).filter((task) => task.status === 'blocked')
+    );
+    expect(reloaded.map((task) => task.id)).toEqual([moving.id, first.id]);
+    expect(reloaded[0]).toMatchObject({
+      status: 'blocked',
+      boardRank: expect.stringMatching(/^v1:/),
+      revision: 2,
+    });
+  });
+});

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -11,28 +11,148 @@ import {
   BOARD_COLUMN_ID_PATTERN,
   type CreateTaskInput,
   type UpdateTaskInput,
+  type Task,
+  type TaskBoardMoveReceipt,
   type TaskSummary,
+  type MoveTaskInput,
 } from '@veritas-kanban/shared';
 import { broadcastTaskChange } from '../services/broadcast-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
-import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { InternalError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { sendPaginated } from '../middleware/response-envelope.js';
 import { setLastModified } from '../middleware/cache-control.js';
 import { sanitizeTaskFields } from '../utils/sanitize.js';
 import { auditLog } from '../services/audit-service.js';
 import { authorizePermission, type AuthenticatedRequest } from '../middleware/auth.js';
-import { actorFromRequest, assertFreshRevision, setRevisionHeaders } from '../utils/concurrency.js';
+import {
+  actorFromRequest,
+  assertFreshRevision,
+  expectedRevisionFromRequest,
+  setRevisionHeaders,
+} from '../utils/concurrency.js';
 import type { TaskIdentityDiagnostics } from '../services/task-identity-diagnostics.js';
 import { TaskExecutionPolicySchema } from '../schemas/task-envelope-schemas.js';
-import { ReorderTasksBodySchema } from '../schemas/task-mutation-schemas.js';
+import { MoveTaskBodySchema, ReorderTasksBodySchema } from '../schemas/task-mutation-schemas.js';
 import { GitBranchNameSchema } from '../schemas/git-ref-schemas.js';
+import { createLogger } from '../lib/logger.js';
 
 const router: RouterType = Router();
+const log = createLogger('tasks-route');
 const taskService = getTaskService();
 const worktreeService = new WorktreeService();
 const blockingService = getBlockingService();
 const delegationService = getDelegationService();
 const progressService = getProgressService();
+const BOARD_MOVE_ACTIVITY_RETRY_DELAYS_MS = [0, 100, 1_000, 5_000] as const;
+const reconciledBoardMoveOperations = new Set<string>();
+const boardMoveAuditReconciliations = new Map<string, Promise<boolean>>();
+
+function writeBoardMoveActivity(task: Task, receipt: TaskBoardMoveReceipt) {
+  const actor = task.updatedBy ?? 'system:unknown';
+  return activityService.logActivityOnce(
+    receipt.operationId,
+    receipt.sourceStatus === task.status ? 'task_updated' : 'status_changed',
+    task.id,
+    task.title,
+    {
+      from: receipt.sourceStatus,
+      status: task.status,
+      position: task.position,
+      actor,
+    },
+    task.agent,
+    actor
+  );
+}
+
+function waitForBoardMoveActivityRetry(delayMs: number): Promise<void> {
+  if (delayMs === 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, delayMs);
+    timer.unref();
+  });
+}
+
+async function retryBoardMoveActivity(
+  task: Task,
+  writeActivity: () => ReturnType<typeof activityService.logActivityOnce>
+): Promise<void> {
+  const operationId = task.lastBoardMove?.operationId;
+  if (!operationId) return;
+  for (const delayMs of BOARD_MOVE_ACTIVITY_RETRY_DELAYS_MS) {
+    await waitForBoardMoveActivityRetry(delayMs);
+    try {
+      const repaired = await writeActivity();
+      if (await finalizeBoardMoveAudit(task)) {
+        if (repaired.created) {
+          broadcastTaskChange('updated', task.id, undefined, { operationId });
+        }
+        return;
+      }
+    } catch {
+      // Continue through the bounded retry schedule.
+    }
+  }
+  log.error({ taskId: task.id, operationId }, 'Board move activity retry schedule exhausted');
+}
+
+async function finalizeBoardMoveAudit(task: Task): Promise<boolean> {
+  const receipt = task.lastBoardMove;
+  if (!receipt) return true;
+  if (receipt.auditCompletedAt) return true;
+  if (!(await taskService.reconcileBoardMoveTelemetry(task))) return false;
+  const completed = await taskService.markBoardMoveAuditComplete(task.id, receipt.operationId);
+  return (
+    completed?.lastBoardMove?.operationId === receipt.operationId &&
+    typeof completed.lastBoardMove.auditCompletedAt === 'string'
+  );
+}
+
+async function reconcileBoardMoveAudit(task: Task): Promise<boolean> {
+  if (!task.lastBoardMove) return true;
+  const receipt = task.lastBoardMove;
+  const operationId = receipt.operationId;
+  const reconciliationKey = `${task.id}:${operationId}`;
+  if (receipt.auditCompletedAt) {
+    reconciledBoardMoveOperations.add(reconciliationKey);
+    return true;
+  }
+  if (reconciledBoardMoveOperations.has(reconciliationKey)) return true;
+  const pending = boardMoveAuditReconciliations.get(reconciliationKey);
+  if (pending) return pending;
+
+  const reconciliation = (async () => {
+    try {
+      const [activity, telemetryReady] = await Promise.all([
+        writeBoardMoveActivity(task, receipt),
+        taskService.reconcileBoardMoveTelemetry(task),
+      ]);
+      if (!telemetryReady) return false;
+      const completed = await taskService.markBoardMoveAuditComplete(task.id, operationId);
+      if (
+        completed?.lastBoardMove?.operationId !== operationId ||
+        !completed.lastBoardMove.auditCompletedAt
+      ) {
+        return false;
+      }
+      reconciledBoardMoveOperations.add(reconciliationKey);
+      if (activity.created) {
+        broadcastTaskChange('updated', task.id, undefined, { operationId });
+      }
+      return true;
+    } catch (error) {
+      log.warn(
+        { taskId: task.id, operationId, err: error },
+        'Board move audit reconciliation remains pending'
+      );
+      return false;
+    } finally {
+      boardMoveAuditReconciliations.delete(reconciliationKey);
+    }
+  })();
+  boardMoveAuditReconciliations.set(reconciliationKey, reconciliation);
+  return reconciliation;
+}
 
 function requireAdminForCleanupOverride(
   req: AuthenticatedRequest,
@@ -324,6 +444,9 @@ router.get(
   '/',
   asyncHandler(async (req, res) => {
     let tasks = await taskService.listTasks();
+    for (const task of tasks) {
+      if (task.lastBoardMove) void reconcileBoardMoveAudit(task);
+    }
     attachTaskIdentityDiagnostics(res, await getRouteTaskIdentityDiagnostics());
 
     // --- Filtering ---
@@ -416,6 +539,7 @@ router.get(
         blockedBy: task.blockedBy,
         blockedReason: task.blockedReason,
         position: task.position,
+        boardRank: task.boardRank,
         attachmentCount: task.attachments?.length ?? 0,
         deliverableCount: task.deliverables?.length ?? 0,
         github: task.github,
@@ -560,6 +684,139 @@ router.post(
     const updated = await taskService.reorderTasks(orderedIds);
     broadcastTaskChange('reordered');
     res.json({ updated: updated.length });
+  })
+);
+
+/**
+ * @openapi
+ * /api/tasks/{id}/move:
+ *   post:
+ *     summary: Atomically move a task on the board
+ *     tags: [Tasks]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *       - in: header
+ *         name: If-Match
+ *         required: true
+ *         schema: { type: string }
+ *         description: ETag containing the task revision loaded by the client
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [operationId, sourceStatus, sourcePosition, destinationStatus, destinationIndex]
+ *             properties:
+ *               operationId: { type: string, format: uuid }
+ *               sourceStatus: { type: string }
+ *               sourcePosition: { type: number, nullable: true }
+ *               destinationStatus: { type: string }
+ *               destinationIndex: { type: integer, minimum: 0 }
+ *     responses:
+ *       200:
+ *         description: Committed or idempotently replayed board move
+ *       409:
+ *         description: Stale task state or reused operation ID
+ */
+router.post(
+  '/:id/move',
+  asyncHandler(async (req, res) => {
+    let parsed: Omit<MoveTaskInput, 'updatedBy'>;
+    try {
+      parsed = MoveTaskBodySchema.parse(req.body) as Omit<MoveTaskInput, 'updatedBy'>;
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+
+    const taskId = req.params.id as string;
+    const oldTask = await taskService.getTask(taskId);
+    if (!oldTask) throw new NotFoundError('Task not found');
+    if (
+      oldTask.lastBoardMove &&
+      oldTask.lastBoardMove.operationId !== parsed.operationId &&
+      !(await reconcileBoardMoveAudit(oldTask))
+    ) {
+      throw new InternalError(
+        'The previous board move is committed but its audit record is still pending. Retry shortly.'
+      );
+    }
+    const expectedRevision = expectedRevisionFromRequest(req);
+    if (expectedRevision === undefined) {
+      throw new ValidationError('A task revision is required for board moves', [
+        {
+          code: 'EXPECTED_REVISION_REQUIRED',
+          message: 'Send the current task revision with If-Match',
+          path: ['expectedRevision'],
+        },
+      ]);
+    }
+
+    if (
+      parsed.destinationStatus === 'in-progress' &&
+      oldTask.status !== 'in-progress' &&
+      (oldTask.blockedBy?.length || oldTask.dependencies?.depends_on?.length)
+    ) {
+      const allTasks = await taskService.listTasks();
+      const { allowed, blockers } = blockingService.canMoveToInProgress(oldTask, allTasks);
+      if (!allowed) throw new ValidationError('Task is blocked', { blockedBy: blockers });
+    }
+
+    const actor = actorFromRequest(req as AuthenticatedRequest);
+    const result = await taskService.moveTask(taskId, {
+      ...parsed,
+      expectedRevision,
+      updatedBy: actor,
+    });
+    if (!result) throw new NotFoundError('Task not found');
+
+    const moveSourceStatus = result.task.lastBoardMove?.sourceStatus ?? oldTask.status;
+    let activityCreated = false;
+    const writeMoveActivity = () =>
+      writeBoardMoveActivity(result.task, {
+        ...(result.task.lastBoardMove ?? parsed),
+        operationId: result.operationId,
+        sourceStatus: moveSourceStatus,
+        completedAt: result.task.lastBoardMove?.completedAt ?? result.task.updated,
+      });
+    try {
+      const moveActivity = await writeMoveActivity();
+      activityCreated = moveActivity.created;
+      await finalizeBoardMoveAudit(result.task);
+    } catch (error) {
+      log.warn(
+        { taskId: result.task.id, operationId: result.operationId, err: error },
+        'Board move activity will be retried in the background'
+      );
+      void retryBoardMoveActivity(result.task, writeMoveActivity);
+    }
+
+    if (!result.replayed) {
+      broadcastTaskChange('moved', result.task.id, undefined, {
+        operationId: result.operationId,
+      });
+    } else if (activityCreated) {
+      broadcastTaskChange('updated', result.task.id, undefined, {
+        operationId: result.operationId,
+      });
+    }
+
+    if (moveSourceStatus !== result.task.status && result.task.github) {
+      getGitHubSyncService()
+        .syncTaskStatusToGitHub(result.task)
+        .catch(() => {
+          /* intentionally silent - don't fail the API call */
+        });
+    }
+
+    setRevisionHeaders(res, 'task', result.task.id, result.task);
+    res.json(result);
   })
 );
 

--- a/server/src/schemas/task-mutation-schemas.ts
+++ b/server/src/schemas/task-mutation-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BOARD_COLUMN_ID_PATTERN } from '@veritas-kanban/shared';
 
 export const MAX_TASK_REORDER_ITEMS = 1_000;
 
@@ -13,6 +14,20 @@ export const ReorderTasksBodySchema = z.object({
 });
 
 export type ReorderTasksBody = z.infer<typeof ReorderTasksBodySchema>;
+
+/**
+ * POST /api/tasks/:id/move - Atomically move one task on the board.
+ */
+export const MoveTaskBodySchema = z.object({
+  operationId: z.string().uuid(),
+  sourceStatus: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN),
+  sourcePosition: z.number().finite().nullable(),
+  destinationStatus: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN),
+  destinationIndex: z.number().int().min(0).max(MAX_TASK_REORDER_ITEMS),
+  expectedRevision: z.number().int().min(0).optional(),
+});
+
+export type MoveTaskBody = z.infer<typeof MoveTaskBodySchema>;
 
 /**
  * POST /api/tasks/:id/apply-template - Apply template to existing task

--- a/server/src/services/activity-service.ts
+++ b/server/src/services/activity-service.ts
@@ -57,6 +57,11 @@ export interface ActivityPage {
   total: number;
 }
 
+export interface ActivityLogOnceResult {
+  activity: Activity;
+  created: boolean;
+}
+
 export interface ActivityServiceOptions {
   activityFile?: string;
   activityDir?: string;
@@ -73,6 +78,7 @@ export class ActivityService {
   private appendRepository: AppendActivityRepository | null = null;
   private sqliteDatabase: SqliteDatabase | null = null;
   private ownsSqliteDatabase = false;
+  private activityMutationQueue: Promise<unknown> = Promise.resolve();
 
   constructor(options: ActivityServiceOptions = {}) {
     this.activityFile = options.activityFile || join(getDataDir(), 'activity.json');
@@ -231,6 +237,46 @@ export class ActivityService {
 
     // Fallback (should not reach here)
     throw new Error('No activity repository configured');
+  }
+
+  /**
+   * Persist one activity for an idempotent operation. Retries after a task
+   * commit can safely repair a failed activity write without duplicating it.
+   */
+  async logActivityOnce(
+    operationId: string,
+    type: ActivityType,
+    taskId: string,
+    taskTitle: string,
+    details?: Record<string, unknown>,
+    agent?: string,
+    actor?: string
+  ): Promise<ActivityLogOnceResult> {
+    const run = this.activityMutationQueue.then(async () => {
+      const existing = (
+        await this.getActivities(this.MAX_ACTIVITIES, {
+          taskId,
+        })
+      ).find((activity) => activity.details?.operationId === operationId);
+      if (existing) return { activity: existing, created: false };
+
+      return {
+        activity: await this.logActivity(
+          type,
+          taskId,
+          taskTitle,
+          { ...details, operationId },
+          agent,
+          actor
+        ),
+        created: true,
+      };
+    });
+    this.activityMutationQueue = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
   }
 
   async clearActivities(): Promise<void> {

--- a/server/src/services/broadcast-service.ts
+++ b/server/src/services/broadcast-service.ts
@@ -115,7 +115,7 @@ function broadcastToClients(payload: string, options: WebSocketDeliveryOptions =
 }
 
 export type TaskChangeType =
-  'created' | 'updated' | 'deleted' | 'archived' | 'restored' | 'reordered';
+  'created' | 'updated' | 'deleted' | 'archived' | 'restored' | 'reordered' | 'moved';
 
 export interface TaskChangeEvent {
   type: 'task:changed';
@@ -124,6 +124,7 @@ export interface TaskChangeEvent {
   timestamp: string;
   sequence: number;
   workspaceId: string;
+  operationId?: string;
 }
 
 export interface TelemetryBroadcastEvent {
@@ -144,7 +145,7 @@ export function broadcastTaskChange(
   changeType: TaskChangeType,
   taskId?: string,
   taskContext?: TaskContext,
-  options: { workspaceId?: string } = {}
+  options: { workspaceId?: string; operationId?: string } = {}
 ): void {
   if (!wssRef) return;
   const workspaceId = normalizeWorkspaceId(options.workspaceId);
@@ -156,6 +157,7 @@ export function broadcastTaskChange(
     timestamp: new Date().toISOString(),
     sequence: nextWebSocketEventSequence(),
     workspaceId,
+    ...(options.operationId ? { operationId: options.operationId } : {}),
   };
 
   const payload = JSON.stringify(message);

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -10,12 +10,26 @@ import type {
   BoardColumnConfig,
   TaskStatus,
   TaskAttempt,
+  MoveTaskInput,
+  MoveTaskResult,
+  TaskBoardMoveReceipt,
 } from '@veritas-kanban/shared';
-import { normalizeBoardColumns, normalizeBoardDefaultStatus } from '@veritas-kanban/shared';
+import {
+  normalizeBoardColumns,
+  normalizeBoardDefaultStatus,
+  sortTasksByBoardPosition,
+  taskBoardRankAtIndex,
+  taskBoardPositionAtIndex,
+} from '@veritas-kanban/shared';
 import { getTelemetryService, type TelemetryService } from './telemetry-service.js';
 import { ConfigService } from './config-service.js';
 import { createLogger } from '../lib/logger.js';
-import { ConflictError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import {
+  ConflictError,
+  InternalError,
+  NotFoundError,
+  ValidationError,
+} from '../middleware/error-handler.js';
 import { fireHook, getHookEventForStatusChange } from './hook-service.js';
 import {
   validateTransition,
@@ -58,6 +72,20 @@ function normalizedTaskRevision(task: Pick<Task, 'revision'>): number {
     : 1;
 }
 
+function normalizedBoardPosition(task: Pick<Task, 'position'>): number | null {
+  return typeof task.position === 'number' && Number.isFinite(task.position) ? task.position : null;
+}
+
+function boardMoveReceiptMatches(receipt: TaskBoardMoveReceipt, input: MoveTaskInput): boolean {
+  return (
+    receipt.operationId === input.operationId &&
+    receipt.sourceStatus === input.sourceStatus &&
+    receipt.sourcePosition === input.sourcePosition &&
+    receipt.destinationStatus === input.destinationStatus &&
+    receipt.destinationIndex === input.destinationIndex
+  );
+}
+
 interface BoardStatusConfig {
   columns: BoardColumnConfig[];
   defaultStatus: TaskStatus;
@@ -66,6 +94,8 @@ interface BoardStatusConfig {
 
 type TaskMutationInput = UpdateTaskInput & {
   attemptPatch?: Pick<TaskAttempt, 'id'> & Partial<Omit<TaskAttempt, 'id'>>;
+  lastBoardMove?: TaskBoardMoveReceipt;
+  boardRank?: string | null;
 };
 
 // Default paths are resolved via the shared paths utility so Docker, tests,
@@ -97,6 +127,7 @@ export class TaskService {
   private sqliteTasks: SqliteTaskRepository | null = null;
   private fileTasks: FileTaskRepository | null = null;
   private sqliteMutationQueue: Promise<unknown> = Promise.resolve();
+  private boardMoveQueue: Promise<unknown> = Promise.resolve();
   private taskMutationQueues = new Map<string, Promise<void>>();
   private configService: Pick<ConfigService, 'getFeatureSettings'>;
   private ceremonyService: Pick<CeremonyService, 'evaluateTaskCompletion'>;
@@ -224,6 +255,139 @@ export class TaskService {
       release();
       if (this.taskMutationQueues.get(id) === current) this.taskMutationQueues.delete(id);
     });
+  }
+
+  private withBoardMoveMutex<T>(callback: (commitStorage: () => void) => Promise<T>): Promise<T> {
+    const storageLockedCallback = async (): Promise<T> => {
+      if (this.sqliteDatabase) {
+        return this.runSqliteMutation(async () => {
+          const database = this.sqliteDatabase?.getConnection();
+          if (!database) throw new Error('SQLite task storage is unavailable');
+          database.exec('BEGIN IMMEDIATE;');
+          let transactionOpen = true;
+          const commitStorage = () => {
+            if (!transactionOpen) return;
+            database.exec('COMMIT;');
+            transactionOpen = false;
+          };
+          try {
+            const result = await callback(commitStorage);
+            commitStorage();
+            return result;
+          } catch (error) {
+            if (transactionOpen) {
+              try {
+                database.exec('ROLLBACK;');
+              } catch {
+                // Preserve the original failure.
+              }
+            }
+            throw error;
+          }
+        });
+      }
+
+      return this.requireFileTasks().withBoardMutation(async () => {
+        await this.loadCacheFromDisk();
+        return callback(() => undefined);
+      });
+    };
+    const run = this.boardMoveQueue.then(storageLockedCallback, storageLockedCallback);
+    this.boardMoveQueue = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
+  private async ensureBoardMoveTelemetry(
+    task: Task,
+    receipt: TaskBoardMoveReceipt
+  ): Promise<boolean> {
+    if (!this.telemetry.isEnabled() || receipt.sourceStatus === task.status) return true;
+
+    try {
+      const wasRecorded = async (): Promise<boolean> =>
+        (await this.telemetry.getTaskEvents(task.id)).some(
+          (event) =>
+            event.type === 'task.status_changed' &&
+            'operationId' in event &&
+            event.operationId === receipt.operationId
+        );
+      if (await wasRecorded()) return true;
+
+      await this.telemetry.emit<TaskTelemetryEvent>({
+        type: 'task.status_changed',
+        taskId: task.id,
+        project: task.project,
+        status: task.status,
+        previousStatus: receipt.sourceStatus,
+        operationId: receipt.operationId,
+      });
+      return wasRecorded();
+    } catch (error) {
+      log.warn(
+        { taskId: task.id, operationId: receipt.operationId, err: error },
+        'Board move telemetry will be retried if the operation is replayed'
+      );
+      return false;
+    }
+  }
+
+  async reconcileBoardMoveTelemetry(task: Task): Promise<boolean> {
+    if (!task.lastBoardMove || task.lastBoardMove.auditCompletedAt) return true;
+    return this.ensureBoardMoveTelemetry(task, task.lastBoardMove);
+  }
+
+  async markBoardMoveAuditComplete(id: string, operationId: string): Promise<Task | null> {
+    return this.withBoardMoveMutex(() =>
+      this.withTaskMutex(id, async () => {
+        if (this.sqliteTasks) {
+          const current = await this.sqliteTasks.findById(id);
+          if (!current) return null;
+          if (
+            current.lastBoardMove?.operationId !== operationId ||
+            current.lastBoardMove.auditCompletedAt
+          ) {
+            return current;
+          }
+          const completed: Task = {
+            ...current,
+            lastBoardMove: {
+              ...current.lastBoardMove,
+              auditCompletedAt: new Date().toISOString(),
+            },
+          };
+          await this.sqliteTasks.replaceActive(completed);
+          return completed;
+        }
+
+        let completed: Task | null = null;
+        const result = await this.requireFileTasks().withActiveMutation(
+          id,
+          async (current, persist) => {
+            if (
+              current.lastBoardMove?.operationId !== operationId ||
+              current.lastBoardMove.auditCompletedAt
+            ) {
+              completed = current;
+              return true;
+            }
+            completed = {
+              ...current,
+              lastBoardMove: {
+                ...current.lastBoardMove,
+                auditCompletedAt: new Date().toISOString(),
+              },
+            };
+            await persist(completed);
+            this.cache.set(id, completed);
+            return true;
+          }
+        );
+        return result === null ? null : completed;
+      })
+    );
   }
 
   /** Get a task from the cache */
@@ -618,7 +782,22 @@ export class TaskService {
   }
 
   async updateTask(id: string, input: UpdateTaskInput): Promise<Task | null> {
-    return this.withTaskMutex(id, () => this.updateTaskMutation(id, input));
+    const affectsBoard = input.position !== undefined || input.status !== undefined;
+    const mutationInput: TaskMutationInput =
+      input.position !== undefined ? { ...input, boardRank: null } : input;
+    if (affectsBoard) {
+      return this.withBoardMoveMutex((commitStorage) =>
+        this.withTaskMutex(id, () =>
+          this.updateTaskMutation(id, mutationInput, true, commitStorage)
+        )
+      );
+    }
+    if (this.sqliteTasks) {
+      return this.runSqliteMutation(() =>
+        this.withTaskMutex(id, () => this.updateTaskMutation(id, mutationInput, true))
+      );
+    }
+    return this.withTaskMutex(id, () => this.updateTaskMutation(id, mutationInput));
   }
 
   async patchTaskAttempt(
@@ -629,10 +808,20 @@ export class TaskService {
     const input: TaskMutationInput = {
       attemptPatch: { id: attemptId, ...patch },
     };
+    if (this.sqliteTasks) {
+      return this.runSqliteMutation(() =>
+        this.withTaskMutex(id, () => this.updateTaskMutation(id, input, true))
+      );
+    }
     return this.withTaskMutex(id, () => this.updateTaskMutation(id, input));
   }
 
-  private async updateTaskMutation(id: string, input: TaskMutationInput): Promise<Task | null> {
+  private async updateTaskMutation(
+    id: string,
+    input: TaskMutationInput,
+    boardStorageLocked = false,
+    afterPersistence?: () => void
+  ): Promise<Task | null> {
     await this.assertTaskIdentityIntegrity('task.update', id);
 
     // Initial read to check existence and compute the lock filepath.
@@ -646,6 +835,7 @@ export class TaskService {
       git: gitUpdate,
       github: githubUpdate,
       blockedReason: blockedReasonUpdate,
+      boardRank: boardRankUpdate,
       expectedRevision: _expectedRevision,
       attemptPatch,
       ...restInput
@@ -659,7 +849,8 @@ export class TaskService {
     let mutationFound = true;
     const runMutation = async (callback: () => Promise<void>): Promise<void> => {
       if (this.sqliteTasks) {
-        await this.runSqliteMutation(callback);
+        if (boardStorageLocked) await callback();
+        else await this.runSqliteMutation(callback);
         return;
       }
 
@@ -898,6 +1089,7 @@ export class TaskService {
               : freshTask.attempt,
         git: gitUpdate ? ({ ...freshTask.git, ...gitUpdate } as Task['git']) : freshTask.git,
         github: githubUpdate ?? freshTask.github,
+        boardRank: boardRankUpdate === null ? undefined : (boardRankUpdate ?? freshTask.boardRank),
         // Handle blockedReason: null means clear, undefined means keep existing
         blockedReason:
           blockedReasonUpdate === null
@@ -931,18 +1123,34 @@ export class TaskService {
         this.identityDiagnosticsCache = null;
         this.cache.set(updatedTask.id, updatedTask);
       }
+      afterPersistence?.();
 
       // Emit telemetry event if status changed
       if (statusChanged) {
-        this.syncAgentRegistryForStatusTransition(updatedTask);
+        if (input.lastBoardMove) {
+          try {
+            this.syncAgentRegistryForStatusTransition(updatedTask);
+          } catch (error) {
+            log.warn(
+              { taskId: updatedTask.id, operationId: input.lastBoardMove.operationId, err: error },
+              'Board move agent registry sync will be repaired by reconciliation'
+            );
+          }
+        } else {
+          this.syncAgentRegistryForStatusTransition(updatedTask);
+        }
 
-        await this.telemetry.emit<TaskTelemetryEvent>({
-          type: 'task.status_changed',
-          taskId: updatedTask.id,
-          project: updatedTask.project,
-          status: updatedTask.status,
-          previousStatus,
-        });
+        if (input.lastBoardMove) {
+          await this.ensureBoardMoveTelemetry(updatedTask, input.lastBoardMove);
+        } else {
+          await this.telemetry.emit<TaskTelemetryEvent>({
+            type: 'task.status_changed',
+            taskId: updatedTask.id,
+            project: updatedTask.project,
+            status: updatedTask.status,
+            previousStatus,
+          });
+        }
 
         // Fire lifecycle hook if applicable
         const hookEvent = getHookEventForStatusChange(previousStatus, updatedTask.status);
@@ -1064,10 +1272,15 @@ export class TaskService {
   }
 
   async deleteTask(id: string): Promise<boolean> {
+    if (this.sqliteTasks) {
+      return this.runSqliteMutation(() =>
+        this.withTaskMutex(id, () => this.deleteTaskMutation(id, true))
+      );
+    }
     return this.withTaskMutex(id, () => this.deleteTaskMutation(id));
   }
 
-  private async deleteTaskMutation(id: string): Promise<boolean> {
+  private async deleteTaskMutation(id: string, sqliteStorageLocked = false): Promise<boolean> {
     if (this.sqliteTasks) {
       await this.assertTaskIdentityIntegrity('task.delete', id, {
         allowSameLocationTaskIdDuplicates: true,
@@ -1076,7 +1289,9 @@ export class TaskService {
       if (!task) return false;
 
       const sqliteTasks = this.sqliteTasks;
-      return this.runSqliteMutation(() => sqliteTasks.deleteActive(id));
+      return sqliteStorageLocked
+        ? sqliteTasks.deleteActive(id)
+        : this.runSqliteMutation(() => sqliteTasks.deleteActive(id));
     }
 
     await this.assertTaskIdentityIntegrity('task.delete', id, {
@@ -1099,12 +1314,18 @@ export class TaskService {
     id: string,
     options?: { deletedAt?: string; deletedBy?: string; purgeAfter?: string }
   ): Promise<boolean> {
+    if (this.sqliteTasks) {
+      return this.runSqliteMutation(() =>
+        this.withTaskMutex(id, () => this.archiveTaskMutation(id, options, true))
+      );
+    }
     return this.withTaskMutex(id, () => this.archiveTaskMutation(id, options));
   }
 
   private async archiveTaskMutation(
     id: string,
-    options?: { deletedAt?: string; deletedBy?: string; purgeAfter?: string }
+    options?: { deletedAt?: string; deletedBy?: string; purgeAfter?: string },
+    sqliteStorageLocked = false
   ): Promise<boolean> {
     if (this.sqliteTasks) {
       await this.assertTaskIdentityIntegrity('task.archive', id, {
@@ -1121,7 +1342,9 @@ export class TaskService {
         purgeAfter: options?.purgeAfter ?? task.purgeAfter,
       };
       const sqliteTasks = this.sqliteTasks;
-      const archived = await this.runSqliteMutation(() => sqliteTasks.archive(id, archivedTask));
+      const archived = await (sqliteStorageLocked
+        ? sqliteTasks.archive(id, archivedTask)
+        : this.runSqliteMutation(() => sqliteTasks.archive(id, archivedTask)));
       if (!archived) return false;
 
       await this.telemetry.emit<TaskTelemetryEvent>({
@@ -1210,17 +1433,24 @@ export class TaskService {
   }
 
   async restoreTask(id: string): Promise<Task | null> {
+    if (this.sqliteTasks) {
+      return this.runSqliteMutation(() =>
+        this.withTaskMutex(id, () => this.restoreTaskMutation(id, true))
+      );
+    }
     return this.withTaskMutex(id, () => this.restoreTaskMutation(id));
   }
 
-  private async restoreTaskMutation(id: string): Promise<Task | null> {
+  private async restoreTaskMutation(id: string, sqliteStorageLocked = false): Promise<Task | null> {
     if (this.sqliteTasks) {
       await this.assertTaskIdentityIntegrity('task.restore', id);
       const task = await this.getArchivedTask(id);
       if (!task || this.isRestoreWindowExpired(task)) return null;
 
       const sqliteTasks = this.sqliteTasks;
-      const restoredTask = await this.runSqliteMutation(() => sqliteTasks.restore(id));
+      const restoredTask = await (sqliteStorageLocked
+        ? sqliteTasks.restore(id)
+        : this.runSqliteMutation(() => sqliteTasks.restore(id)));
       if (!restoredTask) return null;
 
       await this.telemetry.emit<TaskTelemetryEvent>({
@@ -1796,6 +2026,115 @@ export class TaskService {
   }
 
   /**
+   * Atomically move one task to an authoritative board position.
+   *
+   * Only the moved task is written: an exact rank between its destination neighbors
+   * preserves their revisions and makes status plus order one storage mutation.
+   */
+  async moveTask(id: string, input: MoveTaskInput): Promise<MoveTaskResult | null> {
+    return this.withBoardMoveMutex(async (commitStorage) => {
+      const current = await this.getTask(id);
+      if (!current) return null;
+
+      if (current.lastBoardMove?.operationId === input.operationId) {
+        if (!boardMoveReceiptMatches(current.lastBoardMove, input)) {
+          throw new ConflictError('Board move operation ID was reused with different input.', {
+            resourceType: 'task',
+            resourceId: id,
+            reason: 'OPERATION_ID_REUSED',
+            current,
+          });
+        }
+        commitStorage();
+        await this.reconcileBoardMoveTelemetry(current);
+        const currentColumn = sortTasksByBoardPosition(
+          (await this.listTasks()).filter((task) => task.status === current.status)
+        );
+        return {
+          task: current,
+          operationId: input.operationId,
+          orderedTaskIds: currentColumn.map((task) => task.id),
+          replayed: true,
+        };
+      }
+
+      if (current.lastBoardMove && !(await this.reconcileBoardMoveTelemetry(current))) {
+        throw new InternalError(
+          'The previous board move is committed but its telemetry is still pending. Retry shortly.'
+        );
+      }
+
+      const currentPosition = normalizedBoardPosition(current);
+      if (current.status !== input.sourceStatus || currentPosition !== input.sourcePosition) {
+        throw new ConflictError(`task ${id} moved since it was loaded. Reload and try again.`, {
+          resourceType: 'task',
+          resourceId: id,
+          expectedRevision: input.expectedRevision,
+          currentRevision: normalizedTaskRevision(current),
+          reason: 'BOARD_SOURCE_CHANGED',
+          current,
+        });
+      }
+
+      const destinationTasks = sortTasksByBoardPosition(
+        (await this.listTasks()).filter(
+          (task) => task.id !== id && task.status === input.destinationStatus
+        )
+      );
+      if (
+        !Number.isInteger(input.destinationIndex) ||
+        input.destinationIndex < 0 ||
+        input.destinationIndex > destinationTasks.length
+      ) {
+        throw new ValidationError('Destination index is outside the destination column', [
+          {
+            code: 'INVALID_DESTINATION_INDEX',
+            message: `destinationIndex must be between 0 and ${destinationTasks.length}`,
+            path: ['destinationIndex'],
+          },
+        ]);
+      }
+
+      const boardRank = taskBoardRankAtIndex(destinationTasks, input.destinationIndex);
+      const position = taskBoardPositionAtIndex(destinationTasks, input.destinationIndex);
+      const completedAt = new Date().toISOString();
+      const receipt: TaskBoardMoveReceipt = {
+        operationId: input.operationId,
+        sourceStatus: input.sourceStatus,
+        sourcePosition: input.sourcePosition,
+        destinationStatus: input.destinationStatus,
+        destinationIndex: input.destinationIndex,
+        completedAt,
+      };
+      const updated = await this.withTaskMutex(id, () =>
+        this.updateTaskMutation(
+          id,
+          {
+            status: input.destinationStatus,
+            position,
+            boardRank,
+            expectedRevision: input.expectedRevision,
+            updatedBy: input.updatedBy,
+            lastBoardMove: receipt,
+          } as TaskMutationInput,
+          true,
+          commitStorage
+        )
+      );
+      if (!updated) return null;
+
+      const orderedTaskIds = destinationTasks.map((task) => task.id);
+      orderedTaskIds.splice(input.destinationIndex, 0, updated.id);
+      return {
+        task: updated,
+        operationId: input.operationId,
+        orderedTaskIds,
+        replayed: false,
+      };
+    });
+  }
+
+  /**
    * Reorder tasks within a status column.
    * Accepts an ordered array of task IDs and assigns sequential position values.
    */
@@ -1805,18 +2144,22 @@ export class TaskService {
         `Cannot reorder more than ${MAX_TASK_REORDER_ITEMS} tasks in one request`
       );
     }
-    const tasks = await this.listTasks();
-    const updated: Task[] = [];
+    return this.withBoardMoveMutex(async () => {
+      const tasks = await this.listTasks();
+      const updated: Task[] = [];
 
-    for (let i = 0; i < orderedIds.length; i++) {
-      const task = tasks.find((t) => t.id === orderedIds[i]);
-      if (task && task.position !== i) {
-        const result = await this.updateTask(task.id, { position: i });
-        if (result) updated.push(result);
+      for (let i = 0; i < orderedIds.length; i++) {
+        const task = tasks.find((candidate) => candidate.id === orderedIds[i]);
+        if (task && task.position !== i) {
+          const result = await this.withTaskMutex(task.id, () =>
+            this.updateTaskMutation(task.id, { position: i, boardRank: null }, true)
+          );
+          if (result) updated.push(result);
+        }
       }
-    }
 
-    return updated;
+      return updated;
+    });
   }
 
   /**

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -2148,7 +2148,8 @@ export class TaskService {
       const tasks = await this.listTasks();
       const updated: Task[] = [];
 
-      for (let i = 0; i < orderedIds.length; i++) {
+      const reorderCount = Math.min(orderedIds.length, MAX_TASK_REORDER_ITEMS);
+      for (let i = 0; i < reorderCount; i++) {
         const task = tasks.find((candidate) => candidate.id === orderedIds[i]);
         if (task && task.position !== i) {
           const result = await this.withTaskMutex(task.id, () =>

--- a/server/src/storage/sqlite/task-repository.ts
+++ b/server/src/storage/sqlite/task-repository.ts
@@ -463,6 +463,7 @@ export class SqliteTaskRepository implements TaskRepository {
 
   private transaction<T>(callback: () => T): T {
     const db = this.database.getConnection();
+    if (db.isTransaction) return callback();
 
     try {
       db.exec('BEGIN IMMEDIATE;');

--- a/server/src/storage/task-file-repository.ts
+++ b/server/src/storage/task-file-repository.ts
@@ -132,6 +132,11 @@ export class FileTaskRepository {
     });
   }
 
+  async withBoardMutation<T>(mutation: () => Promise<T>): Promise<T> {
+    await this.ensureReady();
+    return withFileLock(path.join(this.taskRoot, 'board-position'), mutation);
+  }
+
   async withActiveMutation<T>(id: string, mutation: ActiveMutation<T>): Promise<T | null> {
     assertLookupId(id);
     await this.ensureReady();
@@ -416,6 +421,8 @@ export class FileTaskRepository {
         observations: data.observations,
         attachments: data.attachments,
         position: data.position,
+        boardRank: data.boardRank,
+        lastBoardMove: data.lastBoardMove,
         costPrediction: data.costPrediction,
         actualCost: data.actualCost,
         lessonsLearned: data.lessonsLearned,

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -239,6 +239,34 @@ export interface TaskGitHub {
   url?: string;
 }
 
+/** Durable receipt for the most recently committed board-move command. */
+export interface TaskBoardMoveReceipt {
+  operationId: string;
+  sourceStatus: TaskStatus;
+  sourcePosition: number | null;
+  destinationStatus: TaskStatus;
+  destinationIndex: number;
+  completedAt: string;
+  auditCompletedAt?: string;
+}
+
+export interface MoveTaskInput {
+  operationId: string;
+  sourceStatus: TaskStatus;
+  sourcePosition: number | null;
+  destinationStatus: TaskStatus;
+  destinationIndex: number;
+  expectedRevision?: number;
+  updatedBy?: string;
+}
+
+export interface MoveTaskResult {
+  task: Task;
+  operationId: string;
+  orderedTaskIds: string[];
+  replayed: boolean;
+}
+
 export interface Task {
   id: string;
   title: string;
@@ -332,6 +360,12 @@ export interface Task {
 
   // Position within column (for drag-and-drop ordering)
   position?: number;
+
+  // Exact durable order key. New board moves use this when numeric positions converge.
+  boardRank?: string;
+
+  // Durable idempotency receipt for the latest board move
+  lastBoardMove?: TaskBoardMoveReceipt;
 
   // Cost prediction and tracking
   costPrediction?: {
@@ -499,6 +533,7 @@ export interface TaskSummary {
   blockedBy?: string[];
   blockedReason?: BlockedReason;
   position?: number;
+  boardRank?: string;
   attachmentCount?: number;
   deliverableCount?: number;
   github?: TaskGitHub;

--- a/shared/src/types/telemetry.types.ts
+++ b/shared/src/types/telemetry.types.ts
@@ -35,6 +35,7 @@ export interface TaskTelemetryEvent extends TelemetryEvent {
   taskId: string;
   status?: TaskStatus;
   previousStatus?: TaskStatus;
+  operationId?: string;
 }
 
 /** Agent run started event */

--- a/shared/src/utils/index.ts
+++ b/shared/src/utils/index.ts
@@ -14,3 +14,4 @@ export * from './agent-helpers.js';
 export * from './acp-json-rpc-peer.js';
 export * from './task-readiness.js';
 export * from './workflow-pipeline.js';
+export * from './task-board-order.js';

--- a/shared/src/utils/task-board-order.ts
+++ b/shared/src/utils/task-board-order.ts
@@ -1,0 +1,218 @@
+import type { Task } from '../types/task.types.js';
+
+// Legacy tasks can have no explicit position. Give each one a stable numeric
+// boundary so a moved task can be persisted between two legacy cards without
+// rewriting either card's revision.
+const LEGACY_BOARD_POSITION_BASE = 10_000_000_000;
+const LEGACY_BOARD_TIME_CEILING_MS = 4_000_000_000_000;
+const BOARD_RANK_PREFIX = 'v1:';
+const MAX_BOARD_RANK_DIGITS = 2048;
+
+type BoardOrderTask = Pick<Task, 'id' | 'created' | 'updated' | 'position' | 'boardRank'>;
+
+interface Rational {
+  numerator: bigint;
+  denominator: bigint;
+}
+
+interface BoardOrderKey {
+  position: Rational;
+  tie: Rational;
+}
+
+function greatestCommonDivisor(left: bigint, right: bigint): bigint {
+  let a = left < 0n ? -left : left;
+  let b = right < 0n ? -right : right;
+  while (b !== 0n) [a, b] = [b, a % b];
+  return a === 0n ? 1n : a;
+}
+
+function normalizeRational(value: Rational): Rational {
+  const sign = value.denominator < 0n ? -1n : 1n;
+  const numerator = value.numerator * sign;
+  const denominator = value.denominator * sign;
+  const divisor = greatestCommonDivisor(numerator, denominator);
+  return { numerator: numerator / divisor, denominator: denominator / divisor };
+}
+
+function decimalToRational(value: number): Rational {
+  const [coefficient, exponentText = '0'] = value.toString().toLowerCase().split('e');
+  const exponent = Number(exponentText);
+  const negative = coefficient.startsWith('-');
+  const unsigned = negative ? coefficient.slice(1) : coefficient;
+  const [whole, fraction = ''] = unsigned.split('.');
+  const digits = `${whole}${fraction}` || '0';
+  let numerator = BigInt(digits) * (negative ? -1n : 1n);
+  let denominator = 10n ** BigInt(fraction.length);
+  if (exponent > 0) numerator *= 10n ** BigInt(exponent);
+  if (exponent < 0) denominator *= 10n ** BigInt(-exponent);
+  return normalizeRational({ numerator, denominator });
+}
+
+function parseRational(value: string): Rational | null {
+  const match = value.match(
+    new RegExp(`^(-?\\d{1,${MAX_BOARD_RANK_DIGITS}})/(\\d{1,${MAX_BOARD_RANK_DIGITS}})$`)
+  );
+  if (!match) return null;
+  const denominator = BigInt(match[2]);
+  if (denominator <= 0n) return null;
+  return normalizeRational({ numerator: BigInt(match[1]), denominator });
+}
+
+function parseBoardRank(value: string | undefined): BoardOrderKey | null {
+  if (!value?.startsWith(BOARD_RANK_PREFIX)) return null;
+  const [positionText, tieText] = value.slice(BOARD_RANK_PREFIX.length).split(';');
+  const position = parseRational(positionText);
+  const tie = tieText ? parseRational(tieText) : { numerator: 0n, denominator: 1n };
+  return position && tie ? { position, tie } : null;
+}
+
+function serializeRational(value: Rational): string {
+  const normalized = normalizeRational(value);
+  const numerator = normalized.numerator.toString();
+  const denominator = normalized.denominator.toString();
+  if (
+    numerator.replace('-', '').length > MAX_BOARD_RANK_DIGITS ||
+    denominator.length > MAX_BOARD_RANK_DIGITS
+  ) {
+    throw new Error('Board rank precision exhausted');
+  }
+  return `${numerator}/${denominator}`;
+}
+
+function serializeBoardRank(value: BoardOrderKey): string {
+  const position = serializeRational(value.position);
+  const tie = normalizeRational(value.tie);
+  return tie.numerator === 0n
+    ? `${BOARD_RANK_PREFIX}${position}`
+    : `${BOARD_RANK_PREFIX}${position};${serializeRational(tie)}`;
+}
+
+function stableIdOffset(id: string): number {
+  let hash = 0;
+  for (const character of id) hash = (hash * 31 + character.charCodeAt(0)) % 499;
+  return hash * 0.000002;
+}
+
+function legacyPosition(task: BoardOrderTask): number {
+  const createdAt = Date.parse(task.created);
+  const fallback = Date.parse(task.updated);
+  const timestamp = Number.isFinite(createdAt)
+    ? createdAt
+    : Number.isFinite(fallback)
+      ? fallback
+      : 0;
+  return (
+    LEGACY_BOARD_POSITION_BASE +
+    (LEGACY_BOARD_TIME_CEILING_MS - timestamp) / 1000 +
+    stableIdOffset(task.id)
+  );
+}
+
+function taskIdTie(id: string): Rational {
+  const base = 65_537n;
+  let numerator = 0n;
+  let denominator = 1n;
+  for (let index = 0; index < id.length; index++) {
+    numerator = numerator * base + BigInt(id.charCodeAt(index) + 1);
+    denominator *= base;
+  }
+  return normalizeRational({ numerator, denominator });
+}
+
+function taskBoardKey(task: BoardOrderTask): BoardOrderKey {
+  const durableRank = parseBoardRank(task.boardRank);
+  if (durableRank) return durableRank;
+  const position =
+    typeof task.position === 'number' && Number.isFinite(task.position)
+      ? task.position
+      : legacyPosition(task);
+  return { position: decimalToRational(position), tie: taskIdTie(task.id) };
+}
+
+function compareRational(left: Rational, right: Rational): number {
+  const delta = left.numerator * right.denominator - right.numerator * left.denominator;
+  return delta < 0n ? -1 : delta > 0n ? 1 : 0;
+}
+
+function rationalToCompatibilityPosition(value: Rational): number {
+  const scaled = (value.numerator * 1_000_000_000_000n) / value.denominator;
+  return Number(scaled) / 1_000_000_000_000;
+}
+
+export function effectiveTaskBoardPosition(task: BoardOrderTask): number {
+  return rationalToCompatibilityPosition(taskBoardKey(task).position);
+}
+
+export function sortTasksByBoardPosition<T extends BoardOrderTask>(tasks: T[]): T[] {
+  return [...tasks].sort((left, right) => {
+    const leftKey = taskBoardKey(left);
+    const rightKey = taskBoardKey(right);
+    const positionDelta = compareRational(leftKey.position, rightKey.position);
+    if (positionDelta !== 0) return positionDelta;
+    const tieDelta = compareRational(leftKey.tie, rightKey.tie);
+    if (tieDelta !== 0) return tieDelta;
+    return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+  });
+}
+
+export function taskBoardRankAtIndex(
+  orderedTasks: BoardOrderTask[],
+  destinationIndex: number
+): string {
+  const previous = destinationIndex > 0 ? taskBoardKey(orderedTasks[destinationIndex - 1]) : null;
+  const next =
+    destinationIndex < orderedTasks.length ? taskBoardKey(orderedTasks[destinationIndex]) : null;
+
+  const zero = { numerator: 0n, denominator: 1n };
+
+  if (!previous && !next) return serializeBoardRank({ position: zero, tie: zero });
+  if (!previous && next) {
+    return serializeBoardRank({
+      position: {
+        numerator: next.position.numerator - next.position.denominator,
+        denominator: next.position.denominator,
+      },
+      tie: zero,
+    });
+  }
+  if (previous && !next) {
+    return serializeBoardRank({
+      position: {
+        numerator: previous.position.numerator + previous.position.denominator,
+        denominator: previous.position.denominator,
+      },
+      tie: zero,
+    });
+  }
+
+  const left = previous as BoardOrderKey;
+  const right = next as BoardOrderKey;
+  if (compareRational(left.position, right.position) === 0) {
+    if (compareRational(left.tie, right.tie) >= 0) {
+      throw new Error('Cannot allocate a board rank between duplicate ordering keys');
+    }
+    return serializeBoardRank({
+      position: left.position,
+      tie: {
+        numerator: left.tie.numerator + right.tie.numerator,
+        denominator: left.tie.denominator + right.tie.denominator,
+      },
+    });
+  }
+  return serializeBoardRank({
+    position: {
+      numerator: left.position.numerator + right.position.numerator,
+      denominator: left.position.denominator + right.position.denominator,
+    },
+    tie: zero,
+  });
+}
+
+export function taskBoardPositionAtIndex(
+  orderedTasks: BoardOrderTask[],
+  destinationIndex: number
+): number {
+  const rank = parseBoardRank(taskBoardRankAtIndex(orderedTasks, destinationIndex));
+  return rationalToCompatibilityPosition((rank as BoardOrderKey).position);
+}

--- a/web/src/__tests__/KanbanBoard.test.tsx
+++ b/web/src/__tests__/KanbanBoard.test.tsx
@@ -22,6 +22,8 @@ const mockTasks: Task[] = [
 ];
 
 let mockUseTasks: () => { data: Task[] | undefined; isLoading: boolean; error: Error | null };
+let mockDragDropActiveTask: Task | null = null;
+let mockDragDropMovePending = false;
 let mockFeatureSettingsResult: { isPlaceholderData: boolean; settings: FeatureSettings } = {
   isPlaceholderData: false,
   settings: createFeatureSettings(),
@@ -56,17 +58,23 @@ vi.mock('@/hooks/useTasks', () => ({
     }
     return result;
   },
-  useUpdateTask: () => ({ mutate: vi.fn() }),
-  useReorderTasks: () => ({ mutate: vi.fn() }),
+  useMoveTask: () => ({ mutateAsync: vi.fn() }),
 }));
 
 vi.mock('@/hooks/useBoardDragDrop', () => ({
-  useBoardDragDrop: () => ({
-    activeTask: null,
+  useBoardDragDrop: ({ tasksByStatus }: { tasksByStatus: Record<string, Task[]> }) => ({
+    activeTask: mockDragDropActiveTask,
+    isDragActive: mockDragDropActiveTask !== null,
+    isMovePending: mockDragDropMovePending,
+    liveTasksByStatus: tasksByStatus,
     sensors: [],
+    collisionDetection: vi.fn(),
+    announcements: {},
+    screenReaderInstructions: {},
     handleDragStart: vi.fn(),
     handleDragOver: vi.fn(),
     handleDragEnd: vi.fn(),
+    handleDragCancel: vi.fn(),
   }),
 }));
 
@@ -126,15 +134,21 @@ vi.mock('@/components/board/KanbanColumn', () => ({
     title,
     tasks,
     canChangeStatus,
+    dragEnabled,
     onTaskClick,
   }: {
     id: string;
     title: string;
     tasks: Task[];
     canChangeStatus?: boolean;
+    dragEnabled?: boolean;
     onTaskClick?: (task: Task) => void;
   }) => (
-    <div data-testid={`column-${id}`} data-can-change-status={String(canChangeStatus)}>
+    <div
+      data-testid={`column-${id}`}
+      data-can-change-status={String(canChangeStatus)}
+      data-drag-enabled={String(dragEnabled)}
+    >
       <h2>{title}</h2>
       {tasks.map((t: Task) => (
         <button
@@ -202,12 +216,29 @@ vi.mock('@/components/shared/LiveAnnouncer', () => ({
 }));
 
 vi.mock('@/components/task/TaskCard', () => ({
-  TaskCard: () => null,
+  TaskCard: ({
+    task,
+    dragEnabled,
+    isDragActive,
+  }: {
+    task: Task;
+    dragEnabled?: boolean;
+    isDragActive?: boolean;
+  }) => (
+    <div
+      data-testid="drag-preview-card"
+      data-task-id={task.id}
+      data-drag-enabled={String(dragEnabled)}
+      data-drag-active={String(isDragActive)}
+    />
+  ),
 }));
 
 vi.mock('@dnd-kit/core', () => ({
   DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DragOverlay: () => null,
+  DragOverlay: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dnd-overlay-layer">{children}</div>
+  ),
   closestCorners: vi.fn(),
 }));
 
@@ -270,6 +301,9 @@ afterEach(() => {
     isPlaceholderData: false,
     settings: createFeatureSettings(),
   };
+  mockDragDropActiveTask = null;
+  mockDragDropMovePending = false;
+  document.documentElement.classList.remove('dark');
   window.history.replaceState({}, '', '/');
 });
 
@@ -392,9 +426,50 @@ describe('KanbanBoard', () => {
     mockUseTasks = () => ({ data: [], isLoading: false, error: null });
     renderDesktopBoard();
 
-    expect(screen.getByRole('group', { name: 'Kanban columns' }).style.gridTemplateColumns).toBe(
-      'repeat(4, minmax(0, 1fr))'
-    );
+    const columns = screen.getByRole('group', { name: 'Kanban columns' });
+    expect(columns.style.gridTemplateColumns).toBe('repeat(4, minmax(0, 1fr))');
+    expect(columns.closest('section')?.parentElement?.className).toContain('items-start');
+  });
+
+  it.each(['light', 'dark'])(
+    'isolates one theme-token drag preview from board geometry in %s mode',
+    (theme) => {
+      if (theme === 'dark') document.documentElement.classList.add('dark');
+      mockUseTasks = () => ({ data: mockTasks, isLoading: false, error: null });
+      mockFeatureSettingsResult = {
+        isPlaceholderData: false,
+        settings: createFeatureSettings({ enableDragAndDrop: true }),
+      };
+      mockDragDropActiveTask = mockTasks[0];
+
+      renderBoard();
+
+      const grid = screen.getByRole('group', { name: 'Kanban columns' });
+      const overlay = document.querySelector<HTMLElement>('[data-board-drag-overlay]');
+      expect(overlay).not.toBeNull();
+      expect(grid.contains(overlay)).toBe(false);
+      expect(overlay?.className).toContain('pointer-events-none');
+      expect(overlay?.className).toContain('h-full');
+      expect(overlay?.className).toContain('w-full');
+      expect(overlay?.className).toContain('bg-card');
+      expect(overlay?.style.contain).toBe('layout paint');
+      expect(screen.getAllByTestId('drag-preview-card')).toHaveLength(1);
+      expect(screen.getByTestId('drag-preview-card').dataset.dragEnabled).toBe('false');
+    }
+  );
+
+  it('disables task dragging while an authoritative move is pending', () => {
+    mockUseTasks = () => ({ data: mockTasks, isLoading: false, error: null });
+    mockFeatureSettingsResult = {
+      isPlaceholderData: false,
+      settings: createFeatureSettings({ enableDragAndDrop: true }),
+    };
+    mockDragDropMovePending = true;
+
+    renderBoard();
+
+    expect(screen.getByTestId('column-todo').dataset.dragEnabled).toBe('false');
+    expect(screen.getByTestId('column-done').dataset.dragEnabled).toBe('false');
   });
 
   it('disables explicit status changes while the browser is offline', () => {

--- a/web/src/__tests__/api-tasks.test.ts
+++ b/web/src/__tests__/api-tasks.test.ts
@@ -130,6 +130,47 @@ describe('tasksApi', () => {
     });
   });
 
+  it('move() sends one revisioned board command with an operation ID', async () => {
+    const moved = createMockTask({ id: 'u1', status: 'blocked', position: 0.5, revision: 8 });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () =>
+        envelope({
+          task: moved,
+          operationId: '00000000-0000-4000-8000-000000000011',
+          orderedTaskIds: ['b1', 'u1'],
+          replayed: false,
+        }),
+    } as Response);
+
+    await tasksApi.move(
+      'u1',
+      {
+        operationId: '00000000-0000-4000-8000-000000000011',
+        expectedRevision: 7,
+        sourceStatus: 'todo',
+        sourcePosition: 0,
+        destinationStatus: 'blocked',
+        destinationIndex: 1,
+      },
+      7
+    );
+
+    expect(fetch).toHaveBeenCalledWith('http://test-api/tasks/u1/move', {
+      credentials: 'include',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'If-Match': '"task:u1:7"' },
+      body: JSON.stringify({
+        operationId: '00000000-0000-4000-8000-000000000011',
+        sourceStatus: 'todo',
+        sourcePosition: 0,
+        destinationStatus: 'blocked',
+        destinationIndex: 1,
+      }),
+    });
+  });
+
   it('addComment() sends the parent task revision when provided', async () => {
     const updated = createMockTask({ id: 'task-1' });
     vi.mocked(fetch).mockResolvedValueOnce({

--- a/web/src/__tests__/board-move-query.test.tsx
+++ b/web/src/__tests__/board-move-query.test.tsx
@@ -1,0 +1,229 @@
+import { createElement, type ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MoveTaskResult, Task } from '@veritas-kanban/shared';
+import { useMoveTask, useTasks } from '@/hooks/useTasks';
+import { useTaskSync } from '@/hooks/useTaskSync';
+import type { UseWebSocketOptions } from '@/hooks/useWebSocket';
+import { createMockTask } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  move: vi.fn(),
+  socketOptions: null as UseWebSocketOptions | null,
+  toast: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: { tasks: { list: mocks.list, move: mocks.move } },
+}));
+
+vi.mock('@/hooks/useToast', () => ({ toast: mocks.toast }));
+
+vi.mock('@/hooks/useWebSocket', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/hooks/useWebSocket')>();
+  return {
+    ...original,
+    useWebSocket: (options: UseWebSocketOptions) => {
+      mocks.socketOptions = options;
+      return {
+        isConnected: true,
+        connectionState: 'connected' as const,
+        reconnectAttempt: 0,
+        connect: vi.fn(),
+      };
+    },
+  };
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe('board move QueryClient and WebSocket convergence', () => {
+  let queryClient: QueryClient;
+  let original: Task;
+  let moved: Task;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+        mutations: { retry: false },
+      },
+    });
+    original = createMockTask({ id: 'move-1', status: 'todo', position: 0, revision: 3 });
+    moved = { ...original, status: 'blocked', position: 0.5, revision: 4 };
+    queryClient.setQueryData(['tasks'], [original]);
+    mocks.list.mockResolvedValue([moved]);
+    mocks.socketOptions = null;
+  });
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+
+  it('keeps the old cache stable while pending, then converges with an echoed move event', async () => {
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    const response = deferred<MoveTaskResult>();
+    mocks.move.mockReturnValue(response.promise);
+    const { result } = renderHook(
+      () => {
+        const tasks = useTasks();
+        const move = useMoveTask();
+        useTaskSync();
+        return { tasks, move };
+      },
+      { wrapper }
+    );
+
+    act(() => {
+      result.current.move.mutate({
+        id: original.id,
+        input: {
+          operationId: '00000000-0000-4000-8000-000000000012',
+          sourceStatus: 'todo',
+          sourcePosition: 0,
+          destinationStatus: 'blocked',
+          destinationIndex: 1,
+        },
+      });
+    });
+
+    await waitFor(() => expect(result.current.move.isPending).toBe(true));
+    expect(queryClient.getQueryData<Task[]>(['tasks'])?.[0]).toEqual(original);
+
+    act(() => {
+      mocks.socketOptions?.onMessage?.({
+        type: 'task:changed',
+        changeType: 'moved',
+        taskId: original.id,
+        operationId: '00000000-0000-4000-8000-000000000012',
+      });
+    });
+    await waitFor(() => expect(result.current.tasks.data?.[0]).toEqual(moved));
+
+    act(() => {
+      response.resolve({
+        task: moved,
+        operationId: '00000000-0000-4000-8000-000000000012',
+        orderedTaskIds: [moved.id],
+        replayed: false,
+      });
+    });
+    await waitFor(() => expect(result.current.move.isSuccess).toBe(true));
+
+    expect(queryClient.getQueryData<Task[]>(['tasks'])?.[0]).toEqual(moved);
+    expect(queryClient.getQueryData<Task>(['tasks', moved.id])).toEqual(moved);
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['activity'] });
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the remote-client board sidebar when a move event arrives', () => {
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    renderHook(() => useTaskSync(), { wrapper });
+
+    act(() => {
+      mocks.socketOptions?.onMessage?.({
+        type: 'task:changed',
+        changeType: 'moved',
+        taskId: original.id,
+        operationId: '00000000-0000-4000-8000-000000000013',
+      });
+    });
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['activity'] });
+  });
+
+  it('retries a dropped response with the same operation identity', async () => {
+    const response: MoveTaskResult = {
+      task: moved,
+      operationId: '00000000-0000-4000-8000-000000000014',
+      orderedTaskIds: [moved.id],
+      replayed: true,
+    };
+    mocks.move
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(response);
+    const { result } = renderHook(() => useMoveTask(), { wrapper });
+    const input = {
+      operationId: response.operationId,
+      sourceStatus: 'todo' as const,
+      sourcePosition: 0,
+      destinationStatus: 'blocked' as const,
+      destinationIndex: 0,
+    };
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: original.id, input });
+    });
+
+    expect(mocks.move).toHaveBeenCalledTimes(2);
+    expect(mocks.move.mock.calls[0]).toEqual(mocks.move.mock.calls[1]);
+    expect(queryClient.getQueryData<Task[]>(['tasks'])?.[0]).toEqual(moved);
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
+  it('loads the authoritative task and reports one task-specific stale-move message', async () => {
+    const current = { ...original, title: 'Edited elsewhere', revision: 4 };
+    const conflict = Object.assign(new Error('stale revision'), {
+      code: 'CONFLICT',
+      details: { current },
+    });
+    mocks.move.mockRejectedValue(conflict);
+    const { result } = renderHook(() => useMoveTask(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        id: original.id,
+        input: {
+          operationId: '00000000-0000-4000-8000-000000000015',
+          sourceStatus: 'todo',
+          sourcePosition: 0,
+          destinationStatus: 'blocked',
+          destinationIndex: 0,
+        },
+      });
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(queryClient.getQueryData<Task[]>(['tasks'])?.[0]).toEqual(current);
+    expect(mocks.move).toHaveBeenCalledOnce();
+    expect(mocks.toast).toHaveBeenCalledOnce();
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Move not saved',
+        description: expect.stringContaining('Edited elsewhere'),
+      })
+    );
+  });
+
+  it('does not retry a read-only write denial', async () => {
+    const denied = Object.assign(new Error('read only'), { code: 'WRITE_FORBIDDEN' });
+    mocks.move.mockRejectedValue(denied);
+    const { result } = renderHook(() => useMoveTask(), { wrapper });
+
+    await expect(
+      act(() =>
+        result.current.mutateAsync({
+          id: original.id,
+          input: {
+            operationId: '00000000-0000-4000-8000-000000000016',
+            sourceStatus: 'todo',
+            sourcePosition: 0,
+            destinationStatus: 'blocked',
+            destinationIndex: 0,
+          },
+        })
+      )
+    ).rejects.toThrow('read only');
+
+    expect(mocks.move).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/__tests__/useBoardDragDrop.test.tsx
+++ b/web/src/__tests__/useBoardDragDrop.test.tsx
@@ -2,14 +2,30 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { KeyboardSensor, PointerSensor } from '@dnd-kit/core';
 import type { DragCancelEvent, DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
 import { describe, expect, it, vi, type Mock } from 'vitest';
-import { DEFAULT_FEATURE_SETTINGS, type Task, type TaskStatus } from '@veritas-kanban/shared';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  type MoveTaskInput,
+  type MoveTaskResult,
+  type Task,
+} from '@veritas-kanban/shared';
 import { createBoardKeyboardCoordinates, useBoardDragDrop } from '@/hooks/useBoardDragDrop';
 import { createMockTask } from './test-utils';
 
 const columns = DEFAULT_FEATURE_SETTINGS.board.columns;
-type StatusChange = (taskId: string, status: TaskStatus) => Promise<void>;
-type Reorder = (taskIds: string[]) => Promise<void>;
+type Move = (
+  taskId: string,
+  input: Omit<MoveTaskInput, 'expectedRevision' | 'updatedBy'>
+) => Promise<MoveTaskResult>;
 type Announce = (message: string) => void;
+
+function moveResult(task: Task, orderedTaskIds: string[] = [task.id]): MoveTaskResult {
+  return {
+    task,
+    operationId: '00000000-0000-4000-8000-000000000099',
+    orderedTaskIds,
+    replayed: false,
+  };
+}
 
 function dragEvent(activeId: string, overId?: string) {
   return {
@@ -24,31 +40,44 @@ function renderDragHook({
     createMockTask({ id: 'todo-2', title: 'Second task', status: 'todo' }),
     createMockTask({ id: 'done-1', title: 'Done task', status: 'done' }),
   ],
-  onStatusChange = vi.fn<StatusChange>().mockResolvedValue(undefined),
-  onReorder = vi.fn<Reorder>().mockResolvedValue(undefined),
+  allTasks = tasks,
+  onMove = vi.fn<Move>().mockImplementation(async (taskId, input) => {
+    const moved = tasks.find((task) => task.id === taskId) as Task;
+    const orderedTaskIds = tasks
+      .filter((task) => task.id !== taskId && task.status === input.destinationStatus)
+      .map((task) => task.id);
+    orderedTaskIds.splice(input.destinationIndex, 0, taskId);
+    return moveResult(
+      { ...moved, status: input.destinationStatus, position: input.destinationIndex },
+      orderedTaskIds
+    );
+  }),
   announce = vi.fn<Announce>(),
 }: {
   tasks?: Task[];
-  onStatusChange?: Mock<StatusChange>;
-  onReorder?: Mock<Reorder>;
+  allTasks?: Task[];
+  onMove?: Mock<Move>;
   announce?: Mock<Announce>;
 } = {}) {
   const tasksByStatus = Object.fromEntries(
     columns.map((column) => [column.id, tasks.filter((task) => task.status === column.id)])
+  );
+  const allTasksByStatus = Object.fromEntries(
+    columns.map((column) => [column.id, allTasks.filter((task) => task.status === column.id)])
   );
 
   const hook = renderHook(() =>
     useBoardDragDrop({
       tasks,
       tasksByStatus,
+      allTasksByStatus,
       columns,
-      onStatusChange,
-      onReorder,
+      onMove,
       announce,
     })
   );
 
-  return { ...hook, announce, onReorder, onStatusChange };
+  return { ...hook, announce, onMove };
 }
 
 describe('useBoardDragDrop keyboard parity', () => {
@@ -128,7 +157,7 @@ describe('useBoardDragDrop keyboard parity', () => {
   });
 
   it('reorders within a column and announces the committed position', async () => {
-    const { result, onReorder, announce } = renderDragHook();
+    const { result, onMove, announce } = renderDragHook();
 
     act(() => result.current.handleDragStart(dragEvent('todo-2') as unknown as DragStartEvent));
     act(() => result.current.handleDragOver(dragEvent('todo-2', 'todo-1') as DragOverEvent));
@@ -136,8 +165,60 @@ describe('useBoardDragDrop keyboard parity', () => {
       result.current.handleDragEnd(dragEvent('todo-2', 'todo-1') as DragEndEvent)
     );
 
-    expect(onReorder).toHaveBeenCalledWith(['todo-2', 'todo-1']);
+    expect(onMove).toHaveBeenCalledWith(
+      'todo-2',
+      expect.objectContaining({
+        sourceStatus: 'todo',
+        sourcePosition: null,
+        destinationStatus: 'todo',
+        destinationIndex: 0,
+      })
+    );
     expect(announce).toHaveBeenCalledWith('Second task moved to To Do, position 1 of 2');
+  });
+
+  it('announces the authoritative order when the committed result differs from projection', async () => {
+    const tasks = [
+      createMockTask({ id: 'todo-1', title: 'First task', status: 'todo' }),
+      createMockTask({ id: 'todo-2', title: 'Second task', status: 'todo' }),
+    ];
+    const onMove = vi.fn<Move>().mockResolvedValue(moveResult(tasks[1], ['todo-1', 'todo-2']));
+    const { result, announce } = renderDragHook({ tasks, onMove });
+
+    act(() => result.current.handleDragStart(dragEvent('todo-2') as unknown as DragStartEvent));
+    act(() => result.current.handleDragOver(dragEvent('todo-2', 'todo-1') as DragOverEvent));
+    await act(async () =>
+      result.current.handleDragEnd(dragEvent('todo-2', 'todo-1') as DragEndEvent)
+    );
+
+    expect(announce).toHaveBeenCalledWith('Second task moved to To Do, position 2 of 2');
+  });
+
+  it('translates a filtered drop relative to the full destination column', async () => {
+    const moving = createMockTask({ id: 'todo-1', title: 'Moving task', status: 'todo' });
+    const hidden = createMockTask({ id: 'done-hidden', status: 'done', position: 0 });
+    const visible = createMockTask({ id: 'done-visible', status: 'done', position: 1 });
+    const onMove = vi
+      .fn<Move>()
+      .mockResolvedValue(
+        moveResult({ ...moving, status: 'done', position: 0.5 }, [hidden.id, moving.id, visible.id])
+      );
+    const { result } = renderDragHook({
+      tasks: [moving, visible],
+      allTasks: [moving, hidden, visible],
+      onMove,
+    });
+
+    act(() => result.current.handleDragStart(dragEvent(moving.id) as unknown as DragStartEvent));
+    act(() => result.current.handleDragOver(dragEvent(moving.id, visible.id) as DragOverEvent));
+    await act(async () =>
+      result.current.handleDragEnd(dragEvent(moving.id, visible.id) as DragEndEvent)
+    );
+
+    expect(onMove).toHaveBeenCalledWith(
+      moving.id,
+      expect.objectContaining({ destinationStatus: 'done', destinationIndex: 1 })
+    );
   });
 
   it('moves a task into an empty column and persists its destination order', async () => {
@@ -150,11 +231,12 @@ describe('useBoardDragDrop keyboard parity', () => {
     document.body.append(originalCard);
     const movedCard = document.createElement('button');
     movedCard.dataset.taskId = 'todo-1';
-    const onStatusChange = vi.fn<StatusChange>().mockImplementation(async () => {
+    const onMove = vi.fn<Move>().mockImplementation(async () => {
       originalCard.remove();
       document.body.append(movedCard);
+      return moveResult({ ...tasks[0], status: 'done', position: 0 });
     });
-    const { result, onReorder, announce } = renderDragHook({ tasks, onStatusChange });
+    const { result, announce } = renderDragHook({ tasks, onMove });
 
     act(() => result.current.handleDragStart(dragEvent('todo-1') as unknown as DragStartEvent));
     act(() => result.current.handleDragOver(dragEvent('todo-1', 'done') as DragOverEvent));
@@ -162,8 +244,14 @@ describe('useBoardDragDrop keyboard parity', () => {
       result.current.handleDragEnd(dragEvent('todo-1', 'done') as DragEndEvent)
     );
 
-    expect(onStatusChange).toHaveBeenCalledWith('todo-1', 'done');
-    expect(onReorder).toHaveBeenCalledWith(['todo-1']);
+    expect(onMove).toHaveBeenCalledWith(
+      'todo-1',
+      expect.objectContaining({
+        sourceStatus: 'todo',
+        destinationStatus: 'done',
+        destinationIndex: 0,
+      })
+    );
     expect(announce).toHaveBeenCalledWith('First task moved to Done, position 1 of 1');
     await waitFor(() => expect(document.activeElement).toBe(movedCard));
     movedCard.remove();
@@ -173,14 +261,13 @@ describe('useBoardDragDrop keyboard parity', () => {
     const card = document.createElement('button');
     card.dataset.taskId = 'todo-1';
     document.body.append(card);
-    const { result, onReorder, onStatusChange, announce } = renderDragHook();
+    const { result, onMove, announce } = renderDragHook();
 
     act(() => result.current.handleDragStart(dragEvent('todo-1') as unknown as DragStartEvent));
     act(() => result.current.handleDragCancel(dragEvent('todo-1') as DragCancelEvent));
 
     await waitFor(() => expect(document.activeElement).toBe(card));
-    expect(onStatusChange).not.toHaveBeenCalled();
-    expect(onReorder).not.toHaveBeenCalled();
+    expect(onMove).not.toHaveBeenCalled();
     expect(announce).toHaveBeenCalledWith(
       'Move canceled. First task returned to To Do, position 1 of 2'
     );
@@ -188,8 +275,8 @@ describe('useBoardDragDrop keyboard parity', () => {
   });
 
   it('announces a same-column rollback when reordering fails', async () => {
-    const onReorder = vi.fn<Reorder>().mockRejectedValue(new Error('network failed'));
-    const { result, announce } = renderDragHook({ onReorder });
+    const onMove = vi.fn<Move>().mockRejectedValue(new Error('network failed'));
+    const { result, announce } = renderDragHook({ onMove });
 
     act(() => result.current.handleDragStart(dragEvent('todo-2') as unknown as DragStartEvent));
     act(() => result.current.handleDragOver(dragEvent('todo-2', 'todo-1') as DragOverEvent));
@@ -202,42 +289,59 @@ describe('useBoardDragDrop keyboard parity', () => {
     );
   });
 
-  it('rolls status back when destination ordering fails', async () => {
-    const onStatusChange = vi.fn<StatusChange>().mockResolvedValue(undefined);
-    const onReorder = vi.fn<Reorder>().mockRejectedValue(new Error('network failed'));
-    const { result, announce } = renderDragHook({ onStatusChange, onReorder });
+  it('keeps the destination projection visible until the move command resolves', async () => {
+    let resolveMove!: (result: MoveTaskResult) => void;
+    const onMove = vi.fn<Move>().mockReturnValue(
+      new Promise((resolve) => {
+        resolveMove = resolve;
+      })
+    );
+    const { result } = renderDragHook({ onMove });
 
     act(() => result.current.handleDragStart(dragEvent('todo-1') as unknown as DragStartEvent));
     act(() => result.current.handleDragOver(dragEvent('todo-1', 'done') as DragOverEvent));
-    await act(async () =>
-      result.current.handleDragEnd(dragEvent('todo-1', 'done') as DragEndEvent)
-    );
+    let completion!: Promise<void>;
+    act(() => {
+      completion = result.current.handleDragEnd(dragEvent('todo-1', 'done') as DragEndEvent);
+    });
 
-    expect(onStatusChange.mock.calls).toEqual([
-      ['todo-1', 'done'],
-      ['todo-1', 'todo'],
-    ]);
-    expect(announce).toHaveBeenCalledWith(
-      'Move failed. First task returned to To Do, position 1 of 2'
-    );
+    expect(result.current.activeTask).toBeNull();
+    expect(result.current.isMovePending).toBe(true);
+    expect(result.current.liveTasksByStatus.done.map((task) => task.id)).toContain('todo-1');
+    expect(result.current.liveTasksByStatus.todo.map((task) => task.id)).not.toContain('todo-1');
+
+    act(() => resolveMove(moveResult({ ...result.current.liveTasksByStatus.done[0] })));
+    await act(async () => completion);
+    expect(result.current.isMovePending).toBe(false);
   });
 
-  it('announces a partial failure when automatic status rollback also fails', async () => {
-    const onStatusChange = vi
-      .fn<StatusChange>()
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error('rollback failed'));
-    const onReorder = vi.fn<Reorder>().mockRejectedValue(new Error('network failed'));
-    const { result, announce } = renderDragHook({ onStatusChange, onReorder });
+  it('rejects another drag while the current task move is pending', async () => {
+    let resolveMove!: (result: MoveTaskResult) => void;
+    const onMove = vi.fn<Move>().mockReturnValue(
+      new Promise((resolve) => {
+        resolveMove = resolve;
+      })
+    );
+    const { result, announce } = renderDragHook({ onMove });
 
     act(() => result.current.handleDragStart(dragEvent('todo-1') as unknown as DragStartEvent));
     act(() => result.current.handleDragOver(dragEvent('todo-1', 'done') as DragOverEvent));
+    let completion!: Promise<void>;
+    act(() => {
+      completion = result.current.handleDragEnd(dragEvent('todo-1', 'done') as DragEndEvent);
+    });
+    act(() => result.current.handleDragStart(dragEvent('todo-2') as unknown as DragStartEvent));
+    act(() => result.current.handleDragOver(dragEvent('todo-2', 'done-1') as DragOverEvent));
     await act(async () =>
-      result.current.handleDragEnd(dragEvent('todo-1', 'done') as DragEndEvent)
+      result.current.handleDragEnd(dragEvent('todo-2', 'done-1') as DragEndEvent)
     );
 
+    expect(onMove).toHaveBeenCalledOnce();
     expect(announce).toHaveBeenCalledWith(
-      'Move partially failed. First task may still be in Done because automatic rollback failed; refresh the board before trying again'
+      'Wait for the current task move to finish before starting another move.'
     );
+
+    act(() => resolveMove(moveResult(createMockTask({ id: 'todo-1', status: 'done' }))));
+    await act(async () => completion);
   });
 });

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useTasks, useTasksByStatus, useUpdateTask, useReorderTasks } from '@/hooks/useTasks';
+import { useMoveTask, useTasks, useTasksByStatus } from '@/hooks/useTasks';
 import { useBoardDragDrop } from '@/hooks/useBoardDragDrop';
 import { KanbanColumn } from './KanbanColumn';
 import { BoardLoadingSkeleton } from './BoardLoadingSkeleton';
@@ -130,6 +130,7 @@ export function KanbanBoard() {
   const [detailNavigationTarget, setDetailNavigationTarget] =
     useState<TaskDetailNavigationTarget | null>(null);
   const defaultSavedViewAppliedRef = useRef(false);
+  const pendingMoveTaskIdsRef = useRef(new Set<string>());
 
   // Initialize filters from URL
   const [filters, setFilters] = useState<FilterState>(() => {
@@ -348,6 +349,7 @@ export function KanbanBoard() {
 
   // Group filtered tasks by status
   const tasksByStatus = useTasksByStatus(filteredTasks, columns);
+  const allTasksByStatus = useTasksByStatus(tasks ?? [], columns);
   const boardColumnGridStyle = isMobileLayout
     ? undefined
     : {
@@ -434,8 +436,26 @@ export function KanbanBoard() {
     return () => window.removeEventListener('open-task', handler);
   }, [tasks]);
 
-  const updateTask = useUpdateTask();
-  const reorderTasks = useReorderTasks();
+  const moveTask = useMoveTask();
+
+  const commitBoardMove = useCallback(
+    async (
+      taskId: string,
+      input: Parameters<ReturnType<typeof useMoveTask>['mutateAsync']>[0]['input']
+    ) => {
+      if (!canWriteTasks || !isOnline) throw new Error('Task movement is unavailable');
+      if (pendingMoveTaskIdsRef.current.has(taskId)) {
+        throw new Error('This task already has a move in progress');
+      }
+      pendingMoveTaskIdsRef.current.add(taskId);
+      try {
+        return await moveTask.mutateAsync({ id: taskId, input });
+      } finally {
+        pendingMoveTaskIdsRef.current.delete(taskId);
+      }
+    },
+    [canWriteTasks, isOnline, moveTask]
+  );
 
   // Handler for moving a task (with screen reader announcement)
   const handleMoveTask = useCallback(
@@ -450,10 +470,29 @@ export function KanbanBoard() {
         announce(`Task ${task?.title || taskId} cannot be moved while this client is offline`);
         return;
       }
-      updateTask.mutate({ id: taskId, input: { status } });
-      announce(`Task ${task?.title || taskId} moved to ${columnName}`);
+      if (!task || task.status === status) return;
+      const destinationIndex = (allTasksByStatus[status] ?? []).filter(
+        (destinationTask) => destinationTask.id !== taskId
+      ).length;
+      void commitBoardMove(taskId, {
+        operationId: crypto.randomUUID(),
+        sourceStatus: task.status,
+        sourcePosition:
+          typeof task.position === 'number' && Number.isFinite(task.position)
+            ? task.position
+            : null,
+        destinationStatus: status,
+        destinationIndex,
+      })
+        .then((result) => {
+          const committedIndex = result.orderedTaskIds.indexOf(result.task.id);
+          announce(
+            `Task ${result.task.title} moved to ${columnName}, position ${committedIndex + 1} of ${result.orderedTaskIds.length}`
+          );
+        })
+        .catch(() => announce(`Move failed. ${task.title} stayed in its current column`));
     },
-    [announce, canWriteTasks, columns, filteredTasks, isOnline, updateTask]
+    [allTasksByStatus, announce, canWriteTasks, columns, commitBoardMove, filteredTasks, isOnline]
   );
 
   // Register callbacks with keyboard context (refs, so no need for useEffect)
@@ -464,6 +503,7 @@ export function KanbanBoard() {
   const {
     activeTask,
     isDragActive,
+    isMovePending,
     liveTasksByStatus,
     sensors,
     collisionDetection,
@@ -476,15 +516,9 @@ export function KanbanBoard() {
   } = useBoardDragDrop({
     tasks: filteredTasks,
     tasksByStatus,
+    allTasksByStatus,
     columns,
-    onStatusChange: async (taskId, status) => {
-      if (!canWriteTasks || !isOnline) throw new Error('Task movement is unavailable');
-      await updateTask.mutateAsync({ id: taskId, input: { status } });
-    },
-    onReorder: async (taskIds) => {
-      if (!canWriteTasks || !isOnline) throw new Error('Task movement is unavailable');
-      await reorderTasks.mutateAsync(taskIds);
-    },
+    onMove: commitBoardMove,
     announce,
   });
 
@@ -587,7 +621,7 @@ export function KanbanBoard() {
       <FeatureErrorBoundary fallbackTitle="Board failed to render">
         <div
           className={cn(
-            'grid grid-cols-1 gap-4',
+            'grid grid-cols-1 items-start gap-4',
             !isDesktopClient && 'xl:grid-cols-5',
             isDesktopClient && rightRailOpen && 'desktop-board-with-right-rail'
           )}
@@ -624,15 +658,23 @@ export function KanbanBoard() {
                       onTaskStatusChange={handleMoveTask}
                       selectedTaskId={selectedTaskId}
                       canChangeStatus={canWriteTasks && isOnline}
-                      dragEnabled={canDragTasks}
+                      dragEnabled={canDragTasks && !isMovePending}
                       isDragActive={isDragActive}
                       statusOptions={statusOptions}
                     />
                   ))}
                 </div>
 
-                <DragOverlay>
-                  {activeTask ? <TaskCard task={activeTask} isDragging /> : null}
+                <DragOverlay dropAnimation={null}>
+                  {activeTask ? (
+                    <div
+                      data-board-drag-overlay
+                      className="pointer-events-none h-full w-full rounded-md bg-card text-card-foreground shadow-2xl ring-1 ring-border"
+                      style={{ contain: 'layout paint' }}
+                    >
+                      <TaskCard task={activeTask} dragEnabled={false} isDragActive />
+                    </div>
+                  ) : null}
                 </DragOverlay>
               </DndContext>
             ) : (
@@ -680,20 +722,22 @@ export function KanbanBoard() {
         </div>
 
         {boardSettings.showDashboard && (
-          <LazyOnVisible
-            className="mt-6 border-t pt-4"
-            fallback={<DashboardLoadingFallback />}
-            minHeight={192}
-            rootMargin="0px 0px"
-          >
-            <Suspense fallback={<DashboardLoadingFallback />}>
-              <Dashboard
-                onTaskClick={(taskId, target) => {
-                  void handleTaskIdClick(taskId, target);
-                }}
-              />
-            </Suspense>
-          </LazyOnVisible>
+          <section aria-label="Board dashboard">
+            <LazyOnVisible
+              className="mt-6 border-t pt-4"
+              fallback={<DashboardLoadingFallback />}
+              minHeight={192}
+              rootMargin="0px 0px"
+            >
+              <Suspense fallback={<DashboardLoadingFallback />}>
+                <Dashboard
+                  onTaskClick={(taskId, target) => {
+                    void handleTaskIdClick(taskId, target);
+                  }}
+                />
+              </Suspense>
+            </LazyOnVisible>
+          </section>
         )}
       </FeatureErrorBoundary>
 

--- a/web/src/hooks/useBoardDragDrop.ts
+++ b/web/src/hooks/useBoardDragDrop.ts
@@ -16,20 +16,30 @@ import {
   useSensors,
 } from '@dnd-kit/core';
 import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
-import type { BoardColumnConfig, Task, TaskStatus } from '@veritas-kanban/shared';
+import type {
+  BoardColumnConfig,
+  MoveTaskInput,
+  MoveTaskResult,
+  Task,
+  TaskStatus,
+} from '@veritas-kanban/shared';
 
 interface UseBoardDragDropOptions {
   tasks: Task[];
   tasksByStatus: Record<string, Task[]>;
+  allTasksByStatus?: Record<string, Task[]>;
   columns: BoardColumnConfig[];
-  onStatusChange: (taskId: string, status: TaskStatus) => Promise<void>;
-  onReorder: (taskIds: string[]) => Promise<void>;
+  onMove: (
+    taskId: string,
+    input: Omit<MoveTaskInput, 'expectedRevision' | 'updatedBy'>
+  ) => Promise<MoveTaskResult>;
   announce: (message: string) => void;
 }
 
 interface UseBoardDragDropReturn {
   activeTask: Task | null;
   isDragActive: boolean;
+  isMovePending: boolean;
   /** Use this for rendering columns — reflects real-time drag state */
   liveTasksByStatus: Record<string, Task[]>;
   sensors: ReturnType<typeof useSensors>;
@@ -146,12 +156,13 @@ export function createBoardKeyboardCoordinates(columnIds: string[]): KeyboardCoo
 export function useBoardDragDrop({
   tasks,
   tasksByStatus,
+  allTasksByStatus = tasksByStatus,
   columns,
-  onStatusChange,
-  onReorder,
+  onMove,
   announce,
 }: UseBoardDragDropOptions): UseBoardDragDropReturn {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
+  const [isMovePending, setIsMovePending] = useState(false);
   // Local copy of tasksByStatus that updates in real-time during drag.
   // null = not dragging, use server state; non-null = mid-drag, use local state
   const [dragState, setDragState] = useState<Record<string, Task[]> | null>(null);
@@ -245,6 +256,7 @@ export function useBoardDragDrop({
     (taskId: string | null) => {
       setActiveTask(null);
       setDragState(null);
+      setIsMovePending(false);
       activeIdRef.current = null;
       if (taskId) focusTask(taskId);
     },
@@ -279,6 +291,10 @@ export function useBoardDragDrop({
 
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
+      if (activeIdRef.current) {
+        announce('Wait for the current task move to finish before starting another move.');
+        return;
+      }
       const task = tasks?.find((t) => t.id === event.active.id);
       if (task) {
         setActiveTask(task);
@@ -287,12 +303,13 @@ export function useBoardDragDrop({
         setDragState({ ...tasksByStatus });
       }
     },
-    [tasks, tasksByStatus]
+    [announce, tasks, tasksByStatus]
   );
 
   const handleDragOver = useCallback(
     (event: DragOverEvent) => {
       const { active, over } = event;
+      if (activeIdRef.current !== active.id) return;
       if (!over) return;
 
       const activeId = active.id as string;
@@ -361,82 +378,92 @@ export function useBoardDragDrop({
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
       const { active, over } = event;
+      if (activeIdRef.current !== active.id) return;
       const finalState = dragState;
       const activeId = active.id as string;
       const originalPosition = describeTaskPosition(activeId, tasksByStatus);
 
-      clearDragState(activeId);
+      // The pointer/keyboard overlay can close at drop, but keep the projected
+      // columns rendered until the one authoritative move command settles.
+      setActiveTask(null);
 
-      if (!over || !finalState) return;
-
-      const overId = over.id as string;
+      if (!over || !finalState) {
+        clearDragState(activeId);
+        return;
+      }
 
       // Find where the task ended up in our local drag state
       const originalColumn = findColumn(activeId, tasksByStatus);
       const finalColumn = findColumn(activeId, finalState);
 
-      if (!originalColumn || !finalColumn) return;
-
-      if (originalColumn === finalColumn && !columnIds.includes(overId as TaskStatus)) {
-        // Same column — check for reorder
-        const columnTasks = finalState[finalColumn] ?? [];
-        const origColumnTasks = tasksByStatus[originalColumn] ?? [];
-        const oldIndex = origColumnTasks.findIndex((t: Task) => t.id === activeId);
-        const newIndex = columnTasks.findIndex((t: Task) => t.id === activeId);
-
-        if (oldIndex !== newIndex && oldIndex >= 0 && newIndex >= 0) {
-          const reordered = arrayMove(origColumnTasks, oldIndex, newIndex);
-          try {
-            await onReorder(reordered.map((t: Task) => t.id));
-            announce(
-              `${taskTitle(activeId)} moved to ${describeTaskPosition(activeId, finalState)}`
-            );
-          } catch {
-            announce(`Move failed. ${taskTitle(activeId)} returned to ${originalPosition}`);
-          }
-        }
-      } else if (originalColumn !== finalColumn) {
-        let statusChanged = false;
-        try {
-          await onStatusChange(activeId, finalColumn);
-          statusChanged = true;
-          const newOrder = (finalState[finalColumn] ?? []).map((t: Task) => t.id);
-          await onReorder(newOrder);
-          announce(`${taskTitle(activeId)} moved to ${describeTaskPosition(activeId, finalState)}`);
-        } catch {
-          if (statusChanged) {
-            try {
-              await onStatusChange(activeId, originalColumn);
-            } catch {
-              const finalColumnTitle =
-                columns.find((column) => column.id === finalColumn)?.title ?? finalColumn;
-              announce(
-                `Move partially failed. ${taskTitle(activeId)} may still be in ${finalColumnTitle} because automatic rollback failed; refresh the board before trying again`
-              );
-              focusTask(activeId);
-              return;
-            }
-          }
-          announce(`Move failed. ${taskTitle(activeId)} returned to ${originalPosition}`);
-        }
+      if (!originalColumn || !finalColumn) {
+        clearDragState(activeId);
+        return;
       }
 
-      // Status changes can remount the card in another column. Restore focus only
-      // after the commit or rollback has updated the task cache.
-      focusTask(activeId);
+      const originalTasks = tasksByStatus[originalColumn] ?? [];
+      const destinationTasks = finalState[finalColumn] ?? [];
+      const oldIndex = originalTasks.findIndex((task) => task.id === activeId);
+      const projectedIndex = destinationTasks.findIndex((task) => task.id === activeId);
+      const fullDestinationTasks = (allTasksByStatus[finalColumn] ?? []).filter(
+        (task) => task.id !== activeId
+      );
+      const followingVisibleId = destinationTasks[projectedIndex + 1]?.id;
+      const precedingVisibleId = destinationTasks[projectedIndex - 1]?.id;
+      const followingIndex = followingVisibleId
+        ? fullDestinationTasks.findIndex((task) => task.id === followingVisibleId)
+        : -1;
+      const precedingIndex = precedingVisibleId
+        ? fullDestinationTasks.findIndex((task) => task.id === precedingVisibleId)
+        : -1;
+      const destinationIndex =
+        followingIndex >= 0
+          ? followingIndex
+          : precedingIndex >= 0
+            ? precedingIndex + 1
+            : fullDestinationTasks.length;
+      const movedTask = tasks.find((task) => task.id === activeId);
+      const changed = originalColumn !== finalColumn || oldIndex !== projectedIndex;
+      if (!movedTask || !changed || projectedIndex < 0) {
+        clearDragState(activeId);
+        return;
+      }
+
+      setIsMovePending(true);
+      try {
+        const result = await onMove(activeId, {
+          operationId: crypto.randomUUID(),
+          sourceStatus: originalColumn,
+          sourcePosition:
+            typeof movedTask.position === 'number' && Number.isFinite(movedTask.position)
+              ? movedTask.position
+              : null,
+          destinationStatus: finalColumn,
+          destinationIndex,
+        });
+        const committedIndex = result.orderedTaskIds.indexOf(result.task.id);
+        const columnTitle =
+          columns.find((column) => column.id === result.task.status)?.title ?? result.task.status;
+        announce(
+          `${result.task.title} moved to ${columnTitle}, position ${committedIndex + 1} of ${result.orderedTaskIds.length}`
+        );
+      } catch {
+        announce(`Move failed. ${taskTitle(activeId)} returned to ${originalPosition}`);
+      } finally {
+        clearDragState(activeId);
+      }
     },
     [
       announce,
+      allTasksByStatus,
       clearDragState,
-      columnIds,
       columns,
       describeTaskPosition,
       dragState,
       findColumn,
-      focusTask,
-      onReorder,
-      onStatusChange,
+      onMove,
       taskTitle,
+      tasks,
       tasksByStatus,
     ]
   );
@@ -456,6 +483,7 @@ export function useBoardDragDrop({
   return {
     activeTask,
     isDragActive: activeTask !== null,
+    isMovePending,
     liveTasksByStatus,
     sensors,
     collisionDetection,

--- a/web/src/hooks/useTaskSync.ts
+++ b/web/src/hooks/useTaskSync.ts
@@ -75,6 +75,7 @@ export function useTaskSync(): {
         // Invalidate activity feed so new events appear in real-time
         queryClient.invalidateQueries({ queryKey: ['activities'] });
         queryClient.invalidateQueries({ queryKey: ['activity-feed'] });
+        queryClient.invalidateQueries({ queryKey: ['activity'] });
 
         // Debounced invalidation of task-counts to prevent rapid re-fetches during bulk operations
         // Clear any existing timer

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -7,9 +7,11 @@ import {
   DEFAULT_FEATURE_SETTINGS,
   normalizeBoardColumns,
   normalizeBoardDefaultStatus,
+  sortTasksByBoardPosition,
   type BoardColumnConfig,
   type Task,
   type CreateTaskInput,
+  type MoveTaskInput,
   type UpdateTaskInput,
 } from '@veritas-kanban/shared';
 
@@ -227,8 +229,7 @@ export function useUpdateTask() {
 
       // Extract enforcement gate error details
       const details = error.details as
-        | Array<{ code: string; message: string; path: string[] }>
-        | undefined;
+        Array<{ code: string; message: string; path: string[] }> | undefined;
 
       // If this is an enforcement gate error, show a detailed toast
       if (details && details.length > 0) {
@@ -282,6 +283,69 @@ export function useUpdateTask() {
     // the mutation start and the refetch completing. The WebSocket
     // task:changed events and polling handle eventual consistency.
     // Status-specific metrics invalidation is handled above (GH-87).
+  });
+}
+
+export function useMoveTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      input,
+    }: {
+      id: string;
+      input: Omit<MoveTaskInput, 'expectedRevision' | 'updatedBy'>;
+    }) => api.tasks.move(id, input, cachedTaskRevision(queryClient, id) ?? 1),
+    retry: (failureCount, error) => {
+      const apiCode =
+        error && typeof error === 'object' && 'code' in error
+          ? (error as { code?: unknown }).code
+          : undefined;
+      const terminalCodes = new Set([
+        'CONFLICT',
+        'VALIDATION_ERROR',
+        'BAD_REQUEST',
+        'NOT_FOUND',
+        'AUTH_REQUIRED',
+        'FORBIDDEN',
+        'WRITE_FORBIDDEN',
+      ]);
+      return failureCount < 1 && (typeof apiCode !== 'string' || !terminalCodes.has(apiCode));
+    },
+    retryDelay: 100,
+    onSuccess: ({ task }) => {
+      patchTaskInCaches(queryClient, task);
+      queryClient.invalidateQueries({ queryKey: ['metrics'] });
+      queryClient.invalidateQueries({ queryKey: ['task-counts'] });
+      queryClient.invalidateQueries({ queryKey: ['activities'] });
+      queryClient.invalidateQueries({ queryKey: ['activity-feed'] });
+      queryClient.invalidateQueries({ queryKey: ['activity'] });
+    },
+    onError: (error: unknown, { id }) => {
+      if (isRevisionConflict(error)) {
+        const current = conflictCurrentTask(error);
+        if (current) patchTaskInCaches(queryClient, current);
+        queryClient.invalidateQueries({ queryKey: ['tasks'] });
+        queryClient.invalidateQueries({ queryKey: ['tasks', id] });
+        toast({
+          title: 'Move not saved',
+          description: current
+            ? `${current.title} changed before the move was committed. The latest task is loaded.`
+            : 'The task changed before the move was committed. Reload and try again.',
+          variant: 'destructive',
+          duration: 10000,
+        });
+        return;
+      }
+
+      toast({
+        title: 'Move failed',
+        description:
+          error instanceof Error ? error.message : 'The task stayed in its original position.',
+        variant: 'destructive',
+      });
+    },
   });
 }
 
@@ -649,16 +713,6 @@ export function useReorderTasks() {
   });
 }
 
-function sortByPosition(tasks: Task[]): Task[] {
-  return [...tasks].sort((a, b) => {
-    const posA = a.position ?? Number.MAX_SAFE_INTEGER;
-    const posB = b.position ?? Number.MAX_SAFE_INTEGER;
-    if (posA !== posB) return posA - posB;
-    // Fallback: newer tasks first (preserve existing behavior for un-positioned tasks)
-    return new Date(b.updated).getTime() - new Date(a.updated).getTime();
-  });
-}
-
 export function useTasksByStatus(
   tasks: Task[] | undefined,
   columns?: BoardColumnConfig[]
@@ -679,7 +733,7 @@ export function useTasksByStatus(
   }
 
   for (const status of Object.keys(grouped)) {
-    grouped[status] = sortByPosition(grouped[status]);
+    grouped[status] = sortTasksByBoardPosition(grouped[status]);
   }
 
   return grouped;

--- a/web/src/lib/api/tasks.ts
+++ b/web/src/lib/api/tasks.ts
@@ -1,7 +1,13 @@
 /**
  * Task API endpoints: CRUD, archive, subtasks, comments, blocking, reorder.
  */
-import type { Task, CreateTaskInput, UpdateTaskInput } from '@veritas-kanban/shared';
+import type {
+  Task,
+  CreateTaskInput,
+  MoveTaskInput,
+  MoveTaskResult,
+  UpdateTaskInput,
+} from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
 
 export const tasksApi = {
@@ -30,6 +36,23 @@ export const tasksApi = {
     const revision = expectedRevision ?? bodyExpectedRevision;
     return apiFetch<Task>(`${API_BASE}/tasks/${id}`, {
       method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(typeof revision === 'number' ? { 'If-Match': `"task:${id}:${revision}"` } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+  },
+
+  move: async (
+    id: string,
+    input: Omit<MoveTaskInput, 'updatedBy'>,
+    expectedRevision?: number
+  ): Promise<MoveTaskResult> => {
+    const revision = expectedRevision ?? input.expectedRevision;
+    const { expectedRevision: _expectedRevision, ...body } = input;
+    return apiFetch<MoveTaskResult>(`${API_BASE}/tasks/${id}/move`, {
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         ...(typeof revision === 'number' ? { 'If-Match': `"task:${id}:${revision}"` } : {}),


### PR DESCRIPTION
## Summary

- replace cross-column status and reorder requests with one revisioned, idempotent board move command
- preserve the pending drag projection until the authoritative response and reconcile task, count, metric, and activity caches
- persist exact board order across file and SQLite storage without rewriting neighboring tasks
- repair move audit projections idempotently and retain a durable completion receipt across restarts and retention
- isolate the drag overlay from board layout and use theme-aware card styling

## Verification

- pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/task-move.test.ts src/__tests__/routes/tasks-coverage.test.ts
- focused web tests: 43 passed
- pnpm exec playwright test e2e/board-drag-atomic.spec.ts --project=chromium --reporter=line: 5 passed
- pnpm build
- focused ESLint: 0 errors
- two independent code reviews: no findings

Fixes #1302
