### PR TITLE
fix: adapt task workspace navigation to panel width

### DIFF
--- a/docs/audits/TASK-WORKSPACE-SHELL-1420.md
+++ b/docs/audits/TASK-WORKSPACE-SHELL-1420.md
@@ -23,4 +23,6 @@ Verified locally:
 
 Browser checks used temporary test data and isolated API/web ports 3194/5194, then shut down. They do not constitute packaged macOS acceptance.
 
-The existing Drawer primitive is deliberately retained in this slice. Shared overlay-stack migration, nested Template/Preview/Workflow surfaces, per-mode content convergence, and Task Chat remain under #1385/#1386. Packaged macOS acceptance (#1387) and all maintained documentation images/GIFs (#1388) remain pending. No installed application or release is updated by this change.
+The combined unsigned macOS candidate passed native task workspace checks in both themes at 1180×760: Results selection and the same workspace survive Task Chat presentation changes, 16px text uses the sidecar and 20px text uses body takeover, controls remain bounded, and keyboard focus stays inside the active task/chat workspace. These are scoped native checks, not final installed-app acceptance. Combined candidate `169f7628` also passed full CI and browser QA in runs 33821267360 and 33821267373, including workspace tests and critical coverage.
+
+The existing Drawer primitive is deliberately retained in this slice. Shared overlay-stack migration, nested Template/Preview/Workflow surfaces, per-mode content convergence, and remaining Task Chat acceptance stay under #1385/#1386. Final installed-app acceptance (#1387) and all maintained documentation images/GIFs (#1388) remain pending. No installed application or release is updated by this change.

--- a/docs/audits/TASK-WORKSPACE-SHELL-1420.md
+++ b/docs/audits/TASK-WORKSPACE-SHELL-1420.md
@@ -1,0 +1,26 @@
+# Task workspace shell sizing
+
+Scope: #1420, one presentation slice of #1385. This is not closure of the task-workspace audit or the desktop release gate.
+
+## Behavior
+
+The task drawer uses the shared task variant's 60rem width, bounded by the viewport. Expanding changes that same mounted drawer to viewport width; task state, active section, and scroll nodes are retained. Header actions wrap, and the header, navigation, section header, and scrolling body use one-rem insets. Mode headings use the shared heading component.
+
+A named container query measures the task panel itself. At 48rem or less, labeled mode and section selectors replace the rail and tabs. This also accounts for increased root text size. Wider panels retain the rail and wrapping section tabs. The cosmetic numbered steps are removed because the five modes are destinations, not a required sequence.
+
+Mantine owns Escape dismissal. The duplicate document listener is removed so dismissing a selector does not also dismiss the task. Existing nested-overlay guards remain.
+
+## Acceptance and remaining work
+
+Regression coverage exercises dark and light themes, 740px-wide panels, 900x480 with 20px root text, selector interaction and Escape, retained section selection, bounded controls, and the existing expanded-view scroll/focus path.
+
+Verified locally:
+
+- Shared build and web typecheck passed; changed web files passed ESLint and diff whitespace checks.
+- Four distinct Chromium cases passed: expanded scroll/focus retention, dark and light responsive geometry with keyboard selector access, and an in-flight edit held through compact/expanded/restored presentations. The last case releases the real PATCH and verifies the edited title through a separate API GET.
+- The first geometry run caught an implementation regression: the generic Drawer content class also reached its positioning wrapper. Moving the class to `classNames.content` corrected it; the same geometry checks then passed.
+- Standards and spec reviews found no remaining implementation blockers. No workspace unit or coverage suite ran for this slice.
+
+Browser checks used temporary test data and isolated API/web ports 3194/5194, then shut down. They do not constitute packaged macOS acceptance.
+
+The existing Drawer primitive is deliberately retained in this slice. Shared overlay-stack migration, nested Template/Preview/Workflow surfaces, per-mode content convergence, and Task Chat remain under #1385/#1386. Packaged macOS acceptance (#1387) and all maintained documentation images/GIFs (#1388) remain pending. No installed application or release is updated by this change.

