### PR TITLE
fix: align Settings modal header

### DIFF
--- a/e2e/mantine-qa-gate.spec.ts
+++ b/e2e/mantine-qa-gate.spec.ts
@@ -514,6 +514,21 @@ test.describe('v5 Mantine migration QA gate', () => {
     await assertNoLegacyPrimitiveSlots(page);
     await assertVisibleInteractiveControlsHaveNames(page);
     await assertFocusRemainsInsideDialog(page, 'Settings');
+    const settingsTitleBox = await settingsDialog
+      .getByText('Settings', { exact: true })
+      .boundingBox();
+    const settingsCloseBox = await settingsDialog
+      .getByRole('button', { name: 'Close settings' })
+      .boundingBox();
+    expect(settingsTitleBox).not.toBeNull();
+    expect(settingsCloseBox).not.toBeNull();
+    expect(
+      Math.abs(
+        settingsTitleBox!.y +
+          settingsTitleBox!.height / 2 -
+          (settingsCloseBox!.y + settingsCloseBox!.height / 2)
+      )
+    ).toBeLessThanOrEqual(1);
     await attachViewportScreenshot(page, testInfo, 'overlay-settings-desktop', 'dark');
     await page.keyboard.press('Escape');
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 });

--- a/web/src/__tests__/settings-dialog-mantine.test.tsx
+++ b/web/src/__tests__/settings-dialog-mantine.test.tsx
@@ -118,6 +118,12 @@ describe('SettingsDialog Mantine shell', () => {
     expect(baseElement.querySelector('.mantine-Button-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-ScrollArea-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-Select-root')).toBeDefined();
+
+    const closeButton = screen.getByRole('button', { name: 'Close settings' });
+    const modalHeader = closeButton.closest('.mantine-Modal-header');
+    expect(modalHeader?.className).toContain('settings-dialog-header');
+    expect(modalHeader?.textContent).toContain('Settings');
+    expect(screen.getAllByText('Settings')).toHaveLength(1);
   });
 
   it('groups every destination exactly once and separates destructive actions', async () => {

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -585,7 +585,18 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
     <Modal
       opened={open}
       onClose={() => onOpenChange(false)}
-      title={<span className="sr-only">Settings</span>}
+      title={
+        <Group gap="xs" wrap="nowrap">
+          <Text component="span" size="sm" fw={600}>
+            Settings
+          </Text>
+          {isBoardOnly && (
+            <Badge size="xs" variant="light" color="cyan">
+              Board Only
+            </Badge>
+          )}
+        </Group>
+      }
       size={1040}
       padding={0}
       centered
@@ -594,12 +605,13 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
       closeButtonProps={{ 'aria-label': 'Close settings' }}
       classNames={{
         content: 'settings-dialog-content',
+        header: 'settings-dialog-header border-b border-border',
         body: 'settings-dialog-body',
       }}
       styles={{
-        content: { height: '85vh', overflow: 'hidden' },
-        body: { height: '100%', padding: 0 },
-        close: { top: '1rem', right: '1rem' },
+        content: { height: '85vh', overflow: 'hidden', display: 'flex', flexDirection: 'column' },
+        header: { minHeight: '3rem', padding: '0.5rem 0.75rem 0.5rem 1rem' },
+        body: { flex: 1, minHeight: 0, padding: 0 },
       }}
     >
       <ErrorBoundary level="section">
@@ -611,14 +623,6 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
           {/* Sidebar Tabs — hidden on narrow screens, shown as dropdown instead */}
           <div className="hidden min-h-0 w-56 flex-col border-r bg-muted/25 py-4 sm:flex">
             <div className="px-4 pb-3">
-              <Group gap="xs">
-                <h2 className="text-sm font-semibold">Settings</h2>
-                {isBoardOnly && (
-                  <Badge size="xs" variant="light" color="cyan">
-                    Board Only
-                  </Badge>
-                )}
-              </Group>
               <Text size="xs" c="dimmed" mt={4}>
                 {isBoardOnly
                   ? 'Board essentials first. Advanced settings remain available.'
@@ -763,7 +767,6 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
           {/* Content */}
           <div className="flex-1 flex flex-col min-w-0 min-h-0">
             <div data-settings-mobile-header className="shrink-0 border-b px-4 py-3 sm:hidden">
-              <h2 className="text-lg font-semibold">Settings</h2>
               <Select
                 value={activeTab}
                 onChange={(value) => {


### PR DESCRIPTION
## Summary

- place the visible Settings title and Board Only badge in the native modal header
- align the close control with that header instead of positioning it over the dialog body
- remove duplicate desktop and mobile Settings headings
- add component and rendered geometry regressions

Closes #1362

## Verification

- `pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/settings-dialog-mantine.test.tsx`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web build`
- isolated Playwright overlay scenario at 1440x1000; title and close-button centers differ by at most 1 px