### PR TITLE
feat(web): add expanded task workspace

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -108,7 +108,7 @@ The Kanban board is the central interface — a drag-and-drop workspace that ref
 
   ![Task work view](assets/v5/v5-task-work-view.png)
 
-- **Task detail panel** — Slide-out sheet with tabbed sections: Details, Git, Agent, Diff, Review, Preview, Attachments, Metrics
+- **Progressive task workspace** — A quick drawer and full-width expanded presentation share Overview, Plan, Run, Results, and History navigation without losing the selected section, attempt, event, edits, scroll position, or board focus
 
   ![Task details panel](assets/v5/v5-task-work-view.png)
 

--- a/docs/design/TASK-WORKSPACE-INFORMATION-ARCHITECTURE.md
+++ b/docs/design/TASK-WORKSPACE-INFORMATION-ARCHITECTURE.md
@@ -136,3 +136,14 @@ Only stable user preferences, such as the last selected mode or collapsed diagno
 5. Remove legacy duplication only after focused deep-link, mutation, permission, and lifecycle verification proves the replacement paths.
 
 The integrated release gate owns the full workspace suite. Each child issue runs only the focused tests and rendered checks for its feature boundary.
+
+## Implemented replacement and retirement map
+
+The drawer and expanded presentation now render the same workspace component tree. Expanding changes only the presentation width, so task edits, the active mode and section, selected attempt and event targets, scroll position, and nested workflow or chat context remain owned by one surface.
+
+- The header retains Chat, Expand or Exit expanded, and Close as workspace-wide actions.
+- Template is owned by Plan. Workflow and Preview are owned by their Run sections.
+- Verification and deliverables no longer compete inside Details; Results owns their reviewed replacement paths.
+- Overview recommendations link to the exact Plan, Run, Results, or History destination instead of duplicating those controls.
+- Legacy `TaskDetailNavigationTarget.tab` links remain a compatibility input, but the mode and local-section translator is the only navigation authority.
+- The board records the invoking control and restores focus there after the workspace closes, with the task card as a stable fallback.

