### PR TITLE
Keep policy action labels readable at desktop sizes

### DIFF
--- a/docs/audits/POLICY-ACTION-LAYOUT-1402.md
+++ b/docs/audits/POLICY-ACTION-LAYOUT-1402.md
@@ -4,4 +4,6 @@ The 190px Actions column compressed flex children while shared labels permitted 
 
 The browser regression failed before the fix and passes afterward in light/dark, 1180/1360px widths, 16/20px text, and both sidebar states. It checks three built-in Edit actions, single-line/unclipped Edit and Test labels, bounded Risk Threshold pills, and correct dialog opening. Web typecheck and changed-file lint pass.
 
-Packaged native verification, keyboard/focus acceptance, and the related action-group audit remain pending. Do not treat this source fix as completion of the larger desktop audit or final documentation media refresh.
+Packaged macOS geometry and keyboard acceptance passed in both themes at 1180x760 with 20px text on integration candidate `d181a26a7999c5ec0da456cfe30933b164a9e65e`, including the independent keyboard fix in PR #1408. Focused Enter opens Edit/Test; Escape after initial dialog focus restores the opener. The Type and action labels are readable in the inspected native captures. The packaged web index hash is `58139e42dd2b55e367fab13a92c7b4ebabca9cbbe64790b67d7034fcff96070d`.
+
+The related audit found Policy is the only DataTable consumer. Populated Template cards have a separate non-wrapping action-group problem at enlarged text, retained under the open Template redesign #1384. Do not treat the Policy fix as completion of that surface, the larger desktop audit, or the final documentation media refresh. The installed app is unchanged.

--- a/docs/audits/POLICY-ACTION-LAYOUT-1402.md
+++ b/docs/audits/POLICY-ACTION-LAYOUT-1402.md
@@ -1,7 +1,7 @@
 # Policy action layout (#1402)
 
-The 190px Actions column compressed flex children while shared labels permitted arbitrary word breaks. Edit consequently rendered four lines tall at a normal 1360px window. The column now reserves 16rem, and action buttons do not shrink; whole controls may wrap within the group.
+The 190px Actions column compressed flex children while shared labels permitted arbitrary word breaks. Edit consequently rendered four lines tall at a normal 1360px window. The column now reserves 16rem, action buttons do not shrink, and the adjacent Type column reserves enough space for its pills; whole controls may wrap within the group without breaking labels into arbitrary characters.
 
-The browser regression failed before the fix and passes afterward in light/dark, 1180/1360px widths, 16/20px text, and both sidebar states. It checks three built-in Edit actions, single-line/unclipped Edit and Test labels, and correct dialog opening. Web typecheck and changed-file lint pass.
+The browser regression failed before the fix and passes afterward in light/dark, 1180/1360px widths, 16/20px text, and both sidebar states. It checks three built-in Edit actions, single-line/unclipped Edit and Test labels, bounded Risk Threshold pills, and correct dialog opening. Web typecheck and changed-file lint pass.
 
 Packaged native verification, keyboard/focus acceptance, and the related action-group audit remain pending. Do not treat this source fix as completion of the larger desktop audit or final documentation media refresh.

--- a/docs/audits/POLICY-ACTION-LAYOUT-1402.md
+++ b/docs/audits/POLICY-ACTION-LAYOUT-1402.md
@@ -1,0 +1,7 @@
+# Policy action layout (#1402)
+
+The 190px Actions column compressed flex children while shared labels permitted arbitrary word breaks. Edit consequently rendered four lines tall at a normal 1360px window. The column now reserves 16rem, and action buttons do not shrink; whole controls may wrap within the group.
+
+The browser regression failed before the fix and passes afterward in light/dark, 1180/1360px widths, 16/20px text, and both sidebar states. It checks three built-in Edit actions, single-line/unclipped Edit and Test labels, and correct dialog opening. Web typecheck and changed-file lint pass.
+
+Packaged native verification, keyboard/focus acceptance, and the related action-group audit remain pending. Do not treat this source fix as completion of the larger desktop audit or final documentation media refresh.

