### PR TITLE
fix: retain preview controls during pending operations

### DIFF
--- a/docs/design/TASK-OVERLAY-ACCEPTANCE.md
+++ b/docs/design/TASK-OVERLAY-ACCEPTANCE.md
@@ -42,6 +42,12 @@ Apply Template owns submission and dismissal until both the task update and non-
 
 The verification contract includes immediate duplicate prevention, retained inputs, deliberate retry and delayed logging failure. `task-template-pending.spec.ts` checks pending and failed states in both themes and motion settings at 1700×900/16px, 1180×760/20px and 900×480/20px, with fixed/reachable footers, exact intercepted update payloads, disabled dismissal/inputs and opener restoration. Fixture-backed browser checks do not establish native utility-operation or final documentation-media acceptance. Delivery evidence is tracked in #1503.
 
+### Preview operations
+
+Start, Stop and Try Again share one synchronous operation guard. Competing controls and dismissal remain disabled until the request settles. Failures focus a visible inline error and release the guard for a deliberate retry without replacing the backend preview status or removing existing output and iframe behavior.
+
+The verification contract covers immediate duplicate prevention, pending dismissal, failed Start and Stop, successful mocked retry and exact task bindings. `task-preview-pending.spec.ts` checks both themes and motion settings at 1700×900/16px, 1180×760/20px and 900×480/20px, including initial error visibility, fixed/reachable controls and opener restoration. Browser fixtures intercept preview writes and reject unexpected worktree writes; they never start or stop a real development server. Native operation acceptance remains separate. Delivery evidence is tracked in #1505.
+
 ### Supporting task dialogs
 
 `task-support-popouts.spec.ts` covers task, comment, attachment, observation, and deliverable deletion plus manual time entry. Each family is exercised in light/dark, normal/reduced motion, and 1700×900 at 16px, 1180×760 at 20px, and 900×480 at 20px. Checks cover bounded bodies, fixed/reachable footers, no horizontal overflow, keyboard opening, trapped focus, exact opener restoration, and retained task title. Delayed synthetic failed requests exercise Escape, header-close, and backdrop dismissal guards, one submission, inline error recovery, and preserved manual-time drafts. This proves retry availability, not a successful retry. No supporting-record mutation reaches the backend.

