### PR TITLE
fix: retain conflict operations through settlement

### DIFF
--- a/docs/design/TASK-OVERLAY-ACCEPTANCE.md
+++ b/docs/design/TASK-OVERLAY-ACCEPTANCE.md
@@ -48,6 +48,12 @@ Start, Stop and Try Again share one synchronous operation guard. Competing contr
 
 The verification contract covers immediate duplicate prevention, pending dismissal, failed Start and Stop, successful mocked retry and exact task bindings. `task-preview-pending.spec.ts` checks both themes and motion settings at 1700×900/16px, 1180×760/20px and 900×480/20px, including initial error visibility, fixed/reachable controls and opener restoration. Browser fixtures intercept preview writes and reject unexpected worktree writes; they never start or stop a real development server. Native operation acceptance remains separate. Delivery evidence is tracked in #1505.
 
+### Conflict operations
+
+Resolve, Continue and confirmed Abort share one synchronous operation guard. File selection, navigation, editing, competing actions and dismissal remain disabled until settlement. Abort failures stay in the nested confirmation. Other failures stay in the resolver. Both focus a visible inline error and release the guard for deliberate retry. A same-file background refresh does not replace a manual draft, and the client consumes the server's `{ aborted: true }` response shape.
+
+The verification contract covers immediate duplicate prevention, nested pending dismissal, all three failure paths, successful mocked retries and retained manual input. `task-conflict-pending.spec.ts` checks both themes and motion settings at 1700×900/16px, 1180×760/20px and 900×480/20px, including focused errors, fixed/reachable controls, exact intercepted writes and opener restoration. Fixture-backed browser checks do not mutate real worktrees or establish packaged native operation acceptance. Delivery evidence is tracked in #1507.
+
 ### Supporting task dialogs
 
 `task-support-popouts.spec.ts` covers task, comment, attachment, observation, and deliverable deletion plus manual time entry. Each family is exercised in light/dark, normal/reduced motion, and 1700×900 at 16px, 1180×760 at 20px, and 900×480 at 20px. Checks cover bounded bodies, fixed/reachable footers, no horizontal overflow, keyboard opening, trapped focus, exact opener restoration, and retained task title. Delayed synthetic failed requests exercise Escape, header-close, and backdrop dismissal guards, one submission, inline error recovery, and preserved manual-time drafts. This proves retry availability, not a successful retry. No supporting-record mutation reaches the backend.

