### PR TITLE
fix: preserve cross-origin download filenames

### DIFF
--- a/docs/audits/DOWNLOAD-FILENAME-CORS-1447.md
+++ b/docs/audits/DOWNLOAD-FILENAME-CORS-1447.md
@@ -1,0 +1,11 @@
+# Cross-origin download filenames
+
+Tracking: #1447.
+
+The telemetry export response already included a task/project scope and date in `Content-Disposition`, but browser JavaScript could not read that non-safelisted response header across origins. Metrics Export consequently used its generic fallback. The CORS options now expose only `Content-Disposition`; origin validation, credentials, methods, and allowed request headers are unchanged. This does not authorize another origin or bypass authentication.
+
+`e2e/download-filename-cors.spec.ts` exercises the actual API middleware and export route with the web and API on different origins. The initial UI assertion reproduced a scoped server filename becoming `telemetry-export.csv`; the middleware assertion reproduced the missing exposure header. The corrected checks cover CSV and JSON filenames, the no-header fallback, credentialed allowed-origin responses, unchanged preflight method/request-header lists, and rejection without exposure for an untrusted origin, a localhost lookalike, and a malformed origin. Only authentication presentation and the run-history read are synthetic; the two scoped export responses use the disposable API store. The fallback response alone is synthetic. No provider runs or private telemetry are used.
+
+Consumer audit: `web/src/components/dashboard/ExportDialog.tsx` is the only web consumer that reads `Content-Disposition`. `ArtifactPreviewModal` names its authenticated blob download from `artifact.safeName`; `AttachmentsSection` uses `attachment.originalName` on a direct download link. Server attachment and agent-bundle routes also supply disposition headers, but no corresponding web header parser was found. No client filename behavior is changed here.
+
+This transport correction is separate from task-overlay geometry, native acceptance, final media recapture, and release delivery.

