### PR TITLE
test: synchronize policy action checks with dialog dismissal

### DIFF
--- a/e2e/policy-action-layout.spec.ts
+++ b/e2e/policy-action-layout.spec.ts
@@ -64,14 +64,25 @@ for (const theme of ['light', 'dark']) {
     }
     await page.screenshot({ path: testInfo.outputPath(`policy-${theme}.png`) });
     const edit = page.getByRole('button', { name: 'Edit', exact: true }).first();
+    const editDialog = page.getByRole('dialog', {
+      name: 'Edit Policy Define when the policy applies, what it checks, and how the agent should respond.',
+      exact: true,
+    });
     await edit.click();
-    await expect(page.getByRole('dialog')).toContainText('Edit Policy');
+    await expect(editDialog).toBeVisible();
     await page.keyboard.press('Escape');
+    // Focus returns before the exit animation finishes. Wait for dismissal too.
+    await expect(editDialog).toHaveCount(0);
     await expect(edit).toBeFocused();
     const preview = page.getByRole('button', { name: 'Test', exact: true }).first();
+    const testDialog = page.getByRole('dialog', {
+      name: 'Test Policy Evaluation Preview how the guard engine would evaluate an action before an agent executes it.',
+      exact: true,
+    });
     await preview.click();
-    await expect(page.getByRole('dialog')).toContainText('Test Policy');
+    await expect(testDialog).toBeVisible();
     await page.keyboard.press('Escape');
+    await expect(testDialog).toHaveCount(0);
     await expect(preview).toBeFocused();
     await cleanupRoutes(page);
   });


### PR DESCRIPTION
Closes #1441. Part of #1389.

The policy action check now waits for each dialog to leave the DOM after Escape and matches each surface by its complete accessible name. Focus can return before the exit animation finishes; the old generic dialog assertion therefore matched both closing Edit and opening Test.

The original two light/dark cases reproduced the exact CI strict-locator failure locally. After the change both pass in 7 seconds, retaining label geometry checks at both widths, normal/enlarged text, sidebar states, and exact opener restoration. No fixed sleeps, retries, animation suppression, or product behavior changes were added.

Verified with `PLAYWRIGHT_API_PORT=3208 PLAYWRIGHT_WEB_PORT=5208 API_BASE_URL=http://127.0.0.1:3208 pnpm exec playwright test e2e/policy-action-layout.spec.ts --project=chromium --reporter=line`, Prettier, and `git diff --check`. Both review axes have no remaining findings after correcting the Test title to include its subtitle. ESLint reports this E2E path as unconfigured, so it is not claimed as a lint pass.

The next integration checkpoint must rerun the combined QA gate. This test-only fix does not claim installed-app, maintained media, or release completion.


## Current source gate

CI run 33833101394 now passes on exact source head `a96b88f6467cb2c9ce800a4e6c8e19320ac84302` after rerunning only the failed advisory job once the service recovered. Both production and all-dependency audit logs report no known vulnerabilities. The separate CodeQL and Gitleaks checks passed. Earlier endpoint failures remain historical evidence, not waived results.

This clears the source PR gate, not final integrated native, documentation-media, installed-app, or release acceptance.
