### PR TITLE
fix: contain dashboard status on mobile screens

### DIFF
--- a/docs/design/MOBILE-NAVIGATION-GEOMETRY.md
+++ b/docs/design/MOBILE-NAVIGATION-GEOMETRY.md
@@ -8,6 +8,12 @@ The existing `e2e/mobile-board-scroll.spec.ts` browser checks cover navigation f
 
 These browser checks do not establish packaged macOS, signed-release, or documentation-media acceptance. Those remain separate integration gates.
 
+## Late dashboard content
+
+Tracking: #1495. The embedded dashboard's enforcement status and update timestamp wrap onto separate lines when they cannot fit side by side. Both remain visible. A below-the-fold row can expand the mobile layout viewport even while the user is interacting with Chat near the top of the page; fixed navigation then moves outside the visual viewport.
+
+`e2e/mobile-dashboard-status.spec.ts` waits for the lazy dashboard to load at 320px with enlarged text, checks both status items and the page width, then verifies Chat close/reopen with draft retention. Do not replace this with a check made before the dashboard mounts, broad overflow clipping, or forced clicks.
+
 ## Populated Activity containment
 
 Activity rows must fit the viewport rather than expanding the mobile layout viewport around fixed navigation. Below the small-screen breakpoint, timestamp/status controls may wrap and task identity occupies a separate line with a wrapping ID and title. Wider layouts retain the existing single-row arrangement. No status, ID, or title is hidden to make the row fit.

--- a/e2e/mobile-dashboard-status.spec.ts
+++ b/e2e/mobile-dashboard-status.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test';
+import { bypassAuth, cleanupRoutes } from './helpers/auth';
+
+test.use({ viewport: { width: 320, height: 844 }, isMobile: true, hasTouch: true });
+test.beforeEach(async ({ page }) => bypassAuth(page));
+test.afterEach(async ({ page }) => cleanupRoutes(page));
+
+test('loaded dashboard status preserves the mobile viewport and chat entry', async ({ page }) => {
+  await page.goto('/');
+  await page.addStyleTag({ content: ':root { font-size: 20px !important; }' });
+  const dashboard = page.getByRole('region', { name: 'Board dashboard', exact: true });
+  await dashboard.scrollIntoViewIfNeeded();
+  const updated = dashboard.getByText(/^Updated \d/);
+  await expect(updated).toBeVisible();
+  const status = updated.locator('..');
+  await expect(status.getByText('Enforcement', { exact: true })).toBeVisible();
+  await expect(status.locator(':scope > div')).toHaveCount(2);
+  expect(
+    await status.evaluate((row) => {
+      const rect = row.getBoundingClientRect();
+      return [...row.children].every((child) => {
+        const box = child.getBoundingClientRect();
+        return box.left >= rect.left && box.right <= rect.right;
+      });
+    })
+  ).toBe(true);
+  expect(await page.evaluate(() => [innerWidth, document.documentElement.scrollWidth])).toEqual([
+    320, 320,
+  ]);
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+  const trigger = page.getByRole('button', { name: 'Open chat', exact: true });
+  await trigger.click();
+  const composer = page.getByRole('textbox', { name: 'Message Board Chat', exact: true });
+  await composer.fill('Unsent dashboard draft');
+  const close = page.getByRole('button', { name: 'Close Board Chat panel', exact: true });
+  await close.click();
+  await expect(composer).not.toBeVisible();
+  expect(await page.evaluate(() => [innerWidth, document.documentElement.scrollWidth])).toEqual([
+    320, 320,
+  ]);
+  await expect(trigger).toBeInViewport({ ratio: 1 });
+  await trigger.click();
+  await expect(composer).toHaveValue('Unsent dashboard draft');
+  await close.click();
+});

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -225,7 +225,7 @@ export function Dashboard({ onTaskClick }: DashboardProps = {}) {
       />
 
       {/* Status bar: enforcement indicator + updated timestamp */}
-      <div className="flex items-center justify-between -mt-2">
+      <div className="-mt-2 flex flex-wrap items-center justify-between gap-2">
         <EnforcementIndicator />
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <RefreshCw className={cn('h-3 w-3', isFetching && 'animate-spin')} />


### PR DESCRIPTION
## Summary

Allow the embedded dashboard's enforcement status and update timestamp to wrap when they do not fit side by side. The previous row could widen a 320px mobile layout to 362px after lazy loading, moving the fixed Chat entry outside the visible screen. Neither item is hidden.

Adds a regression that waits for both status items, checks their bounds and the mobile viewport, and verifies Chat close/reopen with draft retention. Documents the late-loading geometry requirement.

Closes #1495. Targets the integration branch; this is not main or release delivery.

## Verification

The original mobile Chat test failed on the second bounded repeat. Measurements identified the overflowing dashboard row. A diagnostic wrapping override then passed eight repeats. The new regression failed on the original source at the status-child containment assertion.

The source fix passed four focused browser cases across the existing Chat file and new dashboard regression. After review strengthened readiness to require both status items, the changed regression passed again. Web typecheck, formatting, and diff checks passed. Changed-file ESLint has zero errors and one existing non-null-assertion warning on untouched line 178. Specification and standards reviews found no remaining actionable issues.

No dependencies changed. No test retries, forced clicks, zoom suppression, broad clipping, or sleeps were added.

Exact-head CI33892190545 and Security33892192952 passed on `4d1f2200b02a14cb13a807c481e22c26613061be`, including CodeQL and Gitleaks. These source gates do not replace integrated browser or packaged-native acceptance.

## Remaining acceptance

Scheduled QA33888542376 on the prior integration commit was cancelled at its 25-minute limit and remains failed evidence. This focused fix does not certify the full browser suite, remaining native families, signed/installed app, final documentation media, or release. A fresh final build and capture are required after this application change.
