### PR TITLE
fix: retain task creation through settlement

### DIFF
--- a/docs/design/TASK-OVERLAY-ACCEPTANCE.md
+++ b/docs/design/TASK-OVERLAY-ACCEPTANCE.md
@@ -13,6 +13,7 @@ Reduced-motion preferences make CSS transitions immediate, with no transition de
 | Family                                            | Source                                        | Browser geometry evidence                                                                                                 | Packaged macOS evidence |
 | ------------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | Task root                                         | `TaskDetailPanel`, `UiTaskSurface`            | Expanded mode retains section, scroll, board opener                                                                       | Pending                 |
+| Create task                                       | `CreateTaskDialog`                            | Light/dark; three sizes; normal/reduced motion; pending guards, retained draft, focused failure, safe retry boundary      | Pending                 |
 | Apply template                                    | `ApplyTemplateDialog`                         | Light/dark; 1700×900 at 16px, 1180×760 and 900×480 at 20px; fixed footer, parent inert, exact opener                      | Pending                 |
 | Preview                                           | `PreviewPanel`                                | Light/dark; 900×480 at 20px; fixed Start control and parent focus restoration                                             | Pending                 |
 | Conflict resolver and Abort                       | `ConflictResolver`                            | Light/dark; 900×480 at 20px; fixed Abort, nested inert parents, successive Escape ownership                               | Pending                 |
@@ -35,6 +36,12 @@ Reduced-motion preferences make CSS transitions immediate, with no transition de
 - Seven existing task-family component slices: 59 tests passed. They cover task detail, review/preview/conflict actions, Git/workflow actions, agent/template/metrics, supporting sections, work products, and artifact previews. Component tests do not prove rendered geometry.
 - `task-detail.spec.ts` expanded-workspace case passed. `task-popout-stack.spec.ts` adds template and nested-utility browser checks. Fixtures do not launch agents, start preview servers, resolve conflicts, or create managed worktrees; managed ownership exists only in intercepted browser reads.
 - Independent standards and specification source reviews identified scrolling utility controls and non-quiet Cancel actions. Both were corrected and cleared on recheck. Remaining evidence gaps are explicit above.
+
+### Create Task submission
+
+Create Task owns submission and dismissal from the first submit event until the complete single-task or blueprint operation settles. Every form control, template control, duplicate-result action, Cancel action and close route remains disabled while pending. Failure retains the complete draft and selected template state and focuses a visible inline error. A single-task failure or a blueprint failure before any write releases the guard for deliberate retry. A partially written blueprint reports the completed count and blocks blind retry so the operator can reconcile the board first. Form and template state reset only after successful creation.
+
+`create-task-pending.spec.ts` checks fixed-footer geometry in both themes and motion settings at 1700×900/16px, 1180×760/20px and 900×480/20px. At the compact size it also checks disabled dismissal and fields while pending, one-request ownership, a visible focused error, retained title and description, successful same-payload retry and exact opener restoration. The browser fixture accepts only the expected create endpoint; it does not create a real task, exercise a blueprint or establish packaged macOS acceptance. Component coverage checks the partial-blueprint retry block. Delivery remains under parent #1383.
 
 ### Apply Template submission
 

