### PR TITLE
fix: disable unintended reduced-motion layout transitions

### DIFF
--- a/docs/design/TASK-OVERLAY-ACCEPTANCE.md
+++ b/docs/design/TASK-OVERLAY-ACCEPTANCE.md
@@ -8,6 +8,8 @@ The task workspace retains one mounted content tree through drawer, expanded, an
 
 Task confirmations and forms use shared widths and insets, a primary scrolling body, fixed action footers, and quiet Cancel actions. Nested Preview and Conflict Resolver panels become authoring dialogs. Their control bars remain outside the primary scroller. Conflict Resolver's Abort confirmation is inside the shared depth provider, so closing it reactivates the resolver rather than the task behind it.
 
+Reduced-motion preferences make CSS transitions immediate, with no transition delay. A tiny nonzero duration on every element would introduce default `all` transitions and temporarily retain old modal widths, padding, and gaps when text size changes. Footer checks retain exact before/after-scroll geometry rather than waiting away that layout regression. Explicit keyframe animations retain their finite reduced duration for animation-event compatibility.
+
 | Family                                            | Source                                        | Browser geometry evidence                                                                                                 | Packaged macOS evidence |
 | ------------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | Task root                                         | `TaskDetailPanel`, `UiTaskSurface`            | Expanded mode retains section, scroll, board opener                                                                       | Pending                 |

--- a/e2e/task-support-popouts.spec.ts
+++ b/e2e/task-support-popouts.spec.ts
@@ -97,6 +97,12 @@ for (const theme of ['light', 'dark']) {
             }, geometry.fontSize);
             const footer = dialog.locator('.vk-overlay-footer');
             const scroll = dialog.locator('.vk-overlay-scroll');
+            if (reducedMotion === 'reduce') {
+              // A tiny nonzero duration introduces default `all` transitions,
+              // deferring rem-based padding and width changes by a frame.
+              await expect(footer).toHaveCSS('transition-duration', '0s');
+              await expect(footer).toHaveCSS('transition-delay', '0s');
+            }
             for (const action of actions) {
               await expect(
                 footer.getByRole('button', { name: action, exact: true })

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -287,7 +287,9 @@
     *::after {
       animation-duration: 0.01ms !important;
       animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
+      /* Nonzero duration would introduce default `all` layout transitions. */
+      transition-duration: 0s !important;
+      transition-delay: 0s !important;
       scroll-behavior: auto !important;
     }
   }


### PR DESCRIPTION
## Summary

Fix reduced-motion resizing for #1490. The global tiny nonzero transition duration introduced default `all` transitions on elements that otherwise had none, including modal flex-basis and footer padding/gaps. Set CSS transition duration and delay to zero under reduced motion. Normal-motion behavior and finite keyframe animation handling are unchanged.

Add explicit reduced-motion assertions to the existing real support-popout tests and document the behavior. Preserve exact before/after-scroll geometry, viewport reachability, focus, parent inertness, and pending-operation checks. No settling sleeps, test-only production overrides, or relaxed tolerances.

Refs #1383, #1444, #1389. This is stacked on the integration candidate; keep the issue open until the fix reaches main.

## Verification

- Reproduced the original 438×67 to 550×83.5 footer change on the real Delete deliverable dialog. A no-op instead of scrolling reproduced it with scrollTop remaining zero. DOM and protocol bounds agreed, and browser animation records identified the layout transitions.
- New regression failed before the fix: expected zero transition duration, received `1e-05s`.
- All four support-popout cases passed after the fix, covering both themes and motion preferences across normal, enlarged-text, and compact viewports.
- The bounded real-dialog diagnostic passed all 180 resize/font samples, including sixfold CPU throttling, against production CSS without overrides.
- Web typecheck, Prettier, diff checks, and public-documentation checks passed. Light and dark compact confirmation captures were inspected.
- Specification and standards review found no actionable findings.

## Remaining acceptance

This resolves the isolated browser footer regression, not complete integration or native/release acceptance. Linux integration QA, final packaged task-family verification, signed/installed build checks, and final documentation-media publication remain separate gates. No workspace unit, full build, native package, or Docker gate was rerun for this fix.
