### PR TITLE
fix: normalize native relaunch geometry

### DIFF
--- a/docs/audits/NATIVE-UI-CONFORMANCE-1387.md
+++ b/docs/audits/NATIVE-UI-CONFORMANCE-1387.md
@@ -26,6 +26,8 @@ The diagnostic run completed at `2026-09-04T06:38:33.197Z` with 144 recorded sta
 
 The first signed 6.1.7 capture run then proved the 1700×1000 target itself was not portable: the hosted macOS window manager returned 1700×760 for every normal resize, so that single failed precondition cascaded across the normal matrix and all seeded probes. The current contract centralizes runner-safe content sizes for native verification and documentation capture. This is a harness correction, not accepted evidence; a new commit-bound signed candidate must pass the complete matrix.
 
+The next signed capture run, `33917249628`, passed 142 of 144 ordinary states and all seeded probes. Only the light-normal and dark-normal relaunch entries failed: after quitting a minimum-width matrix process, the hosted window manager restored 1180×760 instead of the following entry's 1700×760 target. Relaunch exists to prove persisted renderer state and clean process recovery, not a runner-specific window-restoration policy. The runner now reapplies the declared matrix size immediately after launch before checking the persisted theme, task, geometry, and HTTP ledger. This remains diagnostic evidence; final acceptance requires another exact-commit signed candidate.
+
 These diagnostic runs use an unsigned 6.1.6 package built from `afb447156fd77d24ee4616bdd7f8e556371c4925`, with whole-bundle SHA-256 `52dad82a58e5352c77577d9547323f1ff1cece318e94a22ea415bd93104bc183`. The harness checkout was dirty. They are not clean-commit release acceptance, installed-app verification, or refreshed documentation media. Committing this harness changes HEAD and requires a newly built candidate for final acceptance; old evidence must not be relabeled.
 
 ## Remaining acceptance work

--- a/scripts/native-ui/run.mjs
+++ b/scripts/native-ui/run.mjs
@@ -530,9 +530,10 @@ async function exercise(state, mode, shot) {
     await app.close();
     app = undefined;
     await launch();
-    await expect
-      .poll(() => page.evaluate(() => [innerWidth, innerHeight]))
-      .toEqual([mode.width, mode.height]);
+    // The hosted macOS window manager may restore a constrained prior width
+    // after a process relaunch. Re-establish this matrix entry's content size
+    // before checking the renderer state that the relaunch is meant to prove.
+    await resize(mode.width, mode.height);
     await expect(page.locator('html')).toHaveAttribute('data-mantine-color-scheme', mode.theme);
     await expect(
       page.getByRole('heading', { name: `Native acceptance ${mode.id}`, exact: true })


### PR DESCRIPTION
## Summary

- reapply the declared native matrix content size after packaged-app relaunch
- keep relaunch assertions focused on persisted renderer state and clean process recovery
- record the 142/144 signed diagnostic run and why its two failures were runner geometry leakage

## Verification

- `node --check scripts/native-ui/run.mjs`
- `pnpm exec prettier --check scripts/native-ui/run.mjs docs/audits/NATIVE-UI-CONFORMANCE-1387.md`
- `node --test scripts/native-ui/contract.test.mjs scripts/native-ui/layout-contract.test.mjs scripts/docs-media/contract.test.mjs scripts/release-workflow.test.mjs scripts/release-candidate.test.mjs scripts/release-assets.test.mjs scripts/updater-metadata.test.mjs`
- `git diff --check`

Closes no issue. Continues #1387.