### PR TITLE
Nest embedded Operations Digest headings

### DIFF
--- a/docs/audits/DIGEST-HEADING-1400.md
+++ b/docs/audits/DIGEST-HEADING-1400.md
@@ -1,0 +1,9 @@
+# Embedded Operations Digest headings
+
+The populated Operations Digest produced two level-one headings: the page title and the report's Markdown title. The existing component test replaced MarkdownRenderer with a plain text div, so it could not detect document hierarchy failures. The full primary-page-shell gate exposed the populated-state regression in QA run 33800497397.
+
+The regression now uses the real Markdown renderer. Before the fix it failed with two h1 elements; after the fix the report begins at h3 beneath the Rendered Briefing h2. Deeper source headings retain their relative order up to HTML's h6 limit. Other consumers keep their default heading levels. The source string is never rewritten, so literal headings in code blocks, the source textarea, clipboard text, and downloaded Markdown remain unchanged.
+
+The focused component slice has four passing tests. The browser route matrix covers all 12 primary routes in dark, light, compact, and enlarged-text modes, now with a populated briefing fixture. It passes in 40.4 seconds and checks one page h1, embedded h3/h4/h5 structure, initial route focus, overflow, and byte-for-byte Markdown downloads. All four rendered-briefing captures were inspected. The capture helper writes inspectable PNGs to the test output directory even with the line reporter. Web typecheck, changed-file lint, and formatting pass. Standards and specification reviews found no blockers.
+
+This fixes #1400 and supports the broader desktop audit #1389. It does not close the remaining popout, Task Chat, maintained-media, or packaged-release acceptance work. Required full QA for PR #1398 must run on an integrated revision containing this fix; a focused pass here is not a substitute for that gate.

--- a/e2e/desktop-primary-page-shell.spec.ts
+++ b/e2e/desktop-primary-page-shell.spec.ts
@@ -1,5 +1,9 @@
 import { expect, type Page, type TestInfo, test } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
 import { bypassAuth, cleanupRoutes } from './helpers/auth';
