### PR TITLE
fix: close Session menu on Escape and preserve focus

### DIFF
--- a/docs/audits/SESSION-MENU-ESCAPE-1451.md
+++ b/docs/audits/SESSION-MENU-ESCAPE-1451.md
@@ -1,0 +1,7 @@
+# Session menu keyboard dismissal (#1451)
+
+Escape closes the Session menu when focus is on its trigger or inside the account popover, returning focus to the current trigger. A nested control that consumes Escape keeps ownership of the event. Clicking the trigger again still closes the menu; clicking elsewhere does not force focus back to the header. Members & Permissions, Security Settings, and logout actions are unchanged.
+
+The previous Mantine dropdown handled Escape during capture inside the portaled content only. The trigger was outside that path. The fix handles bubbling key events on both the trigger and dropdown, disables the dropdown's capture handler, and restores focus only for an unconsumed Escape.
+
+The focused layout-chrome regressions reproduce the original failure in both trigger presentations and cover content focus, nested event ownership, mouse toggle, click-away, and identity/security callbacks. Packaged macOS acceptance uses the candidate-bound runner from #1387 at 1700×1000 and 1180×760 in both themes. A passing candidate does not establish signing, installation, refreshed documentation media, or release publication.

--- a/web/src/__tests__/layout-chrome-mantine.test.tsx
+++ b/web/src/__tests__/layout-chrome-mantine.test.tsx
@@ -260,6 +260,77 @@ describe('layout chrome Mantine migration', () => {
     expect(container.querySelector('.mantine-Button-root')).toBeNull();
   });
 