--- a/e2e/create-task-pending.spec.ts
+++ b/e2e/create-task-pending.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test } from '@playwright/test';
+import { bypassAuth, cleanupRoutes } from './helpers/auth';
+
+for (const theme of ['light', 'dark']) {
+  for (const reducedMotion of ['no-preference', 'reduce'] as const) {
+    test(`Create Task retains its draft in ${theme}, motion ${reducedMotion}`, async ({ page }) => {
+      await bypassAuth(page);
+      await page.emulateMedia({ reducedMotion });
+      await page.addInitScript(
+        (theme) => localStorage.setItem('veritas-kanban-theme', theme),
+        theme
+      );
+
+      let release = () => {};
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const writes: unknown[] = [];
+      const unexpectedWrites: Array<{ method: string; path: string }> = [];
+      let attempt = 0;
+      await page.route(/\/api\/tasks(?:\/|\?|$)/, async (route) => {
+        const request = route.request();
+        if (request.method() === 'GET') return route.fallback();
+
+        const path = new URL(request.url()).pathname;
+        if (request.method() !== 'POST' || path !== '/api/tasks') {
+          unexpectedWrites.push({ method: request.method(), path });
+          return route.fulfill({ status: 500, json: { error: 'Unexpected fixture write' } });
+        }
+
+        writes.push(request.postDataJSON());
+        attempt += 1;
+        if (attempt === 1) {
+          await gate;
+          return route.fulfill({
+            status: 503,
+            json: { error: 'Fixture task creation failed' },
+          });
+        }
+
+        return route.fulfill({
+          status: 201,
+          json: {
+            id: 'task_fixture_create',
+            title: 'Retain this complete draft',
+            description: 'Do not discard this task description.',
+            type: 'code',
+            status: 'todo',
+            priority: 'medium',
+            created: '2026-09-04T00:00:00.000Z',
+            updated: '2026-09-04T00:00:00.000Z',
+            subtasks: [],
+            comments: [],
+            reviewComments: [],
+          },
+        });
+      });
+
+      try {
+        await page.setViewportSize({ width: 1700, height: 900 });
+        await page.goto('/board');
+        const opener = page.getByRole('button', { name: 'New Task', exact: true });
+        await opener.press('Enter');
+        const dialog = page.getByRole('dialog', { name: 'Create New Task', exact: true });
+        await expect(dialog).toBeVisible();
+        await dialog.getByLabel('Title', { exact: true }).fill('Retain this complete draft');
+        await dialog
+          .getByLabel('Description', { exact: true })
+          .fill('Do not discard this task description.');
+
+        for (const size of [
+          { width: 1700, height: 900, fontSize: '16px' },
+          { width: 1180, height: 760, fontSize: '20px' },
+          { width: 900, height: 480, fontSize: '20px' },
+        ]) {
+          await page.setViewportSize(size);
+          await page.evaluate((fontSize) => {
+            document.documentElement.style.fontSize = fontSize;
+          }, size.fontSize);
+          await page.evaluate(
+            () =>
+              new Promise<void>((resolve) =>
+                requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+              )
+          );
+          await dialog.evaluate(async (element) => {
+            await Promise.all(
+              element
+                .getAnimations({ subtree: true })
+                .map((animation) => animation.finished.catch(() => {}))
+            );
+          });
+
+          const footer = dialog.locator('.vk-overlay-footer');
+          const before = await footer.boundingBox();
+          await dialog.locator('.vk-overlay-scroll').evaluate((element) => {
+            element.scrollTop = element.scrollHeight;
+          });
+          expect(await footer.boundingBox()).toEqual(before);
+          for (const name of ['Close dialog', 'Cancel', 'Create Task']) {
+            const action = dialog.getByRole('button', { name, exact: true });
+            await expect(action).toBeInViewport({ ratio: 1 });
+            await action.click({ trial: true });
+          }
+          expect(
+            await dialog.evaluate((element) => element.scrollWidth - element.clientWidth)
+          ).toBe(0);
+        }
+
+        const submit = dialog.getByRole('button', { name: 'Create Task', exact: true });
+        await submit.click();
+        await expect.poll(() => writes.length).toBe(1);
+        await page.keyboard.press('Escape');
+        await page.mouse.click(3, 3);
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByRole('button', { name: 'Close dialog' })).toBeDisabled();
+        await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+        await expect(dialog.getByLabel('Title', { exact: true })).toBeDisabled();
+        await expect(dialog.getByLabel('Description', { exact: true })).toBeDisabled();
+        await expect(dialog.getByLabel('Type', { exact: true })).toBeDisabled();
+        await submit.click({ force: true });
+        expect(writes).toHaveLength(1);
+
+        release();
+        const error = dialog.getByRole('alert', { name: 'Task not created' });
+        await expect(error).toContainText('Fixture task creation failed');
+        await expect(error).toBeInViewport({ ratio: 1 });
+        await expect(error).toBeFocused();
+        await expect(dialog.getByLabel('Title', { exact: true })).toHaveValue(
+          'Retain this complete draft'
+        );
+        await expect(dialog.getByLabel('Description', { exact: true })).toHaveValue(
+          'Do not discard this task description.'
+        );
+        await expect(submit).toBeEnabled();
+        await page.screenshot({ path: test.info().outputPath('create-task-failure.png') });
+
+        await submit.click();
+        await expect.poll(() => writes.length).toBe(2);
+        await expect(dialog).toHaveCount(0);
+        await expect(opener).toBeFocused();
+        expect(writes[0]).toEqual({
+          title: 'Retain this complete draft',
+          description: 'Do not discard this task description.',
+          type: 'code',
+          priority: 'medium',
+        });
+        expect(writes[1]).toEqual(writes[0]);
+        expect(unexpectedWrites).toEqual([]);
+      } finally {
+        release();
+        await cleanupRoutes(page).catch(() => {});
+      }
+    });
+  }
+}