--- a/e2e/download-filename-cors.spec.ts
+++ b/e2e/download-filename-cors.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+import { cleanupRoutes, deleteTask, seedTestTask } from './helpers/auth';
+
+const apiBase = process.env.API_BASE_URL ?? 'http://127.0.0.1:3001';
+
+test('cross-origin metrics downloads retain server filenames and the absent-header fallback', async ({
+  page,
+}) => {
+  const task = await seedTestTask(page, { title: 'Cross-origin export fixture', type: 'code' });
+  // Only authentication presentation is mocked. Export requests and CORS use the real server.
+  await page.route('**/api/auth/status', (route) =>
+    route.fulfill({
+      json: {
+        needsSetup: false,
+        authenticated: true,
+        authEnabled: true,
+        sessionExpiry: new Date(Date.now() + 86400000).toISOString(),
+      },
+    })
+  );
+  // Present a synthetic run so the existing Metrics export action is available.
+  // The exported data itself still comes from the real, disposable API store.
+  await page.route(`**/api/telemetry/events/task/${task.id}`, (route) =>
+    route.fulfill({
+      json: [
+        {
+          id: 'evt_export_fixture',
+          type: 'run.started',
+          timestamp: '2026-09-01T10:00:00Z',
+          taskId: task.id,
+          agent: 'fixture',
+          attemptId: 'attempt_fixture',
+        },
+      ],
+    })
+  );
+  try {
+    await page.setViewportSize({ width: 1700, height: 900 });
+    await page.goto('/');
+    expect(new URL(page.url()).origin).not.toBe(new URL(apiBase).origin);
+    await page.getByRole('article', { name: `Task: ${task.title}` }).press('Enter');
+    const workspace = page.getByTestId('task-detail-panel');
+    await workspace.getByRole('button', { name: 'History', exact: true }).click();
+    await workspace.getByRole('tab', { name: 'Metrics', exact: true }).click();
+    for (const format of ['csv', 'json'] as const) {
+      await workspace.getByRole('button', { name: 'Export', exact: true }).click();
+      const dialog = page.getByRole('dialog', { name: 'Export Metrics' });
+      await dialog.getByLabel('Format', { exact: true }).click();
+      await page
+        .getByRole('option', {
+          name: format === 'csv' ? 'CSV (Spreadsheets)' : 'JSON (Programmatic)',
+          exact: true,
+        })
+        .click();
+      const responseEvent = page.waitForResponse((response) =>
+        response.url().includes('/api/telemetry/export?')
+      );
+      const downloadEvent = page.waitForEvent('download');
+      await dialog.getByRole('button', { name: 'Export', exact: true }).click();
+      const response = await responseEvent;
+      expect(new URL(response.url()).origin).toBe(new URL(apiBase).origin);
+      expect(response.status()).toBe(200);
+      const disposition = response.headers()['content-disposition'];
+      expect(disposition).toContain(task.id);
+      const expectedName = disposition.match(/filename="([^"]+)"/)![1];
+      const download = await downloadEvent;
+      expect(download.suggestedFilename()).toBe(expectedName);
+      expect(await download.failure()).toBeNull();
+      expect(expectedName).toMatch(new RegExp(`\\.${format}$`));
+      await expect(dialog).toHaveCount(0);
+    }
+    // A separate synthetic response proves the consumer still has its generic fallback.
+    await page.route('**/api/telemetry/export?*', (route) =>
+      route.fulfill({ contentType: 'text/csv', body: 'fixture\n' })
+    );
+    await workspace.getByRole('button', { name: 'Export', exact: true }).click();
+    const downloadEvent = page.waitForEvent('download');
+    await page
+      .getByRole('dialog', { name: 'Export Metrics' })
+      .getByRole('button', { name: 'Export', exact: true })
+      .click();
+    const download = await downloadEvent;
+    expect(download.suggestedFilename()).toBe('telemetry-export.csv');
+    expect(await download.failure()).toBeNull();
+  } finally {
+    await deleteTask(page, String(task.id)).catch(() => {});
+    await cleanupRoutes(page).catch(() => {});
+  }
+});
+
+test('the live CORS middleware exposes only download metadata to allowed origins', async ({
+  request,
+  baseURL,
+}) => {
+  const origin = new URL(baseURL!).origin;
+  const allowed = await request.get(`${apiBase}/api/health`, { headers: { Origin: origin } });
+  expect(allowed.status()).toBe(200);
+  expect(allowed.headers()['access-control-allow-origin']).toBe(origin);
+  expect(allowed.headers()['access-control-allow-credentials']).toBe('true');
+  expect(allowed.headers()['access-control-expose-headers']).toBe('Content-Disposition');
+  const preflight = await request.fetch(`${apiBase}/api/telemetry/export`, {
+    method: 'OPTIONS',
+    headers: {
+      Origin: origin,
+      'Access-Control-Request-Method': 'GET',
+      'Access-Control-Request-Headers': 'X-API-Key',
+    },
+  });
+  expect(preflight.status()).toBe(204);
+  expect(preflight.headers()['access-control-allow-methods']).toBe(
+    'GET,POST,PUT,PATCH,DELETE,OPTIONS'
+  );
+  expect(preflight.headers()['access-control-allow-headers']).toBe(
+    'Content-Type,Authorization,X-API-Key,X-API-Version,X-Request-ID'
+  );
+  for (const rejectedOrigin of [
+    'https://untrusted.example',
+    'https://localhost.attacker.example',
+    'not-an-origin',
+  ]) {
+    const rejected = await request.get(`${apiBase}/api/health`, {
+      headers: { Origin: rejectedOrigin },
+    });
+    expect(rejected.status()).toBe(403);
+    expect(rejected.headers()['access-control-allow-origin']).toBeUndefined();
+    expect(rejected.headers()['access-control-expose-headers']).toBeUndefined();
+  }
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -340,6 +340,8 @@ const corsOptions: cors.CorsOptions = {
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'X-API-Key', 'X-API-Version', 'X-Request-ID'],
+  // Let authorized browser clients preserve server-provided download filenames.
+  exposedHeaders: ['Content-Disposition'],
 };
 
 // ============================================


### PR DESCRIPTION
## Summary

Expose `Content-Disposition` through the existing CORS policy so authorized cross-origin browser exports retain the server's scoped/date-bearing filename. No origins, credentials, methods, or request-header permissions change. The generic filename remains the fallback when no disposition header is present.

Closes #1447.

## Verification

- Two focused Playwright checks against the real API passed. The UI test uses separate web/API origins and verifies CSV and JSON suggested filenames against the actual response header, plus a synthetic no-header fallback.
- The live middleware check covers allowed-origin credentials and exposure, unchanged preflight method/request-header lists, and three rejected origins with no exposure.
- The tests failed before the fix: the server's scoped filename became `telemetry-export.csv`, and the exposure header was absent.
- Server typecheck, source lint, formatting, and independent specification/standards review.

Authentication presentation and run-history reads are synthetic; scoped exports come from the disposable test API store. No provider runs or private telemetry are used. The consumer audit is recorded in `docs/audits/DOWNLOAD-FILENAME-CORS-1447.md`.

## Risk and scope

This exposes only download filename metadata on responses already allowed by CORS. It does not bypass authentication or expand origin access. No new dependencies. Native UI acceptance, final screenshots/GIFs, and release delivery remain separate work.
