### PR TITLE
fix: wait for rendered settings in UI captures

### DIFF
--- a/scripts/docs-media/run.mjs
+++ b/scripts/docs-media/run.mjs
@@ -289,6 +289,7 @@ try {
   await button('Settings').click();
   const settings = page.getByRole('dialog', { name: /^Settings(?: Board Only)?$/ });
   await expect(settings).toBeVisible();
+  await expect(settings.getByRole('heading', { name: 'General', exact: true })).toBeVisible();
   await still('settings-navigation.png');
   for (const [name, file] of [
     ['Agents', 'agent-providers.png'],

--- a/scripts/native-ui/run.mjs
+++ b/scripts/native-ui/run.mjs
@@ -291,6 +291,7 @@ async function exercise(state, mode, shot) {
       'aria-selected',
       'true'
     );
+    await expect(dialog.getByRole('heading', { name: tab, exact: true })).toBeVisible();
     await shot();
     await dismiss(dialog, opener);
   } else if (state === 'left-rail' || state === 'right-rail') {

--- a/scripts/validate-release-native.test.mjs
+++ b/scripts/validate-release-native.test.mjs
@@ -228,3 +228,24 @@ test('macOS publication stages without upload and verifies the distribution befo
   assert.match(promotionJob, /docs-media\/restore-candidate.mjs/);
   assert.match(promotionJob, /docs-media\/publish.mjs/);
 });
+
+test('settings captures wait for rendered page content instead of the loading skeleton', async () => {
+  const documentationCapture = await readFile(
+    path.join(root, 'scripts/docs-media/run.mjs'),
+    'utf8'
+  );
+  const nativeCapture = await readFile(path.join(root, 'scripts/native-ui/run.mjs'), 'utf8');
+
+  const documentationReady = documentationCapture.indexOf(
+    "settings.getByRole('heading', { name: 'General', exact: true })"
+  );
+  const documentationShot = documentationCapture.indexOf("still('settings-navigation.png')");
+  assert(documentationReady >= 0 && documentationReady < documentationShot);
+
+  const selectedTab = nativeCapture.indexOf("'aria-selected',\n      'true'");
+  const renderedHeading = nativeCapture.indexOf(
+    "dialog.getByRole('heading', { name: tab, exact: true })"
+  );
+  const settingsShot = nativeCapture.indexOf('await shot();', renderedHeading);
+  assert(selectedTab >= 0 && selectedTab < renderedHeading && renderedHeading < settingsShot);
+});


### PR DESCRIPTION
## Summary

- wait for the selected settings page heading before native screenshots
- wait for General settings content before the documentation screenshot
- add a release-native regression test for both readiness gates

Closes #1513

## Verification

- `pnpm exec prettier --check scripts/docs-media/run.mjs scripts/native-ui/run.mjs scripts/validate-release-native.test.mjs`
- `node --test scripts/validate-release-native.test.mjs scripts/native-ui/contract.test.mjs scripts/docs-media/verify.test.mjs scripts/docs-media/record.test.mjs scripts/docs-media/finalize.test.mjs scripts/docs-media/publication.test.mjs scripts/docs-media/restore-candidate.test.mjs`