### PR TITLE
feat(web): migrate task outcomes into Results mode

### DIFF
--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -285,6 +285,53 @@ describe('task detail Mantine migration', () => {
     expect(screen.getByTestId('task-detail-scroll-region')).toBe(scrollRegion);
   });
 
+  it('groups outcomes under Results with review readiness before evidence', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-results-navigation',
+      title: 'Review completed work',
+      type: 'code',
+      status: 'in-progress',
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'task-workspace-results',
+        baseBranch: 'main',
+        worktreePath: '/tmp/task-workspace-results',
+      },
+      reviewComments: [
+        {
+          id: 'finding-1',
+          file: 'web/src/App.tsx',
+          line: 12,
+          content: 'Clarify the result action.',
+          created: '2026-09-02T20:00:00.000Z',
+        },
+      ],
+    });
+    renderWithProviders(<TaskDetailPanel task={task} open onOpenChange={mocks.onOpenChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Results' }));
+
+    const resultSections = screen.getByRole('tablist', { name: 'Results sections' });
+    expect(
+      within(resultSections)
+        .getAllByRole('tab')
+        .map((tab) => tab.textContent)
+    ).toEqual(['Work Products', 'Changes', 'Review', 'Verification', 'Evidence']);
+    expect(screen.getByText('Review: Decision needed')).toBeDefined();
+    expect(screen.getByText('1 open finding')).toBeDefined();
+
+    await user.click(within(resultSections).getByRole('tab', { name: 'Verification' }));
+    expect(
+      await within(screen.getByRole('tabpanel')).findByText('Verification section')
+    ).toBeDefined();
+
+    await user.click(within(resultSections).getByRole('tab', { name: 'Work Products' }));
+    const activePanel = screen.getByRole('tabpanel');
+    expect(await within(activePanel).findByText('No work products yet')).toBeDefined();
+    expect(within(activePanel).getByText('Deliverables section')).toBeDefined();
+  });
+
   it('remembers the selected local section when moving between modes', async () => {
     const user = userEvent.setup();
     renderTaskDetail();

--- a/web/src/__tests__/task-work-view-mantine.test.tsx
+++ b/web/src/__tests__/task-work-view-mantine.test.tsx
@@ -201,6 +201,24 @@ describe('task work view Mantine surface', () => {
     expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
   });
 
+  it('routes incomplete outcome verification directly into Results', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-verification-handoff',
+      status: 'in-progress',
+      type: 'feature',
+      attempt: { id: 'attempt-complete', agent: 'codex', status: 'complete' },
+      verificationSteps: [
+        { id: 'verify-results', description: 'Confirm release output', checked: false },
+      ],
+    });
+
+    renderWorkView(task);
+
+    await user.click(screen.getByRole('button', { name: 'Complete verification' }));
+    expect(mocks.onOpenTab).toHaveBeenCalledWith('verification');
+  });
+
   it('links live execution, code review, handoff, and work products from the Work view', async () => {
     const user = userEvent.setup();
     mocks.useTaskWorkProducts.mockReturnValue({ data: [product], isLoading: false });

--- a/web/src/components/task/ReviewPanel.tsx
+++ b/web/src/components/task/ReviewPanel.tsx
@@ -92,7 +92,7 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
             </ThemeIcon>
             <Stack gap={2} className="min-w-0 flex-1">
               <Text size="sm" fw={500}>
-                {decisionStyles[currentReview.decision].label}
+                Review: {decisionStyles[currentReview.decision].label}
               </Text>
               {currentReview.decidedAt && (
                 <Text size="xs" c="dimmed">

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -218,6 +218,21 @@ export function TaskDetailPanel({
 
   if (!localTask) return null;
 
+  const resultsReviewStatus = !isCodeTask
+    ? null
+    : localTask.review?.decision === 'approved'
+      ? { label: 'Approved', color: 'green' }
+      : localTask.review?.decision === 'changes-requested'
+        ? { label: 'Changes required', color: 'yellow' }
+        : localTask.review?.decision === 'rejected'
+          ? { label: 'Rejected', color: 'red' }
+          : localTask.status === 'done'
+            ? { label: 'Complete', color: 'green' }
+            : !hasWorktree
+              ? { label: 'Worktree required', color: 'gray' }
+              : { label: 'Decision needed', color: 'yellow' };
+  const openFindingCount = localTask.reviewComments?.length ?? 0;
+
   const selectWorkspaceMode = (mode: TaskWorkspaceModeId) => {
     const nextTab = getTaskWorkspaceModeTabId(visibleTabs, mode, lastTabByModeRef.current[mode]);
     if (nextTab) setActiveTab(nextTab);
@@ -418,6 +433,18 @@ export function TaskDetailPanel({
                           <Badge variant="light" color="gray" tt="capitalize">
                             Task: {localTask.status.replaceAll('-', ' ')}
                           </Badge>
+                        )}
+                        {activeMode === 'results' && resultsReviewStatus && (
+                          <>
+                            <Badge variant="light" color={resultsReviewStatus.color}>
+                              Review: {resultsReviewStatus.label}
+                            </Badge>
+                            {openFindingCount > 0 && (
+                              <Badge variant="outline" color="yellow">
+                                {openFindingCount} open finding{openFindingCount === 1 ? '' : 's'}
+                              </Badge>
+                            )}
+                          </>
                         )}
                         {!readOnly && activeMode === 'plan' && (
                           <Button

--- a/web/src/components/task/TaskResultsProductsSection.tsx
+++ b/web/src/components/task/TaskResultsProductsSection.tsx
@@ -1,0 +1,18 @@
+import { Divider, Stack } from '@mantine/core';
+import type { Task } from '@veritas-kanban/shared';
+import { DeliverablesSection } from './DeliverablesSection';
+import { WorkProductsSection } from './WorkProductsSection';
+
+interface TaskResultsProductsSectionProps {
+  task: Task;
+}
+
+export function TaskResultsProductsSection({ task }: TaskResultsProductsSectionProps) {
+  return (
+    <Stack gap="lg">
+      <WorkProductsSection taskId={task.id} />
+      <Divider />
+      <DeliverablesSection task={task} />
+    </Stack>
+  );
+}

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -79,6 +79,7 @@ export type TaskWorkViewTarget =
   | 'timeline'
   | 'changes'
   | 'review'
+  | 'verification'
   | 'metrics';
 
 interface TaskWorkViewProps {
@@ -213,7 +214,7 @@ export function getTaskOverviewComposition(
         title: 'Verification required',
         detail: 'Execution finished with verification steps still unchecked.',
         color: 'yellow',
-        action: { label: 'Complete verification', target: 'details' },
+        action: { label: 'Complete verification', target: 'verification' },
       };
     }
 

--- a/web/src/components/task/WorkProductsSection.tsx
+++ b/web/src/components/task/WorkProductsSection.tsx
@@ -310,16 +310,19 @@ export function WorkProductsSection({ taskId }: WorkProductsSectionProps) {
         </Group>
 
         {sortedProducts.length === 0 ? (
-          <Paper withBorder p="lg" radius="md" className="text-center">
-            <ThemeIcon size="lg" radius="xl" variant="light" className="mx-auto">
-              <FileText className="h-5 w-5" />
-            </ThemeIcon>
-            <Text fw={600} mt="sm">
-              No work products yet
-            </Text>
-            <Text size="sm" c="dimmed" mt={4}>
-              Generated reports, checklists, handoff notes, and evidence summaries will appear here.
-            </Text>
+          <Paper withBorder p="md" radius="md">
+            <Group gap="sm" wrap="nowrap">
+              <ThemeIcon size="md" radius="xl" variant="light" className="flex-shrink-0">
+                <FileText className="h-5 w-5" />
+              </ThemeIcon>
+              <div className="min-w-0">
+                <Text fw={600}>No work products yet</Text>
+                <Text size="sm" c="dimmed" mt={2}>
+                  Generated reports, checklists, handoff notes, and evidence summaries will appear
+                  here.
+                </Text>
+              </div>
+            </Group>
           </Paper>
         ) : (
           <Stack gap="sm">

--- a/web/src/components/task/detail/TaskDetailsTab.tsx
+++ b/web/src/components/task/detail/TaskDetailsTab.tsx
@@ -5,10 +5,8 @@ import { MarkdownEditor } from '@/components/ui/MarkdownEditor';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
 import { TaskMetadataSection } from './TaskMetadataSection';
 import { SubtasksSection } from '../SubtasksSection';
-import { VerificationSection } from '../VerificationSection';
 import { TimeTrackingSection } from '../TimeTrackingSection';
 import { CommentsSection } from '../CommentsSection';
-import { DeliverablesSection } from '../DeliverablesSection';
 import { BlockedReasonSection } from '../BlockedReasonSection';
 import { LessonsLearnedSection } from '../LessonsLearnedSection';
 import { useDeleteTask, useArchiveTask } from '@/hooks/useTasks';
@@ -194,22 +192,12 @@ export function TaskDetailsTab({
         />
       </Box>
 
-      {/* Verification / Done Criteria */}
-      <Box className="border-t pt-4">
-        <VerificationSection task={task} />
-      </Box>
-
       {/* Time Tracking */}
       {taskSettings.enableTimeTracking && (
         <Box className="border-t pt-4">
           <TimeTrackingSection task={task} />
         </Box>
       )}
-
-      {/* Deliverables */}
-      <Box className="border-t pt-4">
-        <DeliverablesSection task={task} />
-      </Box>
 
       {/* Comments */}
       {taskSettings.enableComments && (

--- a/web/src/components/task/task-detail-tabs.tsx
+++ b/web/src/components/task/task-detail-tabs.tsx
@@ -73,8 +73,13 @@ const RunWorkflowPanel = lazy(() =>
 const TaskMetricsPanel = lazy(() =>
   import('./TaskMetricsPanel').then((mod) => ({ default: mod.TaskMetricsPanel }))
 );
-const WorkProductsSection = lazy(() =>
-  import('./WorkProductsSection').then((mod) => ({ default: mod.WorkProductsSection }))
+const TaskResultsProductsSection = lazy(() =>
+  import('./TaskResultsProductsSection').then((mod) => ({
+    default: mod.TaskResultsProductsSection,
+  }))
+);
+const VerificationSection = lazy(() =>
+  import('./VerificationSection').then((mod) => ({ default: mod.VerificationSection }))
 );
 
 export type {
@@ -164,7 +169,7 @@ const TAB_RENDERERS: Record<TaskDetailTabId, (context: TaskDetailRenderContext) 
     />
   ),
   progress: ({ task }) => <ProgressTab task={task} />,
-  'work-products': ({ task }) => <WorkProductsSection taskId={task.id} />,
+  'work-products': ({ task }) => <TaskResultsProductsSection task={task} />,
   observations: ({ task, addObservation, deleteObservation }) => (
     <ObservationsSection
       task={task}
@@ -232,6 +237,7 @@ const TAB_RENDERERS: Record<TaskDetailTabId, (context: TaskDetailRenderContext) 
       onMergeComplete={onClose}
     />
   ),
+  verification: ({ task }) => <VerificationSection task={task} />,
   metrics: ({ task }) => <TaskMetricsPanel task={task} />,
 };
 

--- a/web/src/lib/__tests__/task-detail-workspace.test.ts
+++ b/web/src/lib/__tests__/task-detail-workspace.test.ts
@@ -24,6 +24,7 @@ describe('task workspace navigation', () => {
       access: 'run',
       git: 'run',
       agent: 'run',
+      verification: 'results',
       timeline: 'history',
       evidence: 'results',
       changes: 'results',
@@ -80,6 +81,27 @@ describe('task workspace navigation', () => {
       expect(resolveTaskDetailNavigationTab({ tab: section }, tabs)).toBe(section);
       expect(
         resolveTaskDetailNavigationTab({ workspace: { version: 1, mode: 'run', section } }, tabs)
+      ).toBe(section);
+    }
+    const tabsWithWorktree = getAvailableTaskDetailTabMetadata({
+      isCodeTask: true,
+      hasWorktree: true,
+      attachmentsEnabled: true,
+      dependenciesEnabled: true,
+    });
+    for (const section of [
+      'work-products',
+      'changes',
+      'review',
+      'verification',
+      'evidence',
+    ] as const) {
+      expect(resolveTaskDetailNavigationTab({ tab: section }, tabsWithWorktree)).toBe(section);
+      expect(
+        resolveTaskDetailNavigationTab(
+          { workspace: { version: 1, mode: 'results', section } },
+          tabsWithWorktree
+        )
       ).toBe(section);
     }
     for (const section of [

--- a/web/src/lib/task-detail-tabs.ts
+++ b/web/src/lib/task-detail-tabs.ts
@@ -10,6 +10,7 @@ export type TaskDetailTabId =
   | 'access'
   | 'git'
   | 'agent'
+  | 'verification'
   | 'timeline'
   | 'evidence'
   | 'changes'
@@ -103,8 +104,8 @@ export const TASK_WORKSPACE_MODE_METADATA: readonly TaskWorkspaceModeMetadata[] 
   {
     id: 'results',
     label: 'Results',
-    description: 'Work products, changes, review decisions, and evidence.',
-    sections: ['work-products', 'evidence', 'changes', 'review'],
+    description: 'Work products, changes, review decisions, verification, and evidence.',
+    sections: ['work-products', 'changes', 'review', 'verification', 'evidence'],
   },
   {
     id: 'history',
@@ -191,6 +192,12 @@ export const TASK_DETAIL_TAB_METADATA: readonly TaskDetailTabMetadata[] = [
     icon: 'Bot',
     fallbackTitle: 'Agent panel failed to load',
     isVisible: ({ isCodeTask }) => isCodeTask,
+  },
+  {
+    id: 'verification',
+    label: 'Verification',
+    icon: 'ShieldCheck',
+    fallbackTitle: 'Verification section failed to load',
   },
   {
     id: 'timeline',


### PR DESCRIPTION
## Summary

- Group work products, deliverables, changes, review, verification, and evidence under Results.
- Surface review readiness and open findings before low-level evidence.
- Route incomplete verification directly to Results and keep empty output compact.

## Verification

- `pnpm --filter @veritas-kanban/shared build`
- 56 focused web tests across Results navigation, work products, diff/review, verification, worktree, and deep links
- `pnpm --filter @veritas-kanban/web typecheck`
- ESLint on changed web files
- Rendered review-needed and completed Results states in Chromium

Closes #1339