### PR TITLE
test: await mobile navigation before geometry probes

### DIFF
--- a/docs/design/MOBILE-TOOLTIP-GEOMETRY.md
+++ b/docs/design/MOBILE-TOOLTIP-GEOMETRY.md
@@ -10,6 +10,8 @@ The task-card hint has a delayed opening and an explicit width. At 320px with 20
 
 Browser results do not replace integrated Linux QA, packaged native verification, refreshed documentation media, or release acceptance.
 
+The geometry probe waits for the public Mobile navigation landmark before reading its surface. Navigation is independently lazy-loaded; a visible task status control does not prove navigation has mounted. A diagnostic gate on that module reproduced the previous null-element read before tooltip checks began. The maintained test uses the visible landmark as its prerequisite, without sleeps or module interception.
+
 ## Task status menus
 
 Tracking: #1479. The task-card hint is suppressed while its status dropdown is open, regardless of pointer or keyboard entry. Dropdown lifecycle callbacks own this state; normal card hints remain available after the menu closes. This prevents a non-interactive hint from obscuring actionable option labels without changing tooltip stacking or status-change behavior.

--- a/e2e/mobile-tooltip-viewport.spec.ts
+++ b/e2e/mobile-tooltip-viewport.spec.ts
@@ -36,6 +36,7 @@ for (const width of [320, 430]) {
           exact: true,
         });
         await expect(status).toBeVisible();
+        await expect(page.getByRole('navigation', { name: 'Mobile navigation' })).toBeVisible();
         await status.evaluate((el) => {
           const bar = document
             .querySelector('[data-mobile-navigation-surface]')!


### PR DESCRIPTION
## Summary

Wait for visible Mobile navigation before reading its surface in the tooltip viewport test. Navigation is independently lazy-loaded; a visible task status control is not a readiness signal for it. All tooltip bounds, text containment, status-menu, Chat, and frame-by-frame viewport assertions are unchanged.

Fixes #1486. This is a test-only correction stacked on #1485 for integration, not main or release delivery.

## Verification

The original Linux run failed with a null-element getBoundingClientRect read. A local diagnostic gate delaying the navigation module reproduced that exact failure. Waiting for the public navigation landmark then passed with the module delayed. The diagnostic gate and timer were removed; all four maintained tooltip cases passed. Formatting, diff checks, and independent specification/standards review passed. The existing ESLint configuration does not cover this E2E path.

No application changes, forced clicks, sleeps, retries, or module interception are added. CI run 33882442072 and Security run 33882443808 passed on e65753a740be07a4d4a344393bf4e2099ec75662. Workspace test and coverage jobs were skipped by the selected CI tier; the focused browser evidence above is separate. The supporting-dialog footer failure is still unexplained, and complete integration, packaged, media, and release acceptance remain open.
