### PR TITLE
fix: keep mobile navigation and task summaries readable

### DIFF
--- a/docs/guides/PWA_INSTALL.md
+++ b/docs/guides/PWA_INSTALL.md
@@ -23,6 +23,8 @@ Chrome shows the install prompt only when the manifest and service worker are re
 
 On narrow screens, use **More views** in the header to reach Activity, Backlog, Archive, and other views. Their separate wide-screen shortcuts are omitted to preserve room for the logo, connection status, and task controls. Dropdown menus remain anchored to their controls without changing the page scale.
 
+The bottom navigation uses two rows on narrow phones so Home, Board, Alerts, Runs, Work, and Settings retain readable labels. Content and floating chat controls leave room for its actual height, including larger text and the device safe area. Task Overview actions move below their summary when the panel is too narrow for a readable side-by-side layout.
+
 ## Offline Behavior
 
 The service worker caches only the static app shell, manifest, icons, and same-origin static assets. It does not cache `/api` responses, WebSocket traffic, task data, work products, tokens, comments, or mutation responses.

--- a/e2e/mobile-readable.spec.ts
+++ b/e2e/mobile-readable.spec.ts
@@ -1,0 +1,180 @@
+import { expect, test, type Page } from '@playwright/test';
+import { bypassAuth, cleanupRoutes, deleteTask, seedTestTask } from './helpers/auth';
+
+test.use({ viewport: { width: 320, height: 844 }, isMobile: true, hasTouch: true });
+test.beforeEach(async ({ page }) => bypassAuth(page));
+test.afterEach(async ({ page }) => cleanupRoutes(page));
+
+async function assertNavigationFits(page: Page) {
+  const navigation = page.getByRole('navigation', { name: 'Mobile navigation' });
+  await expect(navigation).toBeVisible();
+  const labels = navigation.locator('[data-mobile-nav-label]');
+  await expect(labels).toHaveText(['Home', 'Board', 'Alerts', 'Runs', 'Work', 'Settings']);
+  expect(
+    await labels.evaluateAll((elements) =>
+      elements.filter((el) => el.scrollWidth > el.clientWidth).map((el) => el.textContent)
+    )
+  ).toEqual([]);
+  const targets = await navigation.locator('button').evaluateAll((buttons) =>
+    buttons.map((button) => {
+      const rect = button.getBoundingClientRect();
+      return {
+        name: button.getAttribute('aria-label'),
+        width: rect.width,
+        height: rect.height,
+        inside: rect.left >= 0 && rect.right <= innerWidth && rect.bottom <= innerHeight,
+        reachable: button.contains(
+          document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2)
+        ),
+      };
+    })
+  );
+  for (const target of targets) {
+    expect(target.inside, target.name!).toBe(true);
+    expect(target.reachable, target.name!).toBe(true);
+    expect(target.width, target.name!).toBeGreaterThanOrEqual(44);
+    expect(target.height, target.name!).toBeGreaterThanOrEqual(44);
+  }
+  await expect
+    .poll(async () => {
+      const nav = await navigation.boundingBox();
+      const chat = await page.getByRole('button', { name: 'Open chat', exact: true }).boundingBox();
+      return !!nav && !!chat && chat.y + chat.height < nav.y;
+    })
+    .toBe(true);
+  expect(
+    await page
+      .locator('#main-content')
+      .evaluate((el) => parseFloat(getComputedStyle(el).paddingBottom))
+  ).toBeGreaterThan((await navigation.boundingBox())!.height);
+}
+
+for (const width of [320, 390, 430]) {
+  for (const textSize of [16, 20]) {
+    for (const theme of ['light', 'dark']) {
+      test(`readable mobile layout at ${width}px, ${textSize}px text, ${theme}`, async ({
+        page,
+      }, testInfo) => {
+        await page.setViewportSize({ width, height: 844 });
+        await page.addInitScript(
+          (value) => localStorage.setItem('veritas-kanban-theme', value),
+          theme
+        );
+        const task = await seedTestTask(page, { title: 'Readable task summary', type: 'code' });
+        try {
+          await page.goto('/');
+          await page.addStyleTag({ content: `:root { font-size: ${textSize}px !important; }` });
+          await expect(page.locator('#mobile-board-columns')).toBeVisible();
+          await assertNavigationFits(page);
+          expect(await page.evaluate(() => innerWidth)).toBe(width);
+          await testInfo.attach('navigation', {
+            body: await page.screenshot(),
+            contentType: 'image/png',
+          });
+          await page.getByRole('heading', { name: 'Readable task summary', exact: true }).click();
+          const detail = page.getByTestId('task-detail-panel');
+          await detail.getByRole('combobox', { name: 'Task workspace mode', exact: true }).click();
+          await page.getByRole('option', { name: 'Overview', exact: true }).click();
+          const card = page.getByTestId('task-overview-primary');
+          await expect(card).toBeVisible();
+          const title = card.getByRole('heading', { name: 'Needs preparation' });
+          const action = card.getByTestId('task-overview-primary-action');
+          const summary = title.locator('..');
+          const [summaryBox, actionBox, cardBox] = await Promise.all([
+            summary.boundingBox(),
+            action.boundingBox(),
+            card.boundingBox(),
+          ]);
+          expect(summaryBox).not.toBeNull();
+          expect(actionBox).not.toBeNull();
+          expect(cardBox).not.toBeNull();
+          expect(actionBox!.y).toBeGreaterThan(summaryBox!.y + summaryBox!.height);
+          expect(summaryBox!.width).toBeGreaterThan(cardBox!.width * 0.75);
+          expect(await summary.evaluate((el) => el.scrollWidth <= el.clientWidth)).toBe(true);
+          await testInfo.attach('summary', {
+            body: await page.screenshot(),
+            contentType: 'image/png',
+          });
+          await action.click();
+          await expect(detail.getByRole('combobox', { name: 'Task workspace mode' })).toHaveValue(
+            'Plan'
+          );
+          await detail.getByRole('button', { name: 'Close task workspace' }).click();
+          await expect(detail).not.toBeVisible();
+        } finally {
+          await deleteTask(page, task.id as string);
+        }
+      });
+    }
+  }
+}
+
+test('navigation height follows window and text resizing', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#mobile-board-columns')).toBeVisible();
+  const navigation = page.getByRole('navigation', { name: 'Mobile navigation' });
+  for (const width of [320, 680, 390]) {
+    await page.setViewportSize({ width, height: 844 });
+    await assertNavigationFits(page);
+    await expect
+      .poll(async () => {
+        const height = (await navigation.boundingBox())!.height;
+        const reserved = await page.evaluate(() =>
+          parseFloat(document.documentElement.style.getPropertyValue('--vk-mobile-nav-height'))
+        );
+        return Math.abs(height - reserved);
+      })
+      .toBeLessThan(1);
+  }
+  await page.addStyleTag({ content: ':root { font-size: 20px !important; }' });
+  await assertNavigationFits(page);
+  // Safe-area changes can alter padding without changing the content box.
+  await navigation.evaluate((el) => {
+    el.style.paddingBottom = '42px';
+  });
+  await expect
+    .poll(async () => {
+      const height = (await navigation.boundingBox())!.height;
+      const reserved = await page.evaluate(() =>
+        parseFloat(document.documentElement.style.getPropertyValue('--vk-mobile-nav-height'))
+      );
+      return Math.abs(height - reserved);
+    })
+    .toBeLessThan(1);
+  await assertNavigationFits(page);
+  await page.setViewportSize({ width: 900, height: 844 });
+  await expect(navigation).not.toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => document.documentElement.style.getPropertyValue('--vk-mobile-nav-height'))
+    )
+    .toBe('0px');
+});
+
+test('all six mobile destinations remain usable', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#mobile-board-columns')).toBeVisible();
+  await page.addStyleTag({ content: ':root { font-size: 20px !important; }' });
+  await page.getByRole('button', { name: 'Mobile runs', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Workflows', exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Mobile board', exact: true }).click();
+  await expect(page.locator('#mobile-board-columns')).toBeVisible();
+  await page.getByRole('button', { name: 'Mobile home', exact: true }).click();
+  await expect.poll(() => page.evaluate(() => scrollY)).toBe(0);
+  await page.getByRole('button', { name: 'Mobile notifications', exact: true }).click();
+  const notifications = page.getByRole('dialog', { name: 'Notifications', exact: true });
+  await expect(notifications).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(notifications).not.toBeVisible();
+  await page.getByRole('button', { name: 'Mobile work', exact: true }).click();
+  const search = page.getByRole('dialog', { name: 'Universal Search', exact: true });
+  await expect(search).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(search).not.toBeVisible();
+  await page.getByRole('button', { name: 'Mobile settings', exact: true }).click();
+  const settings = page.getByRole('dialog', { name: /^Settings/ });
+  await expect(settings).toBeVisible();
+  await settings.getByRole('button', { name: 'Close settings', exact: true }).click();
+  await expect(settings).not.toBeVisible();
+  await assertNavigationFits(page);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -156,7 +156,13 @@ function DesktopAwareAppShell({
             id="main-content"
             px={isDesktopClient ? 'md' : { base: 'md', md: '3.5rem' }}
             pt={isDesktopClient ? 'md' : 'lg'}
-            pb={bottomPanel ? 'md' : isDesktopClient ? 'lg' : { base: '6rem', md: 'lg' }}
+            pb={
+              bottomPanel
+                ? 'md'
+                : isDesktopClient
+                  ? 'lg'
+                  : { base: 'calc(var(--vk-mobile-nav-height, 5rem) + 1rem)', md: 'lg' }
+            }
             tabIndex={-1}
             className="desktop-main-content"
           >

--- a/web/src/__tests__/mantine-ui-primitives.test.tsx
+++ b/web/src/__tests__/mantine-ui-primitives.test.tsx
@@ -321,7 +321,7 @@ describe('Mantine-backed shared UI primitives', () => {
       document.querySelector(".veritas-notifications[data-position='bottom-right']")
     ).not.toBeNull();
     expect(globalStyles).toMatch(
-      /\.veritas-notifications\[data-position\^='bottom-'\]\s*\{[^}]*bottom:\s*calc\(5\.5rem \+ env\(safe-area-inset-bottom\)\);/s
+      /\.veritas-notifications\[data-position\^='bottom-'\]\s*\{[^}]*bottom:\s*calc\(var\(--vk-mobile-nav-height, 5rem\) \+ 1rem\);/s
     );
   });
 

--- a/web/src/components/layout/MobileShell.tsx
+++ b/web/src/components/layout/MobileShell.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ActionIcon, Badge, Drawer, Group, Stack } from '@mantine/core';
 import { Bell, Columns3, Files, Home, Settings, Workflow } from 'lucide-react';
 import { NeedsAttentionQueue } from '@/components/dashboard/NeedsAttentionQueue';
@@ -13,9 +13,30 @@ function scrollToBoardColumns() {
 
 export function MobileShell() {
   const [inboxOpen, setInboxOpen] = useState(false);
+  const navigationRef = useRef<HTMLElement>(null);
   const { authContext, hasPermission } = useIdentity();
   const { navigateToTask, setView, view } = useView();
   const clientMode = authContext?.clientMode;
+
+  // Content, chat, and toasts must clear both navigation rows and the device safe area.
+  useEffect(() => {
+    const navigation = navigationRef.current;
+    if (!navigation) return;
+    const root = document.documentElement;
+    const measure = () => {
+      root.style.setProperty(
+        '--vk-mobile-nav-height',
+        `${navigation.getBoundingClientRect().height}px`
+      );
+    };
+    const observer = new ResizeObserver(measure);
+    observer.observe(navigation, { box: 'border-box' });
+    measure();
+    return () => {
+      observer.disconnect();
+      root.style.removeProperty('--vk-mobile-nav-height');
+    };
+  }, []);
 
   const openBoardHome = () => {
     setView('board');
@@ -87,6 +108,7 @@ export function MobileShell() {
   return (
     <>
       <nav
+        ref={navigationRef}
         aria-label="Mobile navigation"
         className="fixed inset-x-0 bottom-0 z-[100] border-t border-border bg-card/95 px-2 pb-[calc(env(safe-area-inset-bottom)+0.35rem)] pt-1.5 shadow-lg backdrop-blur md:hidden"
       >
@@ -97,7 +119,7 @@ export function MobileShell() {
             </Badge>
           </div>
         )}
-        <div className="grid grid-cols-6 gap-1">
+        <div className="grid grid-cols-3 gap-1 sm:grid-cols-6">
           {navItems.map((item) => {
             const Icon = item.icon;
             return (
@@ -109,7 +131,7 @@ export function MobileShell() {
                 disabled={item.disabled}
                 onClick={item.onClick}
                 className={[
-                  'flex min-h-12 min-w-0 flex-col items-center justify-center overflow-hidden rounded-md px-1 text-[11px] leading-tight text-muted-foreground transition-colors',
+                  'flex min-h-12 min-w-0 flex-col items-center justify-center rounded-md px-1 text-sm leading-tight text-muted-foreground transition-colors',
                   item.active
                     ? 'bg-primary/15 text-primary'
                     : 'hover:bg-muted hover:text-foreground',
@@ -117,7 +139,7 @@ export function MobileShell() {
                 ].join(' ')}
               >
                 <Icon className="mb-0.5 h-4 w-4" aria-hidden="true" />
-                <span data-mobile-nav-label className="block w-full truncate text-center">
+                <span data-mobile-nav-label className="block w-full text-center">
                   {'compactLabel' in item ? item.compactLabel : item.label}
                 </span>
               </button>

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -540,7 +540,8 @@ export function TaskWorkView({
           data-state={overview.state}
         >
           <Group justify="space-between" align="flex-start" gap="lg" wrap="wrap">
-            <Stack gap={6} className="min-w-0 flex-1">
+            {/* Wrap the action before it squeezes the summary into a few words per line. */}
+            <Stack gap={6} className="min-w-0" style={{ flex: '1 1 20rem' }}>
               <Group gap="xs" wrap="wrap">
                 <Text size="xs" fw={700} tt="uppercase" c="dimmed">
                   Task state

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -334,12 +334,12 @@
 @media (max-width: 767px) {
   .floating-chat-trigger {
     right: max(1rem, env(safe-area-inset-right));
-    bottom: calc(5.5rem + env(safe-area-inset-bottom));
+    bottom: calc(var(--vk-mobile-nav-height, 5rem) + 1rem);
   }
 
   /* Keep high-z-index toasts from intercepting the fixed mobile navigation. */
   .veritas-notifications[data-position^='bottom-'] {
-    bottom: calc(5.5rem + env(safe-area-inset-bottom));
+    bottom: calc(var(--vk-mobile-nav-height, 5rem) + 1rem);
   }
 }
 


### PR DESCRIPTION
## Summary

Keep all six mobile navigation labels readable by using two rows on narrow phones. The shell measures the navigation border box so page content, floating chat, and bottom toasts clear its actual height, including padding and safe-area changes. Task Overview gives its summary a readable flex basis and wraps the action underneath when space is tight.

The PWA guide describes the behavior. No dependency, font-size restriction, hidden destination, or screenshot-only workaround is added.

Closes #1465. Stacked on #1466 for the viewport correction; the base must pass its outstanding dependency audit before integration.

## Verification

- The original 320px/20px browser reproduction failed with all six labels clipped and the action still beside the squeezed task summary. It passes after the changes.
- Twelve width/text/theme cases passed: 320, 390, and 430px with 16px and 20px root text in light and dark themes. Checks cover complete labels, touch targets, summary width, action reflow, action navigation, and content/chat clearance. All 24 navigation and summary screenshots were visually inspected.
- A resize case passed across narrow/two-row, wide/one-row, enlarged text, and hidden desktop navigation. Review identified padding-only resize as an uncovered edge: the new regression failed with a 35px stale offset, then passed after switching the observer to the border box.
- A separate interaction check passed for Home, Board, Notifications, Runs, Work, and Settings.
- Web typecheck, changed-source ESLint, formatting, diff check, and public documentation checks passed. Playwright compiled and ran the browser spec; it is outside the web ESLint file scope.
- Independent standards and specification reviews have no remaining findings.

## Remaining boundaries

These are isolated development-browser checks using synthetic tasks and the existing E2E authentication helper. They are not packaged macOS, installed-app, native mobile, or release acceptance. Documentation assets remain unchanged pending #1388 and the exact integrated candidate capture. The enlarged-text captures also show that the floating chat trigger can obscure board-card text; that separate placement defect is tracked in #1467 before media acceptance.

## CI readback

Exact-head CI run 33865676075 and Security Gates run 33865678310 passed for `02d5c152d74b23da3650ee6772c654d046653f66`. The blocking production dependency audit returned no known vulnerabilities. The informational all-dependency audit timed out and is not claimed as completed; its existing non-blocking policy allowed the job to remain green. The parent dependency audit and final integration/release gates remain outstanding.

Full integration CI 33868233851 later found an obsolete primitive-test assertion that still required the previous fixed mobile toast offset. The source CSS already uses measured navigation height plus clearance. Commit `5696e038` updates that assertion without changing application behavior or removing toast routing checks. All 12 focused primitive tests, changed-file lint, formatting, diff checks, and both review axes passed. Fresh source-head CI remains pending; the older green runs above do not certify this new head. Browser coverage continues to assert that a visible toast clears the mobile navigation and leaves Notifications operable.

## Current source gate

Retargeted to main after parent #1466 merged. Exact-head CI33869218621 and Security33869220194 now pass for `5696e0383ed295dd77945fda88f8d9166c0b0c66`. Only the failed dependency-audit job was rerun once the advisory service recovered; both production and all-dependency audit logs report no known vulnerabilities. Full integration CI33872008559 and Security33872029435 also pass at `3bb70b4f`; its Linux browser run remains in progress, so this PR is not merged and final mobile acceptance is still pending.
