### PR TITLE
fix: restore the current opener after interrupted overlay exits

### DIFF
--- a/docs/design/OVERLAY-REOPEN-FOCUS.md
+++ b/docs/design/OVERLAY-REOPEN-FOCUS.md
@@ -1,0 +1,9 @@
+# Interrupted overlay exit and opener ownership
+
+Tracking: #1459, discovered during the packaged task-family acceptance for #1444.
+
+A mounted confirmation can be reused before its previous exit animation finishes. The approval and rejection actions share one such dialog. On candidate `88c2b998361a6dcbcce3f37e8abe85d0ef8804bc`, opening Approve once, closing it, then immediately opening and closing Reject returned focus to Approve once. The native reproduction failed twice; inserting a 250ms delay between the actions avoided the failure across eight theme/motion/window combinations. That timing probe is diagnostic evidence, not an accepted workaround.
+
+The shared overlay registration now distinguishes a committed closed state from React effect replay. A new open cycle captures its current external opener without waiting for an exit callback. If a shortcut reopens while focus still belongs to the exiting surface, it retains the previous logical opener instead of capturing one of its own controls. A stable internal surface identifier distinguishes that control from a valid control in a parent overlay. Exit completion checks the current lifecycle ref so it cannot clear a reopened surface's opener.
+
+The focused regression reproduced the original Approve-versus-Reject mismatch before the fix. Coverage also includes immediate shortcut reopening, existing StrictMode replay, nested focus ownership, and overlay handoff cancellation. Native acceptance of the rebuilt candidate remains required; this source change does not establish installed-app, documentation-media, or release completion.

--- a/web/src/__tests__/ui-overlay.test.tsx
+++ b/web/src/__tests__/ui-overlay.test.tsx
@@ -1,4 +1,5 @@
 import { StrictMode, useEffect, useState } from 'react';
