### PR TITLE
Use shared focus restoration for Policy dialogs

### DIFF
--- a/docs/audits/POLICY-DIALOG-FOCUS-1423.md
+++ b/docs/audits/POLICY-DIALOG-FOCUS-1423.md
@@ -1,0 +1,9 @@
+# Policy dialog focus restoration
+
+Issue #1423 follows the keyboard activation fix in #1407. Full integration runs [33816771758](https://github.com/BradGroux/veritas-kanban/actions/runs/33816771758) and [33817019675](https://github.com/BradGroux/veritas-kanban/actions/runs/33817019675) both failed the exact Test opener focus assertion after sequential Edit and Test dialogs. The other 58 browser tests passed and one was skipped. The earlier native audit waited for initial dialog focus; it did not cover dismissal during opening.
+
+PolicyManager still used two raw Mantine Modals outside the shared overlay stack. Its independent initial-focus and return-focus timers can race during early Escape. The recorded failing interaction presses Escape about 30ms after opening Test. This change uses the existing UiModal registration/restoration lifecycle for both dialogs, with the authoring and form geometry variants. It does not add a timeout, change global keyboard dispatch, or change policy evaluation or persistence.
+
+The browser regression retains immediate Escape, repeats Edit/Test twice, asserts the actual opener after each close, and adds ordinary Cancel restoration. Existing shared-overlay tests cover nested/topmost Escape and subtree unmounts. Typecheck, changed-source lint, formatting, and diff checks passed before publication. Updated browser execution and full integration acceptance are pending; this document is not a green runtime claim. Packaged macOS acceptance remains part of the combined UI gate.
+
+Keep #1423 and the full integration PRs open until the runtime gates pass. Do not substitute a wait for initial focus or an arbitrary sleep for the early-dismissal assertion.

--- a/docs/design/OVERLAY-CONTRACT.md
+++ b/docs/design/OVERLAY-CONTRACT.md
@@ -32,8 +32,8 @@ Line numbers identify the audited opening and may move during migration. A share
 | [AdmissionQueuePanel.tsx](../../web/src/components/digest/AdmissionQueuePanel.tsx)                |          315 | form             | Migration pending                                    |
 | [WorkflowStartDialog.tsx](../../web/src/components/workflows/WorkflowStartDialog.tsx)             |           71 | form             | Migration pending; migrate with nested consumers     |
 | [CreateTaskDialog.tsx](../../web/src/components/task/CreateTaskDialog.tsx)                        |          267 | form             | Migration pending; migrate with nested consumers     |
-| [PolicyManager.tsx](../../web/src/components/policies/PolicyManager.tsx)                          |          550 | authoring        | Migration pending; migrate with nested consumers     |
-| [PolicyManager.tsx](../../web/src/components/policies/PolicyManager.tsx)                          |          906 | authoring        | Migration pending; migrate with nested consumers     |
+| [PolicyManager.tsx](../../web/src/components/policies/PolicyManager.tsx)                          |          552 | authoring        | Shared modal; runtime acceptance pending in #1423    |
+| [PolicyManager.tsx](../../web/src/components/policies/PolicyManager.tsx)                          |          906 | form             | Shared modal; runtime acceptance pending in #1423    |
 | [TimeTrackingSection.tsx](../../web/src/components/task/TimeTrackingSection.tsx)                  |          243 | form             | Migration pending                                    |
 | [BulkActionsBar.tsx](../../web/src/components/board/BulkActionsBar.tsx)                           |          366 | confirm          | Migration pending                                    |
 | [ArchiveSuggestionBanner.tsx](../../web/src/components/board/ArchiveSuggestionBanner.tsx)         |           92 | confirm          | Migration pending                                    |

