### PR TITLE
Keep desktop header branding icon-only

### DIFF
--- a/web/src/__tests__/layout-chrome-mantine.test.tsx
+++ b/web/src/__tests__/layout-chrome-mantine.test.tsx
@@ -281,6 +281,7 @@ describe('layout chrome Mantine migration', () => {
       .getByRole('button', { name: 'Refresh page' })
       .querySelector('img[src="/icons/pwa-icon-192.png"]');
     expect(brandIcon).toBeDefined();
+    expect(document.querySelector('header h1')).toBeNull();
   });
 
   it.each(['right', 'bottom'] as const)(

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -393,10 +393,12 @@ export function Header() {
               title="Refresh page"
             >
               <VeritasMark />
-              <Text component="h1" size="sm" fw={700} lh={1.1} m={0} className="hidden sm:block">
-                <span className="block">Veritas</span>
-                <span className="block text-xs font-medium text-muted-foreground">Kanban</span>
-              </Text>
+              {!isDesktopClient && (
+                <Text component="h1" size="sm" fw={700} lh={1.1} m={0} className="hidden sm:block">
+                  <span className="block">Veritas</span>
+                  <span className="block text-xs font-medium text-muted-foreground">Kanban</span>
+                </Text>
+              )}
             </Box>
             {!isCompactHeader && (
               <>


### PR DESCRIPTION
## Summary

- remove the redundant visible Veritas Kanban wordmark from the desktop header
- keep the app icon as the refresh/home control
- preserve the wordmark on the web layout, where there is no native macOS title bar

Closes #1364

## Verification

- `pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/layout-chrome-mantine.test.tsx`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web build`