### PR TITLE
Accept Critical priority in task APIs

### DIFF
--- a/docs/audits/TASK-CRITICAL-PRIORITY-1428.md
+++ b/docs/audits/TASK-CRITICAL-PRIORITY-1428.md
@@ -1,0 +1,9 @@
+# Critical task priority API contract
+
+The native Create Task check for #1426 selected Critical and received HTTP 400. Both task route schemas accepted only Low, Medium, and High even though the shared task type and UI already supported Critical. The POST and PATCH regressions failed with 400 before the fix.
+
+Both schemas now consume the shared `TASK_PRIORITIES` tuple, and `TaskPriority` derives from the same tuple. This shared declaration matches the pending Template priority change in #1419. Medium remains the create default; unknown priorities remain invalid. No storage format or migration is changed.
+
+The focused task-route integration suite passed all 56 tests, including Critical creation/update, unknown-priority rejection, and the omitted-priority default. Shared build, server typecheck, changed-file formatting, and lint passed; lint reported only existing warnings outside changed lines. Spec and standards reviews found no actionable issues.
+
+The combined unsigned macOS candidate was rebuilt and the exact native Create Task scenario passed in light and dark themes at 1180×760 with 20px text. It created a Critical task through the real API in an isolated temporary profile and found the task again after reloading. A harness locator was corrected to match the task heading within the card, whose accessible name also includes type, priority, and readiness. The installed application and user data were not changed. This API fix does not complete the remaining UI audit or release acceptance.

--- a/server/src/__tests__/routes/tasks-coverage.test.ts
+++ b/server/src/__tests__/routes/tasks-coverage.test.ts
@@ -470,6 +470,29 @@ describe('Tasks Routes (actual module)', () => {
   });
 
   describe('POST /api/tasks', () => {
+    it('accepts critical priority on creation', async () => {
+      mockTaskService.createTask.mockImplementation(async (input) => ({
+        id: 'critical-task',
+        ...input,
+      }));
+      const res = await request(app)
+        .post('/api/tasks')
+        .send({ title: 'Urgent repair', priority: 'critical' });
+      expect(res.status).toBe(201);
+      expect(res.body.priority).toBe('critical');
+      expect(mockTaskService.createTask).toHaveBeenCalledWith(
+        expect.objectContaining({ priority: 'critical' })
+      );
+    });
+
+    it('rejects unknown priority before creation', async () => {
+      const res = await request(app)
+        .post('/api/tasks')
+        .send({ title: 'Invalid priority', priority: 'urgent' });
+      expect(res.status).toBe(400);
+      expect(mockTaskService.createTask).not.toHaveBeenCalled();
+    });
+
     it('should create a task', async () => {
       const newTask = {
         id: 't1',
@@ -483,6 +506,9 @@ describe('Tasks Routes (actual module)', () => {
       const res = await request(app).post('/api/tasks').send({ title: 'New Task' });
       expect(res.status).toBe(201);
       expect(res.body.id).toBe('t1');
+      expect(mockTaskService.createTask).toHaveBeenCalledWith(
+        expect.objectContaining({ priority: 'medium' })
+      );
     });
 
     it('should reject missing title', async () => {
@@ -497,6 +523,21 @@ describe('Tasks Routes (actual module)', () => {
   });
 
   describe('PATCH /api/tasks/:id', () => {
+    it('accepts critical priority on update', async () => {
+      const task = { id: 'critical-task', title: 'Urgent repair', status: 'todo' };
+      mockTaskService.getTask.mockResolvedValue(task);
+      mockTaskService.updateTask.mockImplementation(async (_id, input) => ({ ...task, ...input }));
+      const res = await request(app)
+        .patch('/api/tasks/critical-task')
+        .send({ priority: 'critical' });
+      expect(res.status).toBe(200);
+      expect(res.body.priority).toBe('critical');
+      expect(mockTaskService.updateTask).toHaveBeenCalledWith(
+        'critical-task',
+        expect.objectContaining({ priority: 'critical' })
+      );
+    });
+
     it('should update a task', async () => {
       const oldTask = { id: 't1', title: 'Old', status: 'todo', created: '2025-01-01' };
       const updatedTask = { ...oldTask, title: 'Updated' };

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -9,6 +9,7 @@ import { getDelegationService } from '../services/delegation-service.js';
 import { getProgressService } from '../services/progress-service.js';
 import {
   BOARD_COLUMN_ID_PATTERN,
+  TASK_PRIORITIES,
   type CreateTaskInput,
   type UpdateTaskInput,
   type Task,
@@ -194,7 +195,7 @@ const createTaskSchema = z.object({
   description: z.string().optional().default(''),
   type: z.string().optional().default('code'),
   status: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN).optional(),
-  priority: z.enum(['low', 'medium', 'high']).optional().default('medium'),
+  priority: z.enum(TASK_PRIORITIES).optional().default('medium'),
   project: z.string().optional(),
   sprint: z.string().optional(),
   agent: z.string().max(50).optional(), // "auto" | agent type slug
@@ -352,7 +353,7 @@ const updateTaskSchema = z.object({
   description: z.string().optional(),
   type: z.string().optional(),
   status: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN).optional(),
-  priority: z.enum(['low', 'medium', 'high']).optional(),
+  priority: z.enum(TASK_PRIORITIES).optional(),
   project: z.string().optional(),
   sprint: z.string().optional(),
   agent: z.string().max(50).optional(),

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -3,7 +3,8 @@
 export type TaskType = string;
 export type BuiltInTaskStatus = 'todo' | 'in-progress' | 'blocked' | 'done' | 'cancelled';
 export type TaskStatus = BuiltInTaskStatus | (string & {});
-export type TaskPriority = 'low' | 'medium' | 'high' | 'critical';
+export const TASK_PRIORITIES = ['low', 'medium', 'high', 'critical'] as const;
+export type TaskPriority = (typeof TASK_PRIORITIES)[number];
 
 /** Run mode controls the review/QA strategy for a task. */
 export type RunMode = 'strategy' | 'eng-review' | 'paranoid-review' | 'qa';


### PR DESCRIPTION
## Summary

Task creation and updates now use the shared priority list, including Critical. Medium remains the default and unknown values are rejected. Native Create Task verification exposed the previous HTTP 400 rejection.

Closes #1428. This is separate from the Create Task popout change in #1427. The shared constant matches the pending Template priority declaration in #1419.

## Verification

The new Critical POST/PATCH regressions first failed with HTTP 400. After the fix, all 56 task-route tests passed in the combined integration tree. Shared build, server typecheck, changed-file formatting, and lint passed with existing warnings only. Spec and standards reviews found no actionable issues.

The rebuilt unsigned macOS candidate passed the exact Critical-priority creation scenario in both themes at 1180×760 with 20px text, including real API creation and reload persistence in an isolated temporary profile. The installed app and user data were untouched.

Combined candidate a30e204b passed full CI, critical coverage, browser QA, security gates, Docker contract, and all three unsigned desktop artifacts. Standalone checks are green after retrying only the dependency-audit job that timed out against the npm registry. Final installed/release acceptance remains pending. Evidence is recorded in docs/audits/TASK-CRITICAL-PRIORITY-1428.md.
