### PR TITLE
fix: contain delayed tooltips within mobile viewports

### DIFF
--- a/docs/design/MOBILE-TOOLTIP-GEOMETRY.md
+++ b/docs/design/MOBILE-TOOLTIP-GEOMETRY.md
@@ -1,0 +1,11 @@
+# Mobile tooltip geometry
+
+Tracking: #1463 and #1467. Portaled tooltips must stay within the viewport without changing the document's layout width or displacing mobile navigation and Chat controls.
+
+Use fixed positioning for tooltips, constrain their width to the viewport minus one rem, and wrap both ordinary text and unbroken references. Keep tooltip content and opening behavior intact. Do not hide overflowing content, shrink text, force clicks, or compensate with a higher navigation z-index.
+
+The task-card hint has a delayed opening and an explicit width. At 320px with 20px root text, that width becomes 400px; its eight-pixel horizontal offset expanded the document to 408px. Fast interactions could finish before the hint appeared, while slower interactions displaced fixed controls. Limiting width alone did not pass the original Chat resize sequence; fixed positioning is also required.
+
+`e2e/mobile-tooltip-viewport.spec.ts` waits for the delayed hint before opening a task status menu. It checks tooltip bounds and text overflow, samples viewport width every animation frame through status-menu and Chat open/close, and covers 320/430px screens with normal/enlarged text, including a long unbroken reference. The existing mobile Chat and viewport suites cover the original navigation and resize sequences.
+
+Browser results do not replace integrated Linux QA, packaged native verification, refreshed documentation media, or release acceptance.

--- a/e2e/mobile-tooltip-viewport.spec.ts
+++ b/e2e/mobile-tooltip-viewport.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test';
+import { bypassAuth, cleanupRoutes, deleteTask, seedTestTask } from './helpers/auth';
+
+declare global {
+  interface Window {
+    tooltipViewportProbe: { frame: number; widths: number[] };
+  }
+}
+
+test.use({ viewport: { width: 320, height: 844 }, isMobile: true, hasTouch: true });
+test.beforeEach(async ({ page }) => bypassAuth(page));
+test.afterEach(async ({ page }) => {
+  await page.evaluate(() => cancelAnimationFrame(window.tooltipViewportProbe?.frame));
+  await cleanupRoutes(page);
+});
+
+for (const width of [320, 430]) {
+  for (const textSize of [16, 20]) {
+    test(`delayed task tooltip preserves ${width}px viewport at ${textSize}px text`, async ({
+      page,
+    }, testInfo) => {
+      await page.setViewportSize({ width, height: 844 });
+      const title = `Tooltip viewport ${width} ${textSize}`;
+      const task = await seedTestTask(page, {
+        title,
+        type: 'code',
+        ...(width === 320 && textSize === 20
+          ? { description: `Evidence reference: ${'0123456789abcdef'.repeat(8)}` }
+          : {}),
+      });
+      try {
+        await page.goto('/');
+        await page.addStyleTag({ content: `:root { font-size: ${textSize}px !important; }` });
+        const status = page.getByRole('combobox', {
+          name: `Change status for ${title}`,
+          exact: true,
+        });
+        await expect(status).toBeVisible();
+        await status.evaluate((el) => {
+          const bar = document
+            .querySelector('[data-mobile-navigation-surface]')!
+            .getBoundingClientRect();
+          scrollBy(0, el.getBoundingClientRect().bottom - bar.top + 16);
+        });
+        await page.evaluate(() => {
+          const probe = { frame: 0, widths: [] as number[] };
+          window.tooltipViewportProbe = probe;
+          const sample = () => {
+            probe.widths.push(innerWidth);
+            probe.frame = requestAnimationFrame(sample);
+          };
+          sample();
+        });
+        await status.hover();
+        // Fast local interactions otherwise finish before the card's delayed tooltip opens.
+        const tooltip = page.getByRole('tooltip').filter({ hasText: title });
+        await expect(tooltip).toBeVisible();
+        expect(await page.evaluate(() => innerWidth)).toBe(width);
+        const box = (await tooltip.boundingBox())!;
+        expect(box.x).toBeGreaterThanOrEqual(0);
+        expect(box.x + box.width).toBeLessThanOrEqual(width);
+        expect(await tooltip.evaluate((el) => el.scrollWidth <= el.clientWidth)).toBe(true);
+        await testInfo.attach('delayed-tooltip', {
+          body: await page.screenshot({ path: testInfo.outputPath('delayed-tooltip.png') }),
+          contentType: 'image/png',
+        });
+        await status.click();
+        await expect(page.getByRole('option', { name: 'Blocked', exact: true })).toBeVisible();
+        await page.keyboard.press('Escape');
+        await page.getByRole('button', { name: 'Open chat', exact: true }).click();
+        await expect(
+          page.getByRole('textbox', { name: 'Message Board Chat', exact: true })
+        ).toBeVisible();
+        await page.getByRole('button', { name: 'Close Board Chat panel', exact: true }).click();
+        expect(await page.evaluate(() => innerWidth)).toBe(width);
+        const widths = await page.evaluate(() => {
+          cancelAnimationFrame(window.tooltipViewportProbe.frame);
+          return window.tooltipViewportProbe.widths;
+        });
+        expect(widths.length).toBeGreaterThan(5);
+        expect(Math.min(...widths)).toBe(width);
+        expect(Math.max(...widths)).toBe(width);
+      } finally {
+        await deleteTask(page, task.id as string);
+      }
+    });
+  }
+}

