### PR TITLE
Keep long sprint archive banners inside the Board

### DIFF
--- a/docs/audits/ARCHIVE-BANNER-1434.md
+++ b/docs/audits/ARCHIVE-BANNER-1434.md
@@ -1,0 +1,9 @@
+# Long sprint archive-banner containment
+
+Issue: #1434.
+
+The archive banner allowed its unbroken sprint name to set the flex item's minimum width, leaving its actions outside the Board and causing horizontal panning when focused. The text item now permits shrinking and wraps long words; the action group can move to another line. Archive, dismiss, and confirmation handlers are unchanged.
+
+The focused browser regression failed on the old source in both themes because the banner's scroll width exceeded its client width. It then passed in both themes at 1180px with 16px/20px text and 620px with 20px text. It checks the banner and title width, full archive/dismiss visibility, unchanged horizontal position after opening and cancelling confirmation, and dismissal. Fixtures intercept task/settings/sprint reads and prohibit real archive requests. The smaller browser viewport is not a native-window claim. Web typecheck and changed-source lint pass; no dependencies changed.
+
+Packaged macOS verification remains pending. The installed app, final documentation media, other UI consumers, and release acceptance are unchanged and unfinished.

--- a/docs/audits/ARCHIVE-BANNER-1434.md
+++ b/docs/audits/ARCHIVE-BANNER-1434.md
@@ -6,4 +6,8 @@ The archive banner allowed its unbroken sprint name to set the flex item's minim
 
 The focused browser regression failed on the old source in both themes because the banner's scroll width exceeded its client width. It then passed in both themes at 1180px with 16px/20px text and 620px with 20px text. It checks the banner and title width, full archive/dismiss visibility, unchanged horizontal position after opening and cancelling confirmation, and dismissal. Fixtures intercept task/settings/sprint reads and prohibit real archive requests. The smaller browser viewport is not a native-window claim. Web typecheck and changed-source lint pass; no dependencies changed.
 
-Packaged macOS verification remains pending. The installed app, final documentation media, other UI consumers, and release acceptance are unchanged and unfinished.
+Specification and standards reviews found no actionable gaps.
+
+Rebuilt unsigned candidate `07c5ae972f795251244fd255f2062c43fc8aa11c` passed the packaged macOS check with isolated temporary user data. The harness verified `app.isPackaged` and version 6.1.6. In both themes at 1700×900 with 16px text and native minimum 1180×760 with 20px text, the long unbroken sprint name wraps within the banner, both actions remain fully visible, and opening and cancelling the Board dialogs does not horizontally pan the banner. Destructive requests were intercepted and asserted absent. Native light/dark captures at 1180px were visually inspected. The candidate also contains the separately reviewed #1432 shared Board dialogs.
+
+The installed app, final documentation images/GIFs, other UI consumers, and release acceptance remain unfinished. These native diagnostic captures are not the final documentation media refresh.

