### PR TITLE
fix: contain populated Activity on narrow screens

### DIFF
--- a/docs/design/MOBILE-NAVIGATION-GEOMETRY.md
+++ b/docs/design/MOBILE-NAVIGATION-GEOMETRY.md
@@ -7,3 +7,9 @@ Measure the toolbar at activation, including enlarged text. Round the resulting 
 The existing `e2e/mobile-board-scroll.spec.ts` browser checks cover navigation from Activity and repeated Home/Board activation at 390px and 430px widths with 16px and 20px root text. They require zero overlap and at most two pixels of clearance. At 390px with 20px text, the regression was a 73.5px toolbar and a requested 453.5px scroll offset that Chromium rounded to 454px, obscuring 0.5px of the board.
 
 These browser checks do not establish packaged macOS, signed-release, or documentation-media acceptance. Those remain separate integration gates.
+
+## Populated Activity containment
+
+Activity rows must fit the viewport rather than expanding the mobile layout viewport around fixed navigation. Below the small-screen breakpoint, timestamp/status controls may wrap and task identity occupies a separate line with a wrapping ID and title. Wider layouts retain the existing single-row arrangement. No status, ID, or title is hidden to make the row fit.
+
+`e2e/mobile-navigation-hit-target.spec.ts` supplies populated Activity records with realistic-length IDs independently of prior tests. It checks layout width, all navigation and Chat hit targets, and pointer/keyboard return to Board at narrow widths, enlarged text, and both motion preferences. The original 320px case expanded the layout viewport to 424px while the visual viewport remained 320px; increasing navigation z-index would not fix that mismatch.

--- a/e2e/mobile-navigation-hit-target.spec.ts
+++ b/e2e/mobile-navigation-hit-target.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+import { bypassAuth, cleanupRoutes } from './helpers/auth';
+
+test.use({ viewport: { width: 320, height: 844 }, isMobile: true, hasTouch: true });
+
+test.beforeEach(async ({ page }) => {
+  await bypassAuth(page);
+  await page.route('**/api/status-history?*', (route) =>
+    route.fulfill({
+      json: { success: true, data: [], meta: { timestamp: '2026-09-04T09:00:00.000Z' } },
+    })
+  );
+  await page.route('**/api/activity?*', (route) =>
+    route.fulfill({
+      json: {
+        success: true,
+        meta: { timestamp: '2026-09-04T09:00:00.000Z' },
+        data: Array.from({ length: 20 }, (_, index) => ({
+          id: `activity-mobile-${index}`,
+          type: 'status_changed',
+          taskId: `task_20260904_mobile${index}`,
+          taskTitle: `Populated Activity task ${index}`,
+          actor: 'service:admin',
+          details: { from: 'todo', status: 'blocked' },
+          timestamp: '2026-09-04T09:00:00.000Z',
+        })),
+      },
+    })
+  );
+});
+test.afterEach(async ({ page }) => cleanupRoutes(page));
+
+for (const width of [320, 430]) {
+  for (const textSize of [16, 20]) {
+    for (const reducedMotion of ['no-preference', 'reduce'] as const) {
+      test(`populated Activity preserves mobile controls at ${width}px, ${textSize}px text, ${reducedMotion}`, async ({
+        page,
+      }, testInfo) => {
+        await page.setViewportSize({ width, height: 844 });
+        await page.emulateMedia({ reducedMotion });
+        await page.addInitScript(
+          (theme) => localStorage.setItem('veritas-kanban-theme', theme),
+          textSize === 20 ? 'light' : 'dark'
+        );
+        await page.goto('/');
+        await page.addStyleTag({ content: `:root { font-size: ${textSize}px !important; }` });
+        await page.getByRole('button', { name: 'More views', exact: true }).click();
+        await page.getByRole('menuitem', { name: 'Activity', exact: true }).click();
+        await expect(page.getByRole('heading', { name: 'Activity', exact: true })).toBeVisible();
+        await expect(
+          page.getByRole('button', { name: /Populated Activity task 0$/ })
+        ).toBeVisible();
+        expect(await page.evaluate(() => innerWidth)).toBe(width);
+        expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(width);
+        const screenshot = testInfo.outputPath('populated-activity.png');
+        await page.screenshot({ path: screenshot });
+        await testInfo.attach('populated-activity', { path: screenshot, contentType: 'image/png' });
+        const board = page.getByRole('button', { name: 'Mobile board', exact: true });
+        for (const control of [
+          ...(await page
+            .getByRole('navigation', { name: 'Mobile navigation' })
+            .getByRole('button')
+            .all()),
+          page.getByRole('button', { name: 'Open chat', exact: true }),
+        ]) {
+          await expect
+            .poll(() =>
+              control.evaluate((button) => {
+                const rect = button.getBoundingClientRect();
+                return button.contains(
+                  document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2)
+                );
+              })
+            )
+            .toBe(true);
+        }
+        await board.click();
+        await expect(page.locator('#mobile-board-columns')).toBeVisible();
+        await page.goto('/activity');
+        await page.addStyleTag({ content: `:root { font-size: ${textSize}px !important; }` });
+        await expect(
+          page.getByRole('button', { name: /Populated Activity task 0$/ })
+        ).toBeVisible();
+        expect(await page.locator('html').evaluate((el) => getComputedStyle(el).fontSize)).toBe(
+          `${textSize}px`
+        );
+        await board.focus();
+        await board.press('Enter');
+        await expect(page.locator('#mobile-board-columns')).toBeVisible();
+      });
+    }
+  }
+}