--- a/e2e/focused-control-shortcuts.spec.ts
+++ b/e2e/focused-control-shortcuts.spec.ts
@@ -4,7 +4,7 @@ import { bypassAuth, cleanupRoutes } from './helpers/auth';
 test('focused Policy actions activate by Enter and regain focus after Escape', async ({ page }) => {
   await bypassAuth(page);
   await page.goto('/policies');
-  for (const name of ['Edit', 'Test']) {
+  for (const name of ['Edit', 'Test', 'Edit', 'Test']) {
     const action = page.getByRole('button', { name, exact: true }).first();
     await action.focus();
     await expect(action).toBeFocused();
@@ -12,9 +12,15 @@ test('focused Policy actions activate by Enter and regain focus after Escape', a
     await expect(page.getByRole('dialog')).toContainText(
       name === 'Edit' ? 'Edit Policy' : 'Test Policy'
     );
+    // Intentionally do not wait for initial dialog focus or an animation timeout.
     await page.keyboard.press('Escape');
     await expect(page.getByRole('dialog')).toHaveCount(0);
     await expect(action).toBeFocused();
   }
+  const edit = page.getByRole('button', { name: 'Edit', exact: true }).first();
+  await edit.click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Cancel', exact: true }).click();
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+  await expect(edit).toBeFocused();
   await cleanupRoutes(page);
 });

--- a/web/src/components/policies/PolicyManager.tsx
+++ b/web/src/components/policies/PolicyManager.tsx
@@ -13,7 +13,8 @@ import type {
   PolicyResponseAction,
 } from '@veritas-kanban/shared';
 import { Edit, ExternalLink, FlaskConical, Plus, Trash2 } from 'lucide-react';
-import { Group, Modal, Select, Switch, Textarea, TextInput } from '@mantine/core';
+import { Group, Select, Switch, Textarea, TextInput } from '@mantine/core';
+import { UiModal } from '@/components/ui/UiOverlay';
 import { useToast } from '@/hooks/useToast';
 import {
   useCreatePolicy,
@@ -548,11 +549,10 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
         )}
       </div>
 
-      <Modal
+      <UiModal
         opened={dialogOpen}
         onClose={() => setDialogOpen(false)}
-        size="xl"
-        centered
+        variant="authoring"
         title={
           <div>
             <div className="text-lg font-semibold">
@@ -901,13 +901,12 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
             </UiAction>
           </Group>
         </div>
-      </Modal>
+      </UiModal>
 
-      <Modal
+      <UiModal
         opened={previewOpen}
         onClose={() => setPreviewOpen(false)}
-        size="lg"
-        centered
+        variant="form"
         title={
           <div>
             <div className="text-lg font-semibold">Test Policy Evaluation</div>
@@ -1026,7 +1025,7 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
             {evaluatePolicies.isPending ? 'Evaluating...' : 'Run Preview'}
           </UiAction>
         </Group>
-      </Modal>
+      </UiModal>
     </PrimaryPageShell>
   );
 }


### PR DESCRIPTION
## Summary

Use the shared overlay lifecycle for both Policy dialogs so immediate Escape after keyboard opening restores the exact Edit or Test trigger. Keep the topmost-only Escape and nested-dialog rules. No policy evaluation, persistence, global keyboard dispatch, or timeout behavior changes.

Closes #1423.

## Verification

The original full QA failures are documented in docs/audits/POLICY-DIALOG-FOCUS-1423.md. The unchanged early-dismissal sequence now passes locally and in combined browser QA [33821267373](https://github.com/BradGroux/veritas-kanban/actions/runs/33821267373). Full combined CI [33821267360](https://github.com/BradGroux/veritas-kanban/actions/runs/33821267360) passed workspace tests, coverage, build, lint/typecheck, and security audit.

The rebuilt unsigned macOS candidate passed repeated Edit/Test keyboard opening and immediate Escape in both themes at 1180×760 with 20px text, restoring each exact opener. No sleep or wait-for-initial-focus was substituted for that assertion. Standalone checks for this PR are also green after retrying the advisory-service timeout.

This is scoped Policy focus acceptance. The installed app, final documentation media, remaining overlay inventory, and signed release are still pending.
