### PR TITLE
feat: redesign board color language

### DIFF
--- a/docs/design/BOARD-COLOR-EXPLORATION-1301.html
+++ b/docs/design/BOARD-COLOR-EXPLORATION-1301.html
@@ -1,0 +1,538 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Veritas board color exploration</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: Inter, Roboto, system-ui, sans-serif;
+        --bg: #101013;
+        --panel: #18181d;
+        --card: #202027;
+        --line: #34343d;
+        --text: #f3f3f5;
+        --muted: #a7a6b0;
+        --violet: #9c7cff;
+        --blue: #58a6ff;
+        --red: #ff6b72;
+        --green: #54d18b;
+        --amber: #f2b84b;
+        --cyan: #49c7d5;
+        --orange: #f29a58;
+        --rose: #ee77b7;
+      }
+      [data-theme='light'] {
+        color-scheme: light;
+        --bg: #f4f4f7;
+        --panel: #ffffff;
+        --card: #ffffff;
+        --line: #dcdce4;
+        --text: #1d1d24;
+        --muted: #656572;
+        --violet: #6541d5;
+        --blue: #1769c2;
+        --red: #c5353d;
+        --green: #187c46;
+        --amber: #956311;
+        --cyan: #177986;
+        --orange: #a95016;
+        --rose: #a13970;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+      }
+      header {
+        position: sticky;
+        top: 0;
+        z-index: 2;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 24px;
+        padding: 18px 24px;
+        border-bottom: 1px solid var(--line);
+        background: color-mix(in srgb, var(--bg) 92%, transparent);
+        backdrop-filter: blur(12px);
+      }
+      h1 {
+        margin: 0;
+        font-size: 18px;
+        letter-spacing: -0.02em;
+      }
+      header p {
+        margin: 3px 0 0;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      button {
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        background: var(--panel);
+        color: var(--text);
+        padding: 8px 12px;
+        cursor: pointer;
+      }
+      .preview-controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      select {
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        background: var(--panel);
+        color: var(--text);
+        padding: 8px 12px;
+      }
+      main {
+        display: grid;
+        gap: 30px;
+        padding: 24px;
+      }
+      section {
+        display: grid;
+        gap: 12px;
+      }
+      .concept-head {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        gap: 20px;
+      }
+      h2 {
+        margin: 0;
+        font-size: 15px;
+      }
+      .concept-head p {
+        margin: 3px 0 0;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .verdict {
+        color: var(--muted);
+        font-size: 11px;
+        text-align: right;
+        max-width: 420px;
+      }
+      .board {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(235px, 1fr));
+        gap: 10px;
+        overflow-x: auto;
+      }
+      .column {
+        min-width: 235px;
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: color-mix(in srgb, var(--panel) 78%, var(--bg));
+        padding: 8px;
+      }
+      .column-head {
+        min-height: 38px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        margin-bottom: 8px;
+      }
+      .column-title {
+        font-size: 12px;
+        font-weight: 700;
+      }
+      .count {
+        font:
+          700 10px ui-monospace,
+          monospace;
+        color: var(--muted);
+      }
+      .cards {
+        display: grid;
+        gap: 7px;
+      }
+      .card {
+        position: relative;
+        min-height: 76px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--card);
+        padding: 9px;
+      }
+      .card-title {
+        margin-top: 7px;
+        font-size: 11px;
+        font-weight: 650;
+        line-height: 1.25;
+      }
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 7px;
+      }
+      .tag {
+        border-radius: 4px;
+        background: color-mix(in srgb, var(--line) 55%, transparent);
+        color: var(--muted);
+        padding: 2px 5px;
+        font-size: 9px;
+      }
+      .state {
+        font-weight: 700;
+      }
+      .state.running {
+        color: var(--violet);
+      }
+      .state.blocked,
+      .state.failed {
+        color: var(--red);
+      }
+      .state.review {
+        color: var(--blue);
+      }
+      .state.verified {
+        color: var(--green);
+      }
+      .selected {
+        outline: 2px solid var(--violet);
+        outline-offset: 1px;
+      }
+      .focused {
+        outline: 2px dotted var(--text);
+        outline-offset: 2px;
+      }
+      .dragged {
+        opacity: 0.55;
+        transform: translateY(-2px) rotate(0.5deg);
+      }
+      .drop-target {
+        box-shadow: inset 0 0 0 2px var(--violet);
+      }
+      .running-card {
+        background: color-mix(in srgb, var(--violet) 8%, var(--card));
+      }
+      .blocked-card,
+      .failed-card {
+        background: color-mix(in srgb, var(--red) 7%, var(--card));
+      }
+
+      .c1 .status-plate {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border-radius: 6px;
+        padding: 6px 8px;
+        color: var(--status);
+        background: color-mix(in srgb, var(--status) 13%, var(--card));
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status) 32%, transparent);
+      }
+      .c1 .status-plate .count {
+        color: inherit;
+        opacity: 0.8;
+        padding-left: 6px;
+        border-left: 1px solid color-mix(in srgb, var(--status) 35%, transparent);
+      }
+      .c1 .stamp {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        border-radius: 5px;
+        padding: 3px 6px;
+        color: var(--identity);
+        background: color-mix(in srgb, var(--identity) 13%, var(--card));
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--identity) 30%, transparent);
+        font-size: 9px;
+        font-weight: 750;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+      }
+      .c1 .stamp::before {
+        content: attr(data-glyph);
+        font-size: 10px;
+      }
+
+      .c2 .column-head {
+        border-bottom: 1px solid var(--line);
+      }
+      .c2 .field-row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 4px;
+        margin-top: 7px;
+      }
+      .c2 .field {
+        padding: 4px 6px;
+        border-radius: 4px;
+        background: color-mix(in srgb, var(--identity) 16%, var(--card));
+        color: var(--identity);
+        font-size: 9px;
+        font-weight: 700;
+      }
+      .c2 .state-field {
+        padding: 4px 6px;
+        border-radius: 4px;
+        background: color-mix(in srgb, var(--status) 14%, var(--card));
+        color: var(--status);
+        font-size: 9px;
+        font-weight: 700;
+      }
+
+      .c3 .column-head {
+        padding-inline: 3px;
+      }
+      .c3 .seal {
+        position: absolute;
+        right: 8px;
+        top: 8px;
+        width: 22px;
+        height: 22px;
+        display: grid;
+        place-items: center;
+        border: 1px solid color-mix(in srgb, var(--status) 42%, var(--line));
+        border-radius: 4px 8px 4px 8px;
+        color: var(--status);
+        background: color-mix(in srgb, var(--status) 12%, var(--card));
+        font-size: 11px;
+        font-weight: 800;
+      }
+      .c3 .card-title {
+        padding-right: 26px;
+      }
+      .c3 .identity-key {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        color: var(--identity);
+        font-size: 9px;
+        font-weight: 700;
+      }
+      .c3 .identity-key::before {
+        content: '';
+        width: 8px;
+        height: 8px;
+        border-radius: 2px;
+        background: var(--identity);
+      }
+
+      [data-status='todo'] {
+        --status: var(--muted);
+      }
+      [data-status='in-progress'] {
+        --status: var(--blue);
+      }
+      [data-status='blocked'],
+      [data-state='blocked'],
+      [data-state='failed'] {
+        --status: var(--red);
+      }
+      [data-status='done'],
+      [data-state='verified'] {
+        --status: var(--green);
+      }
+      [data-state='running'] {
+        --status: var(--blue);
+      }
+      [data-state='review'] {
+        --status: var(--blue);
+      }
+      [data-type='code'] {
+        --identity: var(--violet);
+      }
+      [data-type='research'] {
+        --identity: var(--cyan);
+      }
+      [data-type='content'] {
+        --identity: var(--orange);
+      }
+      [data-type='automation'] {
+        --identity: var(--green);
+      }
+      [data-type='bug'] {
+        --identity: var(--red);
+      }
+      [data-type='design'] {
+        --identity: var(--rose);
+      }
+      @media (max-width: 760px) {
+        header,
+        .concept-head {
+          align-items: flex-start;
+        }
+        header {
+          padding: 14px;
+        }
+        main {
+          padding: 14px;
+        }
+        .board {
+          grid-template-columns: repeat(4, 250px);
+        }
+        .verdict {
+          display: none;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        * {
+          transition: none !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div>
+        <h1>Board color language · #1301</h1>
+        <p>Same 24 tasks, same states, three placement systems</p>
+      </div>
+      <div class="preview-controls">
+        <label>
+          <span class="sr-only">Color simulation</span>
+          <select id="simulation" aria-label="Color simulation">
+            <option value="normal">Normal color</option>
+            <option value="grayscale">Grayscale</option>
+            <option value="deuteranopia">Deuteranopia simulation</option>
+          </select>
+        </label>
+        <button id="theme" type="button">Switch theme</button>
+      </div>
+    </header>
+    <svg aria-hidden="true" width="0" height="0" style="position: absolute">
+      <filter id="deuteranopia">
+        <feColorMatrix
+          type="matrix"
+          values="0.625 0.375 0 0 0  0.7 0.3 0 0 0  0 0.3 0.7 0 0  0 0 0 1 0"
+        />
+      </filter>
+    </svg>
+    <main id="concepts"></main>
+    <script>
+      const tasks = [
+        ['Define launch policy', 'code', 'normal'],
+        ['Interview operators', 'research', 'review'],
+        ['Draft release narrative', 'content', 'normal'],
+        ['Automate artifact checks', 'automation', 'running'],
+        ['Repair auth callback', 'bug', 'blocked'],
+        ['Refine empty state', 'design', 'focused'],
+        ['Persist run journal', 'code', 'running'],
+        ['Review provider matrix', 'research', 'normal'],
+        ['Write migration guide', 'content', 'review'],
+        ['Sync release assets', 'automation', 'normal'],
+        ['Fix recovery race', 'bug', 'failed'],
+        ['Map evidence panel', 'design', 'selected'],
+        ['Compile phase authority', 'code', 'normal'],
+        ['Audit dependency graph', 'research', 'normal'],
+        ['Polish operator notes', 'content', 'normal'],
+        ['Publish package metadata', 'automation', 'dragged'],
+        ['Resolve storage lock', 'bug', 'blocked'],
+        ['Tune dense card layout', 'design', 'normal'],
+        ['Verify sandbox contract', 'code', 'verified'],
+        ['Confirm release checksum', 'research', 'verified'],
+        ['Finalize changelog', 'content', 'verified'],
+        ['Tag signed artifacts', 'automation', 'verified'],
+        ['Close regression finding', 'bug', 'verified'],
+        ['Approve visual system', 'design', 'verified'],
+      ];
+      const columns = [
+        ['todo', '○', 'To Do'],
+        ['in-progress', '▶', 'In Progress'],
+        ['blocked', '!', 'Blocked'],
+        ['done', '✓', 'Done'],
+      ];
+      const concepts = [
+        [
+          'c1',
+          '1 · Status plates + classification stamps',
+          'Chosen: fastest status/type scan, distinctive compact objects, clean interaction hierarchy.',
+        ],
+        [
+          'c2',
+          '2 · Integrated metadata fields',
+          'Rejected: coherent but the repeated field tray reads like a generic admin dashboard.',
+        ],
+        [
+          'c3',
+          '3 · Evidence seals + identity keys',
+          'Rejected: Veritas-specific, but verification marks compete with blocked and running state.',
+        ],
+      ];
+      const stateLabel = {
+        normal: 'Ready',
+        running: 'Running',
+        blocked: 'Blocked',
+        failed: 'Failed',
+        review: 'Awaiting review',
+        verified: 'Verified',
+        selected: 'Selected',
+        focused: 'Focused',
+        dragged: 'Dragging',
+      };
+      function cardMarkup(task, concept, index) {
+        const [title, type, state] = task;
+        const classNames = [
+          'card',
+          state === 'selected' ? 'selected' : '',
+          state === 'focused' ? 'focused' : '',
+          state === 'dragged' ? 'dragged' : '',
+          state === 'running' ? 'running-card' : '',
+          state === 'blocked' ? 'blocked-card' : '',
+          state === 'failed' ? 'failed-card' : '',
+        ].join(' ');
+        const glyph = {
+          code: '</>',
+          research: '?',
+          content: '¶',
+          automation: '⚡',
+          bug: '!',
+          design: '◇',
+        }[type];
+        const status = state === 'normal' ? columns[Math.floor(index / 6)][0] : state;
+        if (concept === 'c1')
+          return `<article class="${classNames}" data-type="${type}" data-state="${state}"><span class="stamp" data-glyph="${glyph}">${type}</span><div class="card-title">${title}</div><div class="meta"><span class="tag">Veritas</span><span class="tag state ${state}">${stateLabel[state]}</span><span class="tag">P${index % 4}</span></div></article>`;
+        if (concept === 'c2')
+          return `<article class="${classNames}" data-type="${type}" data-state="${state}"><div class="card-title">${title}</div><div class="field-row"><span class="field">${glyph} ${type}</span><span class="state-field">${stateLabel[state]}</span></div><div class="meta"><span class="tag">Veritas</span><span class="tag">Sprint 6.1</span></div></article>`;
+        return `<article class="${classNames}" data-type="${type}" data-state="${state}"><span class="seal">${state === 'verified' ? 'V' : state === 'blocked' || state === 'failed' ? '!' : state === 'running' ? '▶' : '·'}</span><span class="identity-key">${type}</span><div class="card-title">${title}</div><div class="meta"><span class="tag">Veritas</span><span class="tag state ${state}">${stateLabel[state]}</span></div></article>`;
+      }
+      function conceptMarkup([className, title, verdict]) {
+        return `<section class="${className}"><div class="concept-head"><div><h2>${title}</h2><p>Normal, selected, focused, dragged, running, blocked, failed, review, and verified states</p></div><div class="verdict">${verdict}</div></div><div class="board">${columns
+          .map(
+            ([status, glyph, label], columnIndex) =>
+              `<div class="column ${columnIndex === 1 ? 'drop-target' : ''}" data-status="${status}"><div class="column-head">${className === 'c1' ? `<span class="status-plate"><b>${glyph}</b><span class="column-title">${label}</span><span class="count">6</span></span>` : `<span class="column-title">${glyph} ${label}</span><span class="count">6</span>`}</div><div class="cards">${tasks
+                .slice(columnIndex * 6, columnIndex * 6 + 6)
+                .map((task, offset) => cardMarkup(task, className, columnIndex * 6 + offset))
+                .join('')}</div></div>`
+          )
+          .join('')}</div></section>`;
+      }
+      document.querySelector('#concepts').innerHTML = concepts.map(conceptMarkup).join('');
+      document.querySelector('#theme').addEventListener('click', () => {
+        document.documentElement.dataset.theme =
+          document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+      });
+      document.querySelector('#simulation').addEventListener('change', (event) => {
+        const filters = {
+          normal: 'none',
+          grayscale: 'grayscale(1)',
+          deuteranopia: 'url(#deuteranopia)',
+        };
+        document.querySelector('#concepts').style.filter = filters[event.target.value];
+      });
+    </script>
+  </body>
+</html>

--- a/docs/design/BOARD-COLOR-SYSTEM.md
+++ b/docs/design/BOARD-COLOR-SYSTEM.md
@@ -1,0 +1,41 @@
+# Board color system
+
+This contract defines how the board uses color. Color is never the only signal: every identity and state also has a label, icon, shape, border, or focus treatment.
+
+The 24-task comparison surface is [BOARD-COLOR-EXPLORATION-1301.html](./BOARD-COLOR-EXPLORATION-1301.html). It renders the same tasks and representative normal, selected, focused, dragged, running, blocked, failed, awaiting-review, verified, and drop-target states for all three concepts in dark and light themes.
+
+## Concepts reviewed
+
+1. **Status plates plus classification stamps.** A localized column plate combines status glyph, name, and count. Each card has a compact task-type stamp containing its icon and label. Active operational states may add a restrained tonal card surface. This was selected because status and identity remained fastest to locate at full-board scale, the shapes stayed legible in grayscale, and violet interaction states remained distinct from identity colors.
+2. **Integrated metadata fields with quiet column framing.** Type and state became adjacent fields beneath each title. The geometry was consistent, but repeated field trays slowed title scanning and looked transferable to a generic administration dashboard. Rejected.
+3. **Evidence seals plus identity keys.** A corner seal represented operational or verification state while a small keyed mark represented task identity. The evidence metaphor was distinctive, but the seal competed with blockers, active runs, and selection when several signals appeared together. Rejected.
+
+The selected direction uses compact objects at the point where meaning is read. It does not use full-width status rails, card-side identity rails, glows, gradients, or broad decorative card tints.
+
+## Token roles
+
+| Role        | Source                                                          | Placement                                               | Emphasis                             |
+| ----------- | --------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------ |
+| Identity    | `--vk-identity-*`                                               | Task-type stamp and settings swatch                     | Controlled chroma; repeatable shape  |
+| State       | `--vk-state-*`                                                  | Column status plate and labeled task signal             | Stronger than ordinary metadata      |
+| Urgency     | `--vk-urgency-*`                                                | Blocked, failed, and readiness-warning signals          | Strongest active contrast            |
+| Interaction | Existing `--primary` and `--ring`                               | Selection, keyboard focus, drag source, and drop target | Violet; never inferred from identity |
+| Structure   | Existing background, card, muted, border, and foreground tokens | Board, columns, cards, and secondary metadata           | Neutral stage for semantic color     |
+
+Identity tokens are `neutral`, `violet`, `cyan`, `orange`, `emerald`, `rose`, `amber`, `blue`, `red`, and `umber`. Light and dark values are calibrated as families in `web/src/globals.css`; surfaces and outlines are derived from the same mark with consistent mix ratios.
+
+## Signal hierarchy
+
+- Blocked and failed use the urgency-failure family and may tone the card surface because action is required.
+- Running uses the active-state family and awaiting review uses the review-state family. Both include text and an icon.
+- Verified uses the done-state family with a shield/check label. Incomplete readiness uses warning amber, never failure red by default.
+- Project, sprint, priority, attachment, timing, and progress metadata remain labeled and visible but do not override operational state.
+- Selected and focused states use violet ring geometry independent of the task-type color. Dragged cards use opacity and motion; drop targets use an inset violet boundary.
+
+## Stored configuration migration
+
+`TaskTypeConfig.colorToken` is the semantic contract for new and updated task types. The legacy `color` field remains readable so existing `border-l-*` values load without data loss. The web resolver maps every color previously offered by Settings to the closest semantic token and falls back to `neutral` for unknown values. Saving a color from Settings writes `colorToken`; no arbitrary CSS class is required.
+
+## Responsive and accessibility behavior
+
+The plate and stamp stay compact in both board densities. Columns retain the board's existing responsive layout, while card metadata continues to wrap on narrow surfaces. Status glyphs, labels, counts, signal text, focus rings, and border changes preserve meaning in grayscale and common color-vision-deficiency conditions. Essential text and controls continue to use the established foreground and focus tokens; semantic color is supplemental.

--- a/server/src/routes/task-types.ts
+++ b/server/src/routes/task-types.ts
@@ -1,3 +1,4 @@
+import { TASK_TYPE_COLOR_TOKENS } from '@veritas-kanban/shared';
 import { z } from 'zod';
 import { TaskTypeService } from '../services/task-type-service.js';
 import { getTaskService } from '../services/task-service.js';
@@ -9,12 +10,14 @@ const log = createLogger('task-types');
 const createTaskTypeSchema = z.object({
   label: z.string().min(1),
   icon: z.string().min(1),
+  colorToken: z.enum(TASK_TYPE_COLOR_TOKENS).optional(),
   color: z.string().optional(),
 });
 
 const updateTaskTypeSchema = z.object({
   label: z.string().min(1).optional(),
   icon: z.string().min(1).optional(),
+  colorToken: z.enum(TASK_TYPE_COLOR_TOKENS).optional(),
   color: z.string().optional(),
   isHidden: z.boolean().optional(),
 });

--- a/server/src/services/task-type-service.ts
+++ b/server/src/services/task-type-service.ts
@@ -8,7 +8,7 @@ const DEFAULT_TASK_TYPES: TaskTypeConfig[] = [
     id: 'code',
     label: 'Code',
     icon: 'Code',
-    color: 'border-l-violet-500',
+    colorToken: 'violet',
     order: 0,
     isDefault: true,
     created: new Date().toISOString(),
@@ -18,7 +18,7 @@ const DEFAULT_TASK_TYPES: TaskTypeConfig[] = [
     id: 'research',
     label: 'Research',
     icon: 'Search',
-    color: 'border-l-cyan-500',
+    colorToken: 'cyan',
     order: 1,
     isDefault: true,
     created: new Date().toISOString(),
@@ -28,7 +28,7 @@ const DEFAULT_TASK_TYPES: TaskTypeConfig[] = [
     id: 'content',
     label: 'Content',
     icon: 'FileText',
-    color: 'border-l-orange-500',
+    colorToken: 'orange',
     order: 2,
     isDefault: true,
     created: new Date().toISOString(),
@@ -38,7 +38,7 @@ const DEFAULT_TASK_TYPES: TaskTypeConfig[] = [
     id: 'automation',
     label: 'Automation',
     icon: 'Zap',
-    color: 'border-l-emerald-500',
+    colorToken: 'emerald',
     order: 3,
     isDefault: true,
     created: new Date().toISOString(),
@@ -59,7 +59,7 @@ export class TaskTypeService extends ManagedListService<TaskTypeConfig> {
       referenceCounter: async (typeId: string) => {
         // Count how many tasks use this type
         const tasks = await taskService.listTasks();
-        return tasks.filter((task: any) => task.type === typeId).length;
+        return tasks.filter((task) => task.type === typeId).length;
       },
     });
 

--- a/shared/src/types/managed-list.types.ts
+++ b/shared/src/types/managed-list.types.ts
@@ -18,16 +18,33 @@ export interface ManagedListServiceOptions {
   defaults: ManagedListItem[];
 }
 
-/** Task type configuration with icon and color */
+export const TASK_TYPE_COLOR_TOKENS = [
+  'neutral',
+  'violet',
+  'cyan',
+  'orange',
+  'emerald',
+  'rose',
+  'amber',
+  'blue',
+  'red',
+  'umber',
+] as const;
+
+export type TaskTypeColorToken = (typeof TASK_TYPE_COLOR_TOKENS)[number];
+
+/** Task type configuration with icon and semantic identity color */
 export interface TaskTypeConfig extends ManagedListItem {
-  icon: string;    // Lucide icon name (e.g., "Code", "Search")
-  color?: string;  // Tailwind border color class (e.g., "border-l-violet-500")
+  icon: string; // Lucide icon name (e.g., "Code", "Search")
+  colorToken?: TaskTypeColorToken;
+  /** @deprecated Legacy Tailwind border class retained for stored configuration migration. */
+  color?: string;
 }
 
 /** Project configuration with description and badge color */
 export interface ProjectConfig extends ManagedListItem {
   description?: string;
-  color?: string;  // Tailwind bg color class for badges (e.g., "bg-blue-500/20")
+  color?: string; // Tailwind bg color class for badges (e.g., "bg-blue-500/20")
 }
 
 /** Sprint configuration */

--- a/web/src/__tests__/TaskCard.test.tsx
+++ b/web/src/__tests__/TaskCard.test.tsx
@@ -84,7 +84,7 @@ vi.mock('@/hooks/useTimeTracking', () => ({
 
 vi.mock('@/hooks/useTaskTypes', () => ({
   getTypeIcon: () => () => React.createElement('span', { 'data-testid': 'type-icon' }),
-  getTypeColor: () => 'border-l-violet-500',
+  getTypeColorToken: () => 'violet',
 }));
 
 vi.mock('@/hooks/useProjects', () => ({
@@ -177,7 +177,10 @@ describe('TaskCard', () => {
   it('renders type label', () => {
     const task = createMockTask({ type: 'feature' });
     renderCard(task);
-    expect(screen.getByText('Feature')).toBeDefined();
+    const stamp = screen.getByLabelText('Task type: Feature');
+    expect(stamp.textContent).toContain('Feature');
+    expect(stamp.getAttribute('data-color-token')).toBe('violet');
+    expect(screen.getByRole('article').className).not.toContain('border-l-2');
   });
 
   it('renders project badge when project is set', () => {
@@ -288,10 +291,11 @@ describe('TaskCard', () => {
   });
 
   it('shows blocked badge when isBlocked', () => {
-    const task = createMockTask();
+    const task = createMockTask({ status: 'blocked' });
     renderCard(task, { isBlocked: true, blockerTitles: ['Dependency A'] });
 
     expect(screen.getByText('Blocked')).toBeDefined();
+    expect(screen.getByRole('article').className).toContain('vk-task-card--blocked');
   });
 
   it('shows agent running indicator', () => {
@@ -305,6 +309,39 @@ describe('TaskCard', () => {
     });
     renderCard(task);
     expect(screen.getByText(/Claude running/)).toBeDefined();
+    expect(screen.getByRole('article').className).toContain('vk-task-card--running');
+    expect(screen.getByRole('article').className).not.toContain('shadow-[0_0_15px');
+  });
+
+  it('distinguishes failed, review, and verified semantic signals without color alone', () => {
+    const failedTask = createMockTask({
+      attempt: {
+        id: 'attempt-failed',
+        agent: 'claude-code',
+        status: 'failed',
+        started: '2025-01-01T00:00:00Z',
+      },
+    });
+    const { unmount } = renderCard(failedTask);
+    expect(screen.getByText('Failed')).toBeDefined();
+    expect(screen.getByRole('article').className).toContain('vk-task-card--failed');
+    expect(screen.getByRole('article').getAttribute('aria-label')).toContain(
+      'Latest attempt failed'
+    );
+
+    unmount();
+    renderCard(createMockTask({ status: 'awaiting-review' }));
+    expect(screen.getByText('Awaiting review')).toBeDefined();
+    expect(screen.getByRole('article').className).toContain('vk-task-card--review');
+
+    cleanup();
+    renderCard(
+      createMockTask({
+        verificationSteps: [{ id: 'verify-1', description: 'Feature passes', checked: true }],
+      })
+    );
+    expect(screen.getByText('Verified 1/1')).toBeDefined();
+    expect(screen.getByRole('article').className).toContain('vk-task-card--verified');
   });
 
   it('shows subtask progress', () => {

--- a/web/src/__tests__/board-color-system.test.tsx
+++ b/web/src/__tests__/board-color-system.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { KanbanColumn } from '@/components/board/KanbanColumn';
+import { getTypeColorToken, normalizeTaskTypeColorToken } from '@/hooks/useTaskTypes';
+import type { TaskTypeConfig } from '@veritas-kanban/shared';
+
+const { dropState } = vi.hoisted(() => ({ dropState: { isOver: false } }));
+
+vi.mock('@dnd-kit/core', () => ({
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: dropState.isOver }),
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: {},
+}));
+
+vi.mock('@/hooks/useFeatureSettings', () => ({
+  useFeatureSettings: () => ({ settings: { board: { showDoneMetrics: false } } }),
+}));
+
+vi.mock('@/hooks/useBulkActions', () => ({
+  useBulkActions: () => ({
+    isSelecting: false,
+    selectedIds: new Set<string>(),
+    toggleGroup: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useBulkTaskMetrics', () => ({
+  useBulkTaskMetrics: () => ({ data: undefined }),
+}));
+
+vi.mock('@/hooks/useTasks', () => ({
+  isTaskBlocked: () => false,
+  getTaskBlockers: () => [],
+}));
+
+vi.mock('@/components/task/TaskCard', () => ({
+  TaskCard: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+  dropState.isOver = false;
+});
+
+describe('board color system', () => {
+  it('uses a localized status plate instead of a full-width column rail', () => {
+    render(<KanbanColumn id="in-progress" title="In Progress" tasks={[]} allTasks={[]} />);
+
+    const column = screen.getByRole('region', { name: 'In Progress' });
+    const plate = screen.getByRole('heading', { name: 'In Progress' }).parentElement;
+    expect(column.className).toContain('vk-kanban-column');
+    expect(column.className).not.toContain('border-t-2');
+    expect(plate?.getAttribute('data-status-tone')).toBe('active');
+    expect(screen.getByLabelText('0 tasks').textContent).toBe('0');
+  });
+
+  it('keeps custom review columns meaningful and gives drop targets interaction color', () => {
+    dropState.isOver = true;
+    render(<KanbanColumn id="awaiting-review" title="Awaiting Review" tasks={[]} allTasks={[]} />);
+
+    const column = screen.getByRole('region', { name: 'Awaiting Review' });
+    expect(column.getAttribute('data-drop-target')).toBe('true');
+    expect(column.className).toContain('vk-kanban-column--drop-target');
+    expect(screen.getByRole('heading', { name: 'Awaiting Review' }).parentElement).toHaveProperty(
+      'dataset.statusTone',
+      'review'
+    );
+  });
+
+  it('maps legacy persisted Tailwind colors into semantic identities', () => {
+    const legacyTypes: TaskTypeConfig[] = [
+      {
+        id: 'legacy-research',
+        label: 'Legacy Research',
+        icon: 'Search',
+        color: 'border-l-cyan-500',
+        order: 0,
+        created: '2026-01-01T00:00:00.000Z',
+        updated: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: 'semantic-code',
+        label: 'Semantic Code',
+        icon: 'Code',
+        colorToken: 'violet',
+        color: 'border-l-red-500',
+        order: 1,
+        created: '2026-01-01T00:00:00.000Z',
+        updated: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+
+    expect(normalizeTaskTypeColorToken('border-l-cyan-500')).toBe('cyan');
+    expect(normalizeTaskTypeColorToken('unknown-class')).toBe('neutral');
+    expect(getTypeColorToken(legacyTypes, 'legacy-research')).toBe('cyan');
+    expect(getTypeColorToken(legacyTypes, 'semantic-code')).toBe('violet');
+  });
+});

--- a/web/src/__tests__/settings-managed-list-mantine.test.tsx
+++ b/web/src/__tests__/settings-managed-list-mantine.test.tsx
@@ -99,10 +99,11 @@ describe('Managed list Mantine migration', () => {
     });
   });
 
-  it('keeps the task-type default color available in the Manage tab picker', () => {
+  it('offers semantic task-type colors rather than presentation classes', () => {
     expect(AVAILABLE_COLORS).toContainEqual({
-      value: 'border-l-gray-500',
-      label: 'Gray',
+      value: 'neutral',
+      label: 'Graphite',
     });
+    expect(AVAILABLE_COLORS.some((color) => color.value.startsWith('border-'))).toBe(false);
   });
 });

--- a/web/src/components/board/BoardLoadingSkeleton.tsx
+++ b/web/src/components/board/BoardLoadingSkeleton.tsx
@@ -14,13 +14,9 @@ export function BoardLoadingSkeleton({ columns }: BoardLoadingSkeletonProps) {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
       {columns.map((column) => (
-        <div
-          key={column.id}
-          className="flex flex-col rounded-lg bg-muted/50 border-t-2 border-t-muted-foreground/20"
-        >
+        <div key={column.id} className="vk-kanban-column flex flex-col rounded-lg">
           <div className="flex items-center justify-between px-3 py-2">
-            <Skeleton className="h-4 w-20" />
-            <Skeleton className="h-5 w-6 rounded-full" />
+            <Skeleton className="h-7 w-28 rounded-md" />
           </div>
           <div className="flex-1 p-2 space-y-2 min-h-[calc(100vh-200px)]">
             {[1, 2, 3].map((i) => (

--- a/web/src/components/board/KanbanColumn.tsx
+++ b/web/src/components/board/KanbanColumn.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { BadgeCheck, Ban, CircleDashed, CircleDot, OctagonAlert, Play } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TaskCard } from '@/components/task/TaskCard';
 import { isTaskBlocked, getTaskBlockers } from '@/hooks/useTasks';
@@ -25,13 +26,24 @@ interface KanbanColumnProps {
   statusOptions?: Array<{ value: TaskStatus; label: string }>;
 }
 
-const columnColors: Record<string, string> = {
-  todo: 'border-t-slate-500',
-  'in-progress': 'border-t-blue-500',
-  blocked: 'border-t-red-500',
-  done: 'border-t-green-500',
-  cancelled: 'border-t-gray-400',
+type StatusTone = 'todo' | 'active' | 'blocked' | 'done' | 'cancelled' | 'review' | 'custom';
+
+const columnStatusPresentation: Record<string, { tone: StatusTone; icon: typeof CircleDot }> = {
+  todo: { tone: 'todo', icon: CircleDashed },
+  'in-progress': { tone: 'active', icon: Play },
+  blocked: { tone: 'blocked', icon: OctagonAlert },
+  done: { tone: 'done', icon: BadgeCheck },
+  cancelled: { tone: 'cancelled', icon: Ban },
 };
+
+function getStatusPresentation(status: string) {
+  return (
+    columnStatusPresentation[status] ?? {
+      tone: status.toLowerCase().includes('review') ? ('review' as const) : ('custom' as const),
+      icon: CircleDot,
+    }
+  );
+}
 
 export function KanbanColumn({
   id,
@@ -51,6 +63,8 @@ export function KanbanColumn({
   const { settings: featureSettings } = useFeatureSettings();
   const { isSelecting, selectedIds, toggleGroup } = useBulkActions();
   const showDoneMetrics = featureSettings.board.showDoneMetrics;
+  const statusPresentation = getStatusPresentation(id);
+  const StatusIcon = statusPresentation.icon;
 
   // Get task IDs for done column to fetch bulk metrics
   const doneTaskIds = useMemo(() => {
@@ -74,10 +88,11 @@ export function KanbanColumn({
       role="region"
       aria-labelledby={`column-heading-${id}`}
       aria-roledescription="kanban column"
+      data-column-status={id}
+      data-drop-target={dragEnabled && isOver ? 'true' : undefined}
       className={cn(
-        'flex flex-col rounded-lg bg-muted/50 border-t-2 transition-colors',
-        columnColors[id] ?? 'border-t-primary',
-        dragEnabled && isOver && 'ring-2 ring-primary/50 bg-muted/70'
+        'vk-kanban-column flex flex-col rounded-lg transition-colors',
+        dragEnabled && isOver && 'vk-kanban-column--drop-target'
       )}
     >
       <div className="flex items-center justify-between px-3 py-2">
@@ -94,17 +109,20 @@ export function KanbanColumn({
               aria-label={`Select all ${title} tasks`}
             />
           )}
-          <h2 id={`column-heading-${id}`} className="text-sm font-medium text-muted-foreground">
-            {title}
-          </h2>
+          <div className="vk-column-status-plate" data-status-tone={statusPresentation.tone}>
+            <StatusIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            <h2 id={`column-heading-${id}`} className="text-xs font-semibold">
+              {title}
+            </h2>
+            <span
+              className="vk-column-status-count"
+              aria-live="polite"
+              aria-label={`${tasks.length} ${tasks.length === 1 ? 'task' : 'tasks'}`}
+            >
+              {tasks.length}
+            </span>
+          </div>
         </div>
-        <span
-          className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full"
-          aria-live="polite"
-          aria-label={`${tasks.length} ${tasks.length === 1 ? 'task' : 'tasks'}`}
-        >
-          {tasks.length}
-        </span>
       </div>
 
       <SortableContext items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>

--- a/web/src/components/settings/tabs/ManageTab.tsx
+++ b/web/src/components/settings/tabs/ManageTab.tsx
@@ -6,6 +6,7 @@ import {
   AVAILABLE_COLORS,
   getAvailableIcons,
   getTypeIcon,
+  normalizeTaskTypeColorToken,
   useTaskTypesManager,
 } from '@/hooks/useTaskTypes';
 import { AVAILABLE_PROJECT_COLORS, useProjectsManager } from '@/hooks/useProjects';
@@ -152,9 +153,9 @@ export function ManageTab() {
                     Color
                   </Text>
                   <Select
-                    value={item.color || 'border-l-gray-500'}
-                    onChange={(color) => {
-                      if (color) onChange({ color });
+                    value={normalizeTaskTypeColorToken(item.colorToken ?? item.color)}
+                    onChange={(colorToken) => {
+                      if (colorToken) onChange({ colorToken });
                     }}
                     data={taskTypeColorOptions}
                     size="xs"
@@ -163,7 +164,11 @@ export function ManageTab() {
                     aria-label={`${item.label} color`}
                     renderOption={({ option }) => (
                       <div className="flex items-center gap-2">
-                        <div className={`w-4 h-4 rounded border-l-4 ${option.value}`} />
+                        <div
+                          className="vk-task-type-swatch"
+                          data-color-token={option.value}
+                          aria-hidden="true"
+                        />
                         {option.label}
                       </div>
                     )}
@@ -171,7 +176,7 @@ export function ManageTab() {
                 </div>
               </div>
             )}
-            newItemDefaults={{ icon: 'Code', color: 'border-l-gray-500' }}
+            newItemDefaults={{ icon: 'Code', colorToken: 'neutral' }}
           />
         </div>
       </div>

--- a/web/src/components/task/TaskCard.tsx
+++ b/web/src/components/task/TaskCard.tsx
@@ -25,10 +25,11 @@ import {
   XCircle,
   Save,
   RotateCcw,
+  Eye,
 } from 'lucide-react';
 import { useBulkActions } from '@/hooks/useBulkActions';
 import { formatDuration } from '@/hooks/useTimeTracking';
-import { getTypeIcon, getTypeColor } from '@/hooks/useTaskTypes';
+import { getTypeColorToken, getTypeIcon } from '@/hooks/useTaskTypes';
 import { getProjectColor, getProjectLabel } from '@/hooks/useProjects';
 import { getSprintLabel } from '@/hooks/useSprints';
 import { useFeatureSettings } from '@/hooks/useFeatureSettings';
@@ -114,6 +115,8 @@ function areTaskCardPropsEqual(prev: TaskCardProps, next: TaskCardProps): boolea
     if (pt.attempt?.agent !== nt.attempt?.agent) return false;
     if (pt.blockedReason?.category !== nt.blockedReason?.category) return false;
     if (pt.blockedReason?.note !== nt.blockedReason?.note) return false;
+    if (pt.review?.decision !== nt.review?.decision) return false;
+    if ((pt.reviewComments?.length ?? 0) !== (nt.reviewComments?.length ?? 0)) return false;
     // Subtasks — compare count and completion state
     const pSubs = pt.subtasks || [];
     const nSubs = nt.subtasks || [];
@@ -277,15 +280,20 @@ export const TaskCard = memo(function TaskCard({
   };
 
   const isAgentRunning = task.attempt?.status === 'running';
+  const isAttemptFailed = task.attempt?.status === 'failed';
+  const isBlockedState = isBlocked || task.status === 'blocked';
+  const isAwaitingReview =
+    task.status.toLowerCase().includes('review') ||
+    ((task.reviewComments?.length ?? 0) > 0 && !task.review?.decision);
 
   // Memoize type info
-  const { typeLabel, TypeIconComponent, typeColor } = useMemo(() => {
+  const { typeLabel, TypeIconComponent, typeColorToken } = useMemo(() => {
     const typeConfig = taskTypes.find((t) => t.id === task.type);
     const iconName = typeConfig?.icon || 'Code';
     return {
       typeLabel: typeConfig?.label || task.type,
       TypeIconComponent: getTypeIcon(iconName),
-      typeColor: getTypeColor(taskTypes, task.type),
+      typeColorToken: getTypeColorToken(taskTypes, task.type),
     };
   }, [taskTypes, task.type]);
 
@@ -327,11 +335,10 @@ export const TaskCard = memo(function TaskCard({
     [task]
   );
   const readinessColor = readinessSummary?.ready
-    ? 'bg-green-500/20 text-green-500'
-    : readinessSummary && readinessSummary.percent >= 60
-      ? 'bg-amber-500/20 text-amber-500'
-      : 'bg-red-500/20 text-red-500';
+    ? 'vk-signal-chip--verified'
+    : 'vk-signal-chip--warning';
   const readinessAria = readinessSummary ? `, Readiness: ${readinessSummary.percent}%` : '';
+  const isVerified = allVerificationDone;
 
   // Suppress the outer card tooltip entirely during any drag operation
   const suppressCardTooltip = isDragActive || isDragging || isCurrentlyDragging || tooltipDismissed;
@@ -363,19 +370,23 @@ export const TaskCard = memo(function TaskCard({
         onMouseLeave={() => setTooltipDismissed(false)}
         role="article"
         tabIndex={0}
-        aria-label={`Task: ${task.title}, Priority: ${task.priority}${readinessAria}${isBlocked ? ', Blocked' : ''}${isAgentRunning ? ', Agent running' : ''}`}
+        aria-label={`Task: ${task.title}, Type: ${typeLabel}, Priority: ${task.priority}${readinessAria}${isBlockedState ? ', Blocked' : ''}${isAgentRunning ? ', Agent running' : ''}${isAttemptFailed ? ', Latest attempt failed' : ''}${isAwaitingReview ? ', Awaiting review' : ''}${isVerified ? ', Verified' : ''}`}
+        data-type-color-token={typeColorToken}
+        data-selected={isSelected ? 'true' : undefined}
+        data-dragging={isDragging || isCurrentlyDragging ? 'true' : undefined}
         className={cn(
-          'group bg-card border border-border rounded-md',
+          'vk-task-card group bg-card border border-border rounded-md',
           dragEnabled ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
           isCompact ? 'p-2' : 'p-3',
           'hover:border-muted-foreground/50 hover:bg-card/80 transition-colors',
-          'border-l-2',
-          typeColor,
+          isVerified && 'vk-task-card--verified',
+          isAwaitingReview && 'vk-task-card--review',
+          isAgentRunning && 'vk-task-card--running',
+          isAttemptFailed && 'vk-task-card--failed',
+          isBlockedState && 'vk-task-card--blocked',
           isDragging && 'opacity-50 shadow-lg motion-safe:rotate-2 motion-safe:scale-105',
           isCurrentlyDragging && 'opacity-50',
-          isSelected && 'ring-2 ring-primary border-primary',
-          isAgentRunning &&
-            'ring-2 ring-blue-500/50 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.3)]'
+          isSelected && 'ring-2 ring-primary border-primary'
         )}
       >
         <span className="sr-only">Status: {task.status}</span>
@@ -394,8 +405,13 @@ export const TaskCard = memo(function TaskCard({
               {isChecked && <Check className="h-3 w-3" />}
             </button>
           )}
-          <span className="text-muted-foreground mt-0.5 flex-shrink-0" aria-hidden="true">
-            {TypeIconComponent && <TypeIconComponent className="h-3.5 w-3.5" />}
+          <span
+            className="vk-task-type-stamp"
+            data-color-token={typeColorToken}
+            aria-label={`Task type: ${typeLabel}`}
+          >
+            {TypeIconComponent && <TypeIconComponent className="h-3.5 w-3.5" aria-hidden="true" />}
+            <span className="truncate">{typeLabel}</span>
           </span>
           <div className="flex-1 min-w-0">
             <h3 className="text-sm font-medium leading-tight truncate">{task.title}</h3>
@@ -423,7 +439,7 @@ export const TaskCard = memo(function TaskCard({
                 </div>
               }
             >
-              <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 flex items-center gap-1">
+              <span className="vk-signal-chip vk-signal-chip--running">
                 <span className="sr-only">
                   Agent {agentNames[task.attempt?.agent || ''] || task.attempt?.agent} is actively
                   running on this task
@@ -432,6 +448,18 @@ export const TaskCard = memo(function TaskCard({
                 {agentNames[task.attempt?.agent || ''] || 'Agent'} running
               </span>
             </Tooltip>
+          )}
+          {isAttemptFailed && (
+            <span className="vk-signal-chip vk-signal-chip--failed">
+              <XCircle className="h-3 w-3" aria-hidden="true" />
+              Failed
+            </span>
+          )}
+          {isAwaitingReview && (
+            <span className="vk-signal-chip vk-signal-chip--review">
+              <Eye className="h-3 w-3" aria-hidden="true" />
+              Awaiting review
+            </span>
           )}
           {isBlocked && (
             <Tooltip
@@ -446,7 +474,7 @@ export const TaskCard = memo(function TaskCard({
                 </div>
               }
             >
-              <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 flex items-center gap-1">
+              <span className="vk-signal-chip vk-signal-chip--blocked">
                 <Ban className="h-3 w-3" />
                 Blocked
               </span>
@@ -527,7 +555,7 @@ export const TaskCard = memo(function TaskCard({
                     </div>
                   }
                 >
-                  <span className="text-xs px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400 flex items-center gap-1">
+                  <span className="vk-signal-chip vk-signal-chip--blocked">
                     <BlockedIcon className="h-3 w-3" />
                     {info.shortLabel}
                   </span>
@@ -546,9 +574,6 @@ export const TaskCard = memo(function TaskCard({
               {getSprintLabel(sprints, task.sprint)}
             </span>
           )}
-          <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-            {typeLabel}
-          </span>
           {boardSettings.showPriorityIndicators && (
             <span
               className={cn(
@@ -577,12 +602,7 @@ export const TaskCard = memo(function TaskCard({
                 </div>
               }
             >
-              <span
-                className={cn(
-                  'text-xs px-1.5 py-0.5 rounded flex items-center gap-1',
-                  readinessColor
-                )}
-              >
+              <span className={cn('vk-signal-chip', readinessColor)}>
                 <ShieldCheck className="h-3 w-3" />
                 {readinessSummary.percent}% ready
               </span>
@@ -642,14 +662,15 @@ export const TaskCard = memo(function TaskCard({
             >
               <span
                 className={cn(
-                  'text-xs px-1.5 py-0.5 rounded flex items-center gap-1',
+                  'vk-signal-chip',
                   !subtaskTotal && 'ml-auto',
                   allVerificationDone
-                    ? 'bg-green-500/20 text-green-500'
+                    ? 'vk-signal-chip--verified'
                     : 'bg-muted text-muted-foreground'
                 )}
               >
                 <ShieldCheck className="h-3 w-3" />
+                {allVerificationDone ? 'Verified ' : ''}
                 {verificationChecked}/{verificationTotal}
               </span>
             </Tooltip>
@@ -709,10 +730,10 @@ export const TaskCard = memo(function TaskCard({
                 >
                   <span
                     className={cn(
-                      'text-xs px-1 py-0.5 rounded flex items-center',
+                      'vk-signal-chip',
                       cardMetrics.lastRunSuccess
-                        ? 'bg-green-500/20 text-green-500'
-                        : 'bg-red-500/20 text-red-500'
+                        ? 'vk-signal-chip--verified'
+                        : 'vk-signal-chip--failed'
                     )}
                   >
                     {cardMetrics.lastRunSuccess ? (

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -515,6 +515,25 @@ html[data-client='desktop'] .desktop-board-with-right-rail {
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --vk-identity-neutral: oklch(0.45 0.018 270);
+  --vk-identity-violet: oklch(0.49 0.19 303);
+  --vk-identity-cyan: oklch(0.46 0.105 205);
+  --vk-identity-orange: oklch(0.5 0.14 52);
+  --vk-identity-emerald: oklch(0.43 0.115 160);
+  --vk-identity-rose: oklch(0.5 0.15 345);
+  --vk-identity-amber: oklch(0.47 0.11 82);
+  --vk-identity-blue: oklch(0.47 0.15 250);
+  --vk-identity-red: oklch(0.49 0.17 27);
+  --vk-identity-umber: oklch(0.43 0.075 58);
+  --vk-state-todo: oklch(0.45 0.018 270);
+  --vk-state-active: oklch(0.47 0.15 250);
+  --vk-state-blocked: oklch(0.49 0.17 27);
+  --vk-state-done: oklch(0.43 0.115 160);
+  --vk-state-cancelled: oklch(0.45 0.018 270);
+  --vk-state-review: oklch(0.46 0.105 205);
+  --vk-state-custom: oklch(0.49 0.19 303);
+  --vk-urgency-warning: oklch(0.47 0.11 82);
+  --vk-urgency-failure: oklch(0.49 0.17 27);
 }
 
 .dark {
@@ -551,6 +570,229 @@ html[data-client='desktop'] .desktop-board-with-right-rail {
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --vk-identity-neutral: oklch(0.73 0.018 270);
+  --vk-identity-violet: oklch(0.76 0.15 303);
+  --vk-identity-cyan: oklch(0.76 0.105 205);
+  --vk-identity-orange: oklch(0.77 0.13 52);
+  --vk-identity-emerald: oklch(0.75 0.11 160);
+  --vk-identity-rose: oklch(0.76 0.14 345);
+  --vk-identity-amber: oklch(0.78 0.105 82);
+  --vk-identity-blue: oklch(0.75 0.13 250);
+  --vk-identity-red: oklch(0.73 0.16 27);
+  --vk-identity-umber: oklch(0.72 0.075 58);
+  --vk-state-todo: oklch(0.73 0.018 270);
+  --vk-state-active: oklch(0.75 0.13 250);
+  --vk-state-blocked: oklch(0.73 0.16 27);
+  --vk-state-done: oklch(0.75 0.11 160);
+  --vk-state-cancelled: oklch(0.68 0.018 270);
+  --vk-state-review: oklch(0.76 0.105 205);
+  --vk-state-custom: oklch(0.76 0.15 303);
+  --vk-urgency-warning: oklch(0.78 0.105 82);
+  --vk-urgency-failure: oklch(0.73 0.16 27);
+}
+
+/* Veritas board color contract: identity lives in classification stamps, state
+   lives in status plates and signal chips, urgency owns the strongest tones,
+   and interaction remains on the primary/ring tokens. */
+.vk-kanban-column {
+  border: 1px solid color-mix(in oklch, var(--border) 82%, var(--foreground));
+  background: color-mix(in oklch, var(--muted) 48%, var(--background));
+}
+
+.vk-kanban-column--drop-target {
+  border-color: color-mix(in oklch, var(--primary) 62%, var(--border));
+  background: color-mix(in oklch, var(--primary) 8%, var(--muted));
+  box-shadow: inset 0 0 0 2px color-mix(in oklch, var(--primary) 55%, transparent);
+}
+
+.vk-column-status-plate {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.375rem;
+  border-radius: 0.375rem;
+  padding: 0.375rem 0.5rem;
+  color: var(--vk-state-mark);
+  background: color-mix(in oklch, var(--vk-state-mark) 12%, var(--card));
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--vk-state-mark) 30%, transparent);
+}
+
+.vk-column-status-count {
+  margin-left: 0.125rem;
+  border-left: 1px solid color-mix(in oklch, var(--vk-state-mark) 32%, transparent);
+  padding-left: 0.4375rem;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  opacity: 0.82;
+}
+
+.vk-column-status-plate[data-status-tone='todo'] {
+  --vk-state-mark: var(--vk-state-todo);
+}
+
+.vk-column-status-plate[data-status-tone='active'] {
+  --vk-state-mark: var(--vk-state-active);
+}
+
+.vk-column-status-plate[data-status-tone='blocked'] {
+  --vk-state-mark: var(--vk-state-blocked);
+}
+
+.vk-column-status-plate[data-status-tone='done'] {
+  --vk-state-mark: var(--vk-state-done);
+}
+
+.vk-column-status-plate[data-status-tone='cancelled'] {
+  --vk-state-mark: var(--vk-state-cancelled);
+}
+
+.vk-column-status-plate[data-status-tone='review'] {
+  --vk-state-mark: var(--vk-state-review);
+}
+
+.vk-column-status-plate[data-status-tone='custom'] {
+  --vk-state-mark: var(--vk-state-custom);
+}
+
+.vk-task-type-stamp {
+  display: inline-flex;
+  max-width: 7.5rem;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.3125rem;
+  border-radius: 0.3125rem;
+  padding: 0.1875rem 0.375rem;
+  color: var(--vk-identity-mark);
+  background: color-mix(in oklch, var(--vk-identity-mark) 12%, var(--card));
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--vk-identity-mark) 28%, transparent);
+  font-size: 0.625rem;
+  font-weight: 750;
+  letter-spacing: 0.035em;
+  line-height: 1rem;
+  text-transform: uppercase;
+}
+
+.vk-task-type-swatch {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+  border-radius: 0.25rem;
+  background: color-mix(in oklch, var(--vk-identity-mark) 18%, var(--card));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in oklch, var(--vk-identity-mark) 35%, transparent),
+    inset 0.25rem 0 0 var(--vk-identity-mark);
+}
+
+.vk-task-type-stamp[data-color-token='neutral'],
+.vk-task-type-swatch[data-color-token='neutral'] {
+  --vk-identity-mark: var(--vk-identity-neutral);
+}
+
+.vk-task-type-stamp[data-color-token='violet'],
+.vk-task-type-swatch[data-color-token='violet'] {
+  --vk-identity-mark: var(--vk-identity-violet);
+}
+
+.vk-task-type-stamp[data-color-token='cyan'],
+.vk-task-type-swatch[data-color-token='cyan'] {
+  --vk-identity-mark: var(--vk-identity-cyan);
+}
+
+.vk-task-type-stamp[data-color-token='orange'],
+.vk-task-type-swatch[data-color-token='orange'] {
+  --vk-identity-mark: var(--vk-identity-orange);
+}
+
+.vk-task-type-stamp[data-color-token='emerald'],
+.vk-task-type-swatch[data-color-token='emerald'] {
+  --vk-identity-mark: var(--vk-identity-emerald);
+}
+
+.vk-task-type-stamp[data-color-token='rose'],
+.vk-task-type-swatch[data-color-token='rose'] {
+  --vk-identity-mark: var(--vk-identity-rose);
+}
+
+.vk-task-type-stamp[data-color-token='amber'],
+.vk-task-type-swatch[data-color-token='amber'] {
+  --vk-identity-mark: var(--vk-identity-amber);
+}
+
+.vk-task-type-stamp[data-color-token='blue'],
+.vk-task-type-swatch[data-color-token='blue'] {
+  --vk-identity-mark: var(--vk-identity-blue);
+}
+
+.vk-task-type-stamp[data-color-token='red'],
+.vk-task-type-swatch[data-color-token='red'] {
+  --vk-identity-mark: var(--vk-identity-red);
+}
+
+.vk-task-type-stamp[data-color-token='umber'],
+.vk-task-type-swatch[data-color-token='umber'] {
+  --vk-identity-mark: var(--vk-identity-umber);
+}
+
+.vk-task-card {
+  isolation: isolate;
+}
+
+.vk-task-card--verified {
+  border-color: color-mix(in oklch, var(--vk-state-done) 34%, var(--border));
+  background: color-mix(in oklch, var(--vk-state-done) 5%, var(--card));
+}
+
+.vk-task-card--review {
+  border-color: color-mix(in oklch, var(--vk-state-review) 38%, var(--border));
+  background: color-mix(in oklch, var(--vk-state-review) 6%, var(--card));
+}
+
+.vk-task-card--running {
+  border-color: color-mix(in oklch, var(--primary) 46%, var(--border));
+  background: color-mix(in oklch, var(--primary) 8%, var(--card));
+}
+
+.vk-task-card--failed,
+.vk-task-card--blocked {
+  border-color: color-mix(in oklch, var(--vk-urgency-failure) 58%, var(--border));
+  background: color-mix(in oklch, var(--vk-urgency-failure) 7%, var(--card));
+}
+
+.vk-signal-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.vk-signal-chip--running {
+  color: var(--vk-state-active);
+  background: color-mix(in oklch, var(--vk-state-active) 15%, var(--card));
+}
+
+.vk-signal-chip--review {
+  color: var(--vk-state-review);
+  background: color-mix(in oklch, var(--vk-state-review) 15%, var(--card));
+}
+
+.vk-signal-chip--blocked,
+.vk-signal-chip--failed {
+  color: var(--vk-urgency-failure);
+  background: color-mix(in oklch, var(--vk-urgency-failure) 15%, var(--card));
+}
+
+.vk-signal-chip--warning {
+  color: var(--vk-urgency-warning);
+  background: color-mix(in oklch, var(--vk-urgency-warning) 15%, var(--card));
+}
+
+.vk-signal-chip--verified {
+  color: var(--vk-state-done);
+  background: color-mix(in oklch, var(--vk-state-done) 15%, var(--card));
 }
 
 @theme inline {

--- a/web/src/hooks/useTaskTypes.ts
+++ b/web/src/hooks/useTaskTypes.ts
@@ -1,5 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import type { TaskTypeConfig } from '@veritas-kanban/shared';
+import {
+  TASK_TYPE_COLOR_TOKENS,
+  type TaskTypeColorToken,
+  type TaskTypeConfig,
+} from '@veritas-kanban/shared';
 import * as LucideIcons from 'lucide-react';
 import { useManagedList } from './useManagedList';
 import { apiFetch } from '@/lib/api/helpers';
@@ -68,12 +72,32 @@ export function getAvailableIcons(): string[] {
   return Object.keys(ICON_MAP);
 }
 
-/**
- * Get the color class for a task type
- */
-export function getTypeColor(types: TaskTypeConfig[], typeId: string): string {
-  const type = types.find((t) => t.id === typeId);
-  return type?.color || 'border-l-gray-500';
+const LEGACY_COLOR_TOKENS: Readonly<Record<string, TaskTypeColorToken>> = {
+  'border-l-gray-500': 'neutral',
+  'border-l-violet-500': 'violet',
+  'border-l-cyan-500': 'cyan',
+  'border-l-orange-500': 'orange',
+  'border-l-emerald-500': 'emerald',
+  'border-l-fuchsia-500': 'rose',
+  'border-l-amber-500': 'amber',
+  'border-l-blue-700': 'blue',
+  'border-l-green-700': 'emerald',
+  'border-l-red-500': 'red',
+  'border-l-purple-500': 'violet',
+  'border-l-yellow-400': 'amber',
+  'border-l-amber-800': 'umber',
+};
+
+export function normalizeTaskTypeColorToken(value?: string): TaskTypeColorToken {
+  if (TASK_TYPE_COLOR_TOKENS.includes(value as TaskTypeColorToken)) {
+    return value as TaskTypeColorToken;
+  }
+  return LEGACY_COLOR_TOKENS[value ?? ''] ?? 'neutral';
+}
+
+export function getTypeColorToken(types: TaskTypeConfig[], typeId: string): TaskTypeColorToken {
+  const type = types.find((candidate) => candidate.id === typeId);
+  return normalizeTaskTypeColorToken(type?.colorToken ?? type?.color);
 }
 
 /**
@@ -93,20 +117,17 @@ export function getTypeIconName(types: TaskTypeConfig[], typeId: string): string
 }
 
 /**
- * Available border colors for task types
+ * Semantic task identity colors. Rendering derives theme-aware surfaces from these tokens.
  */
 export const AVAILABLE_COLORS = [
-  { value: 'border-l-gray-500', label: 'Gray' },
-  { value: 'border-l-violet-500', label: 'Violet' },
-  { value: 'border-l-cyan-500', label: 'Cyan' },
-  { value: 'border-l-orange-500', label: 'Orange' },
-  { value: 'border-l-emerald-500', label: 'Emerald' },
-  { value: 'border-l-fuchsia-500', label: 'Pink' },
-  { value: 'border-l-amber-500', label: 'Amber' },
-  { value: 'border-l-blue-700', label: 'Blue' },
-  { value: 'border-l-green-700', label: 'Green' },
-  { value: 'border-l-red-500', label: 'Red' },
-  { value: 'border-l-purple-500', label: 'Purple' },
-  { value: 'border-l-yellow-400', label: 'Yellow' },
-  { value: 'border-l-amber-800', label: 'Brown' },
-];
+  { value: 'neutral', label: 'Graphite' },
+  { value: 'violet', label: 'Violet' },
+  { value: 'cyan', label: 'Cyan' },
+  { value: 'orange', label: 'Orange' },
+  { value: 'emerald', label: 'Emerald' },
+  { value: 'rose', label: 'Rose' },
+  { value: 'amber', label: 'Amber' },
+  { value: 'blue', label: 'Blue' },
+  { value: 'red', label: 'Red' },
+  { value: 'umber', label: 'Umber' },
+] satisfies Array<{ value: TaskTypeColorToken; label: string }>;


### PR DESCRIPTION
## Summary

- Replace generic column top rails and task-type side rails with localized status plates and classification stamps.
- Introduce semantic identity, state, urgency, interaction, and neutral color roles with compatible mapping for persisted legacy Tailwind color classes.
- Make blocked, failed, running, awaiting-review, verified, selected, focused, dragged, and drop-target states distinct without relying on color alone.
- Record the three-concept review on the same populated 24-task board and document the selected contract.

## Verification

- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/TaskCard.test.tsx src/__tests__/board-color-system.test.tsx src/__tests__/settings-managed-list-mantine.test.tsx` (28 tests)
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/server typecheck`
- Changed-file ESLint and Prettier checks
- `node scripts/check-permission-coverage.mjs`
- Rendered review of the actual 24-task board in normal and compact density, light and dark themes, and a 390px mobile viewport
- Rendered concept review in grayscale and deuteranopia simulation

Closes #1301