+
+const populatedBriefing =
+  '# Agent Operations Digest\n\n## Summary\n\n### Active work\n\nOne active task.\n';
 
 const primaryRoutes = [
   { name: 'activity', path: '/activity', title: 'Activity' },
@@ -45,8 +49,10 @@ async function assertNoHorizontalOverflow(page: Page) {
 }
 
 async function capture(page: Page, testInfo: TestInfo, route: string, mode: string) {
+  const path = testInfo.outputPath(`primary-page-${route}-${mode}.png`);
+  await page.screenshot({ path, animations: 'disabled', fullPage: false });
   await testInfo.attach(`primary-page-${route}-${mode}.png`, {
-    body: await page.screenshot({ animations: 'disabled', fullPage: false }),
+    path,
     contentType: 'image/png',
   });
 }
@@ -54,6 +60,12 @@ async function capture(page: Page, testInfo: TestInfo, route: string, mode: stri
 test.describe('desktop primary page shell', () => {
   test.beforeEach(async ({ page }) => {
     await bypassAuth(page);
+    await page.route('**/api/digest/operations?*', (route) => {
+      if (new URL(route.request().url()).searchParams.get('format') !== 'markdown') {
+        return route.continue();
+      }
+      return route.fulfill({ json: { isEmpty: false, markdown: populatedBriefing } });
+    });
     await page.route('**/api/v1/system/health', (route) =>
       route.fulfill({
         status: 200,
@@ -109,6 +121,30 @@ test.describe('desktop primary page shell', () => {
         const shell = page.locator('[data-page-shell="primary"]');
         const heading = shell.getByRole('heading', { level: 1, name: route.title, exact: true });
         const back = shell.getByRole('button', { name: 'Back', exact: true });
+        await expect(heading).toBeFocused();
+        if (route.name === 'operations') {
+          await expect(
+            page.getByRole('heading', { name: 'Agent Operations Digest', exact: true })
+          ).toBeAttached();
+          await expect(
+            page.getByRole('heading', { name: 'Rendered Briefing', level: 2 })
+          ).toBeAttached();
+          await expect(
+            page.getByRole('heading', { name: 'Agent Operations Digest', level: 3 })
+          ).toBeAttached();
+          await expect(page.getByRole('heading', { name: 'Summary', level: 4 })).toBeAttached();
+          await expect(page.getByRole('heading', { name: 'Active work', level: 5 })).toBeAttached();
+          await expect(page.getByLabel('Operations digest markdown')).toHaveValue(
+            populatedBriefing
+          );
+          const downloadPromise = page.waitForEvent('download');
+          await page.getByRole('button', { name: 'Markdown', exact: true }).click();
+          const download = await downloadPromise;
+          const file = await download.path();
+          expect(file).not.toBeNull();
+          expect(await readFile(file!, 'utf8')).toBe(populatedBriefing);
+          await heading.focus();
+        }
         await expect(shell).toHaveCount(1);
         await expect(page.getByRole('heading', { level: 1 })).toHaveCount(1);
         await expect(heading).toBeVisible({ timeout: 15_000 });
@@ -142,6 +178,12 @@ test.describe('desktop primary page shell', () => {
         }
         await assertNoHorizontalOverflow(page);
         await capture(page, testInfo, route.name, mode.name);
+        if (route.name === 'operations') {
+          await page
+            .getByRole('heading', { name: 'Rendered Briefing', level: 2 })
+            .scrollIntoViewIfNeeded();
+          await capture(page, testInfo, 'operations-briefing', mode.name);
+        }
       }
 
       if (regularMetrics.length > 0) {

--- a/web/src/__tests__/operations-digest-mantine.test.tsx
+++ b/web/src/__tests__/operations-digest-mantine.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { OperationsDigestPage } from '@/components/digest/OperationsDigestPage';
+import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
 import { renderWithProviders } from './test-utils';
 import type { AgentOperationsDigest, ScheduledDeliverable } from '@/lib/api';
 
@@ -34,10 +35,8 @@ vi.mock('@/hooks/useOperationsDigest', () => ({
   useRecordOperationsDigestSnapshot: mocks.useRecordOperationsDigestSnapshot,
 }));
 
-vi.mock('@/components/ui/MarkdownRenderer', () => ({
-  MarkdownRenderer: ({ content }: { content: string }) => (
-    <div data-testid="markdown">{content}</div>
-  ),
+vi.mock('@/hooks/useFeatureSettings', () => ({
+  useFeatureSettings: () => ({ settings: { markdown: { enableCodeHighlighting: false } } }),
 }));
 
 vi.mock('@/components/digest/AdmissionQueuePanel', () => ({
@@ -330,7 +329,7 @@ describe('OperationsDigestPage', () => {
       screen.getByRole('button', { name: /Tasks grouped under unknown repository: 1/i })
     ).toBeDefined();
     expect(screen.getByText('Completed in window')).toBeDefined();
-    expect(screen.getByTestId('markdown').textContent).toContain('Agent Operations Digest');
+    expect(screen.getByRole('heading', { name: 'Agent Operations Digest' })).toBeDefined();
     expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThan(4);
     expect(container.querySelector('[data-slot="button"]')).toBeNull();
     expect(screen.getByRole('button', { name: 'Refresh' }).getAttribute('data-variant')).toBe(
@@ -343,6 +342,41 @@ describe('OperationsDigestPage', () => {
     await user.click(screen.getByRole('button', { name: /Active: 1/i }));
 
     expect(onTaskClick).toHaveBeenCalledWith('task_active');
+  });
+
+  it('nests populated briefing headings without changing source or copied Markdown', async () => {
+    const user = userEvent.setup();
+    const markdown =
+      '# Agent Operations Digest\n\n## Summary\n\n### Work\n\n#### Detail\n\n##### Deep\n\n###### Deepest\n\n```md\n# Literal code\n```';
+    mocks.useOperationsDigestMarkdown.mockReturnValue({ data: { isEmpty: false, markdown } });
+    renderWithProviders(<OperationsDigestPage onBack={vi.fn()} />);
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 2, name: 'Rendered Briefing' })).toBeDefined();
+    for (const [name, level] of [
+      ['Agent Operations Digest', 3],
+      ['Summary', 4],
+      ['Work', 5],
+      ['Detail', 6],
+      ['Deep', 6],
+      ['Deepest', 6],
+    ] as const) {
+      expect(screen.getByRole('heading', { level, name })).toBeDefined();
+    }
+    expect(
+      (screen.getByRole('textbox', { name: 'Operations digest markdown' }) as HTMLTextAreaElement)
+        .value
+    ).toBe(markdown);
+    expect(screen.getByText('# Literal code')).toBeDefined();
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText');
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(writeText).toHaveBeenCalledWith(markdown);
+  });
+
+  it('keeps standalone Markdown heading levels unchanged', () => {
+    renderWithProviders(<MarkdownRenderer content={'# Document\n\n## Section\n\n### Detail'} />);
+    expect(screen.getByRole('heading', { name: 'Document', level: 1 })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Section', level: 2 })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Detail', level: 3 })).toBeDefined();
   });
 
   it('passes repo and cwd filters into digest queries', async () => {

--- a/web/src/components/digest/OperationsDigestPage.tsx
+++ b/web/src/components/digest/OperationsDigestPage.tsx
@@ -483,7 +483,7 @@ export function OperationsDigestPage({
               </UiHeading>
               <UiPill>{formatDateTime(digest?.generatedAt)}</UiPill>
             </div>
-            <MarkdownRenderer content={markdown} className="text-sm" />
+            <MarkdownRenderer content={markdown} className="text-sm" headingStartLevel={3} />
           </UiSurface>
         ) : null}
       </div>

--- a/web/src/components/ui/MarkdownRenderer.tsx
+++ b/web/src/components/ui/MarkdownRenderer.tsx
@@ -9,6 +9,8 @@ interface MarkdownRendererProps {
   content: string;
   className?: string;
   artifactSafe?: boolean;
+  /** Heading level for a Markdown h1 when embedded beneath a host section. */
+  headingStartLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 }
 
 const components: Components = {
@@ -65,11 +67,23 @@ export function MarkdownRenderer({
   content,
   className,
   artifactSafe = false,
+  headingStartLevel = 1,
 }: MarkdownRendererProps) {
   const { settings } = useFeatureSettings();
   const enableCodeHighlighting = settings.markdown?.enableCodeHighlighting ?? true;
 
   if (!content) return null;
+
+  const headingTags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
+  const embeddedComponents: Components = {
+    ...components,
+    ...Object.fromEntries(
+      headingTags.map((tag, index) => [
+        tag,
+        components[headingTags[Math.min(index + headingStartLevel - 1, 5)]],
+      ])
+    ),
+  };
 
   return (
     <div className={cn('prose prose-sm max-w-none dark:prose-invert', className)}>
@@ -79,11 +93,11 @@ export function MarkdownRenderer({
         components={
           artifactSafe
             ? {
-                ...components,
+                ...embeddedComponents,
                 a: ({ children }) => <span>{children} (external link omitted)</span>,
                 img: ({ alt }) => <span>[image omitted{alt ? `: ${alt}` : ''}]</span>,
               }
-            : components
+            : embeddedComponents
         }
         urlTransform={(url) => {
           if (artifactSafe) return '';


### PR DESCRIPTION
## Summary

Nest generated Operations Digest headings beneath the Rendered Briefing section instead of creating a second page title. The renderer's default behavior stays unchanged for other consumers. Source, clipboard, and downloaded Markdown are not rewritten.

Closes #1400. Related to #1389 and the failed QA gate on #1398.

## Verification

The regression uses the real Markdown renderer and failed before the fix with two h1 elements. Four focused component tests now pass, covering all six heading levels, unchanged standalone rendering, literal code, source text, and clipboard content. The full 12-route browser matrix passes in dark, light, compact, and enlarged-text modes with populated briefing data and exact Markdown download comparisons. Changed-file lint and web typecheck pass. Independent standards and specification reviews found no blockers.

## Boundaries

This is a heading-hierarchy fix, not completion of the desktop audit or release. Full QA for #1398 still needs to run on an integrated revision. The installed app and final maintained screenshots/GIFs remain unchanged.