--- a/web/src/components/activity/ActivityFeed.tsx
+++ b/web/src/components/activity/ActivityFeed.tsx
@@ -250,7 +250,7 @@ function StatusHistoryPanel({ onTaskClick }: StatusHistoryPanelProps) {
                   <div
                     key={entry.id}
                     className={cn(
-                      'flex items-center gap-3 py-2.5 px-3 rounded-md transition-colors',
+                      'flex flex-wrap items-center gap-3 py-2.5 px-3 rounded-md transition-colors sm:flex-nowrap',
                       entry.taskId && onTaskClick
                         ? 'hover:bg-muted/50 cursor-pointer'
                         : 'hover:bg-muted/30'
@@ -274,15 +274,15 @@ function StatusHistoryPanel({ onTaskClick }: StatusHistoryPanelProps) {
                     <StatusBadge status={entry.previousStatus} isTaskStatus={isTaskStatus} />
                     <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
                     <StatusBadge status={entry.newStatus} isTaskStatus={isTaskStatus} />
-                    <div className="flex-1 min-w-0 flex items-center gap-2">
+                    <div className="flex min-w-0 basis-full flex-col items-start gap-1 sm:flex-1 sm:flex-row sm:items-center sm:gap-2">
                       {entry.taskId && (
-                        <span className="text-sm text-muted-foreground shrink-0">
+                        <span className="max-w-full break-all text-sm text-muted-foreground sm:shrink-0">
                           {entry.taskId}
                         </span>
                       )}
                       <span
                         className={cn(
-                          'text-sm truncate',
+                          'max-w-full break-words text-sm sm:truncate',
                           onTaskClick && 'hover:underline',
                           titleColor
                         )}


### PR DESCRIPTION
## Summary

Closes #1476. This PR targets the UI integration branch; merging it there is not main or release delivery.

Populated Activity rows forced a 320px mobile layout viewport to 424px while the visual viewport remained 320px. Fixed navigation was then hit-tested against underlying Activity content. The failure appeared only with realistic-length task IDs, so short isolated fixtures missed it.

Allow timestamp/status controls to wrap on small screens, and place task identity on a separate wrapping line. Preserve every status, ID, title, and interaction handler. Wider layouts retain the single-row arrangement. No z-index increase, forced click, or global overflow clipping is used.

## Verification

- Original Chromium sequence: 53 passed, then the 320px viewport case timed out clicking Mobile board on populated Activity. Its final cleanup error masked that original action; the retained trace identified row interception.
- Minimal regression failed at layout width 424px versus expected 320px. After the fix, layout and visual widths both remained 320px and the normal Board click passed.
- Related 36-case mobile browser slice passed. After a review correction, a 22-case sequence combining actual board-drag activity, eight deterministic populated-Activity cases, and the original mobile-viewport cases passed.
- Regression covers 320/430px widths, 16/20px text, both motion preferences, all navigation/Chat center-point hit targets, and pointer/keyboard return to Board. The second navigation reapplies and verifies enlarged text before keyboard interaction.
- Web typecheck, changed-source ESLint, formatting and diff checks passed. Both independent source review axes cleared the fix. Dark 320px and enlarged-text light screenshots were inspected.

## Remaining boundaries

Exact-head CI 33874952767 and Security 33874955742 passed. Production and all-dependency audits reported no known vulnerabilities; CodeQL and Gitleaks passed. Integration QA run 33872011056 ended at its deadline with failures, including Settings-label clipping and transient viewport expansion outside Activity; those are not waived by these results. This change requires the next integrated browser/native candidate checks. No signed package, installed app, documentation media, version, or release was changed.
