### PR TITLE
fix: dismiss task hints during status menu interaction

### DIFF
--- a/docs/design/MOBILE-TOOLTIP-GEOMETRY.md
+++ b/docs/design/MOBILE-TOOLTIP-GEOMETRY.md
@@ -9,3 +9,9 @@ The task-card hint has a delayed opening and an explicit width. At 320px with 20
 `e2e/mobile-tooltip-viewport.spec.ts` waits for the delayed hint before opening a task status menu. It checks tooltip bounds and text overflow, samples viewport width every animation frame through status-menu and Chat open/close, and covers 320/430px screens with normal/enlarged text, including a long unbroken reference. The existing mobile Chat and viewport suites cover the original navigation and resize sequences.
 
 Browser results do not replace integrated Linux QA, packaged native verification, refreshed documentation media, or release acceptance.
+
+## Task status menus
+
+Tracking: #1479. The task-card hint is suppressed while its status dropdown is open, regardless of pointer or keyboard entry. Dropdown lifecycle callbacks own this state; normal card hints remain available after the menu closes. This prevents a non-interactive hint from obscuring actionable option labels without changing tooltip stacking or status-change behavior.
+
+`e2e/task-status-tooltip.spec.ts` opens the delayed hint, opens the status menu by pointer or keyboard, verifies the hint is absent, cancels with Escape, and returns to the hint on the same unchanged card. It then reopens the menu, changes status, and returns to the normal hint. Selecting an option must not open the task workspace.

--- a/e2e/task-status-tooltip.spec.ts
+++ b/e2e/task-status-tooltip.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+import { bypassAuth, cleanupRoutes, deleteTask, seedTestTask } from './helpers/auth';
+
+test.use({ viewport: { width: 320, height: 844 }, isMobile: true, hasTouch: true });
+test.beforeEach(async ({ page }) => bypassAuth(page));
+test.afterEach(async ({ page }) => cleanupRoutes(page));
+
+for (const input of ['pointer', 'keyboard']) {
+  test(`task hint stays out of the status menu during ${input} interaction`, async ({
+    page,
+  }, testInfo) => {
+    const title = `Status hint ${input}`;
+    const task = await seedTestTask(page, { title, type: 'code' });
+    try {
+      await page.goto('/');
+      await page.addStyleTag({ content: ':root { font-size: 20px !important; }' });
+      const status = page.getByRole('combobox', {
+        name: `Change status for ${title}`,
+        exact: true,
+      });
+      await expect(status).toBeVisible();
+      await status.evaluate((el) => {
+        const bar = document
+          .querySelector('[data-mobile-navigation-surface]')!
+          .getBoundingClientRect();
+        scrollBy(0, el.getBoundingClientRect().bottom - bar.top + 16);
+      });
+      const hint = page.getByRole('tooltip').filter({ hasText: title });
+      await status.hover();
+      await expect(hint).toBeVisible();
+      const openMenu = async () => {
+        if (input === 'pointer') await status.click();
+        else {
+          await status.focus();
+          await page.keyboard.press('Space');
+        }
+      };
+      await openMenu();
+      const done = page.getByRole('option', { name: 'Done', exact: true });
+      await expect(done).toBeVisible();
+      await expect(hint).not.toBeVisible();
+      await page.screenshot({ path: testInfo.outputPath('status-menu.png') });
+      await page.keyboard.press('Escape');
+      await expect(status).toHaveValue('To Do');
+      await page.getByRole('button', { name: 'Mobile home', exact: true }).hover();
+      await status.hover();
+      await expect(hint).toBeVisible();
+      await openMenu();
+      await expect(done).toBeVisible();
+      await expect(hint).not.toBeVisible();
+      if (input === 'pointer') await done.click();
+      else {
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('Enter');
+      }
+      await expect(status).toHaveValue('Done');
+      await expect(page.getByTestId('task-detail-panel')).not.toBeVisible();
+      await page.getByRole('button', { name: 'Mobile home', exact: true }).hover();
+      await status.hover();
+      await expect(hint).toBeVisible();
+    } finally {
+      await deleteTask(page, task.id as string);
+    }
+  });
+}

--- a/web/src/components/task/TaskCard.tsx
+++ b/web/src/components/task/TaskCard.tsx
@@ -220,6 +220,7 @@ export const TaskCard = memo(function TaskCard({
   });
   const { isSelecting, toggleSelect, isSelected: isBulkSelected } = useBulkActions();
   const [tooltipDismissed, setTooltipDismissed] = useState(false);
+  const [statusMenuOpen, setStatusMenuOpen] = useState(false);
   const isChecked = isBulkSelected(task.id);
   const { settings: featureSettings } = useFeatureSettings();
   const boardSettings = featureSettings.board;
@@ -340,8 +341,9 @@ export const TaskCard = memo(function TaskCard({
   const readinessAria = readinessSummary ? `, Readiness: ${readinessSummary.percent}%` : '';
   const isVerified = allVerificationDone;
 
-  // Suppress the outer card tooltip entirely during any drag operation
-  const suppressCardTooltip = isDragActive || isDragging || isCurrentlyDragging || tooltipDismissed;
+  // Keep card help out of drag operations and the active status menu.
+  const suppressCardTooltip =
+    isDragActive || isDragging || isCurrentlyDragging || tooltipDismissed || statusMenuOpen;
 
   return (
     <Tooltip
@@ -785,6 +787,8 @@ export const TaskCard = memo(function TaskCard({
               size="sm"
               allowDeselect={false}
               checkIconPosition="right"
+              onDropdownOpen={() => setStatusMenuOpen(true)}
+              onDropdownClose={() => setStatusMenuOpen(false)}
             />
           </div>
         )}


### PR DESCRIPTION
## Summary

Closes #1479 when delivered to main. This PR targets the UI integration branch after the tooltip viewport fix was merged there; it is not release acceptance.

Suppress the task card's outer hint while its status dropdown is open. Use the dropdown lifecycle callbacks for pointer and keyboard entry; retain existing drag suppression, status-change handlers, permissions, and propagation guards. Normal hints remain available after the menu closes.

## Verification

- The new rendered regression failed because the hint remained visible over the active status menu.
- Pointer and keyboard selection passed in an eight-case related tooltip/Chat slice. The final two-case regression additionally cancels with Escape and proves hint restoration on the same unchanged card before a status update could remount it.
- Selecting Done updates the status without opening the task workspace. Saved 320px enlarged-text output was inspected with all status options unobscured.
- Web typecheck, changed-source ESLint, formatting/diff checks, and 22 TaskCard unit tests passed.
- Independent specification and standards reviews found no issues.

The initial keyboard test used End, which this control did not use for last-option selection. It was corrected to arrow-key selection followed by Enter; production keyboard handling was not changed.

## Remaining boundaries

Exact-head CI run 33877476026 and Security run 33877479308 passed, including CodeQL and Gitleaks. Production and all-dependency audits reported no known vulnerabilities. Integrated Linux/native checks remain pending. No maintained documentation media, signed package, installed app, version, or release was changed.
