### PR TITLE
test: separate mobile chat and desktop resize coverage

### DIFF
--- a/docs/design/CHAT-BROWSER-ACCEPTANCE.md
+++ b/docs/design/CHAT-BROWSER-ACCEPTANCE.md
@@ -1,0 +1,7 @@
+# Chat browser acceptance
+
+Mobile touch behavior and desktop window resizing use separate browser contexts. The mobile check verifies content clearance, touch targets, menus, opening and closing Chat, and retained drafts. The desktop check resizes from narrow to wide and back with enlarged text, retaining drafts and verifying that close controls remain actionable.
+
+Do not resize a phone-emulated context to a desktop window as a substitute for desktop coverage. Chromium can retain a zoomed visual viewport and offset its automation coordinates after the focused composer is resized. The regression measured a 160px difference between the DOM close-button position and the automation bounding box, with visual viewport scale 1.125. This is not a reason to disable user zoom, force a click, or change application layout.
+
+The checks live in `e2e/mobile-chat-entry.spec.ts`. Their task fixture has a distinct title from the readability suite so failed cleanup cannot make unrelated heading selectors ambiguous. These checks do not establish packaged, signed, installed-app, documentation-media, or release acceptance.

--- a/e2e/mobile-chat-entry.spec.ts
+++ b/e2e/mobile-chat-entry.spec.ts
@@ -6,11 +6,11 @@ test.beforeEach(async ({ page }) => bypassAuth(page));
 test.afterEach(async ({ page }) => cleanupRoutes(page));
 
 test('mobile chat entry does not cover task content', async ({ page }, testInfo) => {
-  const task = await seedTestTask(page, { title: 'Readable task summary', type: 'code' });
+  const task = await seedTestTask(page, { title: 'Mobile chat entry fixture', type: 'code' });
   try {
     await page.goto('/');
     await page.addStyleTag({ content: ':root { font-size: 20px !important; }' });
-    const title = page.getByRole('heading', { name: 'Readable task summary', exact: true });
+    const title = page.getByRole('heading', { name: 'Mobile chat entry fixture', exact: true });
     await expect(title).toBeVisible();
     const trigger = page.getByRole('button', { name: 'Open chat', exact: true });
     await expect(trigger).toBeVisible();
@@ -44,7 +44,7 @@ test('mobile chat entry does not cover task content', async ({ page }, testInfo)
       ).toBe(true);
     }
     const status = page.getByRole('combobox', {
-      name: 'Change status for Readable task summary',
+      name: 'Change status for Mobile chat entry fixture',
       exact: true,
     });
     await status.evaluate((el) => {
@@ -71,13 +71,9 @@ test('mobile chat entry does not cover task content', async ({ page }, testInfo)
       body: await page.screenshot(),
       contentType: 'image/png',
     });
-    await page.setViewportSize({ width: 1440, height: 900 });
-    await expect(composer).toHaveValue('Unsent mobile draft');
     await page.getByRole('button', { name: 'Close Board Chat panel', exact: true }).click();
     await expect(composer).not.toBeVisible();
     await expect(trigger).toBeVisible();
-    expect(await trigger.evaluate((el) => getComputedStyle(el).position)).toBe('fixed');
-    await page.setViewportSize({ width: 320, height: 844 });
     await trigger.click();
     await expect(composer).toHaveValue('Unsent mobile draft');
     await page.getByRole('button', { name: 'Close Board Chat panel', exact: true }).click();
@@ -88,6 +84,30 @@ test('mobile chat entry does not cover task content', async ({ page }, testInfo)
 
 test.describe('wide browser chat entry', () => {
   test.use({ viewport: { width: 1440, height: 900 }, isMobile: false, hasTouch: false });
+  test('retains drafts and actionable controls through narrow-wide-narrow window resizing', async ({
+    page,
+  }) => {
+    // Desktop window resizing must not retain a phone-emulation pinch-zoom viewport.
+    await page.setViewportSize({ width: 320, height: 844 });
+    await page.goto('/');
+    await page.addStyleTag({ content: ':root { font-size: 20px !important; }' });
+    const trigger = page.getByRole('button', { name: 'Open chat', exact: true });
+    await trigger.click();
+    const composer = page.getByRole('textbox', { name: 'Message Board Chat', exact: true });
+    await composer.fill('Unsent resizing draft');
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await expect(composer).toHaveValue('Unsent resizing draft');
+    await page.getByRole('button', { name: 'Close Board Chat panel', exact: true }).click();
+    await expect(composer).not.toBeVisible();
+    await expect(trigger).toBeVisible();
+    expect(await trigger.evaluate((el) => getComputedStyle(el).position)).toBe('fixed');
+    await page.setViewportSize({ width: 320, height: 844 });
+    await trigger.click();
+    await expect(composer).toHaveValue('Unsent resizing draft');
+    await page.getByRole('button', { name: 'Close Board Chat panel', exact: true }).click();
+    await expect(composer).not.toBeVisible();
+  });
+
   test('retains the floating chat control without mobile navigation', async ({ page }) => {
     await page.goto('/');
     const trigger = page.getByRole('button', { name: 'Open chat', exact: true });


### PR DESCRIPTION
## Summary

Separate real mobile-emulation Chat coverage from desktop narrow-wide-narrow window resizing. The mobile case still checks content clearance, touch targets, menus, open/close, and retained drafts. The desktop case retains enlarged text, normal clicks, the wide-screen floating control, and draft retention across both size changes. A distinct fixture title avoids collisions with the readability suite after failed cleanup.

Fixes #1484. This PR targets the integration branch, not main or a release. No application code or dependencies change.

## Verification

The original test failed in Linux acceptance and a local bounded stress run. Failure measurements showed visual viewport scale 1.125 and horizontal offset 160 after the phone-emulated context expanded to desktop size. The close icon's DOM x-coordinate was 1368.5; its automation bounding box was 1208.5. DOM hit testing reached the icon, while the automation clicked the header. Original traces remain retained as failed evidence.

The corrected Chat and readability slice passed all 18 tests against an isolated SQLite server. The desktop resize case passed all eight stress iterations. Formatting and diff checks passed. Separate specification and standards reviews found no actionable issues. ESLint does not cover this E2E path in the current configuration, so no lint acceptance is claimed for that file.

No forced clicks, sleeps, retries, or zoom suppression were added. CI33881857271 and Security33881859193 passed on source8712fdf48a47a809e262e7cf86c96cc218cd8005, including production and all-dependency audits. Other integration browser failures, packaged task-family verification, final documentation media, signing, installation, and release acceptance remain incomplete.
