### PR TITLE
chore: prepare 6.1.7 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.7] - 2026-09-04
+
+Veritas Kanban 6.1.7 corrects desktop and compact-window layout, popout interactions, and task-editing failures found during the broader UI audit.
+
+### Changed
+
+- Standardized page headings, action controls, Settings navigation, popout padding, and dialog sizing. Settings units now stay inside uniformly sized fields, and policy action labels remain readable (#1391-#1395, #1405, #1406, #1454).
+- Removed bottom Workbench docking. Board, Squad, and Task Chat share a consistent surface, while compact layouts collapse sidebars and adapt Chat without discarding drafts (#1390, #1397, #1422, #1466).
+- Made PDF work products download-only through the authorized artifact path. The app no longer attempts inline PDF rendering or automatically opens a downloaded file (#1448, #1449, #1458).
+- Require candidate-bound native and documentation-media evidence before release upload. Reviewed media can be published unchanged in a later documentation-only commit; application changes require a fresh build and capture (#1387, #1388, #1456, #1489).
+
+### Fixed
+
+- Kept task, Settings, workflow, approval, Git, and review popouts open while their requests settle, preserved failed-request context, and restored focus to visible controls after dismissal or responsive layout changes (#1424, #1436, #1444, #1445).
+- Prevented stale close cleanup from removing a rapidly reopened task workspace, and removed unintended reduced-motion layout transitions that changed footer geometry during resizing (#1482, #1490).
+- Contained mobile Board, Activity rows, tooltips, and enlarged-text navigation; kept status menus and Chat controls clear of task content (#1462, #1463, #1465, #1476, #1479).
+- Preserved template task fields, supported critical priority consistently in task creation, retained optional-field clearing, and protected configured workspace run budgets (#1410, #1419, #1429, #1431).
+- Drained active HTTP requests before disposing server storage during desktop shutdown (#1473).
+
+### Compatibility
+
+- All maintained packages move together to 6.1.7. The public REST API remains `v1`, with no new database migration; valid 6.1.6 workspaces remain compatible.
+- Legacy bottom-dock preferences resolve to supported Chat placement. PDF files remain downloadable deliverables and can be opened manually in the system viewer.
+
 ## [6.1.6] - 2026-09-03
 
 Veritas Kanban 6.1.6 is a focused desktop reliability and interface consistency release based on issues found while exercising the compiled 6.1.5 macOS app.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-6.1.6-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-6.1.7-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/releases/v6.1.7.md
+++ b/docs/releases/v6.1.7.md
@@ -1,0 +1,36 @@
+Veritas Kanban 6.1.7 fixes layout and interaction problems across the desktop app, compact windows, task workspaces, and Settings. It follows the wider UI audit prompted by problems in the compiled macOS app.
+
+## What changed
+
+Chat now uses one consistent surface across Board, Squad, and Task Chat. Bottom Workbench docking is removed. Sidebars collapse as space becomes constrained, and Chat adapts to compact layouts without losing drafts. The header no longer presents duplicate-looking dock controls.
+
+Settings, page headings, action buttons, and popouts share consistent spacing and sizing. Units stay inside their input fields, dropdowns align with text inputs, and policy Edit and Test labels stay readable. Enlarged text and narrow windows no longer squeeze mobile navigation, Activity rows, tooltips, or Board controls beyond the viewport.
+
+Task confirmations retain their context while requests are pending or fail. Nested popouts restore focus to visible controls, and quickly closing and reopening a task no longer lets stale cleanup remove the new workspace. Reduced-motion mode no longer introduces unintended layout transitions during window or text-size changes.
+
+Templates preserve their task fields and consistently support critical priority. Workspace run-budget limits survive updates, and desktop shutdown drains active HTTP requests before disposing server storage. PDF work products remain authorized downloads; open the downloaded file manually in your system viewer instead of an inline preview.
+
+Release uploads require native verification and documentation captures tied to the packaged build. Reviewed captures can be published unchanged in a later documentation-only commit, but application changes require a new build and capture.
+
+## Install or upgrade
+
+Version 6.1.7 requires macOS 13 Ventura or later on Apple silicon. Back up the complete stopped-writer workspace before upgrading and retain the backup until the new runtime is accepted.
+
+```bash
+brew update
+brew upgrade --cask bradgroux/tap/veritas-kanban
+```
+
+For a first installation:
+
+```bash
+brew install --cask bradgroux/tap/veritas-kanban
+```
+
+Use the signed and notarized macOS arm64 DMG or ZIP from the release Assets section. Linux and Windows packages remain unsigned verification previews.
+
+## Compatibility and rollback
+
+The public REST API remains `v1`, and 6.1.7 adds no database migration. Valid 6.1.6 workspaces remain compatible. Saved bottom-dock preferences resolve to supported Chat placement. Roll back by reinstalling the complete 6.1.6 application bundle; do not mix package or bundled runtime versions.
+
+See the [changelog](https://github.com/BradGroux/veritas-kanban/blob/v6.1.7/CHANGELOG.md) for issue and pull-request traceability.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the 6.1.7 versioned candidate for #1493, based on the UI integration branch. Align all seven package versions and the README badge, add the dated changelog entry, and add the reviewed release-note source.

The 6.1.6 media paths and captions remain unchanged until the exact versioned release build produces reviewed replacements. No dependencies, lockfile resolutions, or runtime code change here. This is preparation only, not a release or an assertion that native/media acceptance has passed.

## Verification

Source-only release preflight passed for 6.1.7, including version alignment and release-body formatting. Prettier, diff checks, and the public-documentation check across 206 Markdown files passed. Both specification and standards reviews are clear after correcting crossed issue references in the changelog. pnpm confirmed the existing lockfile is up to date.

No workspace tests, browser tests, packaging, or container gates were rerun for these metadata/documentation edits. The next integration milestone must verify the versioned candidate, including the previously fixed browser regressions. Final native verification, signed capture/promotion, media playback and publication, installed-app verification, and distribution readback remain pending.

Refs #1389 and #1388. Keep the release issues open until their actual acceptance conditions are met.