--- a/e2e/task-detail.spec.ts
+++ b/e2e/task-detail.spec.ts
@@ -66,7 +66,9 @@ test.describe('Task Detail Panel', () => {
 
     // The details tab should be active by default and show task info
     await expect(detailPanel.getByRole('tab', { name: 'Details' })).toBeVisible();
-    await expect(detailPanel.locator('.mantine-Select-root').first()).toBeVisible();
+    await expect(
+      detailPanel.getByRole('navigation', { name: 'Task workspace modes' })
+    ).toBeVisible();
 
     // The task title should be editable (it's an input in non-readOnly mode)
     const titleInput = detailPanel.locator('input').first();
@@ -93,5 +95,63 @@ test.describe('Task Detail Panel', () => {
     // Press Escape to close
     await page.keyboard.press('Escape');
     await expect(detailPanel).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test('expanded workspace preserves section, scroll, and board focus', async ({ page }) => {
+    const title = `E2E Expanded Workspace ${Date.now()}`;
+    const task = await seedTestTask(page, {
+      title,
+      description: `Expanded task context\n\n${'Long task detail content. '.repeat(240)}`,
+      type: 'code',
+      status: 'todo',
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'feat/e2e-expanded-workspace',
+        baseBranch: 'main',
+        worktreePath: '/tmp/e2e-expanded-workspace',
+      },
+    });
+    testTaskId = (task as { id: string }).id;
+
+    await page.setViewportSize({ width: 1440, height: 820 });
+    await page.goto('/');
+
+    const taskCard = page.getByRole('article', { name: new RegExp(`Task: ${title}`) });
+    await taskCard.focus();
+    await page.keyboard.press('Enter');
+
+    const detail = page.getByTestId('task-detail-panel');
+    await expect(detail).toBeVisible();
+    await detail.getByRole('button', { name: 'Plan' }).click();
+    await detail.getByRole('tab', { name: 'Details' }).click();
+    const scrollRegion = detail.getByTestId('task-detail-scroll-region');
+    await scrollRegion.evaluate((element) => {
+      element.scrollTop = 240;
+    });
+    const initialScroll = await scrollRegion.evaluate((element) => element.scrollTop);
+    expect(initialScroll).toBeGreaterThan(0);
+
+    await detail.getByRole('button', { name: 'Expand task workspace' }).click();
+    await expect(detail).toHaveAttribute('data-presentation', 'expanded');
+    await expect(detail.getByRole('button', { name: 'Plan' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+    await expect(detail.getByRole('tab', { name: 'Details' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(await scrollRegion.evaluate((element) => element.scrollTop)).toBe(initialScroll);
+    const expandedBox = await detail.boundingBox();
+    expect(expandedBox?.width ?? 0).toBeGreaterThanOrEqual(1439);
+    expect(await detail.evaluate((element) => element.scrollWidth - element.clientWidth)).toBe(0);
+
+    await detail.getByRole('button', { name: 'Exit expanded task workspace' }).click();
+    await expect(detail).toHaveAttribute('data-presentation', 'drawer');
+    expect(await scrollRegion.evaluate((element) => element.scrollTop)).toBe(initialScroll);
+
+    await detail.getByRole('button', { name: 'Close task workspace' }).click();
+    await expect(detail).not.toBeVisible();
+    await expect(taskCard).toBeFocused();
   });
 });

--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -297,6 +297,48 @@ describe('task detail Mantine migration', () => {
     expect(screen.getByTestId('task-detail-scroll-region')).toBe(scrollRegion);
   });
 
+  it('expands the same workspace surface without losing navigation or scroll context', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-expanded-workspace',
+      title: 'Inspect an expanded task workspace',
+      type: 'code',
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'task-workspace-expanded',
+        baseBranch: 'main',
+        worktreePath: '/tmp/task-workspace-expanded',
+      },
+    });
+    renderWithProviders(<TaskDetailPanel task={task} open onOpenChange={mocks.onOpenChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Results' }));
+    await user.click(screen.getByRole('tab', { name: 'Evidence' }));
+    const panel = screen.getByTestId('task-detail-panel');
+    const scrollRegion = screen.getByTestId('task-detail-scroll-region');
+    scrollRegion.scrollTop = 96;
+
+    await user.click(screen.getByRole('button', { name: 'Expand task workspace' }));
+
+    expect(screen.getByTestId('task-detail-panel')).toBe(panel);
+    expect(panel.getAttribute('data-presentation')).toBe('expanded');
+    expect(screen.getByRole('button', { name: 'Results' }).getAttribute('aria-current')).toBe(
+      'page'
+    );
+    expect(screen.getByRole('tab', { name: 'Evidence' }).getAttribute('aria-selected')).toBe(
+      'true'
+    );
+    expect(scrollRegion.scrollTop).toBe(96);
+    expect(screen.getByRole('button', { name: 'Exit expanded task workspace' })).toBe(
+      document.activeElement
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Exit expanded task workspace' }));
+
+    expect(panel.getAttribute('data-presentation')).toBe('drawer');
+    expect(scrollRegion.scrollTop).toBe(96);
+  });
+
   it('groups outcomes under Results with review readiness before evidence', async () => {
     const user = userEvent.setup();
     const task = createMockTask({

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -131,6 +131,9 @@ export function KanbanBoard() {
     useState<TaskDetailNavigationTarget | null>(null);
   const defaultSavedViewAppliedRef = useRef(false);
   const pendingMoveTaskIdsRef = useRef(new Set<string>());
+  const detailFocusReturnRef = useRef<HTMLElement | null>(null);
+  const detailFocusTaskIdRef = useRef<string | null>(null);
+  const wasDetailOpenRef = useRef(false);
 
   // Initialize filters from URL
   const [filters, setFilters] = useState<FilterState>(() => {
@@ -369,12 +372,38 @@ export function KanbanBoard() {
 
   // Handler for opening a task
   const handleTaskClick = useCallback((task: Task, target?: TaskDetailNavigationTarget) => {
+    const activeElement = document.activeElement;
+    detailFocusReturnRef.current =
+      activeElement instanceof HTMLElement && activeElement !== document.body
+        ? activeElement
+        : null;
+    detailFocusTaskIdRef.current = task.id;
     markTaskInHistory(task.id);
     setDetailPanelMounted(true);
     setDetailNavigationTarget(target ?? null);
     setSelectedTask(task);
     setDetailOpen(true);
   }, []);
+
+  useEffect(() => {
+    const wasOpen = wasDetailOpenRef.current;
+    wasDetailOpenRef.current = detailOpen;
+    if (!wasOpen || detailOpen) return;
+
+    const returnTarget = detailFocusReturnRef.current;
+    const taskId = detailFocusTaskIdRef.current;
+    const timer = window.setTimeout(() => {
+      const fallbackTarget = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-task-id]')
+      ).find((element) => element.dataset.taskId === taskId);
+      const focusTarget = returnTarget?.isConnected ? returnTarget : fallbackTarget;
+      focusTarget?.focus({ preventScroll: true });
+      detailFocusReturnRef.current = null;
+      detailFocusTaskIdRef.current = null;
+    }, 220);
+
+    return () => window.clearTimeout(timer);
+  }, [detailOpen]);
 
   const handleTaskIdClick = useCallback(
     async (taskId: string, target?: TaskDetailNavigationTarget) => {

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -30,7 +30,9 @@ import {
   FileCode,
   History,
   LayoutDashboard,
+  Maximize2,
   MessageSquare,
+  Minimize2,
   Monitor,
   PlayCircle,
   X,
@@ -100,6 +102,7 @@ export function TaskDetailPanel({
   const [applyTemplateOpen, setApplyTemplateOpen] = useState(false);
   const [taskChatOpen, setTaskChatOpen] = useState(false);
   const [workflowOpen, setWorkflowOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const [timelineAttemptId, setTimelineAttemptId] = useState<string | null>(null);
   const [timelineEventId, setTimelineEventId] = useState<string | null>(null);
   const lastDefaultedTaskIdRef = useRef<string | undefined>(undefined);
@@ -113,6 +116,10 @@ export function TaskDetailPanel({
     if (!open || !activeTaskId) return;
     return registerOpenTaskConflictSurface(activeTaskId);
   }, [activeTaskId, open]);
+
+  useEffect(() => {
+    if (!open) setExpanded(false);
+  }, [open]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -279,8 +286,13 @@ export function TaskDetailPanel({
         <Drawer.Overlay className="veritas-overlay fixed inset-0 z-50" />
         <Drawer.Content
           aria-label={`Task workspace: ${localTask.title}`}
+          data-presentation={expanded ? 'expanded' : 'drawer'}
           data-testid="task-detail-panel"
-          className="veritas-overlay-surface flex h-full min-h-0 max-h-[100dvh] w-[min(100vw,960px)] flex-col overflow-hidden border-l bg-background bg-clip-padding text-sm shadow-lg sm:w-[min(92vw,960px)] lg:w-[min(62vw,960px)]"
+          className={`veritas-overlay-surface flex h-full min-h-0 max-h-[100dvh] flex-col overflow-hidden bg-background bg-clip-padding text-sm shadow-lg ${
+            expanded
+              ? '!w-screen !max-w-none border-l-0'
+              : 'w-[min(100vw,960px)] border-l sm:w-[min(92vw,960px)] lg:w-[min(62vw,960px)]'
+          }`}
         >
           <Drawer.Body className="flex min-h-0 flex-1 flex-col overflow-hidden p-0">
             <Stack gap={0} className="min-h-0 flex-1 overflow-hidden">
@@ -321,6 +333,22 @@ export function TaskDetailPanel({
                     >
                       Chat
                     </Button>
+                    <ActionIcon
+                      aria-label={
+                        expanded ? 'Exit expanded task workspace' : 'Expand task workspace'
+                      }
+                      aria-pressed={expanded}
+                      title={expanded ? 'Exit expanded workspace' : 'Expand workspace'}
+                      variant="subtle"
+                      color="gray"
+                      onClick={() => setExpanded((current) => !current)}
+                    >
+                      {expanded ? (
+                        <Minimize2 className="h-4 w-4" />
+                      ) : (
+                        <Maximize2 className="h-4 w-4" />
+                      )}
+                    </ActionIcon>
                     <ActionIcon
                       aria-label="Close task workspace"
                       variant="subtle"


### PR DESCRIPTION
## Summary

- add a full-width presentation to the existing task workspace without mounting a second state tree
- preserve workspace navigation, scroll, nested state, and predictable board focus across expand, collapse, and close
- document the implemented replacement and retirement map for legacy task-detail surfaces

## Verification

- shared package build
- 39 focused task-workspace and board component tests
- 4 focused task-detail Playwright lifecycle tests
- web typecheck and changed-file lint
- rendered review in dark desktop and compact light mode with reduced motion and increased text

Closes #1341