--- a/server/src/__tests__/issues-778-780-785-786-787.test.ts
+++ b/server/src/__tests__/issues-778-780-785-786-787.test.ts
@@ -355,15 +355,21 @@ describe('#780 — Bounded retry_step cycles', () => {
   it('retryRouteCount is persisted across saves', async () => {
     mockLoadWorkflow.mockResolvedValue(retryWorkflow(1));
     mockExecuteStep.mockImplementation(async (step: { id: string }) => {
+      if (step.id === 'stepA') {
+        await new Promise((resolve) => setTimeout(resolve, 1_100));
+      }
       if (step.id === 'stepB') throw new Error('always fails');
       return { output: {}, outputPath: '/tmp/x.json' };
     });
 
     const run = await service.startRun('wf-retry');
-    await vi.waitFor(async () => {
-      const saved = await service.getRun(run.id);
-      expect(['failed', 'blocked'].includes(saved.status)).toBe(true);
-    });
+    await vi.waitFor(
+      async () => {
+        const saved = await service.getRun(run.id);
+        expect(['failed', 'blocked'].includes(saved.status)).toBe(true);
+      },
+      { timeout: 5_000 }
+    );
 
     const mod = await import('../services/workflow-run-service.js');
     const service2 = new mod.WorkflowRunService({

--- a/web/src/__tests__/CreateTaskDuplicateDetection.test.tsx
+++ b/web/src/__tests__/CreateTaskDuplicateDetection.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { screen, cleanup, fireEvent, waitFor, act } from '@testing-library/react';
 import { CreateTaskDialog } from '@/components/task/CreateTaskDialog';
 import { api } from '@/lib/api';
 import { renderWithProviders } from './test-utils';
+import { PartialBlueprintCreationError } from '@/hooks/useTemplateForm';
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -31,21 +32,34 @@ vi.mock('@/hooks/useConfig', () => ({
   useConfig: () => ({ data: { agents: [] } }),
 }));
 
-vi.mock('@/hooks/useTemplateForm', () => ({
-  useTemplateForm: () => ({
-    selectedTemplate: null,
-    templates: [],
-    subtasks: [],
-    customVars: {},
-    requiredCustomVars: [],
-    applyTemplate: vi.fn(),
-    clearTemplate: vi.fn(),
-    removeSubtask: vi.fn(),
-    setCustomVars: vi.fn(),
-    createTasks: vi.fn(),
-    isCreating: false,
-  }),
+const templateFormMocks = vi.hoisted(() => ({
+  createTasks: vi.fn(),
+  clearTemplate: vi.fn(),
+  selectedTemplate: null as string | null,
+  templates: [] as Array<Record<string, unknown>>,
+  customVars: {} as Record<string, string>,
+  requiredCustomVars: [] as string[],
 }));
+
+vi.mock('@/hooks/useTemplateForm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/useTemplateForm')>();
+  return {
+    ...actual,
+    useTemplateForm: () => ({
+      selectedTemplate: templateFormMocks.selectedTemplate,
+      templates: templateFormMocks.templates,
+      subtasks: [],
+      customVars: templateFormMocks.customVars,
+      requiredCustomVars: templateFormMocks.requiredCustomVars,
+      applyTemplate: vi.fn(),
+      clearTemplate: templateFormMocks.clearTemplate,
+      removeSubtask: vi.fn(),
+      setCustomVars: vi.fn(),
+      createTasks: templateFormMocks.createTasks,
+      isCreating: false,
+    }),
+  };
+});
 
 const navigateToTaskMock = vi.fn();
 
@@ -61,6 +75,12 @@ describe('CreateTaskDialog duplicate detection', () => {
   beforeEach(() => {
     queryMock.mockReset();
     navigateToTaskMock.mockReset();
+    templateFormMocks.createTasks.mockReset();
+    templateFormMocks.clearTemplate.mockReset();
+    templateFormMocks.selectedTemplate = null;
+    templateFormMocks.templates = [];
+    templateFormMocks.customVars = {};
+    templateFormMocks.requiredCustomVars = [];
   });
 
   afterEach(() => {
@@ -173,5 +193,92 @@ describe('CreateTaskDialog duplicate detection', () => {
 
     expect(await screen.findByText(/Duplicate search is unavailable/i)).toBeDefined();
     expect(screen.queryByText(/spawn qmd ENOENT/i)).toBeNull();
+  });
+
+  it('retains creation ownership through failure and deliberate retry', async () => {
+    let rejectRequest!: (error: Error) => void;
+    const pendingRequest = new Promise<void>((_resolve, reject) => {
+      rejectRequest = reject;
+    });
+    templateFormMocks.createTasks
+      .mockReturnValueOnce(pendingRequest)
+      .mockResolvedValueOnce(undefined);
+
+    const onOpenChange = vi.fn();
+    renderWithProviders(<CreateTaskDialog open onOpenChange={onOpenChange} />);
+
+    const title = screen.getByLabelText('Title') as HTMLInputElement;
+    fireEvent.change(title, { target: { value: 'Retain this complete draft' } });
+
+    const submit = screen.getByRole('button', { name: 'Create Task' });
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+
+    expect(templateFormMocks.createTasks).toHaveBeenCalledTimes(1);
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled).toBe(
+      true
+    );
+    expect(
+      (screen.getByRole('button', { name: 'Close dialog' }) as HTMLButtonElement).disabled
+    ).toBe(true);
+    expect(title.matches(':disabled')).toBe(true);
+
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    await act(async () => rejectRequest(new Error('Fixture task creation failed')));
+    const error = await screen.findByRole('alert', { name: 'Task not created' });
+    await waitFor(() => expect(document.activeElement).toBe(error));
+    expect(error.textContent).toContain('Fixture task creation failed');
+    expect(title.value).toBe('Retain this complete draft');
+    expect(title.matches(':disabled')).toBe(false);
+    expect((submit as HTMLButtonElement).disabled).toBe(false);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    fireEvent.click(submit);
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false));
+    expect(templateFormMocks.createTasks).toHaveBeenCalledTimes(2);
+    expect(templateFormMocks.clearTemplate).toHaveBeenCalledTimes(1);
+  });
+
+  it('locks blueprint variables while pending and blocks blind retry after partial creation', async () => {
+    let rejectRequest!: (error: Error) => void;
+    const pendingRequest = new Promise<void>((_resolve, reject) => {
+      rejectRequest = reject;
+    });
+    templateFormMocks.selectedTemplate = 'release-blueprint';
+    templateFormMocks.templates = [
+      {
+        id: 'release-blueprint',
+        name: 'Release blueprint',
+        version: 1,
+        taskDefaults: {},
+        blueprint: [
+          { refId: 'build', title: 'Build release', taskDefaults: {} },
+          { refId: 'publish', title: 'Publish release', taskDefaults: {} },
+        ],
+        created: '2026-09-04T00:00:00.000Z',
+        updated: '2026-09-04T00:00:00.000Z',
+      },
+    ];
+    templateFormMocks.customVars = { channel: 'stable' };
+    templateFormMocks.requiredCustomVars = ['channel'];
+    templateFormMocks.createTasks.mockReturnValueOnce(pendingRequest);
+
+    renderWithProviders(<CreateTaskDialog open onOpenChange={vi.fn()} />);
+
+    const variable = screen.getByLabelText('channel') as HTMLInputElement;
+    const submit = screen.getByRole('button', { name: 'Create Tasks' }) as HTMLButtonElement;
+    fireEvent.click(submit);
+    expect(variable.disabled).toBe(true);
+
+    await act(async () => rejectRequest(new PartialBlueprintCreationError(1, 2)));
+    const error = await screen.findByRole('alert', { name: 'Task not created' });
+    expect(error.textContent).toContain('1 of 2 blueprint tasks were created');
+    expect(variable.disabled).toBe(false);
+    expect(submit.disabled).toBe(true);
+    fireEvent.submit(submit.closest('form') as HTMLFormElement);
+    expect(templateFormMocks.createTasks).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/__tests__/useTemplateForm.test.tsx
+++ b/web/src/__tests__/useTemplateForm.test.tsx
@@ -1,0 +1,82 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PartialBlueprintCreationError, useTemplateForm } from '@/hooks/useTemplateForm';
+
+const mocks = vi.hoisted(() => ({
+  templates: [] as Array<Record<string, unknown>>,
+  mutateAsync: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTemplates', () => ({
+  useTemplates: () => ({ data: mocks.templates }),
+}));
+
+vi.mock('@/hooks/useTasks', () => ({
+  useCreateTask: () => ({ mutateAsync: mocks.mutateAsync, isPending: false }),
+}));
+
+describe('useTemplateForm blueprint creation', () => {
+  beforeEach(() => {
+    mocks.mutateAsync.mockReset();
+    mocks.templates = [
+      {
+        id: 'release-blueprint',
+        name: 'Release blueprint',
+        version: 1,
+        taskDefaults: {},
+        blueprint: [
+          { refId: 'build', title: 'Build release', taskDefaults: {} },
+          {
+            refId: 'publish',
+            title: 'Publish release',
+            taskDefaults: {},
+            blockedByRefs: ['build'],
+          },
+        ],
+        created: '2026-09-04T00:00:00.000Z',
+        updated: '2026-09-04T00:00:00.000Z',
+      },
+    ];
+  });
+
+  it('reports partial blueprint completion so the UI can block a blind retry', async () => {
+    const failure = new Error('Second task failed');
+    mocks.mutateAsync.mockResolvedValueOnce({ id: 'task_build' }).mockRejectedValueOnce(failure);
+    const { result } = renderHook(() => useTemplateForm());
+
+    act(() => {
+      result.current.applyTemplate(mocks.templates[0] as never);
+    });
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.createTasks('', '', '', '', 'code', 'medium', 'auto');
+      } catch (error) {
+        caught = error;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(PartialBlueprintCreationError);
+    expect(caught).toMatchObject({ completedCount: 1, totalCount: 2, cause: failure });
+    expect(mocks.mutateAsync).toHaveBeenCalledTimes(2);
+    expect(mocks.mutateAsync.mock.calls[1]?.[0]).toMatchObject({
+      title: 'Publish release',
+      blockedBy: ['task_build'],
+    });
+  });
+
+  it('preserves the original error when no blueprint task was created', async () => {
+    const failure = new Error('First task failed');
+    mocks.mutateAsync.mockRejectedValueOnce(failure);
+    const { result } = renderHook(() => useTemplateForm());
+
+    act(() => {
+      result.current.applyTemplate(mocks.templates[0] as never);
+    });
+
+    await expect(result.current.createTasks('', '', '', '', 'code', 'medium', 'auto')).rejects.toBe(
+      failure
+    );
+  });
+});

--- a/web/src/components/task/CreateTaskDialog.tsx
+++ b/web/src/components/task/CreateTaskDialog.tsx
@@ -22,7 +22,7 @@ import { useTaskTypes, getTypeIcon } from '@/hooks/useTaskTypes';
 import { useProjects } from '@/hooks/useProjects';
 import { useSprints } from '@/hooks/useSprints';
 import { useConfig } from '@/hooks/useConfig';
-import { useTemplateForm } from '@/hooks/useTemplateForm';
+import { PartialBlueprintCreationError, useTemplateForm } from '@/hooks/useTemplateForm';
 import { useCreateTaskForm } from '@/hooks/useCreateTaskForm';
 import { BlueprintPreview } from './create/BlueprintPreview';
 import { TemplateVariableInputs } from './create/TemplateVariableInputs';
@@ -62,6 +62,11 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
   const [duplicateResults, setDuplicateResults] = useState<SearchResult[]>([]);
   const [duplicateError, setDuplicateError] = useState<string | null>(null);
   const [isCheckingDuplicates, setIsCheckingDuplicates] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [submissionRetryBlocked, setSubmissionRetryBlocked] = useState(false);
+  const submissionInFlight = useRef(false);
+  const submissionErrorRef = useRef<HTMLDivElement>(null);
   // Consolidated form state via useReducer
   const {
     state: formState,
@@ -207,6 +212,18 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
     ? templates?.find((t) => t.id === selectedTemplate)
     : null;
   const isBlueprint = Boolean(currentTemplate?.blueprint && currentTemplate.blueprint.length > 0);
+  const isPending = isSubmitting || isCreating;
+
+  useEffect(() => {
+    if (!submissionError) return;
+
+    const focusError = window.setTimeout(() => {
+      submissionErrorRef.current?.focus({ preventScroll: true });
+      submissionErrorRef.current?.scrollIntoView?.({ block: 'center', behavior: 'instant' });
+    });
+
+    return () => window.clearTimeout(focusError);
+  }, [submissionError]);
 
   useEffect(() => {
     const query = [title, description].filter(Boolean).join(' ').trim();
@@ -240,7 +257,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
             ? 'Duplicate search is using a reduced index right now. You can still create the task.'
             : null
         );
-      } catch (err) {
+      } catch {
         if (cancelled) return;
         setDuplicateResults([]);
         setDuplicateError(
@@ -260,29 +277,50 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // Use computed canSubmit instead of inline check
-    if (!canSubmit(isBlueprint)) {
-      return;
+    if (submissionInFlight.current || submissionRetryBlocked || !canSubmit(isBlueprint)) return;
+
+    submissionInFlight.current = true;
+    setIsSubmitting(true);
+    setSubmissionError(null);
+    setSubmissionRetryBlocked(false);
+    try {
+      await createTasks(title, description, project, sprint, type, priority, agent);
+      resetForm();
+      clearTemplate();
+      onOpenChange(false);
+    } catch (error) {
+      setSubmissionRetryBlocked(error instanceof PartialBlueprintCreationError);
+      setSubmissionError(error instanceof Error ? error.message : 'Unable to create the task.');
+    } finally {
+      submissionInFlight.current = false;
+      setIsSubmitting(false);
     }
+  };
 
-    await createTasks(title, description, project, sprint, type, priority, agent);
-
-    // Reset form state atomically
-    resetForm();
-    clearTemplate();
+  const handleClose = () => {
+    if (submissionInFlight.current) return;
+    setSubmissionError(null);
+    setSubmissionRetryBlocked(false);
     onOpenChange(false);
   };
 
   return (
     <UiModal
       opened={open}
-      onClose={() => onOpenChange(false)}
+      onClose={handleClose}
+      closeOnEscape={!isPending}
+      closeOnClickOutside={!isPending}
+      closeButtonProps={{ disabled: isPending }}
       title="Create New Task"
       variant="form"
       compound
       centered
     >
-      <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <form
+        onSubmit={handleSubmit}
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        aria-busy={isPending}
+      >
         <div className="vk-overlay-scroll" data-testid="create-task-scroll-region" tabIndex={0}>
           {/* Template selector */}
           {templates && templates.length > 0 && (
@@ -300,6 +338,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                   type="button"
                   variant="subtle"
                   size="sm"
+                  disabled={isPending}
                   onClick={toggleHelp}
                   aria-label={showHelp ? 'Hide template help' : 'Show template help'}
                 >
@@ -342,20 +381,23 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
 
               <Tabs value={categoryFilter} onChange={(value) => setCategoryFilter(value ?? 'all')}>
                 <Tabs.List grow>
-                  <Tabs.Tab value="all">All</Tabs.Tab>
-                  <Tabs.Tab value="bug" aria-label="Bug templates">
+                  <Tabs.Tab value="all" disabled={isPending}>
+                    All
+                  </Tabs.Tab>
+                  <Tabs.Tab value="bug" aria-label="Bug templates" disabled={isPending}>
                     <Bug className="h-4 w-4" />
                   </Tabs.Tab>
-                  <Tabs.Tab value="feature" aria-label="Feature templates">
+                  <Tabs.Tab value="feature" aria-label="Feature templates" disabled={isPending}>
                     <Sparkles className="h-4 w-4" />
                   </Tabs.Tab>
-                  <Tabs.Tab value="sprint" aria-label="Sprint templates">
+                  <Tabs.Tab value="sprint" aria-label="Sprint templates" disabled={isPending}>
                     <RefreshCw className="h-4 w-4" />
                   </Tabs.Tab>
                 </Tabs.List>
               </Tabs>
 
               <Select
+                disabled={isPending}
                 aria-label="Task template"
                 value={selectedTemplate || 'none'}
                 onChange={(value) => handleTemplateSelect(value ?? 'none')}
@@ -373,6 +415,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                 <>
                   <BlueprintPreview template={currentTemplate} />
                   <TemplateVariableInputs
+                    disabled={isPending}
                     variables={requiredCustomVars}
                     values={customVars}
                     onChange={(name, value) =>
@@ -384,6 +427,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
             ) : (
               <>
                 <TextInput
+                  disabled={isPending}
                   id="title"
                   label="Title"
                   value={title}
@@ -393,6 +437,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                 />
 
                 <Textarea
+                  disabled={isPending}
                   id="description"
                   label="Description"
                   value={description}
@@ -434,6 +479,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                               key={`${result.collection}:${result.id}`}
                               component="button"
                               type="button"
+                              disabled={isPending}
                               withBorder
                               radius="md"
                               p="sm"
@@ -485,6 +531,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
 
                 <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
                   <Select
+                    disabled={isPending}
                     label="Type"
                     value={type}
                     onChange={(value) => setType(value ?? 'code')}
@@ -503,6 +550,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                   />
 
                   <Select
+                    disabled={isPending}
                     label="Priority"
                     value={priority}
                     onChange={(value) => setPriority((value ?? 'medium') as TaskPriority)}
@@ -514,6 +562,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                 <Stack gap="xs">
                   {!showNewProject ? (
                     <Select
+                      disabled={isPending}
                       ref={projectSelect}
                       label="Project (optional)"
                       value={project || '__none__'}
@@ -531,6 +580,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                   ) : (
                     <Group gap="sm" align="end" wrap="nowrap">
                       <TextInput
+                        disabled={isPending}
                         ref={newProjectInput}
                         data-mantine-stop-propagation="true"
                         label="New project"
@@ -552,6 +602,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                       />
                       <UiAction
                         type="button"
+                        disabled={isPending}
                         onClick={() => {
                           if (newProjectName.trim()) {
                             setProject(newProjectName.trim());
@@ -560,7 +611,12 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                       >
                         Add
                       </UiAction>
-                      <UiAction type="button" variant="quiet" onClick={hideNewProject}>
+                      <UiAction
+                        type="button"
+                        variant="quiet"
+                        onClick={hideNewProject}
+                        disabled={isPending}
+                      >
                         Cancel
                       </UiAction>
                     </Group>
@@ -569,6 +625,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
 
                 <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
                   <Select
+                    disabled={isPending}
                     label="Sprint (optional)"
                     value={sprint || '__none__'}
                     onChange={(value) => setSprint(value === '__none__' ? '' : (value ?? ''))}
@@ -578,6 +635,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                   />
 
                   <Select
+                    disabled={isPending}
                     label="Agent"
                     value={agent || 'auto'}
                     onChange={(value) => setAgent(value ?? 'auto')}
@@ -587,6 +645,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                 </SimpleGrid>
 
                 <TemplateVariableInputs
+                  disabled={isPending}
                   variables={requiredCustomVars}
                   values={customVars}
                   onChange={(name, value) => setCustomVars((prev) => ({ ...prev, [name]: value }))}
@@ -618,6 +677,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                                 type="button"
                                 variant="subtle"
                                 size="sm"
+                                disabled={isPending}
                                 onClick={() => removeSubtask(subtask.id)}
                                 aria-label={`Remove subtask: ${subtask.title}`}
                               >
@@ -633,13 +693,28 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
               </>
             )}
           </Stack>
+          {submissionError && (
+            <Alert
+              ref={submissionErrorRef}
+              tabIndex={-1}
+              color="red"
+              title="Task not created"
+              className="mt-4 shrink-0"
+            >
+              {submissionError}
+            </Alert>
+          )}
         </div>
         <OverlayFooter>
-          <UiAction type="button" variant="quiet" onClick={() => onOpenChange(false)}>
+          <UiAction type="button" variant="quiet" onClick={handleClose} disabled={isPending}>
             Cancel
           </UiAction>
-          <UiAction type="submit" disabled={!canSubmit(isBlueprint) || isCreating}>
-            {isCreating ? 'Creating...' : isBlueprint ? 'Create Tasks' : 'Create Task'}
+          <UiAction
+            type="submit"
+            disabled={!canSubmit(isBlueprint) || isPending || submissionRetryBlocked}
+            loading={isPending}
+          >
+            {isBlueprint ? 'Create Tasks' : 'Create Task'}
           </UiAction>
         </OverlayFooter>
       </form>

--- a/web/src/components/task/create/TemplateVariableInputs.tsx
+++ b/web/src/components/task/create/TemplateVariableInputs.tsx
@@ -2,12 +2,14 @@ import { Group, Paper, Stack, Text, TextInput, ThemeIcon } from '@mantine/core';
 import { AlertCircle } from 'lucide-react';
 
 interface TemplateVariableInputsProps {
+  disabled?: boolean;
   variables: string[];
   values: Record<string, string>;
   onChange: (name: string, value: string) => void;
 }
 
 export function TemplateVariableInputs({
+  disabled = false,
   variables,
   values,
   onChange,
@@ -29,6 +31,7 @@ export function TemplateVariableInputs({
         </Group>
         {variables.map((varName) => (
           <TextInput
+            disabled={disabled}
             key={varName}
             id={`var-${varName}`}
             label={varName}

--- a/web/src/hooks/useTemplateForm.ts
+++ b/web/src/hooks/useTemplateForm.ts
@@ -7,7 +7,21 @@ import {
   type VariableContext,
 } from '@/lib/template-variables';
 import { nanoid } from 'nanoid';
-import type { Subtask, TaskPriority } from '@veritas-kanban/shared';
+import type { Subtask, Task, TaskPriority } from '@veritas-kanban/shared';
+
+export class PartialBlueprintCreationError extends Error {
+  constructor(
+    readonly completedCount: number,
+    readonly totalCount: number,
+    options?: ErrorOptions
+  ) {
+    super(
+      `${completedCount} of ${totalCount} blueprint tasks were created before the operation failed. Review the board before creating this blueprint again.`,
+      options
+    );
+    this.name = 'PartialBlueprintCreationError';
+  }
+}
 
 export function useTemplateForm() {
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
@@ -166,7 +180,7 @@ export function useTemplateForm() {
     const refIdToTaskId: Record<string, string> = {};
 
     // Create tasks in order, resolving dependencies
-    for (const blueprintTask of template.blueprint) {
+    for (const [index, blueprintTask] of template.blueprint.entries()) {
       // Interpolate title
       const taskTitle = interpolateVariables(blueprintTask.title, context);
 
@@ -199,15 +213,25 @@ export function useTemplateForm() {
         .filter(Boolean);
 
       // Create the task
-      const createdTask = await createTask.mutateAsync({
-        title: taskTitle,
-        description: taskDescription,
-        type: blueprintTask.taskDefaults.type,
-        priority: blueprintTask.taskDefaults.priority,
-        project: blueprintTask.taskDefaults.project || project.trim() || undefined,
-        subtasks: taskSubtasks,
-        blockedBy,
-      });
+      let createdTask: Task;
+      try {
+        createdTask = await createTask.mutateAsync({
+          title: taskTitle,
+          description: taskDescription,
+          type: blueprintTask.taskDefaults.type,
+          priority: blueprintTask.taskDefaults.priority,
+          project: blueprintTask.taskDefaults.project || project.trim() || undefined,
+          subtasks: taskSubtasks,
+          blockedBy,
+        });
+      } catch (error) {
+        if (index > 0) {
+          throw new PartialBlueprintCreationError(index, template.blueprint.length, {
+            cause: error,
+          });
+        }
+        throw error;
+      }
 
       // Store the mapping
       refIdToTaskId[blueprintTask.refId] = createdTask.id;


### PR DESCRIPTION
## Summary

- Keep Create Task in sole control from the first submit event until the complete request settles.
- Disable every dismissal and editing path while pending, retain the draft on failure, focus the inline error, and permit a deliberate same-payload retry.
- Report partial blueprint completion and block blind retries that could duplicate already-created tasks.
- Keep the existing bounded workflow-retry regression stable under CI suite pressure by giving its asynchronous terminal-state check the same explicit five-second ceiling as the adjacent equivalent case.
- Document the browser evidence and preserve packaged macOS verification as an explicit remaining gate under #1383.

## Verification

- `pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/CreateTaskDuplicateDetection.test.tsx src/__tests__/useTemplateForm.test.tsx --testTimeout 15000` (8 passed)
- `pnpm --filter @veritas-kanban/web typecheck`
- Focused ESLint and Prettier checks for all changed source, tests, and documentation
- `pnpm check:public-docs`
- `pnpm exec playwright test e2e/create-task-pending.spec.ts --project=chromium --workers=1` (4 passed)
- Deterministic delayed reproduction of the bounded retry test failed at the original one-second wait with the same CI assertion, then passed with the explicit five-second ceiling
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/issues-778-780-785-786-787.test.ts` (34 passed)
- `pnpm --filter @veritas-kanban/server test` (3,584 passed, 5 skipped)
- Independent specification and standards reviews (no remaining findings)

## Delivery boundary

The browser fixture intercepts task creation and creates no real task. Packaged macOS acceptance, exact-build documentation media, and final release verification remain pending on the integration branch.

Refs #1383, #780
