### PR TITLE
ci: split browser milestone across isolated runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
         run: >-
           node --test
           scripts/check-actions-pinned.test.mjs
+          scripts/check-browser-milestone.test.mjs
           scripts/check-delivery-cadence.test.mjs
           scripts/check-security-gates.test.mjs
           scripts/check-tracked-ignore.test.mjs

--- a/.github/workflows/scheduled-qa.yml
+++ b/.github/workflows/scheduled-qa.yml
@@ -38,18 +38,23 @@ env:
 
 jobs:
   playwright:
-    name: Playwright E2E
+    name: Playwright E2E (${{ matrix.shard }}/2)
     if: >-
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - name: Record milestone selection
         run: |
           {
             echo "### Playwright E2E milestone"
             echo
+            echo "- Shard: ${{ matrix.shard }}/2 (isolated runner, one worker)"
             echo "- Trigger: \`$GITHUB_EVENT_NAME\`"
             echo "- Reason: explicit \`ci:full\`, scheduled, or manual milestone"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -81,13 +86,13 @@ jobs:
         env:
           PLAYWRIGHT_HTML_REPORT: '1'
           PLAYWRIGHT_HTML_OPEN: never
-        run: pnpm test:e2e
+        run: pnpm test:e2e --shard=${{ matrix.shard }}/2
 
       - name: Upload Playwright artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-artifacts
+          name: playwright-artifacts-${{ matrix.shard }}
           path: |
             playwright-report/
             test-results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,6 +326,13 @@ Follow the existing conventions in `.eslintrc.*`, `.prettierrc`, and `tsconfig.j
   Playwright does not retry failures. Screenshots and traces from the first
   failure are retained in `test-results/` and uploaded by Scheduled QA.
 
+  Scheduled QA splits the complete browser inventory across two isolated runners,
+  each with its own server/data directory and one worker. Both shards must pass;
+  a failing shard does not cancel the other. Existing test timeouts and the
+  25-minute job limit are unchanged. Download `playwright-artifacts-1` and
+  `playwright-artifacts-2` for their separate reports and failure evidence.
+  A cancelled or incomplete shard is not a passing milestone.
+
 - **Load smoke tests** use [k6](https://k6.io/):
 
   ```bash

--- a/scripts/check-browser-milestone.test.mjs
+++ b/scripts/check-browser-milestone.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflow = readFileSync(
+  new URL('../.github/workflows/scheduled-qa.yml', import.meta.url),
+  'utf8'
+);
+const browser = workflow.slice(workflow.indexOf('  playwright:'), workflow.indexOf('\n  k6:'));
+const config = readFileSync(new URL('../playwright.config.ts', import.meta.url), 'utf8');
+
+test('browser milestone uses two independent bounded shards without dropping failure evidence', () => {
+  assert.match(browser, /timeout-minutes: 25/);
+  assert.match(browser, /fail-fast: false/);
+  assert.match(browser, /shard: \[1, 2\]/);
+  assert.match(browser, /pnpm test:e2e --shard=\$\{\{ matrix\.shard \}\}\/2/);
+  assert.match(browser, /VERITAS_DATA_DIR=\$RUNNER_TEMP\/veritas-playwright-data/);
+  assert.match(browser, /name: playwright-artifacts-\$\{\{ matrix\.shard \}\}/);
+  assert.match(browser, /if: always\(\)/);
+  assert.doesNotMatch(browser, /continue-on-error: true|--retries|--workers|--grep|--max-failures/);
+  assert.match(config, /fullyParallel: false/);
+  assert.match(config, /retries: 0/);
+  assert.match(config, /workers: 1/);
+});


### PR DESCRIPTION
## Summary

Split Scheduled QA's complete browser inventory across two isolated hosted runners. Each shard retains one worker, its own server/data directory, zero retries, and the existing test and job timeouts. Matrix fail-fast is disabled and artifact names include the shard number, so one failure does not cancel or overwrite the other's evidence. Both shards must pass.

The prior single-runner integration job33888542376 was cancelled at 25 minutes after 159 passing-test markers and one timeout, with 203 tests planned and no final report. #1496 fixes the separately reproduced mobile Chat defect. This change addresses the runner budget without relaxing browser checks.

Closes #1497. Targets the integration branch, not main or release delivery.

## Verification

The new dependency-free workflow contract failed before the matrix change and passed afterward. It is registered in the CI scope-control gate. Formatting, changed-script lint, diff checks, immutable-action validation, and delivery-cadence checks passed. Specification and standards reviews found no actionable issues.

Actual Playwright discovery on this base enumerated 203 tests, divided into disjoint groups of 109 and 94 whose union exactly matches the full inventory. Discovery with the pending mobile regression enumerated 204 tests split into 102 and 102, also with an exact disjoint union. No browser project or test filter was changed.

Exact-head CI33892781064 and Security33892783932 passed on `699eab3276378557835d555d4b45fe7d41b70fee`, including CodeQL and Gitleaks.

## Remaining acceptance

Discovery and workflow checks do not prove runtime completion. Both shards must finish successfully at the next integrated browser milestone. The prior cancelled run remains unsuccessful evidence. This PR does not certify native task families, signed/installed artifacts, final documentation media, or release publication.