+  it.each([false, true])(
+    'dismisses Session menu with Escape from its trigger (compact=%s)',
+    async (compact) => {
+      const user = userEvent.setup();
+      renderWithProviders(<UserMenu compact={compact} />);
+      const trigger = screen.getByRole('button', { name: 'Session menu' });
+      await user.click(trigger);
+      expect(screen.getByRole('dialog')).toBeDefined();
+      expect(document.activeElement).toBe(trigger);
+      await user.keyboard('{Escape}');
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+      expect(document.activeElement).toBe(trigger);
+    }
+  );
+
+  it('returns focus on content Escape without stealing focus on click-away or action handoff', async () => {
+    const user = userEvent.setup();
+    const onOpenSecuritySettings = vi.fn();
+    const onOpenIdentitySettings = vi.fn();
+    renderWithProviders(
+      <>
+        <button>Outside</button>
+        <UserMenu
+          onOpenSecuritySettings={onOpenSecuritySettings}
+          onOpenIdentitySettings={onOpenIdentitySettings}
+        />
+      </>
+    );
+    const trigger = screen.getByRole('button', { name: 'Session menu' });
+    await user.click(trigger);
+    await user.tab();
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: 'Members & Permissions' })
+    );
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+
+    await user.click(trigger);
+    await user.click(trigger);
+    expect(screen.queryByRole('dialog')).toBeNull();
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: 'Outside' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Outside' }));
+
+    for (const [name, callback] of [
+      ['Security Settings', onOpenSecuritySettings],
+      ['Members & Permissions', onOpenIdentitySettings],
+    ] as const) {
+      await user.click(trigger);
+      await user.click(screen.getByRole('button', { name }));
+      expect(callback).toHaveBeenCalledOnce();
+      expect(screen.queryByRole('dialog')).toBeNull();
+    }
+  });
+
+  it('lets nested content consume Escape before dismissing the Session menu', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<UserMenu />);
+    await user.click(screen.getByRole('button', { name: 'Session menu' }));
+    const item = screen.getByRole('button', { name: 'Members & Permissions' });
+    item.addEventListener('keydown', (event) => event.preventDefault(), { once: true });
+    item.focus();
+    await user.keyboard('{Escape}');
+    expect(screen.getByRole('dialog')).toBeDefined();
+    expect(document.activeElement).toBe(item);
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  });
+
   it('renders WebSocket status with a direct Mantine popover', async () => {
     const user = userEvent.setup();
     const { baseElement } = renderWithProviders(<WebSocketIndicator />);

--- a/web/src/components/layout/UserMenu.tsx
+++ b/web/src/components/layout/UserMenu.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 import {
   Badge,
   ActionIcon,
@@ -31,6 +37,17 @@ export function UserMenu({
     useIdentity();
   const [open, setOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Handle both the trigger and portaled content. Mantine's default Escape
+  // listener only sees events captured inside the dropdown.
+  const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (!open || event.defaultPrevented || event.key !== 'Escape') return;
+    event.preventDefault();
+    event.stopPropagation();
+    setOpen(false);
+    triggerRef.current?.focus({ preventScroll: true });
+  };
 
   // Format session expiry
   const formatExpiry = (expiry: string | null) => {
@@ -104,10 +121,13 @@ export function UserMenu({
       radius="md"
       shadow="md"
       withinPortal
+      closeOnEscape={false}
     >
       <Popover.Target>
         {compact ? (
           <ActionIcon
+            ref={triggerRef}
+            onKeyDown={handleMenuKeyDown}
             variant="subtle"
             color="gray"
             size={32}
@@ -119,6 +139,8 @@ export function UserMenu({
           </ActionIcon>
         ) : (
           <Button
+            ref={triggerRef}
+            onKeyDown={handleMenuKeyDown}
             variant="subtle"
             color="gray"
             size="sm"
@@ -137,7 +159,10 @@ export function UserMenu({
           </Button>
         )}
       </Popover.Target>
-      <Popover.Dropdown className="w-72 bg-popover p-0 text-popover-foreground">
+      <Popover.Dropdown
+        className="w-72 bg-popover p-0 text-popover-foreground"
+        onKeyDown={handleMenuKeyDown}
+      >
         <Box className="border-b border-border p-3">
           <Group align="flex-start" gap="xs" wrap="nowrap">
             <Box className="mt-0.5 rounded-full bg-primary/10 p-1.5 text-primary">


### PR DESCRIPTION
## Summary

Fixes #1451. The Session menu closes with Escape from its trigger or portaled content and returns focus to the current trigger. Nested controls can consume Escape first. Mouse toggle, click-away, identity/security callbacks, and logout remain unchanged.

Mantine's dropdown-local capture handler did not receive Escape on the trigger. Scoped bubbling handlers replace that behavior without a global keyboard listener or focus stealing after click-away.

Stacked on draft #1452 to retain the combined candidate and native verification tool. This PR changes only Session menu code, focused regressions, and its behavior note. It does not finish #1387 or authorize merging its draft parent.

## Verification

- Trigger-Escape regressions failed before the fix for both compact and regular controls. All 13 layout-chrome tests then passed, covering content Escape, nested event consumption, click-away, mouse toggle, and identity/security callbacks.
- Web typecheck, changed-file lint/formatting, and independent spec/standards reviews passed.
- Prior clean candidate 7a9e1808533d80c96e52bd5a0191e99c3225f4a4 passed all 144 entries under the preceding native contract. That result is not a pass of the subsequently strengthened contract.
- Current combined candidate ba83a8a9a63f06d76ff484beee1967ccdf8d74cd built and packaged successfully. Its strengthened native matrix completed with 82 passing and 62 failing states, exposing heading/drawer defects tracked in #1454 plus two HTTP 429 responses. All six injected faults were detected. Session menu interaction assertions completed, but the report is failed and not release acceptance.
- CI run 33845967246 on the preceding head passed Build, Lint & Type Check, and Changed Tests. Security Audit failed on npm advisory endpoint timeouts. That result is neither a passing security gate nor CI coverage of the updated head.

Current native evidence: /tmp/vk-session-menu-1451-native-strengthened/evidence.json, completed 2026-09-04T07:07:35.627Z. App version 6.1.6, macOS 26.6.2. Whole-bundle SHA-256: 97e9322252941b76e0957d3945e695b740085a6a652a56fa820d0e689c6f4347.

## Boundaries and remaining work

Unsigned packaged candidates only. No installed-app, signing, refreshed documentation media, or publication acceptance. #1387 still needs a passing strengthened run, media freshness checks, and release-upload enforcement. Stacked branches need explicit CI dispatch; no security gate is waived.
