### PR TITLE
fix: prevent fractional mobile Board scroll overlap

### DIFF
--- a/docs/design/MOBILE-NAVIGATION-GEOMETRY.md
+++ b/docs/design/MOBILE-NAVIGATION-GEOMETRY.md
@@ -1,0 +1,9 @@
+# Mobile Board navigation geometry
+
+Tracking: #1462. Home returns to the top of the board page; Board positions the columns immediately below the sticky toolbar after their content mounts.
+
+Measure the toolbar at activation, including enlarged text. Round the resulting scroll offset down to a whole CSS pixel: browsers can round fractional offsets upward and obscure the top of a column. This intentionally permits less than one pixel of clearance instead of any overlap.
+
+The existing `e2e/mobile-board-scroll.spec.ts` browser checks cover navigation from Activity and repeated Home/Board activation at 390px and 430px widths with 16px and 20px root text. They require zero overlap and at most two pixels of clearance. At 390px with 20px text, the regression was a 73.5px toolbar and a requested 453.5px scroll offset that Chromium rounded to 454px, obscuring 0.5px of the board.
+
+These browser checks do not establish packaged macOS, signed-release, or documentation-media acceptance. Those remain separate integration gates.

--- a/web/src/components/layout/MobileShell.tsx
+++ b/web/src/components/layout/MobileShell.tsx
@@ -13,8 +13,13 @@ function scrollToBoardColumns() {
   // at activation so enlarged text and responsive chrome use their real size.
   const toolbarHeight =
     document.querySelector('.desktop-app-header')?.getBoundingClientRect().height ?? 0;
+  // Browsers can round fractional scroll offsets up. Keep the column edge on
+  // the visible side of the toolbar when enlarged text yields subpixel sizes.
   window.scrollTo({
-    top: Math.max(0, window.scrollY + columns.getBoundingClientRect().top - toolbarHeight),
+    top: Math.max(
+      0,
+      Math.floor(window.scrollY + columns.getBoundingClientRect().top - toolbarHeight)
+    ),
     behavior: 'instant',
   });
   return true;


### PR DESCRIPTION
## Summary

Follow-up to #1462: round the measured mobile Board scroll target down so fractional browser rounding cannot place columns beneath the sticky toolbar. Home navigation is unchanged. Document the geometry contract and keep the existing zero-overlap assertions intact.

## Verification

The existing 390px viewport / 20px text browser test failed before the fix. Instrumentation confirmed a requested 453.5px offset became 454px, leaving the board 0.5px beneath the unchanged 73.5px toolbar. Temporary instrumentation was removed.

After the fix, all 24 Chromium checks across `mantine-qa-gate`, `mobile-board-scroll`, `mobile-chat-entry`, and `mobile-readable` passed using an isolated SQLite test server. Web type checking, changed-file ESLint, formatting, and diff checks passed. Separate scope and standards reviews found no issues.

## Scope

This targets the integration branch, not main. Browser coverage does not establish packaged macOS, signed release, installed-app, or documentation-media acceptance. Those integration gates remain outstanding.
