### PR TITLE
fix: enforce shared heading and drawer geometry

### DIFF
--- a/docs/audits/NATIVE-SHARED-GEOMETRY-1454.md
+++ b/docs/audits/NATIVE-SHARED-GEOMETRY-1454.md
@@ -1,0 +1,7 @@
+# Effective shared native geometry (#1454)
+
+Primary page headings use a 1.5rem font size and 2rem line height. The task drawer body has no outer padding; task header, navigation, content, and chat sections own their insets. These values are applied through the component style boundary because unlayered Mantine defaults override normal Tailwind utilities in the packaged production renderer.
+
+The preceding native candidate measured 34px/44.2px heading typography and 12px drawer body padding at a 16px root size, despite the intended utility classes. The strengthened #1387 contract rejects those values. Focused regressions assert the effective inline declarations while the packaged matrix verifies actual computed layout at normal and minimum window sizes in both themes. The change does not alter heading semantics, navigation handlers, nested overlay ownership, or task state preservation.
+
+Native gate reports and candidate identity remain separate from installed-app, signing, documentation media, and release acceptance. A passing geometry check alone does not complete those boundaries.

--- a/web/src/__tests__/primary-page-shell.test.tsx
+++ b/web/src/__tests__/primary-page-shell.test.tsx
@@ -26,6 +26,8 @@ describe('PrimaryPageShell', () => {
     );
 
     const heading = screen.getByRole('heading', { level: 1, name: 'Evidence Timeline' });
+    expect(heading.style.fontSize).toBe('1.5rem');
+    expect(heading.style.lineHeight).toBe('2rem');
     expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
     await waitFor(() => expect(document.activeElement).toBe(heading));
     expect(screen.getByText('Chronological source-backed evidence.')).toBeTruthy();

--- a/web/src/__tests__/ui-overlay.test.tsx
+++ b/web/src/__tests__/ui-overlay.test.tsx
@@ -58,6 +58,7 @@ describe('shared popout contract', () => {
     // wrapper; the size-container class must only be on the visible content.
     expect(task.classList.contains('vk-task-workspace')).toBe(true);
     expect(task.parentElement?.classList.contains('vk-task-workspace')).toBe(false);
+    expect(task.querySelector<HTMLElement>('.mantine-Drawer-body')?.style.padding).toBe('0px');
     const draft = screen.getByRole('textbox', { name: 'Retained draft' });
     fireEvent.change(draft, { target: { value: 'Changed without saving' } });
     for (const presentation of ['expanded', 'drawer']) {

--- a/web/src/components/layout/PrimaryPageShell.tsx
+++ b/web/src/components/layout/PrimaryPageShell.tsx
@@ -80,7 +80,8 @@ export function PrimaryPageShell({
               id={headingId}
               order={1}
               tabIndex={-1}
-              className="m-0 min-w-0 text-2xl font-bold leading-8 tracking-[-0.012em] outline-none focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              style={{ fontSize: '1.5rem', lineHeight: '2rem' }}
+              className="m-0 min-w-0 font-bold tracking-[-0.012em] outline-none focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
             >
               {title}
             </Title>

--- a/web/src/components/ui/UiOverlay.tsx
+++ b/web/src/components/ui/UiOverlay.tsx
@@ -266,7 +266,10 @@ export function UiTaskSurface({
               'veritas-overlay-surface vk-task-workspace flex h-full min-h-0 max-h-[100dvh] flex-col overflow-hidden border-l bg-background bg-clip-padding text-sm shadow-lg',
           }}
         >
-          <Drawer.Body className="flex min-h-0 flex-1 flex-col overflow-hidden p-0">
+          <Drawer.Body
+            style={{ padding: 0 }}
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          >
             {children}
           </Drawer.Body>
         </Drawer.Content>


### PR DESCRIPTION
## Summary

Fixes #1454. Enforces the existing shared page-heading typography and zero-padding task drawer body through component-owned styles. Mantine's unlayered defaults previously won over normal Tailwind utilities in the packaged renderer, producing 34px/44.2px headings instead of 24px/32px and an unintended 12px outer task inset.

The fix keeps rem-based typography, heading semantics, focus behavior, state preservation, and child section spacing. No global CSS-layer change or native-contract relaxation. Stacked on #1453 to verify the combined candidate; this does not authorize integration of its draft ancestors.

## Verification

- Both new regression assertions failed before the fix.
- All 14 focused PrimaryPageShell and UiOverlay tests passed afterward.
- Changed-file lint, formatting, shared/server builds, and web typecheck/build passed.
- Independent spec and standards reviews found no actionable issues.
- Shared, server, web, desktop builds and unsigned macOS packaging passed for clean candidate ceb6fab8109f7f9284e76122b0b9966a2f880495.
- The actual packaged application passed all 144 strengthened native states across 1700×1000 and 1180×760 in light/dark themes, including computed heading size/line height, header containment/alignment, and task drawer/body insets. All six injected renderer faults were detected. No HTTP 429 or server errors were recorded.
- The separate evidence verifier accepted the exact package, complete PNGs, screenshot hashes, native dimensions, and recorded geometry. Native Tasks settings, task-chat, and minimum-window Policies captures were visually inspected.

Evidence completed at 2026-09-04T07:13:29.455Z on macOS 26.6.2, app 6.1.6 arm64. Whole-bundle SHA-256: f30db50a620e06bcbdf3ab03e95809d334eed6dbf8d418c39b47d4bb3ff0b142. Local evidence: /tmp/vk-native-shared-geometry-1454-native/evidence.json. CI run 33847581609 is still pending; native success does not replace CI.

## Boundaries

This is not installed-app, signing, refreshed documentation media, or release acceptance. Earlier security-audit jobs timed out at the npm advisory endpoint; no security gate is waived. The parent native-gate PR #1452 remains draft for its media-freshness and pre-upload release-enforcement work. See docs/audits/NATIVE-SHARED-GEOMETRY-1454.md.
