### PR TITLE
fix: clarify desktop header controls

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -116,7 +116,7 @@ The Kanban board is the central interface — a drag-and-drop workspace that ref
 - **Markdown storage** — Tasks stored as human-readable `.md` files with YAML frontmatter
 - **Dark/light mode** — Ships dark by default with a toggle in Settings → General → Appearance; persists to localStorage; inline script in `index.html` prevents flash of wrong theme on load
 - **Filter bar** — Search tasks by text, filter by project and task type; filters persist in URL query params
-- **Desktop shell controls** — Native-app-style toolbar with workspace selection, health state, a left-sidebar control, a Board-only right-sidebar control, and visually distinct Board Chat and Squad Chat actions
+- **Desktop shell controls** — Native-app-style toolbar with workspace selection, health state, a left-sidebar control, a Board-only right-sidebar control, and visually distinct Board Chat and Squad Chat actions; auxiliary rails and Workbench collapse when the native window crosses into compact width
 - **Native version identity** — The macOS application menu opens an offline About panel and copies a redacted support string from the same authoritative Electron version, embedded release commit, release channel, OS, and architecture record exposed by the desktop bridge
 - **Mobile shell controls** — Compact navigation uses bounded labels and full accessible names; Board Chat stays fixed above the bottom navigation and device safe area
 - **Resizable Workbench** — Board Chat and Squad Chat open in one bounded right-side dock, preserve the active conversation when switching channels, and clamp their width to keep the application shell recoverable

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -116,7 +116,7 @@ The Kanban board is the central interface — a drag-and-drop workspace that ref
 - **Markdown storage** — Tasks stored as human-readable `.md` files with YAML frontmatter
 - **Dark/light mode** — Ships dark by default with a toggle in Settings → General → Appearance; persists to localStorage; inline script in `index.html` prevents flash of wrong theme on load
 - **Filter bar** — Search tasks by text, filter by project and task type; filters persist in URL query params
-- **Desktop shell controls** — Native-app-style toolbar with workspace selection, health state, view toggles, and bounded left/right/chat dock controls shared by the web and macOS app shells
+- **Desktop shell controls** — Native-app-style toolbar with workspace selection, health state, a left-sidebar control, a Board-only right-sidebar control, and visually distinct Board Chat and Squad Chat actions
 - **Native version identity** — The macOS application menu opens an offline About panel and copies a redacted support string from the same authoritative Electron version, embedded release commit, release channel, OS, and architecture record exposed by the desktop bridge
 - **Mobile shell controls** — Compact navigation uses bounded labels and full accessible names; Board Chat stays fixed above the bottom navigation and device safe area
 - **Resizable Workbench** — Board Chat and Squad Chat open in one bounded right-side dock, preserve the active conversation when switching channels, and clamp their width to keep the application shell recoverable

