### PR TITLE
fix: reject native evidence with late HTTP failures

### DIFF
--- a/docs/audits/NATIVE-UI-CONFORMANCE-1387.md
+++ b/docs/audits/NATIVE-UI-CONFORMANCE-1387.md
@@ -14,6 +14,8 @@ The report hashes the entire bundle, including server/web resources and framewor
 
 Primary routes also record heading, Back, header, and content rectangles. Checks enforce the shared typography, icon-only Back sizing/placement, route-title semantics, and cross-route alignment. Overlay parts record their actual computed padding against the shared rem-based inset contract, including intentionally unpadded compound/task containers. The runner's final status includes structural verification; an unexpected viewport or invalid recorded layout cannot remain a passing run merely because its clicks succeeded.
 
+Final verification also examines the complete recorded HTTP-failure ledger after the app closes. A recorded rate limit (429) or server error (5xx) rejects the run even if every scenario had already passed. Seeded-renderer checks and teardown have their own active-state labels. Missing or malformed HTTP evidence fails closed; an optional chat session returning 404 is not treated as a server failure. Shutdown errors must be fixed, not discarded to obtain a passing report.
+
 After the normal matrix, the disposable renderer receives six deliberately injected faults: blank shell space, a clipped modal, a shifted heading, a board-only rail control on Activity, wrong popout padding, and a visible New Task button with its handler removed. Each fault must be detected by the corresponding geometry or behavioral assertion, retains a native screenshot, and is removed by reloading before the next fault. These expected-failure probes are separate from the ordinary matrix and cannot waive an ordinary failed state. Missing fault probes fail verification.
 
 ## Development checkpoint

