### PR TITLE
fix: center loading buttons with reduced motion

### DIFF
--- a/docs/design/TASK-OVERLAY-ACCEPTANCE.md
+++ b/docs/design/TASK-OVERLAY-ACCEPTANCE.md
@@ -124,4 +124,6 @@ The initial component regression reproduced immediate dismissal after dispatch. 
 
 ## Remaining acceptance
 
+Shared loading buttons retain a static centering transform when reduced-motion transitions omit their styles. Normal-motion transitions continue to own their animated transform. The HTML artifact Refresh regression checks a held request at normal and enlarged text sizes, requiring the loading indicator to remain centered and fully inside its button. The original packaged-candidate clipping remains historical evidence; fresh affected native verification is required after integration and rebuilding.
+
 Complete every family in both themes, normal and enlarged text, minimum native window size, keyboard entry/dismissal, reduced motion, pending-operation states, and viewport/footer reachability. Rebuild the packaged application with the complete family and inspect native captures. Reconcile the consumer inventory only against that evidence. Final installed-app verification and the maintained documentation screenshots/GIF refresh remain separate, unfinished work.

--- a/e2e/task-artifact-format-popouts.spec.ts
+++ b/e2e/task-artifact-format-popouts.spec.ts
@@ -231,6 +231,42 @@ for (const kind of ['image', 'pdf', 'html'] as const) {
             await expect(dialog).toBeVisible();
             await expect(dialog.getByRole('button', { name: 'Close dialog' })).toBeDisabled();
             await expect(dialog.getByRole('button', { name: 'Causal event' })).toBeDisabled();
+            // Reduced-motion transitions must not remove the loader's layout transform.
+            for (const size of [
+              { width: 1700, height: 900, fontSize: '16px' },
+              { width: 1180, height: 760, fontSize: '20px' },
+              { width: 900, height: 480, fontSize: '20px' },
+            ]) {
+              await page.setViewportSize(size);
+              await page.evaluate((fontSize) => {
+                document.documentElement.style.fontSize = fontSize;
+              }, size.fontSize);
+              const refresh = dialog.getByRole('button', { name: 'Refresh', exact: true });
+              await expect(refresh).toBeDisabled();
+              await expect
+                .poll(
+                  () =>
+                    refresh.evaluate((button) => {
+                      const loader = button.querySelector('.mantine-Button-loader');
+                      if (!loader) return false;
+                      const outer = button.getBoundingClientRect();
+                      const inner = loader.getBoundingClientRect();
+                      return (
+                        inner.width > 0 &&
+                        inner.height > 0 &&
+                        inner.left >= outer.left &&
+                        inner.right <= outer.right &&
+                        inner.top >= outer.top &&
+                        inner.bottom <= outer.bottom &&
+                        Math.abs(inner.left + inner.width / 2 - outer.left - outer.width / 2) <=
+                          1 &&
+                        Math.abs(inner.top + inner.height / 2 - outer.top - outer.height / 2) <= 2
+                      );
+                    }),
+                  { message: 'Loading indicator must be centered and fully inside its button' }
+                )
+                .toBe(true);
+            }
             expect(
               audits.filter((entry) => (entry as { action: string }).action === 'refresh')
             ).toHaveLength(1);

--- a/web/src/theme/mantine-theme.ts
+++ b/web/src/theme/mantine-theme.ts
@@ -100,6 +100,11 @@ export const veritasMantineTheme = createTheme({
         radius: 'sm',
       },
       styles: {
+        // Reduced-motion Transition omits styles, including loader positioning.
+        // Normal-motion transition styles override this static layout fallback.
+        loader: {
+          transform: 'translate(-50%, -50%)',
+        },
         root: {
           minHeight: `${VERITAS_UI_METRICS.actionMinHeight}px`,
           minWidth: `${VERITAS_UI_METRICS.actionMinHeight}px`,


### PR DESCRIPTION
## Summary

Fixes #1501. Give shared loading buttons a static centering transform when reduced motion omits Mantine's transition styles. Normal-motion transitions still override the fallback. No dependency, button-size, or motion-preference changes.

The native artifact Refresh diagnostic exposed the clipped spinner. Its position remained unchanged across additional frames; restoring only the centering transform put it fully inside the same button. The original failed captures remain retained.

## Verification

The maintained HTML artifact regression failed on the original source and passed after the fix. All four HTML browser cases passed, covering both themes and motion settings with loader containment and centering at 1700×900/16px, 1180×760/20px, and 900×480/20px. Web typecheck, changed-source lint, formatting and diff checks passed. E2E files are outside the repository ESLint configuration; their checks are Playwright and formatting.

The first browser command had the wrong API helper port and failed before the scenario. It is not counted as the regression's red result. The corrected command reached and failed the new loading-indicator assertion.

## Delivery boundary

This targets the integration branch, not main. Fresh affected packaged verification is still required after integration and rebuilding. Original artifact geometry/download assertions passed but did not catch spinner clipping, so that visual state was not accepted. The separate Create Task startup timeout, final documentation media, signing, installed-app verification and release delivery remain open.