--- a/e2e/task-detail.spec.ts
+++ b/e2e/task-detail.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '@playwright/test';
-import { bypassAuth, seedTestTask, deleteTask, cleanupRoutes } from './helpers/auth';
+import { test, expect, type Route } from '@playwright/test';
+import { bypassAuth, seedTestTask, deleteTask, cleanupRoutes, unwrapApiData } from './helpers/auth';
 
 test.describe('Task Detail Panel', () => {
   let testTaskId: string | null = null;
@@ -153,5 +153,123 @@ test.describe('Task Detail Panel', () => {
     await detail.getByRole('button', { name: 'Close task workspace' }).click();
     await expect(detail).not.toBeVisible();
     await expect(taskCard).toBeFocused();
+  });
+
+  for (const theme of ['dark', 'light']) {
+    test(`task shell adapts to panel width and text size in ${theme}`, async ({ page }) => {
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+      await page.addInitScript((colorScheme) => {
+        localStorage.setItem('veritas-kanban-theme', colorScheme);
+      }, theme);
+      const title = `E2E Responsive Task ${theme}`;
+      const task = await seedTestTask(page, { title, type: 'code', status: 'todo' });
+      testTaskId = (task as { id: string }).id;
+      await page.setViewportSize({ width: 1440, height: 820 });
+      await page.goto('/');
+      await page.getByRole('article', { name: `Task: ${title}` }).click();
+      const detail = page.getByTestId('task-detail-panel');
+      const rail = detail.getByRole('navigation', { name: 'Task workspace modes' });
+      const modeSelector = detail.getByRole('combobox', { name: 'Task workspace mode' });
+      await expect(rail).toBeVisible();
+      await expect(modeSelector).toBeHidden();
+      await detail.getByRole('button', { name: 'Results', exact: true }).click();
+      await detail.getByRole('tab', { name: 'Evidence', exact: true }).click();
+
+      for (const geometry of [
+        { width: 740, height: 700, fontSize: '16px' },
+        { width: 900, height: 480, fontSize: '20px' },
+      ]) {
+        await page.setViewportSize(geometry);
+        await page.evaluate((size) => {
+          document.documentElement.style.fontSize = size;
+        }, geometry.fontSize);
+        await expect(rail).toBeHidden();
+        await expect(modeSelector).toBeVisible();
+        await expect(modeSelector).toHaveValue('Results');
+        await detail.getByRole('textbox', { name: 'Task title', exact: true }).focus();
+        await page.keyboard.press('Tab');
+        await expect(modeSelector).toBeFocused();
+        const sectionSelector = detail.getByRole('combobox', { name: 'Results section' });
+        await expect(sectionSelector).toHaveValue('Evidence');
+        await modeSelector.click();
+        await expect(page.getByRole('listbox')).toBeVisible();
+        await modeSelector.press('Escape');
+        await expect(page.getByRole('listbox')).toBeHidden();
+        await expect(detail).toBeVisible();
+        await sectionSelector.click();
+        await page.getByRole('option', { name: 'Review', exact: true }).click();
+        await expect(sectionSelector).toHaveValue('Review');
+        await sectionSelector.click();
+        await page.getByRole('option', { name: 'Evidence', exact: true }).click();
+        const box = (await detail.boundingBox())!;
+        expect(box.x).toBeGreaterThanOrEqual(0);
+        expect(box.width).toBeLessThanOrEqual(geometry.width);
+        expect(box.y + box.height).toBeLessThanOrEqual(geometry.height + 1);
+        expect(await detail.evaluate((el) => el.scrollWidth - el.clientWidth)).toBe(0);
+        const body = (await detail.getByTestId('task-detail-scroll-region').boundingBox())!;
+        expect(body.height).toBeGreaterThan(40);
+        const close = (await detail
+          .getByRole('button', { name: 'Close task workspace' })
+          .boundingBox())!;
+        expect(close.x + close.width).toBeLessThanOrEqual(geometry.width);
+        expect(close.y + close.height).toBeLessThanOrEqual(geometry.height);
+      }
+
+      await page.setViewportSize({ width: 1440, height: 820 });
+      await page.evaluate(() => {
+        document.documentElement.style.fontSize = '16px';
+      });
+      await expect(rail).toBeVisible();
+      await expect(detail.getByRole('tab', { name: 'Evidence', exact: true })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      await detail.getByRole('button', { name: 'Close task workspace' }).click();
+      await expect(detail).toBeHidden();
+    });
+  }
+
+  test('task shell retains an in-flight edit across compact and expanded views', async ({
+    page,
+  }) => {
+    const title = 'E2E Unsaved Responsive Task';
+    const task = await seedTestTask(page, { title, type: 'code', status: 'todo' });
+    testTaskId = (task as { id: string }).id;
+    let pendingSave: Route | undefined;
+    await page.route(`**/api/tasks/${testTaskId}`, (route) => {
+      if (route.request().method() === 'PATCH') pendingSave = route;
+      else return route.fallback();
+    });
+    try {
+      await page.setViewportSize({ width: 1440, height: 820 });
+      await page.goto('/');
+      await page.getByRole('article', { name: `Task: ${title}` }).click();
+      const detail = page.getByTestId('task-detail-panel');
+      const input = detail.getByRole('textbox', { name: 'Task title', exact: true });
+      const editedTitle = `${title} with a pending edit`;
+      await input.fill(editedTitle);
+      await expect.poll(() => Boolean(pendingSave)).toBe(true);
+      await expect(detail.getByText('Saving...', { exact: true })).toBeVisible();
+      await page.setViewportSize({ width: 740, height: 700 });
+      await expect(input).toHaveValue(editedTitle);
+      await detail.getByRole('button', { name: 'Expand task workspace' }).click();
+      await page.setViewportSize({ width: 1440, height: 820 });
+      await expect(input).toHaveValue(editedTitle);
+      await expect(detail.getByText('Saving...', { exact: true })).toBeVisible();
+      await detail.getByRole('button', { name: 'Exit expanded task workspace' }).click();
+      await expect(input).toHaveValue(editedTitle);
+      await pendingSave!.fallback();
+      pendingSave = undefined;
+      await expect(detail.getByText('Saving...', { exact: true })).toBeHidden();
+      await expect(input).toHaveValue(editedTitle);
+      const persisted = await page.request.get(
+        `${process.env.API_BASE_URL || 'http://127.0.0.1:3001'}/api/tasks/${testTaskId}`
+      );
+      expect(persisted.ok()).toBe(true);
+      expect(unwrapApiData<{ title: string }>(await persisted.json()).title).toBe(editedTitle);
+      await detail.getByRole('button', { name: 'Close task workspace' }).click();
+    } finally {
+      await pendingSave?.abort().catch(() => undefined);
+    }
   });
 });

--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -259,7 +259,9 @@ describe('task detail Mantine migration', () => {
     );
     expect(screen.getByTestId('task-detail-panel').className).toContain('veritas-overlay-surface');
     expect(screen.getByTestId('task-detail-panel').className).toContain('min-h-0');
-    expect(screen.getByTestId('task-workspace-mode-navigation').className).toContain('sm:flex');
+    expect(screen.getByTestId('task-workspace-mode-navigation').className).toContain(
+      'vk-task-workspace-navigation'
+    );
     expect(screen.getByRole('combobox', { name: 'Task workspace mode' })).toBeDefined();
     const scrollRegion = screen.getByTestId('task-detail-scroll-region');
     expect(scrollRegion.className).toContain('min-h-0');

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -2,8 +2,10 @@ import {
   UiPill,
   UiAction,
   UiIconAction,
+  UiHeading,
   semanticToneForLegacyColor,
 } from '@/components/ui/UiVocabulary';
+import { OVERLAY_VARIANTS } from '@/components/ui/UiOverlay';
 import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { Drawer, Group, Select, Stack, Tabs, Text, TextInput } from '@mantine/core';
 import { useTaskTypes, getTypeIcon } from '@/hooks/useTaskTypes';
@@ -115,16 +117,6 @@ export function TaskDetailPanel({
   useEffect(() => {
     if (!open) setExpanded(false);
   }, [open]);
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && open && !nestedOverlayOpen) {
-        onOpenChange(false);
-      }
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [nestedOverlayOpen, open, onOpenChange]);
 
   const isCodeTask = localTask?.type === 'code';
   const hasWorktree = !!localTask?.git?.worktreePath;
@@ -275,7 +267,7 @@ export function TaskDetailPanel({
         opened={open}
         position="right"
         returnFocus
-        size="auto"
+        size={expanded ? '100vw' : `min(100vw, ${OVERLAY_VARIANTS.task.width})`}
         trapFocus
       >
         <Drawer.Overlay className="veritas-overlay fixed inset-0 z-50" />
@@ -283,28 +275,25 @@ export function TaskDetailPanel({
           aria-label={`Task workspace: ${localTask.title}`}
           data-presentation={expanded ? 'expanded' : 'drawer'}
           data-testid="task-detail-panel"
-          className={`veritas-overlay-surface flex h-full min-h-0 max-h-[100dvh] flex-col overflow-hidden bg-background bg-clip-padding text-sm shadow-lg ${
-            expanded
-              ? '!w-screen !max-w-none border-l-0'
-              : 'w-[min(100vw,960px)] border-l sm:w-[min(92vw,960px)] lg:w-[min(62vw,960px)]'
-          }`}
+          classNames={{
+            content:
+              'veritas-overlay-surface vk-task-workspace flex h-full min-h-0 max-h-[100dvh] flex-col overflow-hidden border-l bg-background bg-clip-padding text-sm shadow-lg',
+          }}
         >
           <Drawer.Body className="flex min-h-0 flex-1 flex-col overflow-hidden p-0">
             <Stack gap={0} className="min-h-0 flex-1 overflow-hidden">
-              <header className="flex-shrink-0 border-b px-4 py-4 pr-12 sm:px-6">
+              <header className="vk-task-workspace-header flex-shrink-0 border-b">
                 <Group
                   gap="xs"
                   justify="space-between"
-                  wrap="nowrap"
+                  wrap="wrap"
                   className="text-muted-foreground"
                 >
                   <Group gap="xs" wrap="nowrap">
                     {TypeIconComponent && <TypeIconComponent className="h-4 w-4" />}
-                    <Text size="xs" tt="uppercase" className="tracking-wide">
-                      {typeLabel} Task
-                    </Text>
+                    <Text size="sm">{typeLabel} Task</Text>
                   </Group>
-                  <Group gap="xs" wrap="nowrap">
+                  <Group gap="xs" wrap="wrap">
                     {readOnly && (
                       <UiPill leftSection={<Archive className="h-3 w-3" />}>Archived</UiPill>
                     )}
@@ -344,9 +333,9 @@ export function TaskDetailPanel({
                     </UiIconAction>
                   </Group>
                 </Group>
-                <Drawer.Title className="mt-1 pr-8 text-lg font-semibold text-foreground sm:text-xl">
+                <Drawer.Title className="mt-1 text-lg font-semibold text-foreground">
                   {readOnly ? (
-                    <Text component="span" size="lg" fw={600} className="sm:text-xl">
+                    <Text component="span" size="lg" fw={600} className="break-words">
                       {localTask.title}
                     </Text>
                   ) : (
@@ -357,7 +346,7 @@ export function TaskDetailPanel({
                       placeholder="Task title..."
                       aria-label="Task title"
                       classNames={{
-                        input: 'text-lg font-semibold text-foreground sm:text-xl',
+                        input: 'text-lg font-semibold text-foreground',
                       }}
                     />
                   )}
@@ -378,12 +367,12 @@ export function TaskDetailPanel({
                 <nav
                   aria-label="Task workspace modes"
                   data-testid="task-workspace-mode-navigation"
-                  className="veritas-overlay-scroll hidden w-48 flex-shrink-0 flex-col gap-1 overflow-y-auto border-r px-3 py-4 sm:flex"
+                  className="veritas-overlay-scroll vk-task-workspace-navigation flex-shrink-0 flex-col gap-1 overflow-y-auto border-r"
                 >
-                  <Text size="xs" tt="uppercase" c="dimmed" className="mb-1 px-2 tracking-wide">
+                  <Text size="sm" c="dimmed" className="mb-1 px-2">
                     Workspace
                   </Text>
-                  {workspaceModes.map((mode, index) => {
+                  {workspaceModes.map((mode) => {
                     const Icon = WORKSPACE_MODE_ICONS[mode.id];
                     const active = mode.id === activeMode;
                     return (
@@ -396,9 +385,6 @@ export function TaskDetailPanel({
                         onClick={() => selectWorkspaceMode(mode.id)}
                         className="vk-ui-nav-action w-full text-left"
                       >
-                        <span aria-hidden="true" className="w-4 font-mono text-[10px] opacity-70">
-                          {String(index + 1).padStart(2, '0')}
-                        </span>
                         <Icon className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
                         <span>{mode.label}</span>
                       </UiAction>
@@ -413,7 +399,7 @@ export function TaskDetailPanel({
                   }}
                   className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
                 >
-                  <div className="flex-shrink-0 border-b px-4 py-3 sm:px-5">
+                  <div className="vk-task-workspace-section-header flex-shrink-0 border-b">
                     <Select
                       label="Task workspace mode"
                       value={activeMode}
@@ -426,15 +412,15 @@ export function TaskDetailPanel({
                         if (isTaskWorkspaceModeId(value)) selectWorkspaceMode(value);
                       }}
                       allowDeselect={false}
-                      className="mb-3 sm:hidden"
+                      className="vk-task-workspace-selector mb-3"
                     />
 
                     <Group justify="space-between" align="flex-start" wrap="wrap" gap="sm">
                       <div className="min-w-0">
-                        <Text id="task-workspace-mode-heading" component="h2" fw={650} size="sm">
+                        <UiHeading id="task-workspace-mode-heading">
                           {activeModeMetadata?.label ?? 'Workspace'}
-                        </Text>
-                        <Text size="xs" c="dimmed" className="mt-0.5 max-w-xl">
+                        </UiHeading>
+                        <Text size="sm" c="dimmed" className="mt-0.5 max-w-xl">
                           {activeModeMetadata?.description}
                         </Text>
                       </div>
@@ -488,7 +474,7 @@ export function TaskDetailPanel({
                       <>
                         <Tabs.List
                           aria-label={`${activeModeMetadata?.label ?? 'Workspace'} sections`}
-                          className="mt-3 !hidden w-full justify-start overflow-x-auto sm:!flex"
+                          className="vk-task-workspace-sections mt-3 w-full justify-start"
                         >
                           {activeModeTabs.map((tab) => {
                             const Icon = tab.Icon;
@@ -517,14 +503,14 @@ export function TaskDetailPanel({
                             if (isTaskDetailTabId(value)) setActiveTab(value);
                           }}
                           allowDeselect={false}
-                          className="mt-3 sm:hidden"
+                          className="vk-task-workspace-selector mt-3"
                         />
                       </>
                     )}
                   </div>
 
                   <div
-                    className="veritas-overlay-scroll min-h-0 flex-1 overflow-y-scroll overscroll-contain px-4 py-4 sm:px-5 sm:py-5"
+                    className="veritas-overlay-scroll vk-task-workspace-body min-h-0 flex-1 overflow-y-scroll overscroll-contain"
                     data-testid="task-detail-scroll-region"
                     aria-labelledby="task-workspace-mode-heading task-workspace-section-heading"
                     tabIndex={0}

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -203,6 +203,39 @@
   flex-direction: column;
 }
 
+/* The drawer, not the window behind it, owns task navigation breakpoints.
+   rem units also collapse the rail when the user increases text size. */
+.vk-task-workspace {
+  container: task-workspace / inline-size;
+  max-width: 100vw;
+}
+.vk-task-workspace-header,
+.vk-task-workspace-section-header,
+.vk-task-workspace-body,
+.vk-task-workspace-navigation {
+  padding: 1rem;
+}
+.vk-task-workspace-navigation {
+  display: flex;
+  width: 11rem;
+}
+.vk-task-workspace .vk-task-workspace-sections {
+  display: flex;
+  flex-wrap: wrap;
+}
+.vk-task-workspace-selector {
+  display: none;
+}
+@container task-workspace (max-width: 48rem) {
+  .vk-task-workspace-navigation,
+  .vk-task-workspace .vk-task-workspace-sections {
+    display: none;
+  }
+  .vk-task-workspace-selector {
+    display: block;
+  }
+}
+
 .veritas-overlay-scroll::-webkit-scrollbar {
   width: 0.625rem;
 }


### PR DESCRIPTION
## Summary

Closes #1420. Part of #1385, which remains open.

The task drawer uses the shared 60rem width, bounded by the viewport. Mode rail and section tabs switch to labeled selectors based on panel width, including increased text size. Header actions wrap, insets are consistent, and the same workspace remains mounted across expand and restore. Removing the duplicate Escape listener prevents selector dismissal from also closing the task.

## Verification

Shared build, web typecheck, changed-file lint, and four Chromium cases passed: compact geometry in both themes, enlarged text, dropdown Escape, keyboard access, scroll/focus retention, and a pending edit preserved through resizing with separate API readback. Standards and spec reviews found no blockers.

Combined full CI and browser QA passed on candidate 169f7628 in runs 33821267360 and 33821267373. Packaged native task/chat checks passed in both themes at 1180×760, including Results retention, bounded controls, 16px sidecar and 20px body takeover. Current standalone checks are green. Details are in docs/audits/TASK-WORKSPACE-SHELL-1420.md.

Shared overlay-stack migration, nested task panels, per-mode content convergence, remaining Task Chat acceptance, final installed verification, media, and release stay open under the parent issues. This does not update the installed app.