--- a/e2e/task-preview-pending.spec.ts
+++ b/e2e/task-preview-pending.spec.ts
@@ -1,0 +1,202 @@
+import { expect, test } from '@playwright/test';
+import { bypassAuth, cleanupRoutes, deleteTask, seedTestTask, unwrapApiData } from './helpers/auth';
+
+for (const operation of ['start', 'stop'] as const) {
+  for (const theme of ['light', 'dark']) {
+    for (const reducedMotion of ['no-preference', 'reduce'] as const) {
+      test(`preview ${operation} retains pending ownership in ${theme}, motion ${reducedMotion}`, async ({
+        page,
+      }) => {
+        await bypassAuth(page);
+        await page.emulateMedia({ reducedMotion });
+        await page.addInitScript(
+          (theme) => localStorage.setItem('veritas-kanban-theme', theme),
+          theme
+        );
+        const title = `Preview ${operation} fixture ${theme} ${reducedMotion}`;
+        const task = await seedTestTask(page, {
+          title,
+          type: 'code',
+          git: {
+            repo: 'Fixture/repo',
+            branch: 'fixture',
+            baseBranch: 'main',
+            worktreePath: '/tmp/task-overlay-fixture',
+          },
+        });
+        await page.route(/\/api\/tasks(?:\/[^/?]+)?(?:\?.*)?$/, async (route) => {
+          if (route.request().method() !== 'GET') return route.fallback();
+          const response = await route.fetch();
+          const json = JSON.parse(JSON.stringify(await response.json()), (_key, value) =>
+            value && typeof value === 'object' && value.id === task.id
+              ? { ...value, git: { ...value.git, worktreeManifestId: 'fixture-manifest' } }
+              : value
+          );
+          return route.fulfill({ response, json });
+        });
+        await page.route('**/api/config', async (route) => {
+          if (route.request().method() !== 'GET') return route.fallback();
+          const config = unwrapApiData<Record<string, unknown>>(await (await route.fetch()).json());
+          return route.fulfill({
+            json: {
+              ...config,
+              repos: [
+                { name: 'Fixture/repo', path: '/tmp/task-overlay-fixture', defaultBranch: 'main' },
+              ],
+            },
+          });
+        });
+        const unexpectedWrites: string[] = [];
+        await page.route(`**/api/tasks/${task.id}/worktree`, (route) => {
+          if (route.request().method() !== 'GET') {
+            unexpectedWrites.push(`${route.request().method()} ${route.request().url()}`);
+            return route.fulfill({ status: 405, json: { error: 'Unexpected worktree write' } });
+          }
+          return route.fulfill({
+            json: { hasChanges: false, aheadBehind: { ahead: 1, behind: 0 } },
+          });
+        });
+        await page.route('**/preview-fixture-page', (route) =>
+          route.fulfill({
+            contentType: 'text/html',
+            body: '<!doctype html><h1>Preview fixture</h1><p>No development server is running.</p>',
+          })
+        );
+        const writes: Array<{ method: string; path: string; body: unknown }> = [];
+        let release = () => {};
+        const gate = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const message = `Fixture preview ${operation} failed. The request can be retried without losing the task.`;
+        await page.route(new RegExp(`/api/preview/${task.id}(?:/|\\?|$)`), async (route) => {
+          const request = route.request();
+          if (request.method() === 'GET')
+            return route.fulfill({
+              json:
+                operation === 'start'
+                  ? { status: 'stopped' }
+                  : {
+                      status: 'running',
+                      url: new URL('/preview-fixture-page', request.url()).href,
+                      output: [],
+                    },
+            });
+          writes.push({
+            method: request.method(),
+            path: new URL(request.url()).pathname,
+            body: request.postDataJSON(),
+          });
+          await gate;
+          return route.fulfill({ status: 503, json: { error: message } });
+        });
+        try {
+          await page.setViewportSize({ width: 1700, height: 900 });
+          await page.goto('/');
+          await page.getByRole('article', { name: `Task: ${title}` }).press('Enter');
+          const workspace = page.getByTestId('task-detail-panel');
+          await workspace.getByRole('button', { name: 'Run', exact: true }).click();
+          await workspace.getByRole('tab', { name: /Git/ }).click();
+          const opener = workspace.getByRole('button', { name: 'Preview', exact: true });
+          await opener.press('Enter');
+          const dialog = page.getByRole('dialog', { name: 'Preview', exact: true });
+          await expect(workspace).toHaveAttribute('inert', '');
+          const submit = dialog.getByRole('button', {
+            name: operation === 'start' ? 'Start Preview' : 'Stop preview',
+            exact: true,
+          });
+          await submit.click();
+          await expect.poll(() => writes.length).toBe(1);
+          await submit.evaluate((el) => (el as HTMLButtonElement).click());
+          const controls =
+            operation === 'start'
+              ? ['Start Preview', 'Close dialog']
+              : [
+                  'Stop preview',
+                  'Refresh preview',
+                  'Open preview externally',
+                  'Toggle preview output',
+                  'Close dialog',
+                ];
+          for (const phase of ['pending', 'error'] as const) {
+            if (phase === 'error') {
+              release();
+              const error = dialog.getByRole('alert', { name: 'Preview request failed' });
+              await expect(error).toContainText(message);
+              await expect(error).toBeFocused();
+              await expect(error).toBeInViewport({ ratio: 1 });
+              await expect(error.getByText(message, { exact: true })).toBeInViewport({ ratio: 1 });
+            }
+            for (const size of [
+              { width: 1700, height: 900, fontSize: '16px' },
+              { width: 1180, height: 760, fontSize: '20px' },
+              { width: 900, height: 480, fontSize: '20px' },
+            ]) {
+              await page.setViewportSize(size);
+              await page.evaluate((fontSize) => {
+                document.documentElement.style.fontSize = fontSize;
+              }, size.fontSize);
+              await expect(dialog.getByRole('button', { name: 'Close dialog' })).toHaveCSS(
+                'width',
+                size.fontSize === '20px' ? '42.5px' : '34px'
+              );
+              await dialog.evaluate(async (el) => {
+                await Promise.all(
+                  el
+                    .getAnimations({ subtree: true })
+                    .filter((a) => a.effect?.getTiming().iterations !== Infinity)
+                    .map((a) => a.finished.catch(() => {}))
+                );
+              });
+              const before = await submit.boundingBox();
+              await dialog.locator('.vk-overlay-scroll').evaluate((el) => {
+                el.scrollTop = el.scrollHeight;
+              });
+              expect(await submit.boundingBox()).toEqual(before);
+              for (const name of controls) {
+                const control = dialog.getByRole('button', { name, exact: true });
+                await expect(control).toBeInViewport({ ratio: 1 });
+                if (phase === 'pending') await expect(control).toBeDisabled();
+                else {
+                  await expect(control).toBeEnabled();
+                  await control.click({ trial: true });
+                }
+              }
+              if (phase === 'pending') {
+                await page.keyboard.press('Escape');
+                await dialog
+                  .getByRole('button', { name: 'Close dialog' })
+                  .evaluate((el) => (el as HTMLButtonElement).click());
+                await page.mouse.click(3, 3);
+                await expect(dialog).toBeVisible();
+              } else {
+                const error = dialog.getByRole('alert', { name: 'Preview request failed' });
+                await error.evaluate((el) =>
+                  el.scrollIntoView({ block: 'center', behavior: 'instant' })
+                );
+                await expect(error).toBeInViewport({ ratio: 1 });
+                await expect(error.getByText(message, { exact: true })).toBeInViewport({
+                  ratio: 1,
+                });
+              }
+              expect(await dialog.evaluate((el) => el.scrollWidth - el.clientWidth)).toBe(0);
+            }
+            await page.screenshot({
+              path: test.info().outputPath(`preview-${operation}-${phase}.png`),
+            });
+          }
+          expect(writes).toEqual([
+            { method: 'POST', path: `/api/preview/${task.id}/${operation}`, body: null },
+          ]);
+          await page.keyboard.press('Escape');
+          await expect(dialog).toHaveCount(0);
+          await expect(opener).toBeFocused();
+          expect(unexpectedWrites).toEqual([]);
+        } finally {
+          release();
+          await cleanupRoutes(page).catch(() => {});
+          await deleteTask(page, String(task.id)).catch(() => {});
+        }
+      });
+    }
+  }
+}