--- a/e2e/board-drag-atomic.spec.ts
+++ b/e2e/board-drag-atomic.spec.ts
@@ -101,7 +101,7 @@ test.describe('Atomic board drag', () => {
       await expect(blocked).toBeVisible();
       await expect(page.locator('html')).toHaveAttribute('data-client', 'desktop');
       if (rightRailOpen) await expect(page.getByLabel('Board right sidebar')).toBeVisible();
-      else await expect(page.getByLabel('Board right sidebar')).toHaveCount(0);
+      else await expect(page.getByLabel('Board right sidebar')).toBeHidden();
       await expect(page.getByLabel('Board dashboard')).toBeAttached();
       await page.waitForTimeout(500);
 

--- a/e2e/desktop-board-shell.spec.ts
+++ b/e2e/desktop-board-shell.spec.ts
@@ -43,7 +43,7 @@ test.describe('Desktop board shell containment', () => {
     });
     taskIds.push(destination.id as string);
 
-    await page.setViewportSize({ width: 1224, height: 768 });
+    await page.setViewportSize({ width: 1360, height: 768 });
     await page.goto('/');
     await expect(page.locator('html')).toHaveAttribute('data-client', 'desktop');
     await expect(page.getByLabel('Board right sidebar')).toBeVisible();
@@ -124,8 +124,23 @@ test.describe('Desktop board shell containment', () => {
     await expect(page.getByRole('region', { name: 'Squad Chat' })).toBeVisible();
     expect(await readViewport()).toEqual(expectedViewport);
 
-    await page.getByRole('button', { name: 'Close right dock' }).click();
+    await page.setViewportSize({ width: 1180, height: 760 });
+    await expect(page.getByRole('button', { name: 'Expand left sidebar' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    await expect(page.getByRole('button', { name: 'Expand right sidebar' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
     await expect(page.getByRole('region', { name: 'Workbench right dock' })).toHaveCount(0);
+    expect(await readViewport()).toEqual({
+      innerHeight: 760,
+      documentHeight: 760,
+      scrollY: 0,
+      shellHeight: 760,
+    });
+    await page.setViewportSize({ width: 1360, height: 768 });
 
     await page.getByRole('button', { name: 'Activity', exact: true }).click();
     await expect(page).toHaveURL(/\/activity$/);
@@ -136,7 +151,7 @@ test.describe('Desktop board shell containment', () => {
 
     await page.getByRole('button', { name: 'Board', exact: true }).click();
     await expect(page).toHaveURL(/\/$/);
-    await expect(page.getByRole('button', { name: 'Collapse right sidebar' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Expand right sidebar' })).toBeVisible();
 
     const movingId = taskIds[5];
     const destinationId = destination.id as string;

--- a/e2e/desktop-board-shell.spec.ts
+++ b/e2e/desktop-board-shell.spec.ts
@@ -47,6 +47,29 @@ test.describe('Desktop board shell containment', () => {
     await page.goto('/');
     await expect(page.locator('html')).toHaveAttribute('data-client', 'desktop');
     await expect(page.getByLabel('Board right sidebar')).toBeVisible();
+    const rightRailToggle = page.getByRole('button', { name: 'Collapse right sidebar' });
+    await expect(rightRailToggle).toHaveAttribute('aria-controls', 'board-right-sidebar');
+    await expect(rightRailToggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.locator('#board-right-sidebar')).toBeVisible();
+    await rightRailToggle.click();
+    await expect(page.getByRole('button', { name: 'Expand right sidebar' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    await expect(page.locator('#board-right-sidebar')).toBeHidden();
+    await page.getByRole('button', { name: 'Expand right sidebar' }).click();
+    await expect(page.getByRole('button', { name: 'Collapse right sidebar' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    await expect(page.locator('#board-right-sidebar')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Open chat dock' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Open Board Chat' }).locator('svg')).toHaveClass(
+      /lucide-message-square/
+    );
+    await expect(page.getByRole('button', { name: 'Open Squad Chat' }).locator('svg')).toHaveClass(
+      /lucide-users/
+    );
     await expect
       .poll(() =>
         page.evaluate(() => window.localStorage.getItem('veritas.workbench.dockPosition'))
@@ -61,9 +84,14 @@ test.describe('Desktop board shell containment', () => {
       taskIds.map((taskId) => expect(page.locator(`[data-task-id="${taskId}"]`)).toBeAttached())
     );
 
-    await page.getByRole('button', { name: 'Open chat dock' }).click();
+    await page.getByRole('button', { name: 'Open Board Chat' }).click();
     const workbench = page.getByRole('region', { name: 'Workbench right dock' });
     await expect(workbench).toBeVisible();
+    await expect(workbench).toHaveAttribute('id', 'workbench-right-dock');
+    await expect(page.getByRole('button', { name: 'Close Board Chat' })).toHaveAttribute(
+      'aria-controls',
+      'workbench-right-dock'
+    );
     await expect(workbench.getByRole('radiogroup', { name: 'Dock position' })).toHaveCount(0);
 
     const readViewport = () =>
@@ -98,6 +126,17 @@ test.describe('Desktop board shell containment', () => {
 
     await page.getByRole('button', { name: 'Close right dock' }).click();
     await expect(page.getByRole('region', { name: 'Workbench right dock' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Activity', exact: true }).click();
+    await expect(page).toHaveURL(/\/activity$/);
+    await expect(page.getByRole('button', { name: /right sidebar/i })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Open chat dock' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Open Board Chat' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Open Squad Chat' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Board', exact: true }).click();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByRole('button', { name: 'Collapse right sidebar' })).toBeVisible();
 
     const movingId = taskIds[5];
     const destinationId = destination.id as string;

--- a/web/src/__tests__/KanbanBoard.test.tsx
+++ b/web/src/__tests__/KanbanBoard.test.tsx
@@ -419,7 +419,9 @@ describe('KanbanBoard', () => {
     renderDesktopBoard();
 
     expect(screen.getByTestId('column-todo')).toBeDefined();
-    expect(screen.queryByLabelText('Board right sidebar')).toBeNull();
+    const rightRail = screen.getByLabelText('Board right sidebar');
+    expect(rightRail.id).toBe('board-right-sidebar');
+    expect(rightRail.hasAttribute('hidden')).toBe(true);
   });
 
   it('fits configured board columns across the desktop shell', () => {

--- a/web/src/__tests__/desktop-shell-context.test.tsx
+++ b/web/src/__tests__/desktop-shell-context.test.tsx
@@ -23,6 +23,9 @@ function ShellProbe() {
       <button type="button" onClick={() => shell.setLeftRailOpen(false)}>
         Close left rail
       </button>
+      <button type="button" onClick={() => shell.setLeftRailOpen(true)}>
+        Open left rail
+      </button>
       <button type="button" onClick={() => shell.setRightRailOpen(true)}>
         Open right rail
       </button>
@@ -51,7 +54,7 @@ describe('desktop shell recovery', () => {
     window.localStorage.clear();
     window.history.replaceState({}, '', '/');
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 600 });
-    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1180 });
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1360 });
     Object.defineProperty(window, 'veritasDesktop', {
       configurable: true,
       value: {
@@ -126,6 +129,48 @@ describe('desktop shell recovery', () => {
     await user.click(screen.getByRole('button', { name: 'Open board chat' }));
     act(() => window.dispatchEvent(new PopStateEvent('popstate', { state: {} })));
     expect(screen.getByLabelText('bottom panel').textContent).toBe('closed');
+  });
+
+  it('collapses sidebars and Workbench when the desktop crosses into compact width', async () => {
+    const user = userEvent.setup();
+    render(
+      <DesktopShellProvider>
+        <ShellProbe />
+      </DesktopShellProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open right rail' }));
+    await user.click(screen.getByRole('button', { name: 'Open board chat' }));
+    expect(screen.getByLabelText('left rail').textContent).toBe('true');
+    expect(screen.getByLabelText('right rail').textContent).toBe('true');
+    expect(screen.getByLabelText('bottom panel').textContent).toBe('board-chat');
+
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1180 });
+    act(() => window.dispatchEvent(new Event('resize')));
+
+    expect(screen.getByLabelText('left rail').textContent).toBe('false');
+    expect(screen.getByLabelText('right rail').textContent).toBe('false');
+    expect(screen.getByLabelText('bottom panel').textContent).toBe('closed');
+    expect(window.localStorage.getItem('veritas.desktop.leftRailOpen')).toBe('false');
+    expect(window.localStorage.getItem('veritas.desktop.rightRailOpen')).toBe('false');
+  });
+
+  it('minimizes both sidebars before opening Workbench at compact width', async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1180 });
+    render(
+      <DesktopShellProvider>
+        <ShellProbe />
+      </DesktopShellProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open left rail' }));
+    await user.click(screen.getByRole('button', { name: 'Open right rail' }));
+    await user.click(screen.getByRole('button', { name: 'Open board chat' }));
+
+    expect(screen.getByLabelText('left rail').textContent).toBe('false');
+    expect(screen.getByLabelText('right rail').textContent).toBe('false');
+    expect(screen.getByLabelText('bottom panel').textContent).toBe('board-chat');
   });
 
   it('resets the complete desktop layout from the native recovery command', async () => {

--- a/web/src/__tests__/layout-chrome-mantine.test.tsx
+++ b/web/src/__tests__/layout-chrome-mantine.test.tsx
@@ -269,20 +269,43 @@ describe('layout chrome Mantine migration', () => {
     expect(baseElement.querySelector('[data-slot="popover-content"]')).toBeNull();
   });
 
-  it('renders desktop shell controls and app icon branding in desktop mode', () => {
-    renderDesktopHeaderChrome();
+  it('renders route-valid desktop shell controls and distinct chat actions', () => {
+    const { container } = renderDesktopHeaderChrome();
 
-    expect(screen.getByRole('button', { name: 'Collapse left sidebar' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Expand right sidebar' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Open chat dock' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Open Board Chat' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Open Squad Chat' })).toBeDefined();
+    const leftRail = screen.getByRole('button', { name: 'Collapse left sidebar' });
+    const rightRail = screen.getByRole('button', { name: 'Expand right sidebar' });
+    const boardChat = screen.getByRole('button', { name: 'Open Board Chat' });
+    const squadChat = screen.getByRole('button', { name: 'Open Squad Chat' });
+
+    expect(leftRail.getAttribute('aria-controls')).toBe('desktop-navigation-sidebar');
+    expect(leftRail.getAttribute('aria-expanded')).toBe('true');
+    expect(rightRail.getAttribute('aria-controls')).toBe('board-right-sidebar');
+    expect(rightRail.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByRole('button', { name: 'Open chat dock' })).toBeNull();
+    expect(boardChat.querySelector('.lucide-message-square')).toBeDefined();
+    expect(squadChat.querySelector('.lucide-users')).toBeDefined();
+    expect(container.querySelectorAll('.lucide-panel-right')).toHaveLength(1);
+    expect(screen.getByRole('group', { name: 'Desktop layout controls' })).toBeDefined();
+    expect(screen.getByRole('group', { name: 'Chat controls' })).toBeDefined();
 
     const brandIcon = screen
       .getByRole('button', { name: 'Refresh page' })
       .querySelector('img[src="/icons/pwa-icon-192.png"]');
     expect(brandIcon).toBeDefined();
     expect(document.querySelector('header h1')).toBeNull();
+  });
+
+  it('does not render the board right-rail action on routes without that rail', () => {
+    window.history.replaceState({}, '', '/activity');
+    const { container } = renderDesktopHeaderChrome();
+
+    expect(screen.getByRole('button', { name: 'Collapse left sidebar' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: /right sidebar/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Open chat dock' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Open Board Chat' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Open Squad Chat' })).toBeDefined();
+    expect(container.querySelector('.lucide-panel-right')).toBeNull();
+    expect(container.querySelector('.lucide-panel-right-close')).toBeNull();
   });
 
   it('uses the filled brand treatment with white text for the active desktop navigation item', () => {
@@ -320,6 +343,8 @@ describe('layout chrome Mantine migration', () => {
     await user.click(openBoard);
     const closeBoard = screen.getByRole('button', { name: 'Close Board Chat' });
     expect(closeBoard.getAttribute('aria-pressed')).toBe('true');
+    expect(closeBoard.getAttribute('aria-controls')).toBe('workbench-right-dock');
+    expect(closeBoard.querySelector('.lucide-message-square')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Switch to Squad Chat' })).toBeDefined();
 
     await user.click(closeBoard);
@@ -329,6 +354,8 @@ describe('layout chrome Mantine migration', () => {
     await user.click(screen.getByRole('button', { name: 'Switch to Squad Chat' }));
     const closeSquad = screen.getByRole('button', { name: 'Close Squad Chat' });
     expect(closeSquad.getAttribute('aria-pressed')).toBe('true');
+    expect(closeSquad.getAttribute('aria-controls')).toBe('workbench-right-dock');
+    expect(closeSquad.querySelector('.lucide-users')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Switch to Board Chat' })).toBeDefined();
 
     await user.click(closeSquad);

--- a/web/src/__tests__/layout-chrome-mantine.test.tsx
+++ b/web/src/__tests__/layout-chrome-mantine.test.tsx
@@ -179,6 +179,7 @@ describe('layout chrome Mantine migration', () => {
     vi.clearAllMocks();
     window.localStorage.clear();
     window.history.replaceState({}, '', '/');
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1360 });
     window.HTMLElement.prototype.scrollIntoView = vi.fn();
   });
 

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -733,21 +733,26 @@ export function KanbanBoard() {
             )}
           </section>
 
-          {(!isDesktopClient || rightRailOpen) && (
-            <Suspense
-              fallback={
-                <aside className="min-h-24 rounded-md border border-dashed border-border/70" />
-              }
-            >
-              <aside className="min-w-0" aria-label="Board right sidebar">
+          <aside
+            id="board-right-sidebar"
+            className="min-w-0"
+            aria-label="Board right sidebar"
+            hidden={isDesktopClient && !rightRailOpen}
+          >
+            {(!isDesktopClient || rightRailOpen) && (
+              <Suspense
+                fallback={
+                  <div className="min-h-24 rounded-md border border-dashed border-border/70" />
+                }
+              >
                 <BoardSidebar
                   onTaskClick={(taskId) => {
                     void handleTaskIdClick(taskId);
                   }}
                 />
-              </aside>
-            </Suspense>
-          )}
+              </Suspense>
+            )}
+          </aside>
         </div>
 
         {boardSettings.showDashboard && (

--- a/web/src/components/layout/DesktopBottomPanel.tsx
+++ b/web/src/components/layout/DesktopBottomPanel.tsx
@@ -8,7 +8,7 @@ import {
   type WheelEvent,
 } from 'react';
 import { ActionIcon, Group, SegmentedControl, Text } from '@mantine/core';
-import { GripVertical, MessageSquare, PanelRightClose, Users } from 'lucide-react';
+import { GripVertical, MessageSquare, Users, X } from 'lucide-react';
 
 import {
   MAX_RIGHT_PANEL_WIDTH,
@@ -90,6 +90,7 @@ export function DesktopBottomPanel() {
 
   return (
     <section
+      id="workbench-right-dock"
       className="workbench-chat-dock workbench-chat-dock--right bg-card"
       aria-label="Workbench right dock"
       data-dock-position="right"
@@ -135,7 +136,7 @@ export function DesktopBottomPanel() {
               aria-label="Close right dock"
               title="Close right dock"
             >
-              <PanelRightClose className="h-4 w-4" aria-hidden="true" />
+              <X className="h-4 w-4" aria-hidden="true" />
             </ActionIcon>
           </Group>
         </Group>

--- a/web/src/components/layout/DesktopLeftSidebar.tsx
+++ b/web/src/components/layout/DesktopLeftSidebar.tsx
@@ -49,6 +49,7 @@ export function DesktopLeftSidebar() {
 
   return (
     <aside
+      id="desktop-navigation-sidebar"
       aria-label="Desktop navigation"
       className={cn(
         'desktop-left-sidebar border-r border-border bg-card/80 transition-[width] duration-150',

--- a/web/src/components/layout/DesktopShellContext.tsx
+++ b/web/src/components/layout/DesktopShellContext.tsx
@@ -34,6 +34,7 @@ const RIGHT_PANEL_WIDTH_STORAGE_KEY = 'veritas.workbench.rightPanelWidth';
 const BOTTOM_PANEL_HISTORY_STATE_KEY = 'veritasBottomPanel';
 const RIGHT_PANEL_VIEWPORT_RESERVE = 520;
 const COMPACT_RIGHT_PANEL_WIDTH = 280;
+export const COMPACT_DESKTOP_LAYOUT_WIDTH = 1280;
 export const DEFAULT_RIGHT_PANEL_WIDTH = 420;
 export const MIN_RIGHT_PANEL_WIDTH = 320;
 export const MAX_RIGHT_PANEL_WIDTH = 640;
@@ -121,9 +122,14 @@ function isBottomPanel(value: unknown): value is DesktopBottomPanel {
   return value === 'board-chat' || value === 'squad-chat';
 }
 
+function isCompactDesktopLayout(): boolean {
+  return typeof window !== 'undefined' && window.innerWidth < COMPACT_DESKTOP_LAYOUT_WIDTH;
+}
+
 export function DesktopShellProvider({ children }: { children: ReactNode }) {
   const desktopClient = isDesktopClient();
   const panelTriggerRef = useRef<HTMLElement | null>(null);
+  const compactLayoutRef = useRef(isCompactDesktopLayout());
   const [leftRailOpen, setLeftRailOpenState] = useState(() =>
     readStoredBoolean(LEFT_RAIL_STORAGE_KEY, true)
   );
@@ -175,6 +181,12 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
 
   const openBottomPanel = useCallback(
     (panel: DesktopBottomPanel) => {
+      if (desktopClient && isCompactDesktopLayout()) {
+        setLeftRailOpenState(false);
+        setRightRailOpenState(false);
+        writeStoredValue(LEFT_RAIL_STORAGE_KEY, 'false');
+        writeStoredValue(RIGHT_RAIL_STORAGE_KEY, 'false');
+      }
       if (!bottomPanel && document.activeElement instanceof HTMLElement) {
         panelTriggerRef.current = document.activeElement;
       }
@@ -194,7 +206,7 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
         window.history.pushState(state, '', window.location.href);
       }
     },
-    [bottomPanel]
+    [bottomPanel, desktopClient]
   );
 
   const toggleBottomPanel = useCallback(
@@ -242,6 +254,14 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
+    if (!desktopClient || !compactLayoutRef.current) return;
+    setLeftRailOpenState(false);
+    setRightRailOpenState(false);
+    writeStoredValue(LEFT_RAIL_STORAGE_KEY, 'false');
+    writeStoredValue(RIGHT_RAIL_STORAGE_KEY, 'false');
+  }, [desktopClient]);
+
+  useEffect(() => {
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.key !== 'Escape' || !bottomPanel) return;
       event.preventDefault();
@@ -260,6 +280,17 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
         }
         return next;
       });
+
+      const compact = isCompactDesktopLayout();
+      const becameCompact = compact && !compactLayoutRef.current;
+      compactLayoutRef.current = compact;
+      if (!desktopClient || !becameCompact) return;
+
+      setLeftRailOpenState(false);
+      setRightRailOpenState(false);
+      writeStoredValue(LEFT_RAIL_STORAGE_KEY, 'false');
+      writeStoredValue(RIGHT_RAIL_STORAGE_KEY, 'false');
+      if (bottomPanel) closeBottomPanel();
     };
 
     window.addEventListener('keydown', handleKeyDown);
@@ -272,7 +303,7 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
       window.removeEventListener('resize', handleResize);
       document.removeEventListener('fullscreenchange', handleResize);
     };
-  }, [bottomPanel, closeBottomPanel, restorePanelFocus]);
+  }, [bottomPanel, closeBottomPanel, desktopClient, restorePanelFocus]);
 
   useEffect(() => {
     const desktop = (

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -418,56 +418,47 @@ export function Header() {
             className="min-w-0 shrink-0"
           >
             {isDesktopClient && (
-              <Group gap={4} wrap="nowrap" className="desktop-no-drag">
-                {isDesktopClient && (
-                  <>
-                    <ActionIcon
-                      variant={leftRailOpen ? 'light' : 'subtle'}
-                      color={leftRailOpen ? 'veritas' : 'gray'}
-                      size={32}
-                      onClick={() => setLeftRailOpen(!leftRailOpen)}
-                      aria-label={leftRailOpen ? 'Collapse left sidebar' : 'Expand left sidebar'}
-                      aria-pressed={leftRailOpen}
-                      title={leftRailOpen ? 'Collapse left sidebar' : 'Expand left sidebar'}
-                    >
-                      {leftRailOpen ? (
-                        <PanelLeftClose className="h-4 w-4" aria-hidden="true" />
-                      ) : (
-                        <PanelLeft className="h-4 w-4" aria-hidden="true" />
-                      )}
-                    </ActionIcon>
-                    <ActionIcon
-                      variant={rightRailOpen ? 'light' : 'subtle'}
-                      color={rightRailOpen ? 'veritas' : 'gray'}
-                      size={32}
-                      onClick={() => setRightRailOpen(!rightRailOpen)}
-                      aria-label={rightRailOpen ? 'Collapse right sidebar' : 'Expand right sidebar'}
-                      aria-pressed={rightRailOpen}
-                      title={rightRailOpen ? 'Collapse right sidebar' : 'Expand right sidebar'}
-                    >
-                      {rightRailOpen ? (
-                        <PanelRightClose className="h-4 w-4" aria-hidden="true" />
-                      ) : (
-                        <PanelRight className="h-4 w-4" aria-hidden="true" />
-                      )}
-                    </ActionIcon>
-                  </>
-                )}
+              <Group
+                gap={4}
+                wrap="nowrap"
+                role="group"
+                aria-label="Desktop layout controls"
+                className="desktop-no-drag"
+              >
                 <ActionIcon
-                  variant={bottomPanel ? 'light' : 'subtle'}
-                  color={bottomPanel ? 'veritas' : 'gray'}
+                  variant={leftRailOpen ? 'light' : 'subtle'}
+                  color={leftRailOpen ? 'veritas' : 'gray'}
                   size={32}
-                  onClick={() => toggleBottomPanel('board-chat')}
-                  aria-label={bottomPanel ? 'Close right chat dock' : 'Open chat dock'}
-                  aria-pressed={Boolean(bottomPanel)}
-                  title={bottomPanel ? 'Close right chat dock' : 'Open chat dock'}
+                  onClick={() => setLeftRailOpen(!leftRailOpen)}
+                  aria-label={leftRailOpen ? 'Collapse left sidebar' : 'Expand left sidebar'}
+                  aria-controls="desktop-navigation-sidebar"
+                  aria-expanded={leftRailOpen}
+                  title={leftRailOpen ? 'Collapse left sidebar' : 'Expand left sidebar'}
                 >
-                  {bottomPanel ? (
-                    <PanelRightClose className="h-4 w-4" aria-hidden="true" />
+                  {leftRailOpen ? (
+                    <PanelLeftClose className="h-4 w-4" aria-hidden="true" />
                   ) : (
-                    <PanelRight className="h-4 w-4" aria-hidden="true" />
+                    <PanelLeft className="h-4 w-4" aria-hidden="true" />
                   )}
                 </ActionIcon>
+                {view === 'board' && (
+                  <ActionIcon
+                    variant={rightRailOpen ? 'light' : 'subtle'}
+                    color={rightRailOpen ? 'veritas' : 'gray'}
+                    size={32}
+                    onClick={() => setRightRailOpen(!rightRailOpen)}
+                    aria-label={rightRailOpen ? 'Collapse right sidebar' : 'Expand right sidebar'}
+                    aria-controls="board-right-sidebar"
+                    aria-expanded={rightRailOpen}
+                    title={rightRailOpen ? 'Collapse right sidebar' : 'Expand right sidebar'}
+                  >
+                    {rightRailOpen ? (
+                      <PanelRightClose className="h-4 w-4" aria-hidden="true" />
+                    ) : (
+                      <PanelRight className="h-4 w-4" aria-hidden="true" />
+                    )}
+                  </ActionIcon>
+                )}
               </Group>
             )}
             {isCompactHeader ? (
@@ -529,7 +520,7 @@ export function Header() {
               <Search className="h-4 w-4" aria-hidden="true" />
             </ActionIcon>
             {!isCompactHeader && (
-              <>
+              <Group gap={4} wrap="nowrap" role="group" aria-label="Chat controls">
                 <ActionIcon
                   variant={boardChatActive ? 'light' : 'subtle'}
                   color={boardChatActive ? 'veritas' : 'gray'}
@@ -537,6 +528,7 @@ export function Header() {
                   onClick={toggleChatPanel}
                   aria-label={boardChatAction}
                   aria-pressed={boardChatActive}
+                  aria-controls={boardChatActive ? 'workbench-right-dock' : undefined}
                   title={boardChatAction}
                 >
                   <MessageSquare className="h-4 w-4" aria-hidden="true" />
@@ -548,11 +540,12 @@ export function Header() {
                   onClick={toggleSquadChatPanel}
                   aria-label={squadChatAction}
                   aria-pressed={squadChatActive}
+                  aria-controls={squadChatActive ? 'workbench-right-dock' : undefined}
                   title={squadChatAction}
                 >
                   <Users className="h-4 w-4" aria-hidden="true" />
                 </ActionIcon>
-              </>
+              </Group>
             )}
             {!isCompactHeader && (
               <ActionIcon


### PR DESCRIPTION
## Summary

- render the board right-sidebar control only on the Board route and bind it to the real sidebar region
- remove the generic chat-dock action so Board Chat and Squad Chat are the only chat entry points
- keep stable, distinct message and people glyphs for chat while using pressed state and accessible names to communicate state
- group layout and chat actions, add valid controlled-region relationships, and replace the Workbench panel glyph with an unambiguous close icon
- automatically minimize the left rail and close the Board rail and Workbench when the native window crosses below 1280px; opening Workbench at that width also minimizes both rails
- document the desktop shell behavior and add route, state, icon, and interaction regression coverage

## Verification

- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/layout-chrome-mantine.test.tsx src/__tests__/KanbanBoard.test.tsx src/__tests__/desktop-shell-context.test.tsx` (31 tests passed)
- `pnpm --filter @veritas-kanban/web typecheck`
- changed-file ESLint and Prettier checks
- `VERITAS_ADMIN_KEY=header-controls-e2e-key API_BASE_URL=http://127.0.0.1:34231 PLAYWRIGHT_API_PORT=34231 PLAYWRIGHT_WEB_PORT=34230 pnpm exec playwright test e2e/desktop-board-shell.spec.ts --project=chromium --reporter=line` (1 passed)
- `pnpm desktop:package:mac:dir`
- launched `desktop/release/mac-arm64/veritas-kanban.app` from this commit with an isolated profile on macOS 26.6.2 arm64
- physically toggled both sidebars and opened and closed both chat channels in the packaged app
- verified Board and Activity routes at 1360x900 and the minimum supported 1180x760 window size in dark and light themes
- opened both sidebars and Workbench at 1360x900, resized the actual Electron window to 1180x760, and verified both rails collapsed, Workbench closed, and the renderer remained exactly viewport-contained
- verified no generic dock action, no dock-position selector, one Board-only right-panel glyph, stable chat glyphs, and no document overflow

## Follow-up

The minimum-size packaged-app review confirmed that the right Workbench can still compress the board and Squad Chat toolbar too aggressively. That broader geometry and padding work remains tracked by #1383.

Closes #1379
