### PR TITLE
fix: drain HTTP before disposing server storage

### DIFF
--- a/docs/architecture/SERVER-SHUTDOWN.md
+++ b/docs/architecture/SERVER-SHUTDOWN.md
@@ -1,0 +1,13 @@
+# Server shutdown
+
+SIGTERM, SIGINT, and fatal-error shutdown share one drain operation. The HTTP listener stops accepting connections first. Already-connected requests finish while their services and storage remain available. WebSocket clients receive a close frame; peers that do not acknowledge within three seconds are terminated.
+
+Only after HTTP and WebSocket closure does the server stop service workers, close tool sessions, flush telemetry and registry writes, and dispose storage. Failures are fatal, not successful shutdowns. One ten-second deadline bounds the complete operation. An expired drain must not proceed into service disposal, and repeated signals must not start another disposal pass. Fatal-error shutdown retains a nonzero exit status.
+
+The focused regression uses a real HTTP server and partial request headers to hold a connected request across shutdown. The native diagnostic repeats this against an authenticated packaged server and quits/relaunches an isolated synthetic profile:
+
+```sh
+node scripts/native-ui/shutdown.mjs --app /absolute/path/veritas-kanban.app --commit <packaged-sha> --version <version> --output /absolute/path/shutdown.json
+```
+
+The diagnostic requires successful task responses and clean server exits. It neither touches the operator profile nor replaces complete native conformance, artifact-integrity, release, or installed-app verification.

--- a/scripts/native-ui/shutdown.mjs
+++ b/scripts/native-ui/shutdown.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { readFile, writeFile } from 'node:fs/promises';
+import net from 'node:net';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { parseArgs } from 'node:util';
+import { createNativeSession } from './session.mjs';
+
+const { values } = parseArgs({
+  options: {
+    app: { type: 'string' },
+    commit: { type: 'string' },
+    version: { type: 'string' },
+    output: { type: 'string' },
+  },
+});
+for (const key of ['app', 'commit', 'version', 'output'])
+  assert(values[key], `--${key} is required`);
+const session = await createNativeSession({
+  packagePath: values.app,
+  commit: values.commit,
+  version: values.version,
+});
+const report = {
+  commit: values.commit,
+  version: values.version,
+  profile: session.profile,
+  status: 'running',
+  cycles: [],
+};
+try {
+  // Reuse only this synthetic profile to exercise quit and subsequent relaunch.
+  for (let cycle = 0; cycle < 2; cycle += 1) {
+    const { app, page } = await session.launch();
+    let socket;
+    let closing;
+    const result = { cycle, httpFailures: [] };
+    report.cycles.push(result);
+    page.on('response', (response) => {
+      if (response.status() >= 500)
+        result.httpFailures.push({
+          status: response.status(),
+          path: new URL(response.url()).pathname,
+        });
+    });
+    try {
+      assert.equal(await page.evaluate(async () => (await fetch('/api/tasks')).status), 200);
+      // Electron uses its own session partition; browser-context cookies are
+      // not authoritative here. Keep this synthetic credential in memory only.
+      const cookies = await app.evaluate(
+        async ({ BrowserWindow }, origin) =>
+          BrowserWindow.getAllWindows()[0].webContents.session.cookies.get({ url: origin }),
+        session.origin
+      );
+      assert(
+        cookies.some((cookie) => cookie.name === 'veritas_session'),
+        'Missing isolated login'
+      );
+      const cookie = cookies.map((item) => `${item.name}=${item.value}`).join('; ');
+      socket = net.connect(Number(new URL(session.origin).port), '127.0.0.1');
+      await once(socket, 'connect');
+      const chunks = [];
+      socket.on('data', (chunk) => chunks.push(chunk));
+      const ended = once(socket, 'end');
+      void ended.catch(() => {}); // Awaited below; handle early socket errors too.
+      socket.setTimeout(15_000, () => socket.destroy(new Error('Diagnostic request timed out')));
+      socket.write(
+        `GET /api/tasks HTTP/1.1\r\nHost: ${new URL(session.origin).host}\r\nCookie: ${cookie}\r\nConnection: close\r\n`
+      );
+      await delay(100);
+      const started = Date.now();
+      closing = app.close();
+      void closing.catch(() => {});
+      await delay(100);
+      socket.write('\r\n');
+      await ended;
+      await closing;
+      result.elapsedMs = Date.now() - started;
+      result.statusLine = Buffer.concat(chunks).toString().split('\r\n')[0];
+      assert.match(
+        result.statusLine,
+        /^HTTP\/1.1 200 /,
+        'Connected task request outlived its storage'
+      );
+      assert.deepEqual(result.httpFailures, []);
+    } finally {
+      socket?.destroy();
+      await (closing ?? app.close());
+    }
+  }
+  const log = await readFile(
+    path.join(session.profile, 'profiles/native-ui-conformance/workspaces/local/logs/server.log'),
+    'utf8'
+  );
+  assert(
+    !/Forced shutdown|Graceful shutdown failed|Unhandled error/.test(log),
+    'Server shutdown logged a failure'
+  );
+  assert.equal(
+    (log.match(/\[desktop\] exited code=0 signal=null/g) ?? []).length,
+    2,
+    'Both server exits must be clean'
+  );
+  report.status = 'passed';
+} catch (error) {
+  report.status = 'failed';
+  report.error = error.message;
+} finally {
+  await writeFile(values.output, `${JSON.stringify(report, null, 2)}\n`);
+}
+console.log(`Native shutdown ${report.status}: ${values.output}`);
+process.exitCode = report.status === 'passed' ? 0 : 1;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -85,6 +85,7 @@ import {
 } from './services/websocket-permissions.js';
 import { closeWebSocketSafely } from './utils/websocket-close.js';
 import { startAfterInitialization } from './utils/startup-gate.js';