--- a/web/src/theme/mantine-theme.ts
+++ b/web/src/theme/mantine-theme.ts
@@ -155,6 +155,19 @@ export const veritasMantineTheme = createTheme({
         },
       },
     },
+    Tooltip: {
+      defaultProps: {
+        // Portaled hints must not expand the mobile document while positioning.
+        floatingStrategy: 'fixed',
+      },
+      styles: {
+        tooltip: {
+          maxWidth: 'calc(100vw - 1rem)',
+          whiteSpace: 'normal',
+          overflowWrap: 'anywhere',
+        },
+      },
+    },
     TextInput: {
       defaultProps: {
         radius: 'sm',


### PR DESCRIPTION
## Summary

Follow-up for #1463 and #1467, targeting the UI integration branch. This does not close final packaged-app or media acceptance.

Keep portaled tooltips within the viewport using fixed positioning, a viewport-relative width limit, and wrapping for ordinary text and unbroken references. Preserve tooltip content, opening behavior, and font size.

A delayed task-card hint measured 400px wide at 20px root text and expanded a 320px mobile document to 408px. Fast interactions often finished before the hint opened. That timing difference let isolated checks pass while slower CI interactions displaced fixed navigation and Chat controls.

## Verification

- Explicitly waiting for the delayed hint reproduced 408px versus 320px. The final hover-first regression also failed on the original source at normal text: 328px versus 320px.
- Width limiting alone failed the original Chat resize sequence. Fixed positioning plus the limit passed the related 13-case tooltip, Chat, and viewport slice.
- A long unbroken reference separately failed horizontal text containment; wrapping corrected it. The 13-case slice then passed with frame-by-frame viewport sampling.
- Final hover-first regression passed all four 320/430px and 16/20px cases, including the unbroken reference. It verifies hint bounds, text containment, status-menu/Chat interactions, and every sampled viewport width. Saved enlarged-text output was visually inspected.
- Web typecheck, changed-source ESLint, formatting/diff checks, and 34 focused TaskCard/primitive unit tests passed. Independent specification and standards reviews cleared the delta.

## Remaining boundaries

Exact-head focused CI 33877014865 and Security 33877017319 passed. Production and all-dependency audits reported no known vulnerabilities. This PR does not claim final integrated Linux, packaged native, documentation-media, installed-app, or release acceptance. The existing tooltip/menu visual-overlap defect is tracked separately in #1479; the regression checks the hint before opening the menu so it does not require that unwanted overlap. No version or maintained documentation image was changed.