--- a/e2e/archive-banner.spec.ts
+++ b/e2e/archive-banner.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+import { DEFAULT_FEATURE_SETTINGS } from '../shared/dist/index.js';
+import { bypassAuth, cleanupRoutes } from './helpers/auth';
+
+for (const theme of ['light', 'dark']) {
+  test(`long sprint names and archive actions stay inside the Board in ${theme}`, async ({
+    page,
+  }) => {
+    await bypassAuth(page);
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.addInitScript((theme) => {
+      localStorage.setItem('veritas-kanban-theme', theme);
+      Object.defineProperty(window, 'veritasDesktop', {
+        configurable: true,
+        value: { onMenuCommand: () => () => undefined },
+      });
+    }, theme);
+    const sprint = 'LongSprintName'.repeat(8);
+    await page.route('**/api/settings/features', (route) =>
+      route.fulfill({
+        json: {
+          ...DEFAULT_FEATURE_SETTINGS,
+          board: { ...DEFAULT_FEATURE_SETTINGS.board, showArchiveSuggestions: true },
+        },
+      })
+    );
+    await page.route('**/api/tasks/archive/suggestions', (route) =>
+      route.fulfill({ json: [{ sprint, taskCount: 3 }] })
+    );
+    await page.route(/\/api\/tasks(?:\?.*)?$/, (route) => route.fulfill({ json: [] }));
+    let archiveRequests = 0;
+    await page.route('**/api/tasks/archive/sprint/**', (route) => {
+      archiveRequests += 1;
+      return route.abort();
+    });
+    await page.goto('/');
+    for (const size of [
+      { width: 1180, height: 760, font: '16px' },
+      { width: 1180, height: 760, font: '20px' },
+      { width: 620, height: 760, font: '20px' },
+    ]) {
+      await page.setViewportSize(size);
+      await page.evaluate((font) => {
+        document.documentElement.style.fontSize = font;
+      }, size.font);
+      const dismiss = page.getByRole('button', {
+        name: `Dismiss archive suggestion for ${sprint}`,
+      });
+      const banner = dismiss.locator('../..');
+      await expect(banner).toBeVisible();
+      expect(await banner.evaluate((el) => el.scrollWidth <= el.clientWidth)).toBe(true);
+      const title = banner.getByText(`Sprint "${sprint}" is complete!`, { exact: true });
+      expect(await title.evaluate((el) => el.scrollWidth <= el.clientWidth)).toBe(true);
+      const archive = banner.getByRole('button', { name: 'Archive Sprint', exact: true });
+      await expect(archive).toBeInViewport({ ratio: 1 });
+      await expect(dismiss).toBeInViewport({ ratio: 1 });
+      const before = await banner.boundingBox();
+      await archive.click();
+      const dialog = page.getByRole('dialog');
+      await dialog.getByRole('button', { name: 'Cancel', exact: true }).click();
+      await expect(dialog).toBeHidden();
+      await expect(archive).toBeFocused();
+      const after = await banner.boundingBox();
+      expect(after!.x).toBe(before!.x);
+    }
+    await page.getByRole('button', { name: `Dismiss archive suggestion for ${sprint}` }).click();
+    await expect(page.getByText(`Sprint "${sprint}" is complete!`, { exact: true })).toBeHidden();
+    expect(archiveRequests).toBe(0);
+    await cleanupRoutes(page);
+  });
+}

--- a/web/src/components/board/ArchiveSuggestionBanner.tsx
+++ b/web/src/components/board/ArchiveSuggestionBanner.tsx
@@ -43,13 +43,13 @@ export function ArchiveSuggestionBanner() {
           <div
             key={suggestion.sprint}
             className={cn(
-              'flex items-center justify-between gap-4 px-4 py-3 rounded-lg',
+              'flex flex-wrap items-center justify-between gap-4 px-4 py-3 rounded-lg',
               'bg-green-500/10 border border-green-500/20 text-green-700 dark:text-green-400'
             )}
           >
-            <div className="flex items-center gap-3">
+            <div className="flex min-w-0 flex-1 basis-64 items-center gap-3">
               <CheckCircle className="h-5 w-5 flex-shrink-0" />
-              <div>
+              <div className="min-w-0 flex-1 [overflow-wrap:anywhere]">
                 <p className="font-medium">Sprint "{suggestion.sprint}" is complete!</p>
                 <p className="text-sm opacity-80">
                   All {suggestion.taskCount} task{suggestion.taskCount !== 1 ? 's' : ''} are done.
@@ -58,7 +58,7 @@ export function ArchiveSuggestionBanner() {
               </div>
             </div>
 
-            <div className="flex items-center gap-2 flex-shrink-0">
+            <div className="flex max-w-full flex-wrap items-center gap-2 flex-shrink-0">
               <Button
                 variant="outline"
                 size="sm"


### PR DESCRIPTION
## Changes

Keeps long, unbroken sprint names inside the archive banner and allows its action group to wrap without clipping or horizontally panning the Board. Archive and dismissal handlers are unchanged.

## Verification

The focused browser regression failed on the original source in both themes and passes after the fix at 1180px with normal/enlarged text and 620px with enlarged text. It covers title containment, both actions, confirmation cancellation, stable horizontal position, dismissal, and no destructive requests. Web typecheck and changed-file lint pass.

Rebuilt unsigned macOS candidate `07c5ae972f795251244fd255f2062c43fc8aa11c` passes in both themes at 1700×900 and native minimum 1180×760, including enlarged text and the separately reviewed Board dialogs. Specification and standards reviews have no outstanding findings. Details: `docs/audits/ARCHIVE-BANNER-1434.md`.

Installed-app replacement, other UI families, final documentation images/GIFs, and release remain open.

Closes #1434