--- a/scripts/native-ui/contract.mjs
+++ b/scripts/native-ui/contract.mjs
@@ -228,6 +228,27 @@ export function evidenceFailures(report, expected, now = Date.now()) {
   const errors = [];
   if (report?.schema !== schema) return ['unknown or missing native evidence schema'];
   if (report.status !== 'passed') errors.push('native run did not pass');
+  // Responses can arrive after a scenario's completion check, including while
+  // the app closes. Validate the final ledger, not only the per-state verdicts.
+  if (
+    !Array.isArray(report.httpFailures) ||
+    report.httpFailures.some(
+      (failure) =>
+        !Number.isInteger(failure?.status) ||
+        failure.status < 400 ||
+        failure.status > 599 ||
+        ![failure.state, failure.method, failure.path].every(
+          (value) => typeof value === 'string' && value.length > 0
+        )
+    )
+  ) {
+    errors.push('missing or malformed native HTTP evidence');
+  } else {
+    for (const failure of report.httpFailures) {
+      if (failure.status === 429 || failure.status >= 500)
+        errors.push(`${failure.state}: HTTP ${failure.status} ${failure.method} ${failure.path}`);
+    }
+  }
   if (
     report.boundary !== 'packaged-macos' ||
     report.identity?.packaged !== true ||

--- a/scripts/native-ui/contract.test.mjs
+++ b/scripts/native-ui/contract.test.mjs
@@ -45,6 +45,7 @@ function report() {
     packageDigest: digest,
     version: '6.1.6',
     dirty: false,
+    httpFailures: [],
     identity: {
       packaged: true,
       platform: 'darwin',
@@ -176,6 +177,35 @@ const failures = (value) =>
   evidenceFailures(value, { commit, packageDigest: digest, version: '6.1.6' }, now);
 test('complete candidate-bound matrix is accepted by the structural validator', () =>
   assert.deepEqual(failures(report()), []));
+test('late rate limits and server failures reject otherwise passing native evidence', () => {
+  for (const status of [429, 500, 503]) {
+    for (const state of ['startup', 'light-normal/board', 'seed/dead-header', 'teardown']) {
+      const r = report();
+      r.httpFailures.push({ state, path: '/api/tasks', method: 'GET', status });
+      assert(
+        failures(r).includes(`${state}: HTTP ${status} GET /api/tasks`),
+        `accepted late HTTP ${status} in ${state}`
+      );
+    }
+  }
+});
+test('missing or malformed HTTP evidence fails closed', () => {
+  for (const httpFailures of [undefined, null, {}, [{ status: '500' }]]) {
+    const r = report();
+    r.httpFailures = httpFailures;
+    assert(failures(r).includes('missing or malformed native HTTP evidence'));
+  }
+});
+test('a missing optional chat session is not a server failure', () => {
+  const r = report();
+  r.httpFailures.push({
+    state: 'light-normal/task-chat',
+    path: '/api/chat/sessions/task_fixture',
+    method: 'GET',
+    status: 404,
+  });
+  assert.deepEqual(failures(r), []);
+});
 test('partial, duplicate and failed matrices cannot pass', () => {
   for (const mutate of [
     (r) => r.entries.pop(),

--- a/scripts/native-ui/run.mjs
+++ b/scripts/native-ui/run.mjs
@@ -50,6 +50,7 @@ const report = {
   packageDigest: await packageDigest(packagePath),
   startedAt: new Date().toISOString(),
   entries: [],
+  httpFailures: [],
 };
 const persist = () =>
   writeFile(path.join(output, 'evidence.json'), JSON.stringify(report, null, 2) + '\n');
@@ -59,15 +60,15 @@ const { origin } = session;
 let app;
 let page;
 let fixtureTask;
+let activeState = 'startup';
 async function launch() {
   const launched = await session.launch();
   ({ app, page } = launched);
   report.identity = launched.identity;
   page.on('response', (response) => {
     if (response.status() >= 400) {
-      report.httpFailures ??= [];
       report.httpFailures.push({
-        state: report.entries.at(-1)?.id ?? 'startup',
+        state: activeState,
         path: new URL(response.url()).pathname,
         method: response.request().method(),
         status: response.status(),
@@ -544,6 +545,7 @@ async function checkSeededRendererFailures() {
   report.seededFailures = [];
   for (const [id, expectedFailure] of seededCases) {
     const entry = { id: `seed/${id}`, status: 'running' };
+    activeState = entry.id;
     report.seededFailures.push(entry);
     try {
       await configure(modes[0]);
@@ -650,6 +652,7 @@ try {
   for (const mode of modes) {
     for (const state of states) {
       const entry = { id: `${mode.id}/${state}`, status: 'running' };
+      activeState = entry.id;
       report.entries.push(entry);
       let captured = false;
       try {
@@ -715,6 +718,7 @@ try {
   report.status = 'failed';
   report.error = error.message;
 } finally {
+  activeState = 'teardown';
   if (app) await app.close();
   report.completedAt = new Date().toISOString();
   report.validationErrors = evidenceFailures(report, {


### PR DESCRIPTION
## Summary

Reject final native UI evidence containing recorded HTTP 429 or 5xx responses, including those arriving after scenario completion or during teardown. The runner now initializes a required HTTP ledger and labels seeded checks and teardown explicitly. Missing or malformed ledgers fail closed; optional-chat 404 responses remain allowed.

Fixes #1471. Stacked on the integration candidate #1470. This fixes a false-positive acceptance gate, not the shutdown failure that exposed it.

## Verification

- The new regression tests failed against the original validator, then all 16 native contract tests passed after the fix.
- All seven release-validator integration tests passed; runner syntax, formatting, and diff checks passed.
- Replayed the unmodified b558a80f candidate report: the strengthened validator rejects its four recorded GET /api/tasks HTTP 500 responses even though all 144 scenario entries say passed. No evidence was rewritten or relabeled.
- Specification and standards review found no actionable issues.

## Remaining

The server shutdown behavior still needs diagnosis and correction, followed by a clean packaged-candidate native run. This PR does not claim native acceptance, installation, signing, documentation-media acceptance, or release publication. Older evidence without an explicit HTTP ledger is intentionally rejected.