+import { createServerShutdown } from './utils/server-shutdown.js';
 import { getCommunicationAdapterService } from './services/communication-adapter-service.js';
 import { getRunEventJournalService } from './services/run-event-journal-service.js';
 import { getToolControlPlaneService } from './services/tool-control-plane-service.js';
@@ -95,6 +96,7 @@ import { createAgentProgressWatchdogActionExecutor } from './services/progress-w
 
 const log = createLogger('server');
 let progressWatchdogCoordinator: ProgressWatchdogCoordinatorService | undefined;
+let shutdownServer: (() => Promise<void>) | undefined;
 
 // ============================================
 // Process Error Handlers (register early)
@@ -1218,11 +1220,8 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
 // Export for use in other modules
 export { wss, chatSubscriptions };
 
-// Graceful shutdown handler
-async function gracefulShutdown(signal: string) {
-  log.info({ signal }, 'Shutting down gracefully');
-
-  // 1. Stop heartbeat interval and close WebSocket connections
+async function closeServerWebSockets(): Promise<void> {
+  // Stop recurring admission and heartbeat work while HTTP drains.
   clearInterval(heartbeatInterval);
   if (credentialReconciliationInterval) {
     clearInterval(credentialReconciliationInterval);
@@ -1242,27 +1241,30 @@ async function gracefulShutdown(signal: string) {
     closeWebSocketSafely(client, 1001, 'Server going away');
   });
 
-  // Close the WebSocket server itself (stop accepting new connections)
-  // Timeout: if clients don't close within 3s, continue shutdown
-  await Promise.race([
-    new Promise<void>((resolve) => {
-      wss.close((err) => {
-        if (err) log.error({ err }, 'Error closing WebSocket server');
-        else log.info('WebSocket server closed');
-        resolve();
-      });
-    }),
-    new Promise<void>((resolve) =>
-      setTimeout(() => {
-        log.warn('WebSocket server close timed out after 3s — continuing shutdown');
-        resolve();
-      }, 3000)
-    ),
-  ]);
-
-  // 2. Dispose services (release file watchers, flush buffers)
+  // Upgraded sockets are not drained by HTTP close. Give peers time to
+  // acknowledge, then terminate only those remaining upgraded sockets.
+  const timeout = setTimeout(() => {
+    log.warn('Terminating WebSocket clients still open during shutdown');
+    wss.clients.forEach((client) => client.terminate());
+  }, 3000);
   try {
-    log.info('Disposing services');
+    await new Promise<void>((resolve, reject) => {
+      wss.close((err) => {
+        if (err) reject(err);
+        else {
+          log.info('WebSocket server closed');
+          resolve();
+        }
+      });
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function disposeServerServices(): Promise<void> {
+  try {
+    log.info('HTTP server closed; disposing services');
 
     stopScheduledDeliverablesRunner();
     log.info('Scheduled deliverables runner stopped');
@@ -1275,27 +1277,12 @@ async function gracefulShutdown(signal: string) {
     await getCommunicationAdapterService().shutdown();
     log.info('Communication adapter workers stopped');
 
-    await Promise.race([
-      getToolControlPlaneService().closeAll(),
-      new Promise<void>((resolve) =>
-        setTimeout(() => {
-          log.warn('Tool control-plane shutdown timed out after 3s');
-          resolve();
-        }, 3000)
-      ),
-    ]);
+    await getToolControlPlaneService().closeAll();
     log.info('Tool control-plane sessions stopped');
 
-    // Flush pending telemetry writes (timeout: 5s)
-    await Promise.race([
-      getTelemetryService().flush(),
-      new Promise<void>((resolve) =>
-        setTimeout(() => {
-          log.warn('Telemetry flush timed out after 5s — continuing shutdown');
-          resolve();
-        }, 5000)
-      ),
-    ]);
+    // The shared shutdown deadline bounds this flush. Never dispose storage
+    // while it or tool shutdown is still pending.
+    await getTelemetryService().flush();
     log.info('Telemetry flushed');
 
     // Dispose task service (closes file watchers, clears cache)
@@ -1320,19 +1307,29 @@ async function gracefulShutdown(signal: string) {
     }
   } catch (err) {
     log.error({ err }, 'Error during service disposal');
+    throw err;
   }
+}
 
-  // 3. Close HTTP server last
-  server.close(() => {
-    log.info('HTTP server closed');
-    process.exit(0);
-  });
-
-  // Force exit after 10 seconds
-  setTimeout(() => {
-    log.fatal('Forced shutdown after timeout');
-    process.exit(1);
-  }, 10000);
+async function gracefulShutdown(signal: string): Promise<void> {
+  if (!shutdownServer) {
+    log.info({ signal }, 'Shutting down gracefully');
+    shutdownServer = createServerShutdown({
+      server,
+      closeWebSockets: closeServerWebSockets,
+      disposeServices: disposeServerServices,
+    });
+  }
+  if (signal === 'uncaughtException' || signal === 'unhandledRejection') process.exitCode = 1;
+  return shutdownServer().then(
+    () => {
+      process.exit(process.exitCode ? 1 : 0);
+    },
+    (err) => {
+      log.fatal({ err }, 'Graceful shutdown failed');
+      process.exit(1);
+    }
+  );
 }
 
 // Register shutdown handlers

--- a/server/src/utils/server-shutdown.test.ts
+++ b/server/src/utils/server-shutdown.test.ts
@@ -1,0 +1,134 @@
+import { createServer } from 'node:http';
+import { connect } from 'node:net';
+import { once } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { createServerShutdown } from './server-shutdown.js';
+
+describe('server shutdown', () => {
+  it('finishes an already-connected request before disposing its storage', async () => {
+    let disposed = false;
+    const server = createServer((_req, res) => {
+      res.writeHead(disposed ? 500 : 200);
+      res.end(disposed ? 'storage disposed' : 'task response');
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing test port');
+    const accepted = once(server, 'connection');
+    const socket = connect(address.port, '127.0.0.1');
+    const connected = once(socket, 'connect');
+    const [acceptedSocket] = await accepted;
+    await connected;
+    const chunks: Buffer[] = [];
+    socket.on('data', (chunk) => chunks.push(chunk));
+    const ended = once(socket, 'end');
+    const received = once(acceptedSocket, 'data');
+    socket.write('GET /tasks HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n');
+    await received;
+    let finishWebSockets!: () => void;
+    const websockets = new Promise<void>((resolve) => {
+      finishWebSockets = resolve;
+    });
+    const disposeServices = vi.fn(async () => {
+      disposed = true;
+    });
+    const shutdown = createServerShutdown({
+      server,
+      closeWebSockets: () => websockets,
+      disposeServices,
+    });
+    try {
+      const first = shutdown();
+      expect(shutdown()).toBe(first);
+      finishWebSockets();
+      // Release the remaining headers after shutdown has started. No timer race.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      socket.write('\r\n');
+      await ended;
+      await first;
+      expect(Buffer.concat(chunks).toString()).toMatch(/^HTTP\/1.1 200 /);
+      expect(disposeServices).toHaveBeenCalledTimes(1);
+    } finally {
+      socket.destroy();
+      server.closeAllConnections();
+      server.close();
+    }
+  });
+
+  it('bounds a stalled drain without disposing resources if it eventually completes', async () => {
+    vi.useFakeTimers();
+    let release!: () => void;
+    const closeWebSockets = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        })
+    );
+    const disposeServices = vi.fn(async () => {});
+    const shutdown = createServerShutdown({
+      server: createServer(),
+      closeWebSockets,
+      disposeServices,
+      timeoutMs: 20,
+    });
+    try {
+      const pending = shutdown();
+      const rejected = expect(pending).rejects.toThrow('deadline exceeded');
+      await vi.advanceTimersByTimeAsync(20);
+      await rejected;
+      release();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(shutdown()).toBe(pending);
+      expect(closeWebSockets).toHaveBeenCalledTimes(1);
+      expect(disposeServices).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('propagates disposal failures and cancels the deadline', async () => {
+    vi.useFakeTimers();
+    const failure = new Error('registry flush failed');
+    const disposeServices = vi.fn(async () => {
+      throw failure;
+    });
+    const shutdown = createServerShutdown({
+      server: createServer(),
+      closeWebSockets: async () => {},
+      disposeServices,
+    });
+    try {
+      const result = expect(shutdown()).rejects.toBe(failure);
+      await vi.advanceTimersByTimeAsync(0);
+      await result;
+      expect(vi.getTimerCount()).toBe(0);
+      expect(disposeServices).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('also bounds disposal that never finishes', async () => {
+    vi.useFakeTimers();
+    const disposeServices = vi.fn(() => new Promise<void>(() => {}));
+    const shutdown = createServerShutdown({
+      server: createServer(),
+      closeWebSockets: async () => {},
+      disposeServices,
+      timeoutMs: 20,
+    });
+    try {
+      const pending = shutdown();
+      const rejected = expect(pending).rejects.toThrow('deadline exceeded');
+      await vi.advanceTimersByTimeAsync(20);
+      await rejected;
+      expect(disposeServices).toHaveBeenCalledTimes(1);
+      expect(shutdown()).toBe(pending);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/server/src/utils/server-shutdown.ts
+++ b/server/src/utils/server-shutdown.ts
@@ -1,0 +1,45 @@
+import type { Server } from 'node:http';
+
+/** One shutdown owns the listener drain and dependent service disposal. */
+export function createServerShutdown(options: {
+  server: Server;
+  closeWebSockets: () => Promise<void>;
+  disposeServices: () => Promise<void>;
+  timeoutMs?: number;
+}): () => Promise<void> {
+  let pending: Promise<void> | undefined;
+  return () => {
+    pending ??= Promise.resolve().then(async () => {
+      let expired = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const deadline = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          expired = true;
+          reject(new Error('Graceful shutdown deadline exceeded'));
+        }, options.timeoutMs ?? 10_000);
+      });
+      // Stop accepting TCP connections immediately, but let already-connected
+      // HTTP work finish while its services and storage are still available.
+      const httpClosed = new Promise<void>((resolve, reject) => {
+        options.server.close((error) => {
+          if (error && (error as NodeJS.ErrnoException).code !== 'ERR_SERVER_NOT_RUNNING')
+            reject(error);
+          else resolve();
+        });
+      });
+      try {
+        await Promise.race([
+          deadline,
+          (async () => {
+            await Promise.all([httpClosed, options.closeWebSockets()]);
+            // A late drain must not dispose storage after the deadline failed.
+            if (!expired) await options.disposeServices();
+          })(),
+        ]);
+      } finally {
+        clearTimeout(timer);
+      }
+    });
+    return pending;
+  };
+}


### PR DESCRIPTION
## Summary

Drain connected HTTP requests before disposing their services and storage. The previous shutdown order reproducibly returned HTTP 500 for an authenticated task request that completed its headers during app quit.

Repeated signals share one shutdown operation. HTTP and WebSocket closure precede service cleanup; a single ten-second deadline bounds shutdown, and a late drain cannot start disposal after that deadline fails. Tool-session shutdown and pending telemetry/registry writes are awaited instead of bypassed by independent timeout races. Cleanup failures retain a nonzero exit status.

Closes #1473. Stacked on #1472; this does not waive the strengthened full native gate or complete the UI integration/release work.

## Verification

- The packaged b558a80f candidate reproduced HTTP 500 repeatedly with an authenticated, already-connected request during native quit. The retained pre-fix diagnostic fails rather than accepting that response.
- A real-HTTP regression failed with the same storage-disposed response before the ordering fix. Four focused tests now pass, covering in-flight requests, repeated shutdown calls, a late drain after deadline expiry, failed cleanup, and stalled cleanup.
- Server typecheck, changed-source lint, formatting, diff checks, and server/web builds passed. Independent specification and standards reviews found no actionable issues.
- Added an isolated packaged-app quit/relaunch diagnostic and shutdown documentation. It keeps synthetic login cookies in memory, never touches the operator profile, and requires both task responses and server exits to succeed.
- The rebuilt unsigned macOS package identifies as `e9be870d7c6d9db19dd3039843ddebd88b8345a5`. Both quit/relaunch cycles passed: connected authenticated task requests returned HTTP 200, server logs show HTTP closure before storage disposal, and both server processes exited with code 0. Measured quit durations were 280ms and 270ms. No HTTP 500 or forced shutdown was recorded. This is scoped native shutdown evidence, not complete UI conformance or installed-app acceptance.

## Remaining

Exact-head CI33870745300 passed build, dependency audit, lint/typecheck, workspace tests, changed tests, and critical coverage. Security Gates33870747703 passed Gitleaks and CodeQL. Full integrated native conformance, browser failures, maintained documentation screenshots/GIFs, installed-app replacement, signing, version bump, and release publication remain unfinished.