--- a/web/src/__tests__/task-detail-review-preview-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-review-preview-mantine.test.tsx
@@ -44,11 +44,13 @@ vi.mock('@/hooks/usePreview', () => ({
   usePreviewOutput: mocks.usePreviewOutput,
   useStartPreview: () => ({
     mutate: mocks.startPreviewMutate,
+    mutateAsync: mocks.startPreviewMutate,
     isPending: false,
     error: null,
   }),
   useStopPreview: () => ({
     mutate: mocks.stopPreviewMutate,
+    mutateAsync: mocks.stopPreviewMutate,
     isPending: false,
   }),
 }));
@@ -108,6 +110,8 @@ describe('task detail review and preview Mantine migration', () => {
     window.HTMLElement.prototype.scrollIntoView = vi.fn();
     vi.stubGlobal('open', vi.fn());
     mocks.mergeWorktreeMutate.mockReset().mockResolvedValue(undefined);
+    mocks.startPreviewMutate.mockReset().mockResolvedValue(undefined);
+    mocks.stopPreviewMutate.mockReset().mockResolvedValue(undefined);
     mocks.resolveConflictMutateAsync.mockResolvedValue({ success: true });
     mocks.abortConflictMutateAsync.mockResolvedValue({ success: true });
     mocks.continueConflictMutateAsync.mockResolvedValue({ success: true });
@@ -498,6 +502,67 @@ describe('task detail review and preview Mantine migration', () => {
     expect(onStartAddComment).toHaveBeenCalledTimes(2);
     expect(container.querySelector('.veritas-secondary-action')).toBe(addComment);
   });
+
+  it.each(['start', 'stop'] as const)(
+    'retains preview %s ownership through failure and retry',
+    async (operation) => {
+      let rejectRequest!: (error: Error) => void;
+      const mutation = operation === 'start' ? mocks.startPreviewMutate : mocks.stopPreviewMutate;
+      mutation.mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectRequest = reject;
+          })
+      );
+      mocks.usePreviewStatus.mockReturnValue({
+        data:
+          operation === 'start'
+            ? { status: 'error', error: 'Previous preview failed' }
+            : { status: 'running', url: 'http://localhost:4321', output: [] },
+        isLoading: false,
+      });
+      const onOpenChange = vi.fn();
+      renderWithProviders(
+        <PreviewPanel
+          task={createMockTask({
+            id: 'task-preview-pending',
+            git: { repo: 'veritas', branch: 'fixture', baseBranch: 'main' },
+          })}
+          open
+          onOpenChange={onOpenChange}
+        />
+      );
+      await waitFor(() =>
+        expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close dialog' }))
+      );
+      const submit = screen.getByRole('button', {
+        name: operation === 'start' ? 'Start Preview' : 'Stop preview',
+      });
+      fireEvent.click(submit);
+      fireEvent.click(submit);
+      if (operation === 'start') fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+      fireEvent.keyDown(document.body, { key: 'Escape' });
+      fireEvent.click(screen.getByRole('button', { name: 'Close dialog' }));
+      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(mutation).toHaveBeenCalledExactlyOnceWith('task-preview-pending');
+      expect((submit as HTMLButtonElement).disabled).toBe(true);
+      if (operation === 'stop') {
+        for (const name of ['Refresh preview', 'Open preview externally', 'Toggle preview output'])
+          expect((screen.getByRole('button', { name }) as HTMLButtonElement).disabled).toBe(true);
+      }
+      await act(async () => rejectRequest(new Error(`Fixture ${operation} request failed`)));
+      const error = screen.getByRole('alert', { name: 'Preview request failed' });
+      expect(error.textContent).toContain(`Fixture ${operation} request failed`);
+      expect(document.activeElement).toBe(error);
+      expect((submit as HTMLButtonElement).disabled).toBe(false);
+      await act(async () => fireEvent.click(submit));
+      expect(mutation).toHaveBeenCalledTimes(2);
+      expect(screen.queryByRole('alert', { name: 'Preview request failed' })).toBeNull();
+      expect(onOpenChange).not.toHaveBeenCalled();
+      fireEvent.keyDown(document.body, { key: 'Escape' });
+      expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+    }
+  );
 
   it('renders preview drawer controls through direct Mantine primitives', async () => {
     const user = userEvent.setup();

--- a/web/src/components/task/PreviewPanel.tsx
+++ b/web/src/components/task/PreviewPanel.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { UiDrawer as Drawer } from '@/components/ui/UiOverlay';
 import {
   ActionIcon,
+  Alert,
   Button,
   Code,
   Group,
@@ -22,7 +23,6 @@ import {
   Square,
   RefreshCw,
   ExternalLink,
-  Loader2,
   Terminal,
   Monitor,
   AlertCircle,
@@ -38,6 +38,18 @@ interface PreviewPanelProps {
 export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
   const [showOutput, setShowOutput] = useState(false);
   const [iframeKey, setIframeKey] = useState(0);
+  const [operation, setOperation] = useState<'start' | 'stop' | null>(null);
+  const [requestError, setRequestError] = useState<string | null>(null);
+  const requestInFlight = useRef(false);
+  const errorRef = useRef<HTMLDivElement>(null);
+  const isPending = operation !== null;
+
+  useEffect(() => {
+    if (requestError) {
+      errorRef.current?.focus({ preventScroll: true });
+      errorRef.current?.scrollIntoView({ block: 'center', behavior: 'instant' });
+    }
+  }, [requestError]);
 
   const { data: status, isLoading } = usePreviewStatus(open ? task.id : undefined);
   const { data: outputData } = usePreviewOutput(open && showOutput ? task.id : undefined);
@@ -50,12 +62,34 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
   const hasError = status && 'error' in status && status.error;
   const previewUrl = status && 'url' in status ? status.url : null;
 
-  const handleStart = () => {
-    startPreview.mutate(task.id);
+  const runOperation = async (nextOperation: 'start' | 'stop') => {
+    if (
+      requestInFlight.current ||
+      (nextOperation === 'start' && (!task.git?.repo || isRunning || isStarting)) ||
+      (nextOperation === 'stop' && !isRunning)
+    )
+      return;
+    requestInFlight.current = true;
+    setOperation(nextOperation);
+    setRequestError(null);
+    try {
+      if (nextOperation === 'start') await startPreview.mutateAsync(task.id);
+      else await stopPreview.mutateAsync(task.id);
+    } catch (error) {
+      setRequestError(
+        error instanceof Error ? error.message : `Unable to ${nextOperation} preview.`
+      );
+    } finally {
+      requestInFlight.current = false;
+      setOperation(null);
+    }
   };
 
-  const handleStop = () => {
-    stopPreview.mutate(task.id);
+  const handleClose = () => {
+    if (!requestInFlight.current) {
+      setRequestError(null);
+      onOpenChange(false);
+    }
   };
 
   const handleRefresh = () => {
@@ -71,7 +105,10 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
   return (
     <Drawer
       opened={open}
-      onClose={() => onOpenChange(false)}
+      onClose={handleClose}
+      closeOnEscape={!isPending}
+      closeOnClickOutside={!isPending}
+      closeButtonProps={{ disabled: isPending }}
       position="right"
       compound
       title={
@@ -95,6 +132,7 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
                   variant="outline"
                   size="lg"
                   aria-label="Refresh preview"
+                  disabled={isPending}
                   onClick={handleRefresh}
                 >
                   <RefreshCw className="h-4 w-4" />
@@ -103,6 +141,7 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
                   variant="outline"
                   size="lg"
                   aria-label="Open preview externally"
+                  disabled={isPending}
                   onClick={handleOpenExternal}
                 >
                   <ExternalLink className="h-4 w-4" />
@@ -111,6 +150,7 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
                   variant={showOutput ? 'filled' : 'outline'}
                   size="lg"
                   aria-label="Toggle preview output"
+                  disabled={isPending}
                   onClick={() => setShowOutput(!showOutput)}
                 >
                   <Terminal className="h-4 w-4" />
@@ -120,31 +160,23 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
                   variant="filled"
                   size="lg"
                   aria-label="Stop preview"
-                  onClick={handleStop}
-                  disabled={stopPreview.isPending}
+                  onClick={() => void runOperation('stop')}
+                  disabled={isPending}
+                  loading={operation === 'stop'}
                 >
-                  {stopPreview.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Square className="h-4 w-4" />
-                  )}
+                  <Square className="h-4 w-4" />
                 </ActionIcon>
               </>
             )}
 
             {!isRunning && !isStarting && (
               <Button
-                onClick={handleStart}
-                disabled={startPreview.isPending || !task.git?.repo}
-                leftSection={
-                  startPreview.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Play className="h-4 w-4" />
-                  )
-                }
+                onClick={() => void runOperation('start')}
+                disabled={isPending || !task.git?.repo}
+                loading={operation === 'start'}
+                leftSection={<Play className="h-4 w-4" />}
               >
-                {startPreview.isPending ? 'Starting...' : 'Start Preview'}
+                Start Preview
               </Button>
             )}
           </Group>
@@ -152,6 +184,17 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
 
         {/* Content Area */}
         <Stack gap={0} className="vk-overlay-scroll">
+          {requestError && (
+            <Alert
+              ref={errorRef}
+              tabIndex={-1}
+              color="red"
+              title="Preview request failed"
+              className="m-4 shrink-0"
+            >
+              {requestError}
+            </Alert>
+          )}
           {/* Loading state */}
           {(isLoading || isStarting) && (
             <Stack align="center" justify="center" gap="sm" className="flex-1">
@@ -173,7 +216,11 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
               <Text size="sm" c="dimmed" className="max-w-md">
                 {status && 'error' in status ? status.error : 'An error occurred'}
               </Text>
-              <Button onClick={handleStart} leftSection={<RefreshCw className="h-4 w-4" />}>
+              <Button
+                onClick={() => void runOperation('start')}
+                disabled={isPending || !task.git?.repo}
+                leftSection={<RefreshCw className="h-4 w-4" />}
+              >
                 Try Again
               </Button>
             </Stack>
@@ -189,11 +236,6 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
                   ? 'Start the dev server to see a live preview of your changes.'
                   : 'Configure a repository for this task to use preview.'}
               </Text>
-              {startPreview.error && (
-                <Text size="sm" c="red">
-                  {startPreview.error.message}
-                </Text>
-              )}
             </Stack>
           )}
 


### PR DESCRIPTION
## Summary

Fixes #1505. Preview Start, Stop and Try Again now share one synchronous operation guard. Competing controls and dismissal remain disabled until settlement. Failures focus a visible inline error and release the guard for a deliberate retry while preserving backend status, iframe and output behavior.

## Verification

The delayed-operation component regressions reproduced dismissal during Start and Stop on the original source. Three focused cases pass after the correction, including immediate duplicate prevention, failure recovery and successful mocked retry. Web typecheck, changed-source lint, formatting and diff checks pass.

Eight browser cases pass across both themes and motion settings. Pending and failed states are checked at 1700×900/16px, 1180×760/20px and 900×480/20px, including initial focused error visibility before test scrolling, fixed/reachable controls, disabled dismissal, exact intercepted Start/Stop requests and opener restoration. Worktree fixtures reject and record unexpected writes. Compact light Start and dark reduced-motion Stop failure captures were inspected. No actual preview service is started or stopped.

The first browser attempt failed after forced scrolling left a one-pixel edge of the alert outside the viewport. The corrected test separately checks the actual initial reveal before resizing or scrolling, then uses centered scrolling for subsequent size checks. No product CSS or tolerance was changed to pass it. A test-only unsupported query option was also corrected before the passing typecheck. Original failed outputs remain retained.

## Delivery boundary

This targets the integration candidate, not main. Packaged native utility-operation verification, Conflict Resolver and startup checks, final maintained documentation media, signing, installation and release remain pending. Earlier native evidence retains its original build identity and is not acceptance of this source change.
