### PR TITLE
test: register documentation publication contracts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
           scripts/ci-pr-label-state.test.mjs
           scripts/validate-release-native.test.mjs
           scripts/native-ui/contract.test.mjs
+          scripts/docs-media/verify.test.mjs
+          scripts/docs-media/record.test.mjs
+          scripts/docs-media/finalize.test.mjs
+          scripts/docs-media/publication.test.mjs
+          scripts/docs-media/restore-candidate.test.mjs
 
       - name: Guard delivery cadence
         run: node scripts/check-delivery-cadence.mjs

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "test:load": "k6 run load-tests/k6/smoke.js && k6 run load-tests/k6/read-load.js && k6 run load-tests/k6/write-load.js && k6 run load-tests/k6/mixed-load.js && k6 run load-tests/k6/ws-stress.js && k6 run load-tests/k6/v5-remote-mix.js",
     "smoke:cli-mcp": "node scripts/smoke-cli-mcp-compat.mjs",
     "test:release-format": "node --test scripts/validate-release-format.test.mjs",
-    "test:release-native": "node --test scripts/validate-release-native.test.mjs scripts/native-ui/contract.test.mjs scripts/docs-media/verify.test.mjs scripts/docs-media/record.test.mjs scripts/docs-media/finalize.test.mjs",
+    "test:release-native": "node --test scripts/validate-release-native.test.mjs scripts/native-ui/contract.test.mjs scripts/docs-media/verify.test.mjs scripts/docs-media/record.test.mjs scripts/docs-media/finalize.test.mjs scripts/docs-media/publication.test.mjs scripts/docs-media/restore-candidate.test.mjs",
     "validate:release": "node scripts/validate-release.mjs",
     "desktop:ui:mac": "node scripts/native-ui/run.mjs",
     "desktop:ui:verify": "node scripts/native-ui/verify.mjs",


### PR DESCRIPTION
## Summary

Register the existing documentation-media contracts in CI and the canonical release-contract command. The publication and candidate-restoration tests introduced in #1489 were verified locally but omitted from `test:release-native`; media contract files were also absent from the existing dependency-free CI control-tests step.

Refs #1388. No application behavior, dependency, workspace test tier, or capture format changes.

## Verification

Prettier, diff checks, immutable-action validation, and delivery-cadence checks passed. Specification and standards review confirmed the registered tests use Node built-ins and isolated Git fixtures, without installed workspace dependencies, browsers, ffmpeg, credentials, or network access. Existing unchanged test results are retained rather than rerun for command registration. The next integration CI run will exercise the registered set.
