### PR TITLE
fix(server): isolate concurrent health probes

### DIFF
--- a/server/src/__tests__/memory-health-feature.test.ts
+++ b/server/src/__tests__/memory-health-feature.test.ts
@@ -26,7 +26,7 @@ vi.mock('../services/metrics/index.js', () => ({
 }));
 
 import { classifyMemoryPressure } from '../utils/memory-pressure.js';
-import { healthRouter } from '../routes/health.js';
+import { checkStorage, healthRouter } from '../routes/health.js';
 import { systemHealthRouter } from '../routes/system-health.js';
 import { errorHandler } from '../middleware/error-handler.js';
 
@@ -133,6 +133,16 @@ describe('memory health feature', () => {
       checks: { memory: 'ok' },
       memoryPressure: healthyPressure,
     });
+  });
+
+  it('keeps simultaneous storage probes independent when timestamps match', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_788_409_000_000);
+
+    const statuses = await Promise.all(Array.from({ length: 25 }, () => checkStorage())).finally(
+      () => nowSpy.mockRestore()
+    );
+
+    expect(statuses).toEqual(Array.from({ length: 25 }, () => 'ok'));
   });
 
   it('reports real pressure consistently without weakening one-warning severity', async () => {

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -7,6 +7,7 @@
  *   GET /health/deep  — Full diagnostics (admin only)
  */
 import { Router } from 'express';
+import { randomUUID } from 'node:crypto';
 import fs from 'fs/promises';
 import path from 'path';
 import { z } from 'zod';
@@ -61,12 +62,12 @@ export function setHealthWss(wss: WebSocketServer): void {
 /**
  * Check that the data directory exists and is writable.
  */
-async function checkStorage(): Promise<'ok' | 'fail'> {
+export async function checkStorage(): Promise<'ok' | 'fail'> {
   const dataDir = getRuntimeDir();
   try {
     await fs.access(dataDir, fs.constants.R_OK | fs.constants.W_OK);
     // Write and remove a temp file to verify actual write access
-    const tmpFile = path.join(dataDir, `.health-check-${Date.now()}.tmp`);
+    const tmpFile = path.join(dataDir, `.health-check-${process.pid}-${randomUUID()}.tmp`);
     await fs.writeFile(tmpFile, 'ok');
     await fs.unlink(tmpFile);
     return 'ok';


### PR DESCRIPTION
## Summary

- give every storage writability probe a process-scoped UUID temporary path
- prevent simultaneous readiness and deep-health checks from removing each others probe file
- add a deterministic concurrent regression with a fixed clock

## Root cause

The storage check used Date.now() as its only filename discriminator. Concurrent probes in the same millisecond shared a file, so one unlink could make another probe report a false storage failure and readiness HTTP 503.

## Verification

- 12 focused memory-health and health-route tests
- server typecheck
- changed-file lint

Fixes #1351