### PR TITLE
fix: cancel stale task close cleanup on reopen

### DIFF
--- a/docs/design/TASK-REOPEN-LIFECYCLE.md
+++ b/docs/design/TASK-REOPEN-LIFECYCLE.md
@@ -1,0 +1,7 @@
+# Task close and reopen lifecycle
+
+Closing a task retains its selected record briefly for the exit transition. That cleanup belongs to the closed state and is cancelled when any task opens again or the Board unmounts. Both history-driven dismissal and direct close use this lifecycle.
+
+An earlier unowned timeout could clear a newly opened task after a rapid close/reopen. Reduced-motion navigation made the race particularly visible. Regression coverage closes a task, immediately opens the same or a different task, and confirms an edit saves while the new workspace stays visible. It does not add a delay between close and reopen.
+
+This lifecycle does not change browser-history entries, task mutation semantics, exit timing, or opener focus restoration. Packaged task-workspace checks exercise the same rapid transition alongside retained section, scroll, pending edit, chat draft, and historical-attempt selection.

--- a/e2e/task-reopen.spec.ts
+++ b/e2e/task-reopen.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { bypassAuth, seedTestTask, deleteTask, cleanupRoutes } from './helpers/auth';
+
+for (const target of ['same', 'different'] as const) {
+  test(`the ${target} task remains editable when opened immediately after closing`, async ({
+    page,
+  }) => {
+    await bypassAuth(page);
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    const task = await seedTestTask(page, { title: 'Immediate reopen fixture', status: 'todo' });
+    const id = (task as { id: string }).id;
+    let targetId = id;
+    try {
+      if (target === 'different') {
+        const other = await seedTestTask(page, {
+          title: 'Different reopen fixture',
+          status: 'todo',
+        });
+        targetId = (other as { id: string }).id;
+      }
+      await page.goto('/');
+      const card = page.locator(`[data-task-id="${id}"]`);
+      const detail = page.getByTestId('task-detail-panel');
+      await card.focus();
+      await card.press('Enter');
+      await expect(detail).toBeVisible();
+      await detail.getByRole('button', { name: 'Close task workspace', exact: true }).click();
+      await expect(detail).toHaveCount(0);
+      const nextCard = page.locator(`[data-task-id="${targetId}"]`);
+      await nextCard.focus();
+      await nextCard.press('Enter');
+      const title = detail.getByRole('textbox', { name: 'Task title', exact: true });
+      await expect(title).toHaveValue(
+        target === 'same' ? 'Immediate reopen fixture' : 'Different reopen fixture'
+      );
+      const [saved] = await Promise.all([
+        page.waitForResponse(
+          (response) =>
+            new URL(response.url()).pathname === `/api/tasks/${targetId}` &&
+            response.request().method() === 'PATCH',
+          { timeout: 5000 }
+        ),
+        title.fill('Reopened task stays editable'),
+      ]);
+      expect(saved.ok()).toBeTruthy();
+      await expect(detail).toBeVisible();
+      await expect(title).toHaveValue('Reopened task stays editable');
+    } finally {
+      if (targetId !== id) await deleteTask(page, targetId);
+      await deleteTask(page, id);
+      await cleanupRoutes(page);
+    }
+  });
+}

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -296,11 +296,18 @@ export function KanbanBoard() {
     const handlePopState = () => {
       if (!detailOpen || taskIdFromHistory() === selectedTask?.id) return;
       setDetailOpen(false);
-      setTimeout(() => setSelectedTask(null), 200);
     };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
   }, [detailOpen, selectedTask?.id]);
+
+  // Retain the closing task for its exit transition, but cancel that cleanup
+  // when a task is reopened before the transition finishes.
+  useEffect(() => {
+    if (detailOpen || !selectedTask) return;
+    const timer = window.setTimeout(() => setSelectedTask(null), 200);
+    return () => window.clearTimeout(timer);
+  }, [detailOpen, selectedTask]);
 
   // Apply the configured default saved view only when the current URL has no board filters.
   useEffect(() => {
@@ -558,8 +565,6 @@ export function KanbanBoard() {
     }
     setDetailOpen(open);
     if (!open) {
-      // Small delay to allow animation to complete
-      setTimeout(() => setSelectedTask(null), 200);
       returnFromTask();
     }
   };


### PR DESCRIPTION
## Summary

Closes #1482 when delivered to main. This PR targets the UI integration branch, not release acceptance.

Own the selected-task exit cleanup in a cancellable closed-state effect. History-driven and direct dismissal still retain the closing task for 200 ms, but reopening the same or another task cancels the old cleanup. Browser history, mutation handling, and opener focus behavior are unchanged.

## Verification

- Two packaged diagnostics reproduced the old failure, with the second preserving a trace and screenshot of the disappeared task workspace. The historical diagnostic's inter-case wait had hidden this edge.
- The focused rendered regression failed before the source fix and passed afterward. Initial failure reporting also exposed a test promise/cleanup issue; the final regression joins the edit and response wait and bounds the response timeout.
- All 11 related browser checks passed, covering same/different task reopen, task chat, compact/expanded navigation, scroll, pending edits, and focus.
- All 16 Board unit tests, web typecheck, changed-source lint, formatting, and diff checks passed.
- Specification and standards reviews found no issues.
- The rebuilt unsigned package at `bfc2166cc61ab24bdd5ef4b5a577a11e57db6f23` passed all 24 task-root captures across eight theme/motion/size combinations without the old inter-case delay. Retained pending edits, node/scroll/section state, chat drafts, historical attempts, and final opener focus passed. There were no recorded 429/5xx responses from fixture creation through shutdown.
- The separate verifier accepted the exact report and rejected wrong-mode metadata, inconsistent rectangles, missing scenarios, changed image hashes, and a late HTTP 500. The previously failing reduced-motion capture was visually inspected.

Package digest: `42a0ec8f00496f6a8e47a206144faa8d1cc12fc6cdecd4696d879e35dac0835a`. Report digest: `c6a606108574e44de915abeb12bc44d133b08cbd65ff034914644697b4a82959`, completed 2026-09-04T13:49:00.118Z. This bounded task-root diagnostic explicitly excludes startup/login HTTP coverage and is not the complete native matrix or release gate.

## Remaining boundaries

Exact-head CI33879968089 and Security33879971028 passed, including CodeQL, Gitleaks, and production/all dependency audits. The earlier candidate's successful shared native matrix does not prove this fix. Full integration QA, remaining task families, maintained media, signed/installed verification, version/changelog, and release work remain separate and incomplete.
