### PR TITLE
fix: update vulnerable transitive dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@babel/core@<7.29.1': 7.29.7
   '@hono/node-server': '>=1.19.15'
   '@modelcontextprotocol/sdk>express-rate-limit': 8.6.2
-  '@xmldom/xmldom': 0.8.13
+  '@xmldom/xmldom': 0.8.15
   body-parser@<2.3.0: 2.3.0
   brace-expansion@<5.0.9: 5.0.9
   esbuild@<0.28.1: 0.28.1
@@ -19,7 +19,8 @@ overrides:
   js-yaml@<4.3.1: 4.3.1
   nanoid@<3.3.18: 3.3.18
   postcss: '>=8.5.23'
-  qs: ^6.14.2
+  postcss-selector-parser: 7.1.5
+  qs: 6.16.0
   uuid@^8.3.0: 11.1.1
   minimatch: '>=10.2.3'
   path-to-regexp: '>=8.4.0'
@@ -1720,10 +1721,9 @@ packages:
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
-  '@xmldom/xmldom@0.8.13':
-    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+  '@xmldom/xmldom@0.8.15':
+    resolution: {integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -4137,8 +4137,8 @@ packages:
     peerDependencies:
       postcss: '>=8.5.23'
 
-  postcss-selector-parser@7.1.1:
-    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+  postcss-selector-parser@7.1.5:
+    resolution: {integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==}
     engines: {node: '>=4'}
 
   postcss-simple-vars@7.0.1:
@@ -4217,8 +4217,8 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -4581,6 +4581,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -6579,7 +6583,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  '@xmldom/xmldom@0.8.13': {}
+  '@xmldom/xmldom@0.8.15': {}
 
   abbrev@4.0.0: {}
 
@@ -6870,7 +6874,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -7809,7 +7813,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.16.0
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -8755,7 +8759,7 @@ snapshots:
 
   mammoth@1.12.2:
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       argparse: 1.0.10
       base64-js: 1.5.1
       bluebird: 3.4.7
@@ -9433,7 +9437,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -9455,7 +9459,7 @@ snapshots:
   postcss-nested@7.0.2(postcss@8.5.26):
     dependencies:
       postcss: 8.5.26
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.5
 
   postcss-preset-mantine@1.18.0(postcss@8.5.26):
     dependencies:
@@ -9463,7 +9467,7 @@ snapshots:
       postcss-mixins: 12.1.2(postcss@8.5.26)
       postcss-nested: 7.0.2(postcss@8.5.26)
 
-  postcss-selector-parser@7.1.1:
+  postcss-selector-parser@7.1.5:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
@@ -9540,9 +9544,10 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quick-format-unescaped@4.0.4: {}
 
@@ -10024,6 +10029,14 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -10198,7 +10211,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.2
+      qs: 6.16.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ overrides:
   '@babel/core@<7.29.1': 7.29.7
   '@hono/node-server': '>=1.19.15'
   '@modelcontextprotocol/sdk>express-rate-limit': 8.6.2
-  '@xmldom/xmldom': 0.8.13
+  '@xmldom/xmldom': 0.8.15
   'body-parser@<2.3.0': 2.3.0
   'brace-expansion@<5.0.9': 5.0.9
   'esbuild@<0.28.1': 0.28.1
@@ -28,7 +28,8 @@ overrides:
   'js-yaml@<4.3.1': 4.3.1
   'nanoid@<3.3.18': 3.3.18
   postcss: '>=8.5.23'
-  qs: ^6.14.2
+  postcss-selector-parser: 7.1.5
+  qs: 6.16.0
   'uuid@^8.3.0': 11.1.1
   minimatch: '>=10.2.3'
   path-to-regexp: '>=8.4.0'


### PR DESCRIPTION
## Summary

- update `qs` to 6.16.0 for both moderate advisories
- update `@xmldom/xmldom` to 0.8.15 for the XML serialization advisory
- update `postcss-selector-parser` to 7.1.5 for the dev-toolchain recursion advisory
- keep the change limited to package-manager overrides because Express, Mammoth, and the Mantine PostCSS preset are already current

Closes #1360

## Verification

- `pnpm audit --prod` reports no known vulnerabilities
- `pnpm audit` reports no known vulnerabilities
- 21 focused server request-parsing and text-extraction tests
- `pnpm typecheck`
- `pnpm build`
- Electron artifact contract passes as part of the workspace build