### PR TITLE
fix: keep mobile chat entry clear of task content

### DIFF
--- a/docs/guides/PWA_INSTALL.md
+++ b/docs/guides/PWA_INSTALL.md
@@ -23,7 +23,7 @@ Chrome shows the install prompt only when the manifest and service worker are re
 
 On narrow screens, use **More views** in the header to reach Activity, Backlog, Archive, and other views. Their separate wide-screen shortcuts are omitted to preserve room for the logo, connection status, and task controls. Dropdown menus remain anchored to their controls without changing the page scale.
 
-The bottom navigation uses two rows on narrow phones so Home, Board, Alerts, Runs, Work, and Settings retain readable labels. Content and floating chat controls leave room for its actual height, including larger text and the device safe area. Task Overview actions move below their summary when the panel is too narrow for a readable side-by-side layout.
+The bottom navigation uses two rows on narrow phones so Home, Board, Alerts, Runs, Work, and Settings retain readable labels. Chat sits beside these destinations in the same reserved area instead of floating over task cards. Content and bottom notifications leave room for that area's actual height, including larger text and the device safe area. Wider browser windows retain the floating chat button. Task Overview actions move below their summary when the panel is too narrow for a readable side-by-side layout.
 
 ## Offline Behavior
 

--- a/e2e/mobile-chat-entry.spec.ts
+++ b/e2e/mobile-chat-entry.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+import { bypassAuth, cleanupRoutes, deleteTask, seedTestTask } from './helpers/auth';
+
+test.use({ viewport: { width: 320, height: 844 }, isMobile: true, hasTouch: true });
+test.beforeEach(async ({ page }) => bypassAuth(page));
+test.afterEach(async ({ page }) => cleanupRoutes(page));
+
+test('mobile chat entry does not cover task content', async ({ page }, testInfo) => {
+  const task = await seedTestTask(page, { title: 'Readable task summary', type: 'code' });
+  try {
+    await page.goto('/');
+    await page.addStyleTag({ content: ':root { font-size: 20px !important; }' });
+    const title = page.getByRole('heading', { name: 'Readable task summary', exact: true });
+    await expect(title).toBeVisible();
+    const trigger = page.getByRole('button', { name: 'Open chat', exact: true });
+    await expect(trigger).toBeVisible();
+    const overlaps = await title.evaluate((el) => {
+      const titleBox = el.getBoundingClientRect();
+      const chatBox = document.querySelector('[aria-label="Open chat"]')!.getBoundingClientRect();
+      return (
+        Math.min(titleBox.right, chatBox.right) > Math.max(titleBox.left, chatBox.left) &&
+        Math.min(titleBox.bottom, chatBox.bottom) > Math.max(titleBox.top, chatBox.top)
+      );
+    });
+    expect(overlaps).toBe(false);
+    const surface = page.locator('[data-mobile-navigation-surface]');
+    for (const top of [0, 180, 450, 800]) {
+      await page.evaluate((y) => window.scrollTo(0, y), top);
+      expect(
+        await trigger.evaluate((el) => {
+          const rect = el.getBoundingClientRect();
+          const bar = el.closest('[data-mobile-navigation-surface]')!.getBoundingClientRect();
+          return (
+            rect.top >= bar.top &&
+            rect.bottom <= bar.bottom &&
+            rect.right <= innerWidth &&
+            rect.width >= 44 &&
+            rect.height >= 44 &&
+            el.contains(
+              document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2)
+            )
+          );
+        })
+      ).toBe(true);
+    }
+    const status = page.getByRole('combobox', {
+      name: 'Change status for Readable task summary',
+      exact: true,
+    });
+    await status.evaluate((el) => {
+      const bar = document
+        .querySelector('[data-mobile-navigation-surface]')!
+        .getBoundingClientRect();
+      window.scrollBy(0, el.getBoundingClientRect().bottom - bar.top + 16);
+    });
+    expect((await status.boundingBox())!.y + (await status.boundingBox())!.height).toBeLessThan(
+      (await surface.boundingBox())!.y
+    );
+    await status.click();
+    await expect(page.getByRole('option', { name: 'Blocked', exact: true })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await testInfo.attach('mobile-chat-entry', {
+      body: await page.screenshot(),
+      contentType: 'image/png',
+    });
+    await trigger.click();
+    const composer = page.getByRole('textbox', { name: 'Message Board Chat', exact: true });
+    await expect(composer).toBeVisible();
+    await composer.fill('Unsent mobile draft');
+    await testInfo.attach('mobile-chat-open', {
+      body: await page.screenshot(),
+      contentType: 'image/png',
+    });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await expect(composer).toHaveValue('Unsent mobile draft');
+    await page.getByRole('button', { name: 'Close Board Chat panel', exact: true }).click();
+    await expect(composer).not.toBeVisible();
+    await expect(trigger).toBeVisible();
+    expect(await trigger.evaluate((el) => getComputedStyle(el).position)).toBe('fixed');
+    await page.setViewportSize({ width: 320, height: 844 });
+    await trigger.click();
+    await expect(composer).toHaveValue('Unsent mobile draft');
+    await page.getByRole('button', { name: 'Close Board Chat panel', exact: true }).click();
+  } finally {
+    await deleteTask(page, task.id as string);
+  }
+});
+
+test.describe('wide browser chat entry', () => {
+  test.use({ viewport: { width: 1440, height: 900 }, isMobile: false, hasTouch: false });
+  test('retains the floating chat control without mobile navigation', async ({ page }) => {
+    await page.goto('/');
+    const trigger = page.getByRole('button', { name: 'Open chat', exact: true });
+    await expect(trigger).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Mobile navigation' })).not.toBeVisible();
+    expect(await trigger.evaluate((el) => getComputedStyle(el).position)).toBe('fixed');
+    await trigger.click();
+    await expect(
+      page.getByRole('textbox', { name: 'Message Board Chat', exact: true })
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Close Board Chat panel', exact: true }).click();
+    await expect(trigger).toBeVisible();
+  });
+});

--- a/e2e/mobile-readable.spec.ts
+++ b/e2e/mobile-readable.spec.ts
@@ -37,16 +37,16 @@ async function assertNavigationFits(page: Page) {
   }
   await expect
     .poll(async () => {
-      const nav = await navigation.boundingBox();
+      const nav = await page.locator('[data-mobile-navigation-surface]').boundingBox();
       const chat = await page.getByRole('button', { name: 'Open chat', exact: true }).boundingBox();
-      return !!nav && !!chat && chat.y + chat.height < nav.y;
+      return !!nav && !!chat && chat.y >= nav.y && chat.y + chat.height <= nav.y + nav.height;
     })
     .toBe(true);
   expect(
     await page
       .locator('#main-content')
       .evaluate((el) => parseFloat(getComputedStyle(el).paddingBottom))
-  ).toBeGreaterThan((await navigation.boundingBox())!.height);
+  ).toBeGreaterThan((await page.locator('[data-mobile-navigation-surface]').boundingBox())!.height);
 }
 
 for (const width of [320, 390, 430]) {
@@ -113,12 +113,13 @@ test('navigation height follows window and text resizing', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('#mobile-board-columns')).toBeVisible();
   const navigation = page.getByRole('navigation', { name: 'Mobile navigation' });
+  const surface = page.locator('[data-mobile-navigation-surface]');
   for (const width of [320, 680, 390]) {
     await page.setViewportSize({ width, height: 844 });
     await assertNavigationFits(page);
     await expect
       .poll(async () => {
-        const height = (await navigation.boundingBox())!.height;
+        const height = (await surface.boundingBox())!.height;
         const reserved = await page.evaluate(() =>
           parseFloat(document.documentElement.style.getPropertyValue('--vk-mobile-nav-height'))
         );
@@ -129,12 +130,12 @@ test('navigation height follows window and text resizing', async ({ page }) => {
   await page.addStyleTag({ content: ':root { font-size: 20px !important; }' });
   await assertNavigationFits(page);
   // Safe-area changes can alter padding without changing the content box.
-  await navigation.evaluate((el) => {
+  await surface.evaluate((el) => {
     el.style.paddingBottom = '42px';
   });
   await expect
     .poll(async () => {
-      const height = (await navigation.boundingBox())!.height;
+      const height = (await surface.boundingBox())!.height;
       const reserved = await page.evaluate(() =>
         parseFloat(document.documentElement.style.getPropertyValue('--vk-mobile-nav-height'))
       );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,12 +43,6 @@ const UiVocabularyGallery = lazy(() =>
   }))
 );
 
-const FloatingChat = lazy(() =>
-  import('./components/chat/FloatingChat').then((mod) => ({
-    default: mod.FloatingChat,
-  }))
-);
-
 const DesktopOnboardingDialog = lazy(() =>
   import('./components/auth/DesktopOnboarding').then((mod) => ({
     default: mod.DesktopOnboardingDialog,
@@ -175,12 +169,9 @@ function DesktopAwareAppShell({
       </div>
       <Toaster />
       <CommandPalette />
-      {!isDesktopClient && !bottomPanel && (
-        <Suspense fallback={null}>
-          <FloatingChat />
-        </Suspense>
-      )}
-      <Suspense fallback={null}>{!isDesktopClient && <MobileShell />}</Suspense>
+      <Suspense fallback={null}>
+        {!isDesktopClient && <MobileShell showChat={!bottomPanel} />}
+      </Suspense>
       {showDesktopOnboarding && (
         <Suspense fallback={null}>
           <DesktopOnboardingDialog

--- a/web/src/__tests__/activity-chat-mantine.test.tsx
+++ b/web/src/__tests__/activity-chat-mantine.test.tsx
@@ -272,7 +272,9 @@ describe('activity and chat Mantine migration', () => {
     expect(await screen.findByText('Board Chat')).toBeDefined();
     expect(screen.getByText('Ready to help with the board.')).toBeDefined();
     const chatTrigger = screen.getByLabelText('Open chat');
-    expect(chatTrigger.style.position).toBe('fixed');
+    // Responsive CSS owns placement; inline fixed positioning would override mobile navigation.
+    expect(chatTrigger.style.position).toBe('');
+    expect(chatTrigger.textContent).toContain('Chat');
     expect(chatTrigger.className).toContain('floating-chat-trigger');
     expect(baseElement.querySelector('[data-overlay-variant="chat"]')).not.toBeNull();
     expect(baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();

--- a/web/src/components/chat/FloatingChat.tsx
+++ b/web/src/components/chat/FloatingChat.tsx
@@ -11,7 +11,7 @@ const ChatPanel = lazy(() =>
 );
 
 /**
- * Floating chat bubble — bottom-right corner.
+ * Board chat entry: mobile navigation control, floating bubble on wider screens.
  * Opens a board-level ChatPanel (no taskId).
  * Pulses when a new response arrives while closed.
  */
@@ -54,7 +54,7 @@ export function FloatingChat() {
         size={56}
         radius="xl"
         variant="filled"
-        style={{ position: 'fixed' }}
+        classNames={{ icon: 'floating-chat-icon' }}
         className={cn(
           'floating-chat-trigger z-40 h-14 w-14 rounded-full shadow-lg',
           'bg-primary hover:bg-primary/90 text-primary-foreground',
@@ -64,6 +64,7 @@ export function FloatingChat() {
         aria-label="Open chat"
       >
         <MessageSquare className="h-6 w-6" />
+        <span className="text-sm md:hidden">Chat</span>
         {hasUnread && (
           <span className="absolute -top-1 -right-1 flex h-4 w-4" aria-hidden="true">
             <span className="inline-flex h-4 w-4 rounded-full bg-emerald-500" />

--- a/web/src/components/layout/MobileShell.tsx
+++ b/web/src/components/layout/MobileShell.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ActionIcon, Badge, Drawer, Group, Stack } from '@mantine/core';
 import { Bell, Columns3, Files, Home, Settings, Workflow } from 'lucide-react';
 import { NeedsAttentionQueue } from '@/components/dashboard/NeedsAttentionQueue';
+import { FloatingChat } from '@/components/chat/FloatingChat';
 import { useIdentity } from '@/hooks/useIdentity';
 import { useView } from '@/contexts/ViewContext';
 
@@ -11,9 +12,9 @@ function scrollToBoardColumns() {
   }, 0);
 }
 
-export function MobileShell() {
+export function MobileShell({ showChat = true }: { showChat?: boolean }) {
   const [inboxOpen, setInboxOpen] = useState(false);
-  const navigationRef = useRef<HTMLElement>(null);
+  const navigationRef = useRef<HTMLDivElement>(null);
   const { authContext, hasPermission } = useIdentity();
   const { navigateToTask, setView, view } = useView();
   const clientMode = authContext?.clientMode;
@@ -107,46 +108,49 @@ export function MobileShell() {
 
   return (
     <>
-      <nav
+      <div
         ref={navigationRef}
-        aria-label="Mobile navigation"
-        className="fixed inset-x-0 bottom-0 z-[100] border-t border-border bg-card/95 px-2 pb-[calc(env(safe-area-inset-bottom)+0.35rem)] pt-1.5 shadow-lg backdrop-blur md:hidden"
+        data-mobile-navigation-surface
+        className="mobile-navigation-surface fixed inset-x-0 bottom-0 z-[100] flex items-stretch gap-1 border-t border-border bg-card/95 px-2 pb-[calc(env(safe-area-inset-bottom)+0.35rem)] pt-1.5 shadow-lg backdrop-blur md:contents"
       >
-        {clientMode && (
-          <div className="mb-1 flex justify-center">
-            <Badge size="xs" variant="light" color="gray">
-              {clientMode}
-            </Badge>
+        <nav aria-label="Mobile navigation" className="min-w-0 flex-1 md:hidden">
+          {clientMode && (
+            <div className="mb-1 flex justify-center">
+              <Badge size="xs" variant="light" color="gray">
+                {clientMode}
+              </Badge>
+            </div>
+          )}
+          <div className="grid grid-cols-3 gap-1 sm:grid-cols-6">
+            {navItems.map((item) => {
+              const Icon = item.icon;
+              return (
+                <button
+                  key={item.label}
+                  type="button"
+                  aria-label={`Mobile ${item.label.toLowerCase()}`}
+                  aria-current={item.active ? 'page' : undefined}
+                  disabled={item.disabled}
+                  onClick={item.onClick}
+                  className={[
+                    'flex min-h-12 min-w-0 flex-col items-center justify-center rounded-md px-1 text-sm leading-tight text-muted-foreground transition-colors',
+                    item.active
+                      ? 'bg-primary/15 text-primary'
+                      : 'hover:bg-muted hover:text-foreground',
+                    item.disabled ? 'cursor-not-allowed opacity-40' : '',
+                  ].join(' ')}
+                >
+                  <Icon className="mb-0.5 h-4 w-4" aria-hidden="true" />
+                  <span data-mobile-nav-label className="block w-full text-center">
+                    {'compactLabel' in item ? item.compactLabel : item.label}
+                  </span>
+                </button>
+              );
+            })}
           </div>
-        )}
-        <div className="grid grid-cols-3 gap-1 sm:grid-cols-6">
-          {navItems.map((item) => {
-            const Icon = item.icon;
-            return (
-              <button
-                key={item.label}
-                type="button"
-                aria-label={`Mobile ${item.label.toLowerCase()}`}
-                aria-current={item.active ? 'page' : undefined}
-                disabled={item.disabled}
-                onClick={item.onClick}
-                className={[
-                  'flex min-h-12 min-w-0 flex-col items-center justify-center rounded-md px-1 text-sm leading-tight text-muted-foreground transition-colors',
-                  item.active
-                    ? 'bg-primary/15 text-primary'
-                    : 'hover:bg-muted hover:text-foreground',
-                  item.disabled ? 'cursor-not-allowed opacity-40' : '',
-                ].join(' ')}
-              >
-                <Icon className="mb-0.5 h-4 w-4" aria-hidden="true" />
-                <span data-mobile-nav-label className="block w-full text-center">
-                  {'compactLabel' in item ? item.compactLabel : item.label}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      </nav>
+        </nav>
+        {showChat && <FloatingChat />}
+      </div>
 
       <Drawer
         opened={inboxOpen}

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -307,6 +307,7 @@
 
 /* Mantine's unlayered ActionIcon position wins over Tailwind utilities. */
 .floating-chat-trigger {
+  position: fixed;
   right: 1.5rem;
   bottom: 1.5rem;
 }
@@ -332,9 +333,22 @@
 }
 
 @media (max-width: 767px) {
-  .floating-chat-trigger {
-    right: max(1rem, env(safe-area-inset-right));
-    bottom: calc(var(--vk-mobile-nav-height, 5rem) + 1rem);
+  .mobile-navigation-surface .floating-chat-trigger {
+    position: relative;
+    inset: auto;
+    flex: 0 0 2.75rem;
+    min-width: 44px;
+    width: 2.75rem;
+    min-height: max(44px, 3rem);
+    height: auto;
+    align-self: center;
+    border-radius: 0.375rem;
+    box-shadow: none;
+  }
+
+  .mobile-navigation-surface .floating-chat-icon {
+    flex-direction: column;
+    gap: 0.25rem;
   }
 
   /* Keep high-z-index toasts from intercepting the fixed mobile navigation. */


### PR DESCRIPTION
## Summary

Move the mobile Chat entry into the reserved bottom navigation area so it no longer floats over task titles or status controls. Keep all six navigation destinations, readable labels, touch targets, and safe-area clearance. Wider browser windows retain the floating Chat button, and resizing preserves an unsent draft through the same chat instance.

Closes #1467. Stacked on #1468. The PWA guide describes the updated behavior. No dependency or lockfile changes.

## Verification

The new overlap regression failed before the fix. The final focused browser run passed all 16 cases across the chat-entry and mobile-readable suites. Coverage includes 320/390/430px widths, normal/enlarged text, both themes, scrolling and status-menu access, navigation destinations, border-box padding changes, and narrow/wide draft retention. Representative narrow-screen captures were visually inspected.

Shared build, web typecheck, changed-source lint, formatting, public-documentation validation, and diff checks passed. Independent specification and standards reviews reported no actionable findings.

## Remaining

This is browser evidence, not native macOS acceptance or refreshed maintained documentation media. CI run 33866696203 passed the production dependency audit but failed an obsolete component assertion requiring inline fixed positioning. Commit 829fa865 corrects that assertion: responsive CSS owns placement, and the component must not override it inline. The four-test component slice, lint, formatting, and both source reviews pass. Security Gates run 33866698769 passed on the preceding head; new-head CI and security checks remain pending. The combined candidate, complete integration gates, maintained screenshot/GIF refresh, installed app, version bump, and release remain unfinished.
