### PR TITLE
fix: persist clearing optional template fields

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -5384,6 +5384,19 @@ These endpoints follow the same auth/error patterns documented above:
 
 ---
 
+### Clearing optional template fields
+
+`PATCH /api/templates/:id` preserves omitted fields. Send explicit JSON `null` to clear `description`, `category`, or individual `taskDefaults` fields (`type`, `priority`, `project`, `descriptionTemplate`, `agent`). Cleared fields are omitted from subsequent GET responses in both file and SQLite storage; unrelated defaults remain unchanged.
+
+```json
+{
+  "description": null,
+  "taskDefaults": { "project": null, "agent": null }
+}
+```
+
+The required name and the `taskDefaults` container cannot be null. Creation continues to use omitted optional fields rather than null. Existing clients that omit fields keep their current patch behavior.
+
 ## v4.0 API Reference
 
 ### User Feedback (`/api/feedback`)

--- a/docs/audits/TEMPLATE-CLEARING-1415.md
+++ b/docs/audits/TEMPLATE-CLEARING-1415.md
@@ -1,0 +1,19 @@
+# Optional template field clearing
+
+Issue: [#1415](https://github.com/BradGroux/veritas-kanban/issues/1415).
+
+## Cause and contract
+
+The editor represented an emptied optional field as `undefined`. JSON omitted it, and both storage implementations retained the existing value when merging the patch. A temporary real-service reproduction failed in both modes: clear, save, and reopen returned `old-project` instead of an absent project. This was not a UI-cache failure.
+
+Update inputs now use explicit `null` to clear optional metadata and individual defaults. Omitted fields retain their previous values. A shared server helper applies the same rule before file or SQLite persistence, and no null marker is stored. The editor sends nulls only when updating; creation still omits blank optional fields. Optional dropdowns expose labeled clear actions now that the operation can persist.
+
+## Evidence
+
+- Original JSON/service reproduction: failed for both file and SQLite storage before the change; passed for both using the new explicit clearing representation. The temporary script was removed.
+- Four real-router JSON tests passed: create, patch, GET/reopen, partial clearing with unrelated defaults preserved, clearing every default, setting a cleared field again, and rejecting null names/containers in both storage modes. Only the route service's data target is redirected; service logic and persistence are real.
+- Three focused editor regressions passed: explicit null payloads when text fields and dropdowns are cleared, and Tab followed by Enter or Space to clear a dropdown and return focus to its input. The keyboard check first reproduced focus falling onto the page body; explicit input focus restoration corrected it. Clear actions are labeled and keyboard-focusable.
+- Server and web typechecks passed. No production dependencies or storage migrations were added.
+- Changed-file lint passed with four existing `any` warnings in the file service. Independent specification and standards reviews found no blockers; the standards review's keyboard-focus follow-up produced the regression and fix above.
+
+The authoring-layout change remains separate in #1384. Final integrated browser/native acceptance and maintained documentation image/GIF replacement are not proven by these focused persistence checks.

--- a/server/src/__tests__/routes/template-clearing.test.ts
+++ b/server/src/__tests__/routes/template-clearing.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express from 'express';
+import request from 'supertest';
+import { TemplateService } from '../../services/template-service.js';
+import { SqliteDatabase } from '../../storage/sqlite/database.js';
+import { errorHandler } from '../../middleware/error-handler.js';
+
+vi.mock('../../services/session-template-service.js', () => ({
+  getSessionTemplateService: () => ({}),
+}));
+import templatesRouter from '../../routes/templates.js';
+
+describe.each(['file', 'sqlite'] as const)('Template clearing through JSON (%s)', (storageType) => {
+  let root: string;
+  let database: SqliteDatabase;
+  let app: express.Express;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'vk-template-api-clear-'));
+    database = new SqliteDatabase({ databasePath: join(root, 'templates.db') });
+    const service = new TemplateService({
+      storageType,
+      templatesDir: join(root, 'templates'),
+      sqliteDatabase: database,
+    });
+    // Route calls use the real service and storage, redirected only to this test's data.
+    const createTemplate = service.createTemplate.bind(service);
+    const updateTemplate = service.updateTemplate.bind(service);
+    const getTemplate = service.getTemplate.bind(service);
+    vi.spyOn(TemplateService.prototype, 'createTemplate').mockImplementation(createTemplate);
+    vi.spyOn(TemplateService.prototype, 'updateTemplate').mockImplementation(updateTemplate);
+    vi.spyOn(TemplateService.prototype, 'getTemplate').mockImplementation(getTemplate);
+    app = express().use(express.json()).use('/api/templates', templatesRouter).use(errorHandler);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    database.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('clears explicit null fields, preserves omitted fields, and reopens the persisted result', async () => {
+    const created = await request(app)
+      .post('/api/templates')
+      .send({
+        name: 'Clear regression',
+        description: 'Old summary',
+        category: 'feature',
+        taskDefaults: {
+          type: 'code',
+          priority: 'high',
+          project: 'old-project',
+          descriptionTemplate: 'Old Markdown',
+          agent: 'custom-agent',
+        },
+      })
+      .expect(201);
+    const url = `/api/templates/${created.body.id}`;
+    await request(app)
+      .patch(url)
+      .send({ description: null, taskDefaults: { project: null, descriptionTemplate: null } })
+      .expect(200);
+    const partial = await request(app).get(url).expect(200);
+    expect(partial.body).not.toHaveProperty('description');
+    expect(partial.body.category).toBe('feature');
+    expect(partial.body.taskDefaults).toEqual({
+      type: 'code',
+      priority: 'high',
+      agent: 'custom-agent',
+    });
+
+    await request(app)
+      .patch(url)
+      .send({ category: null, taskDefaults: { type: null, priority: null, agent: null } })
+      .expect(200);
+    const empty = await request(app).get(url).expect(200);
+    expect(empty.body).not.toHaveProperty('category');
+    expect(empty.body.taskDefaults).toEqual({});
+    expect(empty.body.name).toBe('Clear regression');
+
+    await request(app)
+      .patch(url)
+      .send({ taskDefaults: { project: 'new-project' } })
+      .expect(200);
+    const restored = await request(app).get(url).expect(200);
+    expect(restored.body.taskDefaults).toEqual({ project: 'new-project' });
+  });
+
+  it('rejects null names and null defaults containers without modifying the template', async () => {
+    const created = await request(app)
+      .post('/api/templates')
+      .send({ name: 'Keep name', taskDefaults: { priority: 'high' } })
+      .expect(201);
+    const url = `/api/templates/${created.body.id}`;
+    await request(app).patch(url).send({ name: null }).expect(400);
+    await request(app).patch(url).send({ taskDefaults: null }).expect(400);
+    const reopened = await request(app).get(url).expect(200);
+    expect(reopened.body.name).toBe('Keep name');
+    expect(reopened.body.taskDefaults).toEqual({ priority: 'high' });
+  });
+});

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -91,15 +91,15 @@ const createTemplateSchema = z.object({
 
 const updateTemplateSchema = z.object({
   name: z.string().min(1).optional(),
-  description: z.string().optional(),
-  category: z.string().optional(),
+  description: z.string().nullable().optional(),
+  category: z.string().nullable().optional(),
   taskDefaults: z
     .object({
-      type: z.string().optional(),
-      priority: z.enum(['low', 'medium', 'high']).optional(),
-      project: z.string().optional(),
-      descriptionTemplate: z.string().optional(),
-      agent: z.string().min(1).max(80).optional(),
+      type: z.string().nullable().optional(),
+      priority: z.enum(['low', 'medium', 'high']).nullable().optional(),
+      project: z.string().nullable().optional(),
+      descriptionTemplate: z.string().nullable().optional(),
+      agent: z.string().min(1).max(80).nullable().optional(),
     })
     .optional(),
   subtaskTemplates: z.array(subtaskTemplateSchema).optional(),

--- a/server/src/services/template-service.ts
+++ b/server/src/services/template-service.ts
@@ -12,6 +12,7 @@ import type { TemplateRepository } from '../storage/interfaces.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteTemplateRepository } from '../storage/sqlite/template-repository.js';
 import { getTemplatesDir } from '../utils/paths.js';
+import { applyTemplateUpdate } from '../utils/template-update.js';
 const log = createLogger('template-service');
 
 export interface TemplateServiceOptions {
@@ -214,21 +215,7 @@ export class TemplateService {
     const existing = await this.getTemplate(id);
     if (!existing) return null;
 
-    const updated: TaskTemplate = {
-      ...existing,
-      name: input.name ?? existing.name,
-      description: input.description ?? existing.description,
-      category: input.category ?? existing.category,
-      version: existing.version, // Preserve version
-      taskDefaults: {
-        ...existing.taskDefaults,
-        ...input.taskDefaults,
-      },
-      subtaskTemplates: input.subtaskTemplates ?? existing.subtaskTemplates,
-      blueprint: input.blueprint ?? existing.blueprint,
-      launch: input.launch ?? existing.launch,
-      updated: new Date().toISOString(),
-    };
+    const updated = applyTemplateUpdate(existing, input);
 
     // Recursively filter out undefined values for YAML serialization
     const cleanTemplate = this.cleanTemplateForYaml(updated);

--- a/server/src/storage/sqlite/template-repository.ts
+++ b/server/src/storage/sqlite/template-repository.ts
@@ -5,6 +5,7 @@ import type {
 } from '@veritas-kanban/shared';
 import type { TemplateRepository } from '../interfaces.js';
 import type { SqliteDatabase } from './database.js';
+import { applyTemplateUpdate } from '../../utils/template-update.js';
 
 interface TemplateRow {
   template_json: string;
@@ -63,21 +64,7 @@ export class SqliteTemplateRepository implements TemplateRepository {
     const existing = await this.getTemplate(id);
     if (!existing) return null;
 
-    const updated: TaskTemplate = {
-      ...existing,
-      name: input.name ?? existing.name,
-      description: input.description ?? existing.description,
-      category: input.category ?? existing.category,
-      version: existing.version,
-      taskDefaults: {
-        ...existing.taskDefaults,
-        ...input.taskDefaults,
-      },
-      subtaskTemplates: input.subtaskTemplates ?? existing.subtaskTemplates,
-      blueprint: input.blueprint ?? existing.blueprint,
-      launch: input.launch ?? existing.launch,
-      updated: new Date().toISOString(),
-    };
+    const updated = applyTemplateUpdate(existing, input);
 
     this.upsertTemplate(updated);
     return updated;

--- a/server/src/utils/template-update.ts
+++ b/server/src/utils/template-update.ts
@@ -1,0 +1,34 @@
+import type { TaskTemplate, UpdateTemplateInput } from '@veritas-kanban/shared';
+
+function optionalField<T>(existing: T | undefined, patch: T | null | undefined): T | undefined {
+  return patch === null ? undefined : patch === undefined ? existing : patch;
+}
+
+/** Shared patch semantics for file and SQLite persistence. Null is never stored. */
+export function applyTemplateUpdate(
+  existing: TaskTemplate,
+  input: UpdateTemplateInput
+): TaskTemplate {
+  const defaults = input.taskDefaults;
+  return {
+    ...existing,
+    name: input.name ?? existing.name,
+    description: optionalField(existing.description, input.description),
+    category: optionalField(existing.category, input.category),
+    taskDefaults: {
+      ...existing.taskDefaults,
+      type: optionalField(existing.taskDefaults.type, defaults?.type),
+      priority: optionalField(existing.taskDefaults.priority, defaults?.priority),
+      project: optionalField(existing.taskDefaults.project, defaults?.project),
+      descriptionTemplate: optionalField(
+        existing.taskDefaults.descriptionTemplate,
+        defaults?.descriptionTemplate
+      ),
+      agent: optionalField(existing.taskDefaults.agent, defaults?.agent),
+    },
+    subtaskTemplates: input.subtaskTemplates ?? existing.subtaskTemplates,
+    blueprint: input.blueprint ?? existing.blueprint,
+    launch: input.launch ?? existing.launch,
+    updated: new Date().toISOString(),
+  };
+}

--- a/shared/src/types/template.types.ts
+++ b/shared/src/types/template.types.ts
@@ -151,17 +151,17 @@ export interface CreateTemplateInput {
   launch?: LaunchTemplateMetadata;
 }
 
-/** Input for updating an existing template */
+/** Omitted optional fields are preserved; explicit null clears the field. */
 export interface UpdateTemplateInput {
   name?: string;
-  description?: string;
-  category?: string;
+  description?: string | null;
+  category?: string | null;
   taskDefaults?: {
-    type?: TaskType;
-    priority?: TaskPriority;
-    project?: string;
-    descriptionTemplate?: string;
-    agent?: AgentType;
+    type?: TaskType | null;
+    priority?: TaskPriority | null;
+    project?: string | null;
+    descriptionTemplate?: string | null;
+    agent?: AgentType | null;
   };
   subtaskTemplates?: SubtaskTemplate[];
   blueprint?: BlueprintTask[];

--- a/web/src/__tests__/template-editor-dialog-mantine.test.tsx
+++ b/web/src/__tests__/template-editor-dialog-mantine.test.tsx
@@ -128,4 +128,47 @@ describe('TemplateEditorDialog', () => {
       })
     );
   });
+
+  it('sends explicit nulls when optional fields are cleared from an existing template', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TemplateEditorDialog template={template} open onOpenChange={vi.fn()} />);
+    await user.clear(screen.getByRole('textbox', { name: 'Description' }));
+    await user.click(screen.getByRole('button', { name: 'Clear category' }));
+    await user.click(screen.getByRole('tab', { name: 'Task Defaults' }));
+    await user.clear(screen.getByRole('textbox', { name: 'Default Project' }));
+    await user.clear(screen.getByRole('textbox', { name: 'Description Template' }));
+    for (const field of ['type', 'priority', 'agent']) {
+      await user.click(screen.getByRole('button', { name: `Clear default ${field}` }));
+    }
+    await user.click(screen.getByRole('button', { name: 'Update Template' }));
+    expect(mocks.updateTemplate).toHaveBeenCalledWith({
+      id: template.id,
+      input: {
+        name: template.name,
+        description: null,
+        category: null,
+        taskDefaults: {
+          type: null,
+          priority: null,
+          project: null,
+          agent: null,
+          descriptionTemplate: null,
+        },
+      },
+    });
+  });
+
+  it.each(['{Enter}', ' '])('clears a default with %s and restores input focus', async (key) => {
+    const user = userEvent.setup();
+    renderWithProviders(<TemplateEditorDialog template={template} open onOpenChange={vi.fn()} />);
+    const category = screen.getByRole('combobox', { name: 'Category' });
+    await user.click(screen.getByRole('textbox', { name: 'Description' }));
+    await user.tab();
+    expect(document.activeElement).toBe(category);
+    await user.tab();
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Clear category' }));
+    await user.keyboard(key);
+    expect(screen.queryByRole('button', { name: 'Clear category' })).toBeNull();
+    expect(document.activeElement).toBe(category);
+  });
 });

--- a/web/src/components/templates/TemplateEditorDialog.tsx
+++ b/web/src/components/templates/TemplateEditorDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Group, Select, Stack, Tabs, Text, Textarea, TextInput } from '@mantine/core';
 import { UiModal as Modal, OverlayFooter } from '@/components/ui/UiOverlay';
 import { useCreateTemplate, useUpdateTemplate, type TaskTemplate } from '@/hooks/useTemplates';
@@ -55,6 +55,10 @@ function serializeForm(values: TemplateFormValues): string {
 }
 
 export function TemplateEditorDialog({ template, open, onOpenChange }: TemplateEditorDialogProps) {
+  const categoryRef = useRef<HTMLInputElement>(null);
+  const typeRef = useRef<HTMLInputElement>(null);
+  const priorityRef = useRef<HTMLInputElement>(null);
+  const agentRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState<string>('');
@@ -161,7 +165,21 @@ export function TemplateEditorDialog({ template, open, onOpenChange }: TemplateE
       };
 
       if (template) {
-        await updateTemplate.mutateAsync({ id: template.id, input });
+        await updateTemplate.mutateAsync({
+          id: template.id,
+          input: {
+            ...input,
+            description: input.description ?? null,
+            category: input.category ?? null,
+            taskDefaults: {
+              type: input.taskDefaults.type ?? null,
+              priority: input.taskDefaults.priority ?? null,
+              project: input.taskDefaults.project ?? null,
+              agent: input.taskDefaults.agent ?? null,
+              descriptionTemplate: input.taskDefaults.descriptionTemplate ?? null,
+            },
+          },
+        });
         toast({
           title: 'Success',
           description: `Template "${name}" updated successfully.`,
@@ -245,6 +263,14 @@ export function TemplateEditorDialog({ template, open, onOpenChange }: TemplateE
                   <Select
                     id="category"
                     label="Category"
+                    ref={categoryRef}
+                    onClear={() => categoryRef.current?.focus()}
+                    clearable
+                    clearButtonProps={{
+                      'aria-label': 'Clear category',
+                      'aria-hidden': false,
+                      tabIndex: 0,
+                    }}
                     value={category || null}
                     onChange={(value) => setCategory(value ?? '')}
                     data={categoryOptions}
@@ -260,6 +286,14 @@ export function TemplateEditorDialog({ template, open, onOpenChange }: TemplateE
                     <Select
                       id="type"
                       label="Default Type"
+                      ref={typeRef}
+                      onClear={() => typeRef.current?.focus()}
+                      clearable
+                      clearButtonProps={{
+                        'aria-label': 'Clear default type',
+                        'aria-hidden': false,
+                        tabIndex: 0,
+                      }}
                       value={type || null}
                       onChange={(value) => setType(value ?? '')}
                       data={taskTypeOptions}
@@ -281,6 +315,14 @@ export function TemplateEditorDialog({ template, open, onOpenChange }: TemplateE
                     <Select
                       id="priority"
                       label="Default Priority"
+                      ref={priorityRef}
+                      onClear={() => priorityRef.current?.focus()}
+                      clearable
+                      clearButtonProps={{
+                        'aria-label': 'Clear default priority',
+                        'aria-hidden': false,
+                        tabIndex: 0,
+                      }}
                       value={priority || null}
                       onChange={(value) => setPriority((value as TaskPriority | null) ?? '')}
                       data={priorityOptions}
@@ -300,6 +342,14 @@ export function TemplateEditorDialog({ template, open, onOpenChange }: TemplateE
                     <Select
                       id="agent"
                       label="Default Agent"
+                      ref={agentRef}
+                      onClear={() => agentRef.current?.focus()}
+                      clearable
+                      clearButtonProps={{
+                        'aria-label': 'Clear default agent',
+                        'aria-hidden': false,
+                        tabIndex: 0,
+                      }}
                       value={agent || null}
                       onChange={(value) => setAgent((value as AgentType | null) ?? '')}
                       data={agentOptions}


### PR DESCRIPTION
## Summary

Fix template edits that appeared to clear optional fields but restored their old values after reopening. PATCH now distinguishes omitted fields (preserve) from explicit null (clear), with shared semantics for file and SQLite storage. The editor sends explicit clears and exposes labeled, keyboard-focusable dropdown clear buttons that return focus to their inputs.

Closes #1415. The authoring layout remains separate in #1384 / #1416. The existing priority vocabulary mismatch is tracked in #1417.

## Verification

- Reproduced the original JSON omission bug against both real storage implementations, then confirmed the explicit-clear fix.
- Four real-router JSON tests passed for persistence, partial clearing, reopening, resetting a cleared field, and rejecting null required fields/containers.
- Three focused editor checks passed for payloads and Tab plus Enter/Space clearing with input-focus restoration.
- Shared build, server/web typechecks, and changed-file lint passed. Four pre-existing any warnings remain in the file service.
- Specification and standards reviews found no blockers. The keyboard-focus follow-up reproduced and corrected a real focus-loss bug.

No production dependency or storage migration. Packaged macOS integration, the complete UI audit, and maintained documentation screenshot/GIF refresh are still outstanding and are not claimed by this PR.
