### PR TITLE
test: refresh Settings end-to-end assertions

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -53,11 +53,13 @@ test.describe('Settings', () => {
 
     await dialog.getByRole('tab', { name: 'Maintenance' }).click();
 
-    await expect(dialog.getByText('Maintenance Center')).toBeVisible({ timeout: 5_000 });
-    await expect(dialog.getByText('Health')).toBeVisible();
-    await expect(dialog.getByText('Storage Usage')).toBeVisible();
-    await expect(dialog.getByText('Cleanup Preview').first()).toBeVisible();
-    await expect(dialog.getByText('Backup and Restore')).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Maintenance', exact: true })).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(dialog.getByText('Health', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('Storage Usage', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('Cleanup Preview', { exact: true })).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Backup and Restore' })).toBeVisible();
     await expect(dialog.getByLabel('Redacted log tail')).toBeVisible();
   });
 
@@ -75,7 +77,9 @@ test.describe('Settings', () => {
     await dialog.getByRole('tab', { name: 'Board' }).click();
 
     // The Board tab should show display options
-    await expect(dialog.locator('text=Board & Display')).toBeVisible({ timeout: 3_000 });
+    await expect(dialog.getByRole('heading', { name: 'Board and display' })).toBeVisible({
+      timeout: 3_000,
+    });
 
     // Verify a setting exists — "Show Dashboard" toggle
     await expect(dialog.getByText('Show Dashboard').first()).toBeVisible();


### PR DESCRIPTION
## Summary

- update two stale Settings headings introduced by the completed layout migration
- use accessible heading locators for the Board and Maintenance pages
- tighten Maintenance text matches to avoid description collisions

## Verification

- `pnpm --filter @veritas-kanban/shared build`
- `pnpm exec playwright test e2e/settings.spec.ts --project=chromium --reporter=line` (6 passed)
- Prettier and `git diff --check`

Closes #1332
Parent: #1297