--- a/e2e/policy-action-layout.spec.ts
+++ b/e2e/policy-action-layout.spec.ts
@@ -31,6 +31,13 @@ for (const theme of ['light', 'dark']) {
           const toggle = page.getByRole('button', { name: /^(Expand|Collapse) left sidebar$/ });
           if ((await toggle.getAttribute('aria-expanded')) !== String(sidebar === 'open'))
             await toggle.click();
+          for (const label of await page.getByText('Risk Threshold', { exact: true }).all()) {
+            const geometry = await label.evaluate((element) => ({
+              height: element.getBoundingClientRect().height,
+              lineHeight: parseFloat(getComputedStyle(element).lineHeight),
+            }));
+            expect(geometry.height).toBeLessThanOrEqual(geometry.lineHeight * 2 + 8);
+          }
           for (const name of ['Edit', 'Test']) {
             for (const button of await page.getByRole('button', { name, exact: true }).all()) {
               const geometry = await button.evaluate((element) => {
@@ -56,12 +63,16 @@ for (const theme of ['light', 'dark']) {
       }
     }
     await page.screenshot({ path: testInfo.outputPath(`policy-${theme}.png`) });
-    await page.getByRole('button', { name: 'Edit', exact: true }).first().click();
+    const edit = page.getByRole('button', { name: 'Edit', exact: true }).first();
+    await edit.click();
     await expect(page.getByRole('dialog')).toContainText('Edit Policy');
     await page.keyboard.press('Escape');
-    await page.getByRole('button', { name: 'Test', exact: true }).first().click();
+    await expect(edit).toBeFocused();
+    const preview = page.getByRole('button', { name: 'Test', exact: true }).first();
+    await preview.click();
     await expect(page.getByRole('dialog')).toContainText('Test Policy');
     await page.keyboard.press('Escape');
+    await expect(preview).toBeFocused();
     await cleanupRoutes(page);
   });
 }

--- a/e2e/policy-action-layout.spec.ts
+++ b/e2e/policy-action-layout.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+import { bypassAuth, cleanupRoutes } from './helpers/auth';
+
+for (const theme of ['light', 'dark']) {
+  test(`policy actions retain whole labels and open the correct dialogs (${theme})`, async ({
+    page,
+  }, testInfo) => {
+    await bypassAuth(page);
+    await page.addInitScript(() => {
+      window.localStorage.setItem('veritas.desktop.leftRailOpen', 'false');
+      Object.defineProperty(window, 'veritasDesktop', {
+        configurable: true,
+        value: { onMenuCommand: () => () => undefined },
+      });
+    });
+    await page.goto('/policies');
+    await expect(page.getByRole('button', { name: 'Edit', exact: true }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Edit', exact: true })).toHaveCount(3);
+    for (const width of [1360, 1180]) {
+      await page.setViewportSize({ width, height: 760 });
+      for (const fontSize of [16, 20]) {
+        await page.evaluate(
+          ({ theme, fontSize }) => {
+            document.documentElement.style.fontSize = `${fontSize}px`;
+            document.documentElement.dataset.mantineColorScheme = theme;
+            document.documentElement.classList.toggle('dark', theme === 'dark');
+          },
+          { theme, fontSize }
+        );
+        for (const sidebar of ['open', 'closed']) {
+          const toggle = page.getByRole('button', { name: /^(Expand|Collapse) left sidebar$/ });
+          if ((await toggle.getAttribute('aria-expanded')) !== String(sidebar === 'open'))
+            await toggle.click();
+          for (const name of ['Edit', 'Test']) {
+            for (const button of await page.getByRole('button', { name, exact: true }).all()) {
+              const geometry = await button.evaluate((element) => {
+                const label = element.querySelector('.mantine-Button-label')!;
+                const bounds = label.getBoundingClientRect();
+                const font = parseFloat(getComputedStyle(label).fontSize);
+                return {
+                  height: bounds.height,
+                  font,
+                  buttonHeight: element.getBoundingClientRect().height,
+                  labelWidth: label.clientWidth,
+                  labelScrollWidth: label.scrollWidth,
+                };
+              });
+              expect(geometry.height, `${name} label at ${width}/${fontSize}`).toBeLessThan(
+                geometry.font * 2
+              );
+              expect(geometry.buttonHeight).toBeLessThan(fontSize * 3);
+              expect(geometry.labelScrollWidth).toBeLessThanOrEqual(geometry.labelWidth + 1);
+            }
+          }
+        }
+      }
+    }
+    await page.screenshot({ path: testInfo.outputPath(`policy-${theme}.png`) });
+    await page.getByRole('button', { name: 'Edit', exact: true }).first().click();
+    await expect(page.getByRole('dialog')).toContainText('Edit Policy');
+    await page.keyboard.press('Escape');
+    await page.getByRole('button', { name: 'Test', exact: true }).first().click();
+    await expect(page.getByRole('dialog')).toContainText('Test Policy');
+    await page.keyboard.press('Escape');
+    await cleanupRoutes(page);
+  });
+}

--- a/web/src/components/policies/PolicyManager.tsx
+++ b/web/src/components/policies/PolicyManager.tsx
@@ -462,18 +462,19 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
     {
       key: 'actions',
       header: 'Actions',
-      className: 'w-[190px]',
+      className: 'w-[16rem] min-w-[16rem]',
       cell: (policy) => (
-        <div className="flex gap-2">
-          <UiAction variant="secondary" onClick={() => openEditDialog(policy)}>
+        <div className="flex flex-wrap items-start gap-2">
+          <UiAction className="shrink-0" variant="secondary" onClick={() => openEditDialog(policy)}>
             <Edit className="mr-1 h-3.5 w-3.5" />
             Edit
           </UiAction>
-          <UiAction variant="secondary" onClick={() => openPreview(policy)}>
+          <UiAction className="shrink-0" variant="secondary" onClick={() => openPreview(policy)}>
             <FlaskConical className="mr-1 h-3.5 w-3.5" />
             Test
           </UiAction>
           <UiIconAction
+            className="shrink-0"
             variant="destructive"
             onClick={() => void handleDelete(policy)}
             aria-label={`Delete ${policy.name}`}

--- a/web/src/components/policies/PolicyManager.tsx
+++ b/web/src/components/policies/PolicyManager.tsx
@@ -425,6 +425,7 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
     {
       key: 'type',
       header: 'Type',
+      className: 'min-w-[9rem]',
       cell: (policy) => <UiPill>{policyTypeLabel(policy.type)}</UiPill>,
     },
     {


### PR DESCRIPTION
## Summary

Reserve a scalable Actions column and keep Edit, Test, and Delete controls from shrinking into vertical labels. Whole controls can wrap without changing their handlers.

Refs #1402.

## Verification

The browser regression failed before the fix with a four-line Edit label. It now passes across light/dark, 1180/1360px, 16/20px text, and both sidebar states. Tests require all three built-in Edit controls, unclipped single-line labels, and correct Edit/Test dialogs. Web typecheck and changed-file lint pass. Independent standards/spec review found no code blockers.

## Native acceptance

Packaged native geometry now passes in both themes at 1180x760 with 20px text, including readable Type pills beside the action group. Focused Enter and Escape focus restoration pass with the separate keyboard fix #1408; merge that dependency first. Exact candidate source/hash are in docs/audits/POLICY-ACTION-LAYOUT-1402.md. The related audit found separate Template card action wrapping, retained under #1384. The installed app is unchanged. This does not complete the broader UI audit or documentation media refresh.