+import { flushSync } from 'react-dom';
 import { MantineProvider } from '@mantine/core';
 import { act, cleanup, fireEvent, renderHook, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +16,86 @@ import { renderWithProviders } from './test-utils';
 afterEach(cleanup);
 
 describe('shared popout contract', () => {
+  it('retains the external opener when a shortcut reopens before deferred restoration', async () => {
+    function Probe() {
+      const [opened, setOpened] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpened(true)}>External opener</button>
+          <UiModal
+            opened={opened}
+            onClose={() => setOpened(false)}
+            title="Shortcut decision"
+            keepMounted
+            transitionProps={{ duration: 10_000 }}
+          >
+            <button
+              onClick={() => {
+                flushSync(() => setOpened(false));
+                flushSync(() => setOpened(true));
+              }}
+            >
+              Reopen immediately
+            </button>
+            <button onClick={() => setOpened(false)}>Close shortcut decision</button>
+          </UiModal>
+        </>
+      );
+    }
+    renderWithProviders(
+      <MantineProvider env="default">
+        <Probe />
+      </MantineProvider>
+    );
+    const trigger = screen.getByRole('button', { name: 'External opener' });
+    vi.spyOn(trigger, 'getClientRects').mockReturnValue([
+      new DOMRect(0, 0, 100, 32),
+    ] as unknown as DOMRectList);
+    trigger.focus();
+    fireEvent.click(trigger);
+    const reopen = await screen.findByRole('button', { name: 'Reopen immediately' });
+    reopen.focus();
+    fireEvent.click(reopen);
+    fireEvent.click(screen.getByRole('button', { name: 'Close shortcut decision' }));
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+  it('captures the new opener when a mounted dialog reopens before its exit completes', async () => {
+    function Probe() {
+      const [opened, setOpened] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpened(true)}>Approve opener</button>
+          <button onClick={() => setOpened(true)}>Reject opener</button>
+          <UiModal
+            opened={opened}
+            onClose={() => setOpened(false)}
+            title="Reused decision"
+            keepMounted
+            transitionProps={{ duration: 10_000 }}
+          >
+            <button onClick={() => setOpened(false)}>Close decision</button>
+          </UiModal>
+        </>
+      );
+    }
+    renderWithProviders(
+      <StrictMode>
+        <MantineProvider env="default">
+          <Probe />
+        </MantineProvider>
+      </StrictMode>
+    );
+    for (const name of ['Approve opener', 'Reject opener']) {
+      const trigger = screen.getByRole('button', { name });
+      vi.spyOn(trigger, 'getClientRects').mockReturnValue([
+        new DOMRect(0, 0, 100, 32),
+      ] as unknown as DOMRectList);
+      trigger.focus();
+      fireEvent.click(trigger);
+      fireEvent.click(await screen.findByRole('button', { name: 'Close decision' }));
+      await waitFor(() => expect(document.activeElement).toBe(trigger));
+    }
+  });
   it('keeps task content mounted across presentation changes and stacks nested utilities', async () => {
     const closeTask = vi.fn();
     function Probe() {

--- a/web/src/components/ui/UiOverlay.tsx
+++ b/web/src/components/ui/UiOverlay.tsx
@@ -114,29 +114,41 @@ function useOverlayRegistration(
   const depth = useContext(OverlayDepth);
   const stack = useContext(OverlayStack);
   const register = stack?.register;
-  const opener = useRef<HTMLElement | null | undefined>(undefined);
+  const opener = useRef<HTMLElement | null>(null);
+  const wasOpened = useRef(false);
   // Register before paint so a rapidly reopened surface is never inert for
   // the next keyboard event while a passive registration effect is pending.
   useLayoutEffect(() => {
-    if (!opened) return;
+    if (!opened) {
+      wasOpened.current = false;
+      return;
+    }
     // Effect replay (including a lazy surface reveal) must not replace the
     // original opener with a field or background heading focused during mount.
-    if (opener.current === undefined) {
-      opener.current =
-        document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    // A committed close starts a new cycle even if its exit is interrupted.
+    if (!wasOpened.current) {
+      const focused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      // Shortcut reopening can beat deferred focus restoration. An exiting
+      // control is not a new logical opener for its own surface.
+      if (focused?.closest('[data-overlay-id]')?.getAttribute('data-overlay-id') !== id) {
+        opener.current = focused;
+      }
     }
+    wasOpened.current = true;
     const trigger = returnFocus ? opener.current : null;
     return register?.({ id, depth, trigger });
   }, [opened, register, id, depth, returnFocus]);
   const index = stack?.entries.findIndex((entry) => entry.id === id) ?? 0;
   const active = !stack || stack.entries.at(-1)?.id === id;
   return {
+    id,
     active,
     depth,
     zIndex: getDefaultZIndex('modal') + Math.max(index, 0),
     onExitTransitionEnd: () => {
-      // An interrupted exit retains its opener. Restore before a new surface
-      // captures the target during an explicit overlay handoff.
+      // An old transition must not clear a reopened surface's current opener.
+      if (wasOpened.current) return;
+      // Restore before an explicit overlay handoff captures its target.
       const target = resolveFocusTarget(opener.current);
       const anotherOverlayOpen = stack?.entries.some((entry) => entry.id !== id);
       if (
@@ -147,7 +159,7 @@ function useOverlayRegistration(
       ) {
         target.focus({ preventScroll: true });
       }
-      opener.current = undefined;
+      opener.current = null;
       onExitTransitionEnd?.();
     },
   };
@@ -173,6 +185,7 @@ export function UiModal({
       {...props}
       size={definition.width}
       data-overlay-variant={variant}
+      data-overlay-id={overlay.id}
       data-overlay-presentation={definition.presentation}
       data-overlay-compound={compound || undefined}
       data-overlay-active={active || undefined}
@@ -256,6 +269,7 @@ export function UiTaskSurface({
         <Drawer.Content
           aria-label={label}
           data-overlay-variant="task"
+          data-overlay-id={overlay.id}
           data-overlay-active={overlay.active || undefined}
           data-presentation={expanded ? 'expanded' : 'drawer'}
           data-testid="task-detail-panel"


### PR DESCRIPTION
## Summary

Fixes #1459. A shared confirmation that closes and reopens before its exit animation completes now captures the current external opener. The approval-to-rejection sequence previously returned focus to Approve once after closing Reject.

Committed open/close cycles are tracked separately from effect replay. Shortcut reopening retains the prior logical opener when focus is still inside the exiting surface, and stale exit callbacks check current lifecycle state before clearing focus ownership. No dependencies or provider behavior changed.

## Verification

- Native reproduction failed twice on parent candidate `88c2b998361a6dcbcce3f37e8abe85d0ef8804bc`. Waiting 250ms between approval dialogs avoided the failure in all eight diagnostic modes; that delay is not the fix or acceptance.
- The focused shared-overlay regression reproduced the exact wrong-opener failure before the source change.
- All 14 shared-overlay tests pass, covering the new distinct-opener and shortcut-reopen cases plus existing effect replay, nested ownership, and handoff behavior.
- Web typecheck, changed-file lint, formatting, and both source review axes pass.
- The unsigned packaged macOS build succeeded at `f94570346944e5294be767191b07fa8bc14768d1`. Its native diagnostic passed all 64 idle/failure states for Overview stop, Agent stop, approval, and rejection across both themes/motion settings at 1700x1000 with 16px text and 1180x760 with 20px text. The original approval-to-rejection sequence passed without any added delay. Pending guards, footer hit targets, full error/hash visibility, exact request bindings, and opener restoration passed. All 32 writes were intercepted failures; no provider was stopped and no real decision was sent. Evidence completed `2026-09-04T08:53:34.359Z`; package SHA-256 `718ce20db99aec3fb57ab6b00c73e01b2ac09d91532956a5d0c899895c62b492`. Representative enlarged-text light/dark captures were inspected.

## Remaining

The same exact packaged candidate passed the broader 144-state native UI matrix and detected all six seeded renderer failures. Evidence completed `2026-09-04T08:56:25.196Z`; the independent evidence verifier passed package/commit identity, screenshot digests, uncropped dimensions, geometry, and required-case coverage. Representative minimum-size chat and Settings captures were inspected. This is native UI acceptance, not signing or installation evidence.

CI and Security Gates remain in progress on this exact head. This PR is stacked on #1458 and does not establish the complete parent task-family reconciliation, refreshed documentation media, installed-app acceptance, or release completion. Documentation-freshness validation remains separate from the six renderer seeds.
