### PR TITLE
Preserve keyboard reorder before React renders

### DIFF
--- a/docs/audits/BOARD-KEYBOARD-REORDER-1413.md
+++ b/docs/audits/BOARD-KEYBOARD-REORDER-1413.md
@@ -1,0 +1,33 @@
+# Keyboard reorder timing regression
+
+Issue: [#1413](https://github.com/BradGroux/veritas-kanban/issues/1413).
+
+## Cause
+
+Full integration QA for #1398 failed the real-sensor cancel, empty-column move, and same-column keyboard reorder scenario: the second move request never arrived. The unchanged scenario reproduced locally twice against revision `3fcd9bedf8ef3de8cdeef5a395fb54df53bc13d1`.
+
+Temporary sensor instrumentation showed that ArrowUp reached the keyboard coordinate getter and selected the correct preceding card. The subsequent drop read the previous render's `dragState`, before React committed the projected order. The unchanged-order guard then discarded the move. The instrumentation was removed after diagnosis.
+
+A deterministic hook regression dispatching drag-over and drag-end in one React batch failed on the original implementation: zero move requests instead of one. This distinguishes a stale-state race from a missing key event, wrong collision target, or a need to delay the browser test.
+
+## Change
+
+Keep the latest drag projection in a synchronous ref alongside its rendered state. Start, drag-over, and clear update both; drop consumes the ref. Server commits remain authoritative, and the existing atomic move command, rollback announcements, and focus restoration are unchanged.
+
+Regression cases cover same-column reorder and an empty destination before the next render. Cancellation coverage also checks that a queued drop cannot persist a canceled move and a later drag cannot inherit the canceled projection.
+
+## Verification
+
+- Focused hook file: 13 tests passed, including the baseline-failing batched regression.
+- Original real-sensor scenario: passed in 4.7 seconds without editing the E2E test, adding waits, increasing timeouts, or enabling retries.
+- Web typecheck, changed-file ESLint, and `git diff --check`: passed.
+- Independent specification and standards reviews are recorded in the delivery task.
+
+Browser reproduction used isolated API/Vite ports 3194/5194 and temporary test data, not the installed application's data. Full integration QA on the integrated revision is still required before closing #1413. This is not packaged macOS or release acceptance.
+
+```sh
+pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/useBoardDragDrop.test.tsx
+API_BASE_URL=http://127.0.0.1:3194 PLAYWRIGHT_API_PORT=3194 PLAYWRIGHT_WEB_PORT=5194 pnpm exec playwright test e2e/board-drag-atomic.spec.ts --grep 'handles cancel' --project chromium --reporter line
+pnpm --filter @veritas-kanban/web typecheck
+pnpm --filter @veritas-kanban/web exec eslint src/hooks/useBoardDragDrop.ts src/__tests__/useBoardDragDrop.test.tsx
+```

--- a/web/src/__tests__/useBoardDragDrop.test.tsx
+++ b/web/src/__tests__/useBoardDragDrop.test.tsx
@@ -177,6 +177,28 @@ describe('useBoardDragDrop keyboard parity', () => {
     expect(announce).toHaveBeenCalledWith('Second task moved to To Do, position 1 of 2');
   });
 
+  it.each([
+    { overId: 'todo-1', destinationStatus: 'todo' },
+    { overId: 'blocked', destinationStatus: 'blocked' },
+  ])(
+    'commits the latest $destinationStatus projection before a render',
+    async ({ overId, destinationStatus }) => {
+      const { result, onMove } = renderDragHook();
+
+      act(() => result.current.handleDragStart(dragEvent('todo-2') as unknown as DragStartEvent));
+      await act(async () => {
+        result.current.handleDragOver(dragEvent('todo-2', overId) as DragOverEvent);
+        await result.current.handleDragEnd(dragEvent('todo-2', 'todo-2') as DragEndEvent);
+      });
+
+      expect(onMove).toHaveBeenCalledOnce();
+      expect(onMove).toHaveBeenCalledWith(
+        'todo-2',
+        expect.objectContaining({ destinationStatus, destinationIndex: 0 })
+      );
+    }
+  );
+
   it('announces the authoritative order when the committed result differs from projection', async () => {
     const tasks = [
       createMockTask({ id: 'todo-1', title: 'First task', status: 'todo' }),
@@ -264,7 +286,17 @@ describe('useBoardDragDrop keyboard parity', () => {
     const { result, onMove, announce } = renderDragHook();
 
     act(() => result.current.handleDragStart(dragEvent('todo-1') as unknown as DragStartEvent));
-    act(() => result.current.handleDragCancel(dragEvent('todo-1') as DragCancelEvent));
+    await act(async () => {
+      result.current.handleDragOver(dragEvent('todo-1', 'done') as DragOverEvent);
+      result.current.handleDragCancel(dragEvent('todo-1') as DragCancelEvent);
+      await result.current.handleDragEnd(dragEvent('todo-1', 'done') as DragEndEvent);
+    });
+
+    // A new drag must not inherit the canceled projection.
+    await act(async () => {
+      result.current.handleDragStart(dragEvent('todo-1') as unknown as DragStartEvent);
+      await result.current.handleDragEnd(dragEvent('todo-1', 'todo-1') as DragEndEvent);
+    });
 
     await waitFor(() => expect(document.activeElement).toBe(card));
     expect(onMove).not.toHaveBeenCalled();

--- a/web/src/hooks/useBoardDragDrop.ts
+++ b/web/src/hooks/useBoardDragDrop.ts
@@ -166,6 +166,9 @@ export function useBoardDragDrop({
   // Local copy of tasksByStatus that updates in real-time during drag.
   // null = not dragging, use server state; non-null = mid-drag, use local state
   const [dragState, setDragState] = useState<Record<string, Task[]> | null>(null);
+  // Sensor events can arrive before React renders. Drops must use the latest
+  // projection, not the state captured by the previous render's callback.
+  const dragStateRef = useRef<Record<string, Task[]> | null>(null);
   const activeIdRef = useRef<string | null>(null);
   const columnIds = useMemo(() => columns.map((column) => column.id), [columns]);
   const keyboardCoordinateGetter = useMemo(
@@ -255,6 +258,7 @@ export function useBoardDragDrop({
   const clearDragState = useCallback(
     (taskId: string | null) => {
       setActiveTask(null);
+      dragStateRef.current = null;
       setDragState(null);
       setIsMovePending(false);
       activeIdRef.current = null;
@@ -300,7 +304,8 @@ export function useBoardDragDrop({
         setActiveTask(task);
         activeIdRef.current = event.active.id as string;
         // Snapshot current server state into local drag state
-        setDragState({ ...tasksByStatus });
+        dragStateRef.current = { ...tasksByStatus };
+        setDragState(dragStateRef.current);
       }
     },
     [announce, tasks, tasksByStatus]
@@ -316,7 +321,8 @@ export function useBoardDragDrop({
       const overId = over.id as string;
       if (activeId === overId) return;
 
-      setDragState((prev) => {
+      const nextState = (() => {
+        const prev = dragStateRef.current;
         if (!prev) return prev;
 
         const activeColumn = findColumn(activeId, prev);
@@ -370,7 +376,9 @@ export function useBoardDragDrop({
           [activeColumn]: newSource,
           [overColumn]: newDest,
         };
-      });
+      })();
+      dragStateRef.current = nextState;
+      setDragState(nextState);
     },
     [columnIds, findColumn]
   );
@@ -379,7 +387,7 @@ export function useBoardDragDrop({
     async (event: DragEndEvent) => {
       const { active, over } = event;
       if (activeIdRef.current !== active.id) return;
-      const finalState = dragState;
+      const finalState = dragStateRef.current;
       const activeId = active.id as string;
       const originalPosition = describeTaskPosition(activeId, tasksByStatus);
 
@@ -459,7 +467,6 @@ export function useBoardDragDrop({
       clearDragState,
       columns,
       describeTaskPosition,
-      dragState,
       findColumn,
       onMove,
       taskTitle,


### PR DESCRIPTION
## Summary

Keep the drag projection synchronous with sensor events so a quick keyboard drop cannot read the previous render's order and silently discard a reorder. Start and clear reset the projection together with rendered state. Atomic server moves, focus restoration, cancellation, and rollback behavior remain unchanged.

Addresses #1413. That issue remains open until the full integration milestone in #1398 passes on the integrated revision.

## Evidence and verification

The unchanged real-sensor scenario failed twice locally. Instrumentation showed ArrowUp selecting the correct preceding card, followed by drop reading the old render's state. A batched drag-over/drop hook regression failed on the original implementation and passes with the fix. Temporary instrumentation was removed; the browser test was not changed.

- Focused hook file: 13 tests passed, including same-column, empty-column, cancellation, rollback, pending move, and batched-event coverage.
- Original real-sensor E2E scenario: passed in 4.7 seconds, without added waits, retries, or timeout changes.
- Web typecheck, changed-file ESLint, and diff checks passed.
- Independent specification and standards reviews found no blockers.

See `docs/audits/BOARD-KEYBOARD-REORDER-1413.md` for commands and the diagnosis. Tests used isolated temporary data on API/Vite ports 3194/5194. Full integrated QA and packaged macOS release acceptance remain separate gates; the installed app and its data were not changed.