--- a/e2e/task-conflict-pending.spec.ts
+++ b/e2e/task-conflict-pending.spec.ts
@@ -1,0 +1,203 @@
+import { expect, test } from '@playwright/test';
+import { bypassAuth, cleanupRoutes, deleteTask, seedTestTask, unwrapApiData } from './helpers/auth';
+
+for (const operation of ['resolve', 'abort', 'continue'] as const) {
+  for (const theme of ['light', 'dark']) {
+    for (const reducedMotion of ['no-preference', 'reduce'] as const) {
+      test(`conflict ${operation} retains pending ownership in ${theme}, motion ${reducedMotion}`, async ({
+        page,
+      }) => {
+        await bypassAuth(page);
+        await page.emulateMedia({ reducedMotion });
+        await page.addInitScript(
+          (value) => localStorage.setItem('veritas-kanban-theme', value),
+          theme
+        );
+        const title = `Conflict ${operation} fixture ${theme} ${reducedMotion}`;
+        const task = await seedTestTask(page, {
+          title,
+          type: 'code',
+          git: {
+            repo: 'Fixture/repo',
+            branch: 'fixture',
+            baseBranch: 'main',
+            worktreePath: '/tmp/task-overlay-fixture',
+          },
+        });
+        await page.route(/\/api\/tasks(?:\/[^/?]+)?(?:\?.*)?$/, async (route) => {
+          if (route.request().method() !== 'GET') return route.fallback();
+          const response = await route.fetch();
+          const json = JSON.parse(JSON.stringify(await response.json()), (_key, value) =>
+            value && typeof value === 'object' && value.id === task.id
+              ? { ...value, git: { ...value.git, worktreeManifestId: 'fixture-manifest' } }
+              : value
+          );
+          return route.fulfill({ response, json });
+        });
+        await page.route('**/api/config', async (route) => {
+          if (route.request().method() !== 'GET') return route.fallback();
+          const config = unwrapApiData<Record<string, unknown>>(await (await route.fetch()).json());
+          return route.fulfill({
+            json: {
+              ...config,
+              repos: [
+                { name: 'Fixture/repo', path: '/tmp/task-overlay-fixture', defaultBranch: 'main' },
+              ],
+            },
+          });
+        });
+        const unexpectedWrites: string[] = [];
+        await page.route(`**/api/tasks/${task.id}/worktree`, (route) => {
+          if (route.request().method() !== 'GET') {
+            unexpectedWrites.push(`${route.request().method()} ${route.request().url()}`);
+            return route.fulfill({ status: 405, json: { error: 'Unexpected worktree write' } });
+          }
+          return route.fulfill({
+            json: { hasChanges: false, aheadBehind: { ahead: 1, behind: 0 } },
+          });
+        });
+        await page.route(`**/api/conflicts/${task.id}`, (route) =>
+          route.fulfill({
+            json: {
+              hasConflicts: true,
+              conflictingFiles: operation === 'continue' ? [] : ['fixture.txt'],
+              rebaseInProgress: true,
+              mergeInProgress: false,
+            },
+          })
+        );
+        await page.route(`**/api/conflicts/${task.id}/file?*`, (route) =>
+          route.fulfill({
+            json: {
+              path: 'fixture.txt',
+              content: 'Initial resolution',
+              oursContent: 'Ours\n'.repeat(80),
+              theirsContent: 'Theirs\n'.repeat(80),
+              baseContent: '',
+              markers: [],
+            },
+          })
+        );
+        const writes: Array<{ method: string; path: string; body: unknown }> = [];
+        let release = () => {};
+        const gate = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const message = `Fixture conflict ${operation} failed. The draft remains available.`;
+        await page.route(
+          new RegExp(`/api/conflicts/${task.id}/(?:resolve|abort|continue)(?:\\?|$)`),
+          async (route) => {
+            const request = route.request();
+            writes.push({
+              method: request.method(),
+              path: new URL(request.url()).pathname,
+              body: request.postDataJSON(),
+            });
+            await gate;
+            return route.fulfill({ status: 503, json: { error: message } });
+          }
+        );
+        try {
+          await page.setViewportSize({ width: 1700, height: 900 });
+          await page.goto('/');
+          await page.locator(`[role="article"][data-task-id="${task.id}"]`).press('Enter');
+          const workspace = page.getByTestId('task-detail-panel');
+          await workspace.getByRole('button', { name: 'Run', exact: true }).click();
+          await workspace.getByRole('tab', { name: /Git/ }).click();
+          const opener = workspace.getByRole('button', { name: 'Resolve Conflicts', exact: true });
+          await opener.press('Enter');
+          const resolver = page.getByRole('dialog', { name: 'Merge Conflicts', exact: true });
+          let owner = resolver;
+          let submit;
+          if (operation === 'resolve') {
+            await resolver.getByRole('tab', { name: 'Manual Edit' }).click();
+            await resolver
+              .getByPlaceholder('Edit the file content to resolve conflicts...')
+              .fill('Keep my resolution');
+            submit = resolver.getByRole('button', { name: 'Save Resolution' });
+          } else if (operation === 'abort') {
+            await resolver.getByRole('button', { name: 'Abort', exact: true }).click();
+            owner = page.getByRole('dialog', { name: 'Abort Rebase?', exact: true });
+            submit = owner.getByRole('button', { name: 'Abort', exact: true });
+          } else submit = resolver.getByRole('button', { name: 'Continue Rebase' });
+          await submit.click();
+          await expect.poll(() => writes.length).toBe(1);
+          await submit.evaluate((element) => (element as HTMLButtonElement).click());
+          for (const phase of ['pending', 'error'] as const) {
+            if (phase === 'error') {
+              release();
+              const error = owner.getByRole('alert', { name: 'Conflict operation failed' });
+              await expect(error).toContainText(message);
+              await expect(error).toBeFocused();
+              await expect(error).toBeInViewport({ ratio: 1 });
+            }
+            for (const size of [
+              { width: 1700, height: 900, fontSize: '16px' },
+              { width: 1180, height: 760, fontSize: '20px' },
+              { width: 900, height: 480, fontSize: '20px' },
+            ]) {
+              await page.setViewportSize(size);
+              await page.evaluate((fontSize) => {
+                document.documentElement.style.fontSize = fontSize;
+              }, size.fontSize);
+              await expect(owner).toBeInViewport({ ratio: 1 });
+              await expect(submit).toBeInViewport({ ratio: 1 });
+              if (phase === 'pending') {
+                await expect(submit).toBeDisabled();
+                if (operation === 'resolve') {
+                  await expect(resolver.getByRole('tab', { name: 'Manual Edit' })).toBeDisabled();
+                  await expect(resolver.getByRole('tab', { name: 'Side by Side' })).toBeDisabled();
+                }
+                await page.keyboard.press('Escape');
+                await owner
+                  .getByRole('button', { name: 'Close dialog' })
+                  .evaluate((element) => (element as HTMLButtonElement).click());
+                await page.mouse.click(3, 3);
+                await expect(owner).toBeVisible();
+              } else {
+                await expect(submit).toBeEnabled();
+                const error = owner.getByRole('alert', { name: 'Conflict operation failed' });
+                await error.evaluate((element) =>
+                  element.scrollIntoView({ block: 'center', behavior: 'instant' })
+                );
+                await expect(error).toBeInViewport({ ratio: 1 });
+              }
+              expect(
+                await owner.evaluate((element) => element.scrollWidth - element.clientWidth)
+              ).toBe(0);
+            }
+            await page.screenshot({
+              path: test.info().outputPath(`conflict-${operation}-${phase}.png`),
+            });
+          }
+          if (operation === 'resolve')
+            await expect(
+              resolver.getByPlaceholder('Edit the file content to resolve conflicts...')
+            ).toHaveValue('Keep my resolution');
+          expect(writes).toEqual([
+            {
+              method: 'POST',
+              path: `/api/conflicts/${task.id}/${operation}`,
+              body:
+                operation === 'resolve'
+                  ? { resolution: 'manual', manualContent: 'Keep my resolution' }
+                  : operation === 'continue'
+                    ? {}
+                    : null,
+            },
+          ]);
+          await page.keyboard.press('Escape');
+          await expect(owner).toHaveCount(0);
+          if (operation === 'abort') await page.keyboard.press('Escape');
+          await expect(resolver).toHaveCount(0);
+          await expect(opener).toBeFocused();
+          expect(unexpectedWrites).toEqual([]);
+        } finally {
+          release();
+          await cleanupRoutes(page).catch(() => {});
+          await deleteTask(page, String(task.id)).catch(() => {});
+        }
+      });
+    }
+  }
+}

