### PR TITLE
fix: preserve enlarged mobile navigation label width

### DIFF
--- a/docs/design/MOBILE-NAVIGATION-GEOMETRY.md
+++ b/docs/design/MOBILE-NAVIGATION-GEOMETRY.md
@@ -13,3 +13,9 @@ These browser checks do not establish packaged macOS, signed-release, or documen
 Activity rows must fit the viewport rather than expanding the mobile layout viewport around fixed navigation. Below the small-screen breakpoint, timestamp/status controls may wrap and task identity occupies a separate line with a wrapping ID and title. Wider layouts retain the existing single-row arrangement. No status, ID, or title is hidden to make the row fit.
 
 `e2e/mobile-navigation-hit-target.spec.ts` supplies populated Activity records with realistic-length IDs independently of prior tests. It checks layout width, all navigation and Chat hit targets, and pointer/keyboard return to Board at narrow widths, enlarged text, and both motion preferences. The original 320px case expanded the layout viewport to 424px while the visual viewport remained 320px; increasing navigation z-index would not fix that mismatch.
+
+## Enlarged navigation labels
+
+Tracking: #1465. Narrow navigation buttons give their full grid-cell width to the label, with spacing between buttons supplied by the grid gap. Do not spend that width on horizontal button padding or shrink the text to fit. The Settings label needs more space with wider platform fonts; the 320px, 20px-text regression measured a 72px word in a 67px content box.
+
+`e2e/mobile-readable.spec.ts` includes a wider-platform-font case in addition to the default-font size/theme matrix. It checks every full label, 44px minimum touch targets, hit testing, and content clearance. This remains browser coverage, not final documentation-media or packaged-app acceptance.

--- a/e2e/mobile-readable.spec.ts
+++ b/e2e/mobile-readable.spec.ts
@@ -109,6 +109,15 @@ for (const width of [320, 390, 430]) {
   }
 }
 
+test('enlarged navigation labels fit wider platform fonts', async ({ page }) => {
+  await page.goto('/');
+  await page.addStyleTag({
+    content: `:root { font-size: 20px !important; }
+      [aria-label="Mobile navigation"] { font-family: Verdana, 'DejaVu Sans', sans-serif; }`,
+  });
+  await assertNavigationFits(page);
+});
+
 test('navigation height follows window and text resizing', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('#mobile-board-columns')).toBeVisible();

--- a/web/src/components/layout/MobileShell.tsx
+++ b/web/src/components/layout/MobileShell.tsx
@@ -175,7 +175,7 @@ export function MobileShell({ showChat = true }: { showChat?: boolean }) {
                   disabled={item.disabled}
                   onClick={item.onClick}
                   className={[
-                    'flex min-h-12 min-w-0 flex-col items-center justify-center rounded-md px-1 text-sm leading-tight text-muted-foreground transition-colors',
+                    'flex min-h-12 min-w-0 flex-col items-center justify-center rounded-md px-0 text-sm leading-tight text-muted-foreground transition-colors',
                     item.active
                       ? 'bg-primary/15 text-primary'
                       : 'hover:bg-muted hover:text-foreground',


### PR DESCRIPTION
## Summary

Follow-up for #1465. This PR targets the UI integration branch, not main or a release.

Give mobile navigation labels the full width of their grid cells instead of consuming it with horizontal button padding. Grid gaps still separate controls; font sizes, accessible names, handlers, and touch targets are unchanged.

At 320px with 20px root text, a wider platform font made Settings require 72px in a 67px content box. The regression now exercises Verdana/DejaVu Sans in addition to the existing default-font size/theme matrix.

## Verification

- New browser regression failed on the original padding with Settings reported as overflowing.
- The corrected readable-navigation and populated-Activity slice passed all 23 cases, including 320/390/430px, 16/20px text, light/dark themes, pointer/keyboard navigation, hit targets, and clearance.
- Web typecheck, changed-source ESLint, formatting, and diff checks passed.
- Independent specification and standards reviews found no issues.

## Remaining boundaries

Exact-head focused CI 33876564565 and Security 33876016097 passed. Production and all-dependency audits reported no known vulnerabilities. An accidentally selected full-scope run, 33876013380, was cancelled and is not verification evidence. The separate delayed-tooltip viewport and Chat failure is not fixed by this padding change. Integrated Linux/browser, packaged-app, final documentation-media, and release acceptance remain incomplete; no version or installed application was changed.