--- a/web/src/__tests__/task-detail-review-preview-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-review-preview-mantine.test.tsx
@@ -717,7 +717,7 @@ describe('task detail review and preview Mantine migration', () => {
       }
       await act(async () => rejectRequest(new Error('Fixture conflict request failed')));
       const error = within(owner).getByRole('alert', { name: 'Conflict operation failed' });
-      expect(document.activeElement).toBe(error);
+      await waitFor(() => expect(document.activeElement).toBe(error));
       expect(error.textContent).toContain('Fixture conflict request failed');
       expect((submit as HTMLButtonElement).disabled).toBe(false);
       if (operation === 'resolve')
@@ -766,7 +766,7 @@ describe('task detail review and preview Mantine migration', () => {
       name: 'Conflict operation failed',
     });
     expect(error.textContent).toContain('was not aborted');
-    expect(document.activeElement).toBe(error);
+    await waitFor(() => expect(document.activeElement).toBe(error));
     expect(onOpenChange).not.toHaveBeenCalled();
     expect(confirmation.isConnected).toBe(true);
   });

--- a/web/src/__tests__/task-detail-review-preview-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-review-preview-mantine.test.tsx
@@ -112,9 +112,11 @@ describe('task detail review and preview Mantine migration', () => {
     mocks.mergeWorktreeMutate.mockReset().mockResolvedValue(undefined);
     mocks.startPreviewMutate.mockReset().mockResolvedValue(undefined);
     mocks.stopPreviewMutate.mockReset().mockResolvedValue(undefined);
-    mocks.resolveConflictMutateAsync.mockResolvedValue({ success: true });
-    mocks.abortConflictMutateAsync.mockResolvedValue({ success: true });
-    mocks.continueConflictMutateAsync.mockResolvedValue({ success: true });
+    mocks.resolveConflictMutateAsync
+      .mockReset()
+      .mockResolvedValue({ success: true, remainingConflicts: [] });
+    mocks.abortConflictMutateAsync.mockReset().mockResolvedValue({ aborted: true });
+    mocks.continueConflictMutateAsync.mockReset().mockResolvedValue({ success: true });
     mocks.useDecisionReviews.mockReturnValue({ data: [], isLoading: false });
     mocks.createDecisionReviewMutateAsync.mockResolvedValue({
       id: 'decision_review_new',
@@ -170,7 +172,7 @@ describe('task detail review and preview Mantine migration', () => {
     });
     mocks.useFileConflict.mockReturnValue({
       data: {
-        filePath: 'src/App.tsx',
+        path: 'src/App.tsx',
         content: 'resolved content',
         oursContent: 'ours content',
         theirsContent: 'theirs content',
@@ -604,6 +606,169 @@ describe('task detail review and preview Mantine migration', () => {
       'noopener,noreferrer'
     );
     expect(mocks.stopPreviewMutate).toHaveBeenCalledWith('task-preview');
+  });
+
+  it.each(['resolve', 'abort', 'continue'] as const)(
+    'retains conflict %s ownership and recovers without losing the draft',
+    async (operation) => {
+      let rejectRequest!: (error: Error) => void;
+      const mutation =
+        operation === 'resolve'
+          ? mocks.resolveConflictMutateAsync
+          : operation === 'abort'
+            ? mocks.abortConflictMutateAsync
+            : mocks.continueConflictMutateAsync;
+      mutation.mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectRequest = reject;
+          })
+      );
+      if (operation === 'continue')
+        mocks.useConflictStatus.mockReturnValue({
+          data: {
+            hasConflicts: false,
+            conflictingFiles: [],
+            rebaseInProgress: true,
+            mergeInProgress: false,
+          },
+          isLoading: false,
+        });
+      const onOpenChange = vi.fn();
+      const props = {
+        task: createMockTask({ id: 'task-conflict-pending' }),
+        open: true,
+        onOpenChange,
+      };
+      const view = renderWithProviders(<ConflictResolver {...props} />);
+      const resolver = screen.getByRole('dialog', { name: 'Merge Conflicts' });
+      await waitFor(() =>
+        expect(document.activeElement).toBe(
+          within(resolver).getByRole('button', { name: 'Close dialog' })
+        )
+      );
+      if (operation !== 'continue') {
+        fireEvent.click(within(resolver).getByRole('tab', { name: 'Manual Edit' }));
+        fireEvent.change(
+          screen.getByPlaceholderText('Edit the file content to resolve conflicts...'),
+          { target: { value: 'Keep my resolution' } }
+        );
+      }
+      if (operation === 'abort')
+        fireEvent.click(within(resolver).getByRole('button', { name: 'Abort' }));
+      const owner =
+        operation === 'abort' ? screen.getByRole('dialog', { name: 'Abort Rebase?' }) : resolver;
+      await waitFor(() =>
+        expect(document.activeElement).toBe(
+          within(owner).getByRole('button', { name: 'Close dialog' })
+        )
+      );
+      const submit = within(owner).getByRole('button', {
+        name:
+          operation === 'resolve'
+            ? 'Save Resolution'
+            : operation === 'abort'
+              ? 'Abort'
+              : 'Continue Rebase',
+      });
+      fireEvent.click(submit);
+      fireEvent.click(submit);
+      fireEvent.keyDown(document.body, { key: 'Escape' });
+      fireEvent.click(within(owner).getByRole('button', { name: 'Close dialog' }));
+      if (operation === 'abort')
+        fireEvent.click(within(owner).getByRole('button', { name: 'Cancel' }));
+      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(owner.isConnected).toBe(true);
+      expect(mutation).toHaveBeenCalledTimes(1);
+      expect((submit as HTMLButtonElement).disabled).toBe(true);
+      if (operation === 'resolve') {
+        expect(
+          (within(resolver).getByRole('tab', { name: 'Manual Edit' }) as HTMLButtonElement).disabled
+        ).toBe(true);
+        expect(
+          (within(resolver).getByRole('tab', { name: 'Side by Side' }) as HTMLButtonElement)
+            .disabled
+        ).toBe(true);
+        expect(
+          (
+            screen.getByPlaceholderText(
+              'Edit the file content to resolve conflicts...'
+            ) as HTMLTextAreaElement
+          ).disabled
+        ).toBe(true);
+        expect(
+          (
+            within(resolver).getByRole('button', {
+              name: 'Abort',
+            }) as HTMLButtonElement
+          ).disabled
+        ).toBe(true);
+        mocks.useFileConflict.mockReturnValue({
+          data: {
+            path: 'src/App.tsx',
+            content: 'Background refresh',
+            oursContent: 'ours',
+            theirsContent: 'theirs',
+            markers: [],
+          },
+          isLoading: false,
+        });
+        view.rerender(<ConflictResolver {...props} />);
+      }
+      await act(async () => rejectRequest(new Error('Fixture conflict request failed')));
+      const error = within(owner).getByRole('alert', { name: 'Conflict operation failed' });
+      expect(document.activeElement).toBe(error);
+      expect(error.textContent).toContain('Fixture conflict request failed');
+      expect((submit as HTMLButtonElement).disabled).toBe(false);
+      if (operation === 'resolve')
+        expect(
+          (
+            screen.getByPlaceholderText(
+              'Edit the file content to resolve conflicts...'
+            ) as HTMLTextAreaElement
+          ).value
+        ).toBe('Keep my resolution');
+      await act(async () => fireEvent.click(submit));
+      expect(mutation).toHaveBeenCalledTimes(2);
+      if (operation === 'resolve') {
+        expect(mutation).toHaveBeenLastCalledWith({
+          taskId: props.task.id,
+          filePath: 'src/App.tsx',
+          resolution: 'manual',
+          manualContent: 'Keep my resolution',
+        });
+        expect(onOpenChange).not.toHaveBeenCalled();
+        expect(screen.queryByRole('button', { name: 'Save Resolution' })).toBeNull();
+      } else expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+    }
+  );
+
+  it('keeps Abort open when a fulfilled response does not confirm the abort', async () => {
+    mocks.abortConflictMutateAsync.mockResolvedValueOnce({ aborted: false });
+    const onOpenChange = vi.fn();
+    renderWithProviders(
+      <ConflictResolver
+        task={createMockTask({ id: 'task-abort-unconfirmed' })}
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+    const resolver = screen.getByRole('dialog', { name: 'Merge Conflicts' });
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        within(resolver).getByRole('button', { name: 'Close dialog' })
+      )
+    );
+    fireEvent.click(within(resolver).getByRole('button', { name: 'Abort' }));
+    const confirmation = screen.getByRole('dialog', { name: 'Abort Rebase?' });
+    fireEvent.click(within(confirmation).getByRole('button', { name: 'Abort' }));
+    const error = await within(confirmation).findByRole('alert', {
+      name: 'Conflict operation failed',
+    });
+    expect(error.textContent).toContain('was not aborted');
+    expect(document.activeElement).toBe(error);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(confirmation.isConnected).toBe(true);
   });
 
   it('renders conflict resolution drawer and abort modal through direct Mantine controls', async () => {

--- a/web/src/components/task/ConflictResolver.tsx
+++ b/web/src/components/task/ConflictResolver.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { UiDrawer as Drawer, UiModal as Modal, OverlayFooter } from '@/components/ui/UiOverlay';
 import { UiAction } from '@/components/ui/UiVocabulary';
 import {
   Button,
+  Alert,
   Code,
   Group,
   Loader,
@@ -44,7 +45,18 @@ interface ConflictResolverProps {
 export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverProps) {
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [manualContent, setManualContent] = useState('');
+  const [activeTab, setActiveTab] = useState<string | null>('sidebyside');
   const [showAbortDialog, setShowAbortDialog] = useState(false);
+  const [operation, setOperation] = useState<'resolve' | 'abort' | 'continue' | null>(null);
+  const [operationError, setOperationError] = useState<string | null>(null);
+  const [errorOperation, setErrorOperation] = useState<'resolve' | 'abort' | 'continue' | null>(
+    null
+  );
+  const operationInFlight = useRef(false);
+  const operationErrorRef = useRef<HTMLDivElement>(null);
+  const manualFileKey = useRef<string | null>(null);
+  const resolutionStatus = useRef<{ before: string[]; after: string[] } | null>(null);
+  const isPending = operation !== null;
 
   const { data: status, isLoading: statusLoading } = useConflictStatus(open ? task.id : undefined);
   const { data: fileConflict, isLoading: fileLoading } = useFileConflict(
@@ -58,48 +70,93 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
 
   // Auto-select first file if none selected
   useEffect(() => {
-    if (status?.conflictingFiles.length && !selectedFile) {
-      setSelectedFile(status.conflictingFiles[0]);
+    let files = status?.conflictingFiles ?? [];
+    if (resolutionStatus.current) {
+      if (
+        files.length === resolutionStatus.current.before.length &&
+        files.every((file, index) => file === resolutionStatus.current?.before[index])
+      ) {
+        files = resolutionStatus.current.after;
+      } else {
+        resolutionStatus.current = null;
+      }
+    }
+    const firstUnresolved = files[0];
+    if (firstUnresolved && !selectedFile) {
+      setSelectedFile(firstUnresolved);
     }
   }, [status?.conflictingFiles, selectedFile]);
 
-  const handleResolve = async (resolution: 'ours' | 'theirs' | 'manual') => {
+  useEffect(() => {
+    if (operationError) {
+      operationErrorRef.current?.focus({ preventScroll: true });
+      operationErrorRef.current?.scrollIntoView({ block: 'center', behavior: 'instant' });
+    }
+  }, [operationError]);
+
+  const runOperation = async (
+    nextOperation: 'resolve' | 'abort' | 'continue',
+    request: () => Promise<void>
+  ) => {
+    if (operationInFlight.current) return;
+    operationInFlight.current = true;
+    setOperation(nextOperation);
+    setOperationError(null);
+    setErrorOperation(null);
+    try {
+      await request();
+    } catch (error) {
+      setErrorOperation(nextOperation);
+      setOperationError(error instanceof Error ? error.message : 'Unable to update conflicts.');
+    } finally {
+      operationInFlight.current = false;
+      setOperation(null);
+    }
+  };
+
+  const handleResolve = (resolution: 'ours' | 'theirs' | 'manual') => {
     if (!selectedFile) return;
-
-    await resolveConflict.mutateAsync({
-      taskId: task.id,
-      filePath: selectedFile,
-      resolution,
-      manualContent: resolution === 'manual' ? manualContent : undefined,
+    const filePath = selectedFile;
+    const draft = manualContent;
+    const previousFiles = status?.conflictingFiles ?? [];
+    void runOperation('resolve', async () => {
+      const result = await resolveConflict.mutateAsync({
+        taskId: task.id,
+        filePath,
+        resolution,
+        manualContent: resolution === 'manual' ? draft : undefined,
+      });
+      if (!result.success) throw new Error('The conflict was not resolved.');
+      resolutionStatus.current = { before: previousFiles, after: result.remainingConflicts };
+      const nextFile = result.remainingConflicts.find((file) => file !== filePath) ?? null;
+      manualFileKey.current = null;
+      setSelectedFile(nextFile);
     });
-
-    // Move to next file or close if done
-    const remaining = status?.conflictingFiles.filter((f) => f !== selectedFile) || [];
-    if (remaining.length > 0) {
-      setSelectedFile(remaining[0]);
-    } else {
-      setSelectedFile(null);
-    }
   };
 
-  const handleAbort = async () => {
-    await abortConflict.mutateAsync(task.id);
-    setShowAbortDialog(false);
-    onOpenChange(false);
-  };
-
-  const handleContinue = async () => {
-    const result = await continueConflict.mutateAsync({ taskId: task.id });
-    if (result.success) {
+  const handleAbort = () => {
+    void runOperation('abort', async () => {
+      const result = await abortConflict.mutateAsync(task.id);
+      if (result.aborted !== true) throw new Error('The conflict operation was not aborted.');
+      setShowAbortDialog(false);
       onOpenChange(false);
-    }
+    });
+  };
+
+  const handleContinue = () => {
+    void runOperation('continue', async () => {
+      const result = await continueConflict.mutateAsync({ taskId: task.id });
+      if (!result.success)
+        throw new Error(result.error || 'Unable to continue the conflict operation.');
+      onOpenChange(false);
+    });
   };
 
   const currentIndex =
     selectedFile && status?.conflictingFiles ? status.conflictingFiles.indexOf(selectedFile) : -1;
 
   const navigateFile = (direction: 'prev' | 'next') => {
-    if (!status?.conflictingFiles.length) return;
+    if (operationInFlight.current || !status?.conflictingFiles.length) return;
 
     const newIndex =
       direction === 'prev'
@@ -114,15 +171,28 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
 
   // Initialize manual content when file changes
   useEffect(() => {
-    if (fileConflict) {
+    const fileKey = selectedFile && fileConflict ? `${task.id}\u0000${selectedFile}` : null;
+    if (fileConflict && fileKey && manualFileKey.current !== fileKey) {
+      manualFileKey.current = fileKey;
       setManualContent(fileConflict.content);
     }
-  }, [fileConflict]);
+  }, [fileConflict, selectedFile, task.id]);
+
+  const handleClose = () => {
+    if (!operationInFlight.current) {
+      setOperationError(null);
+      setErrorOperation(null);
+      onOpenChange(false);
+    }
+  };
 
   return (
     <Drawer
       opened={open}
-      onClose={() => onOpenChange(false)}
+      onClose={handleClose}
+      closeOnEscape={!isPending}
+      closeOnClickOutside={!isPending}
+      closeButtonProps={{ disabled: isPending }}
       position="right"
       compound
       title={
@@ -139,12 +209,48 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
           </Text>
 
           <Group gap="xs">
+            {selectedFile && activeTab === 'sidebyside' && (
+              <>
+                <Button
+                  size="xs"
+                  variant="outline"
+                  onClick={() => handleResolve('ours')}
+                  disabled={isPending}
+                >
+                  Accept Ours
+                </Button>
+                <Button
+                  size="xs"
+                  variant="outline"
+                  onClick={() => handleResolve('theirs')}
+                  disabled={isPending}
+                >
+                  Accept Theirs
+                </Button>
+              </>
+            )}
+            {selectedFile && activeTab === 'manual' && (
+              <Button
+                size="xs"
+                onClick={() => handleResolve('manual')}
+                disabled={isPending}
+                leftSection={
+                  operation === 'resolve' ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Check className="h-4 w-4" />
+                  )
+                }
+              >
+                Save Resolution
+              </Button>
+            )}
             {status?.conflictingFiles.length === 0 && (
               <Button
                 onClick={handleContinue}
-                disabled={continueConflict.isPending}
+                disabled={isPending}
                 leftSection={
-                  continueConflict.isPending ? (
+                  operation === 'continue' ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
                   ) : (
                     <GitMerge className="h-4 w-4" />
@@ -158,6 +264,7 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
               variant="outline"
               color="red"
               onClick={() => setShowAbortDialog(true)}
+              disabled={isPending}
               leftSection={<X className="h-4 w-4" />}
             >
               Abort
@@ -166,6 +273,17 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
         </Group>
 
         <div className="vk-overlay-scroll flex flex-wrap">
+          {operationError && errorOperation !== 'abort' && (
+            <Alert
+              ref={operationErrorRef}
+              tabIndex={-1}
+              color="red"
+              title="Conflict operation failed"
+              className="m-4 w-full shrink-0"
+            >
+              {operationError}
+            </Alert>
+          )}
           {/* File list sidebar */}
           <div className="w-64 shrink-0 border-r flex flex-col">
             <div className="p-3 border-b bg-muted/50">
@@ -194,6 +312,7 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
                     <button
                       key={file}
                       onClick={() => setSelectedFile(file)}
+                      disabled={isPending}
                       className={cn(
                         'w-full text-left px-3 py-2 rounded-md text-sm truncate',
                         'hover:bg-muted transition-colors',
@@ -223,7 +342,7 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
                       variant="subtle"
                       size="xs"
                       onClick={() => navigateFile('prev')}
-                      disabled={!status?.conflictingFiles.length}
+                      disabled={isPending || !status?.conflictingFiles.length}
                     >
                       <ChevronLeft className="h-4 w-4" />
                     </Button>
@@ -234,7 +353,7 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
                       variant="subtle"
                       size="xs"
                       onClick={() => navigateFile('next')}
-                      disabled={!status?.conflictingFiles.length}
+                      disabled={isPending || !status?.conflictingFiles.length}
                     >
                       <ChevronRight className="h-4 w-4" />
                     </Button>
@@ -243,10 +362,18 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
                 </div>
 
                 {/* Conflict viewer tabs */}
-                <Tabs defaultValue="sidebyside" className="flex-1 flex flex-col overflow-hidden">
+                <Tabs
+                  value={activeTab}
+                  onChange={setActiveTab}
+                  className="flex-1 flex flex-col overflow-hidden"
+                >
                   <Tabs.List className="mx-4 mt-2 w-fit">
-                    <Tabs.Tab value="sidebyside">Side by Side</Tabs.Tab>
-                    <Tabs.Tab value="manual">Manual Edit</Tabs.Tab>
+                    <Tabs.Tab value="sidebyside" disabled={isPending}>
+                      Side by Side
+                    </Tabs.Tab>
+                    <Tabs.Tab value="manual" disabled={isPending}>
+                      Manual Edit
+                    </Tabs.Tab>
                   </Tabs.List>
 
                   {/* Side by side view */}
@@ -264,21 +391,6 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
                               Ours (Current)
                             </Text>
                           </Group>
-                          <Button
-                            size="xs"
-                            variant="outline"
-                            onClick={() => handleResolve('ours')}
-                            disabled={resolveConflict.isPending}
-                            leftSection={
-                              resolveConflict.isPending ? (
-                                <Loader2 className="h-3 w-3 animate-spin" />
-                              ) : (
-                                <Check className="h-3 w-3" />
-                              )
-                            }
-                          >
-                            Accept Ours
-                          </Button>
                         </Group>
                         <ScrollArea className="flex-1">
                           <pre className="p-3 text-xs font-mono whitespace-pre-wrap">
@@ -299,21 +411,6 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
                               Theirs (Incoming)
                             </Text>
                           </Group>
-                          <Button
-                            size="xs"
-                            variant="outline"
-                            onClick={() => handleResolve('theirs')}
-                            disabled={resolveConflict.isPending}
-                            leftSection={
-                              resolveConflict.isPending ? (
-                                <Loader2 className="h-3 w-3 animate-spin" />
-                              ) : (
-                                <Check className="h-3 w-3" />
-                              )
-                            }
-                          >
-                            Accept Theirs
-                          </Button>
                         </Group>
                         <ScrollArea className="flex-1">
                           <pre className="p-3 text-xs font-mono whitespace-pre-wrap">
@@ -334,24 +431,11 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
                         <Text size="sm" fw={500}>
                           Manual Resolution
                         </Text>
-                        <Button
-                          size="xs"
-                          onClick={() => handleResolve('manual')}
-                          disabled={resolveConflict.isPending}
-                          leftSection={
-                            resolveConflict.isPending ? (
-                              <Loader2 className="h-4 w-4 animate-spin" />
-                            ) : (
-                              <Check className="h-4 w-4" />
-                            )
-                          }
-                        >
-                          Save Resolution
-                        </Button>
                       </Group>
                       <Textarea
                         value={manualContent}
                         onChange={(e) => setManualContent(e.currentTarget.value)}
+                        disabled={isPending}
                         className="flex-1 font-mono text-xs resize-none border-0 rounded-none focus-visible:ring-0"
                         placeholder="Edit the file content to resolve conflicts..."
                       />
@@ -377,27 +461,48 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
         variant="confirm"
         compound
         opened={showAbortDialog}
-        onClose={() => setShowAbortDialog(false)}
+        onClose={() => {
+          if (!operationInFlight.current) {
+            setOperationError(null);
+            setErrorOperation(null);
+            setShowAbortDialog(false);
+          }
+        }}
+        closeOnEscape={!isPending}
+        closeOnClickOutside={!isPending}
+        closeButtonProps={{ disabled: isPending }}
         title={`Abort ${status?.rebaseInProgress ? 'Rebase' : 'Merge'}?`}
         centered
       >
         <div className="vk-overlay-scroll">
+          {operationError && errorOperation === 'abort' && (
+            <Alert
+              ref={operationErrorRef}
+              tabIndex={-1}
+              color="red"
+              title="Conflict operation failed"
+              className="mb-4 shrink-0"
+            >
+              {operationError}
+            </Alert>
+          )}
           <Text size="sm" c="dimmed">
             This will discard all conflict resolutions and return to the state before the
             {status?.rebaseInProgress ? ' rebase' : ' merge'} started.
           </Text>
         </div>
         <OverlayFooter>
-          <UiAction variant="quiet" onClick={() => setShowAbortDialog(false)}>
+          <UiAction variant="quiet" disabled={isPending} onClick={() => setShowAbortDialog(false)}>
             Cancel
           </UiAction>
           <UiAction
             variant="destructive"
+            disabled={isPending}
             onClick={() => {
               void handleAbort();
             }}
             leftSection={
-              abortConflict.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
+              operation === 'abort' ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
             }
           >
             Abort

--- a/web/src/components/task/ConflictResolver.tsx
+++ b/web/src/components/task/ConflictResolver.tsx
@@ -88,10 +88,16 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
   }, [status?.conflictingFiles, selectedFile]);
 
   useEffect(() => {
-    if (operationError) {
+    if (!operationError) return;
+
+    // Nested modal focus traps finish their initial-focus pass after this render.
+    // Defer the error handoff so the actionable failure keeps focus deterministically.
+    const focusError = window.setTimeout(() => {
       operationErrorRef.current?.focus({ preventScroll: true });
       operationErrorRef.current?.scrollIntoView({ block: 'center', behavior: 'instant' });
-    }
+    });
+
+    return () => window.clearTimeout(focusError);
   }, [operationError]);
 
   const runOperation = async (

--- a/web/src/hooks/useConflicts.ts
+++ b/web/src/hooks/useConflicts.ts
@@ -1,10 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { 
-  api, 
-  type ConflictStatus, 
-  type ConflictFile, 
+import {
+  api,
+  type ConflictStatus,
+  type ConflictFile,
   type ResolveResult,
-  type ConflictMarker 
+  type ConflictMarker,
 } from '../lib/api';
 
 export type { ConflictStatus, ConflictFile, ResolveResult, ConflictMarker };
@@ -16,7 +16,13 @@ export function useConflictStatus(taskId: string | undefined) {
   return useQuery<ConflictStatus>({
     queryKey: ['conflicts', taskId],
     queryFn: async () => {
-      if (!taskId) return { hasConflicts: false, conflictingFiles: [], rebaseInProgress: false, mergeInProgress: false };
+      if (!taskId)
+        return {
+          hasConflicts: false,
+          conflictingFiles: [],
+          rebaseInProgress: false,
+          mergeInProgress: false,
+        };
       return api.conflicts.getStatus(taskId);
     },
     enabled: !!taskId,
@@ -50,12 +56,16 @@ export function useFileConflict(taskId: string | undefined, filePath: string | u
 export function useResolveConflict() {
   const queryClient = useQueryClient();
 
-  return useMutation<ResolveResult, Error, {
-    taskId: string;
-    filePath: string;
-    resolution: 'ours' | 'theirs' | 'manual';
-    manualContent?: string;
-  }>({
+  return useMutation<
+    ResolveResult,
+    Error,
+    {
+      taskId: string;
+      filePath: string;
+      resolution: 'ours' | 'theirs' | 'manual';
+      manualContent?: string;
+    }
+  >({
     mutationFn: async ({ taskId, filePath, resolution, manualContent }) => {
       return api.conflicts.resolve(taskId, filePath, resolution, manualContent);
     },
@@ -72,7 +82,7 @@ export function useResolveConflict() {
 export function useAbortConflict() {
   const queryClient = useQueryClient();
 
-  return useMutation<{ success: boolean }, Error, string>({
+  return useMutation<{ aborted: boolean }, Error, string>({
     mutationFn: (taskId) => api.conflicts.abort(taskId),
     onSuccess: (_data, taskId) => {
       queryClient.invalidateQueries({ queryKey: ['conflicts', taskId] });
@@ -87,7 +97,11 @@ export function useAbortConflict() {
 export function useContinueConflict() {
   const queryClient = useQueryClient();
 
-  return useMutation<{ success: boolean; error?: string }, Error, { taskId: string; message?: string }>({
+  return useMutation<
+    { success: boolean; error?: string },
+    Error,
+    { taskId: string; message?: string }
+  >({
     mutationFn: ({ taskId, message }) => api.conflicts.continue(taskId, message),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['conflicts', variables.taskId] });

--- a/web/src/lib/api/diff.ts
+++ b/web/src/lib/api/diff.ts
@@ -57,8 +57,8 @@ export const conflictsApi = {
     );
   },
 
-  abort: async (taskId: string): Promise<{ success: boolean }> => {
-    return apiFetch<{ success: boolean }>(`${API_BASE}/conflicts/${taskId}/abort`, {
+  abort: async (taskId: string): Promise<{ aborted: boolean }> => {
+    return apiFetch<{ aborted: boolean }>(`${API_BASE}/conflicts/${taskId}/abort`, {
       method: 'POST',
     });
   },


### PR DESCRIPTION
## Summary

Fixes #1507. Conflict Resolve, Continue and confirmed Abort now share one synchronous operation guard. Competing actions, tabs, file navigation, editing and dismissal remain disabled until settlement. Failures stay in their owning surface, focus a visible inline error and release the guard for deliberate retry. Manual drafts survive same-file background refreshes, and successful resolution follows the mutation's authoritative remaining-file response while invalidated query data is stale.

Resolution actions now live in the fixed resolver control bar after browser verification exposed a clipped Save Resolution action at compact enlarged-text geometry. The abort client type now matches the server's `{ aborted: true }` response.

## Verification

Three focused delayed-operation cases failed on the original source: Resolve and Continue dismissed twice during pending requests, and confirmed Abort closed its nested dialog. Four focused conflict cases pass after the correction, including all three failure/retry paths, nested dismissal ownership, retained manual input through a background refresh, disabled tabs and exact retry payloads. Web typecheck, changed-source lint, formatting and diff checks pass.

The first browser run reproduced the clipped Save Resolution action at 900×480/20px. After moving resolution actions, a corrected run passed eight Resolve and Abort cases but exposed a Continue fixture setup error: `hasConflicts: false` correctly hid the resolver opener. The fixture now retains `hasConflicts: true` with zero remaining files. The final 12 cases pass across Resolve, Abort and Continue, both themes and both motion settings. Each checks pending and failed states at 1700×900/16px, 1180×760/20px and 900×480/20px, including fixed/reachable controls, disabled tabs/dismissal, focused errors, exact intercepted writes, retained drafts and opener restoration. Unexpected worktree writes are rejected and asserted absent. Light Resolve and dark reduced-motion Abort failure captures were inspected. No real worktree mutation occurred.

Independent standards review found that the controlled tabs remained enabled while pending; they and their regressions were corrected before the passing gates. Specification review found no remaining requirement gap.

The first exact-head CI run exposed a focus-timing race between the nested modal trap and the error alert. The error handoff is now deferred until the trap's initial-focus pass finishes, and all affected assertions wait for the observable focus result. The complete 14-test review/preview/conflict file passes locally. Exact-head CI run 33906045250 and Security Gates run 33906047466 both passed on `ab4f271ee586864146d303cf94916f868e1667c3`, including the selected full workspace suite, critical-path coverage, CodeQL and Gitleaks.

## Delivery boundary

This targets the integration candidate, not main. Packaged native utility-operation verification, startup checks, final maintained documentation media, signing, installation and release remain pending. Earlier native evidence retains its original build identity and is not acceptance of this source change.
