### PR TITLE
fix: allow docs index media publication

### DIFF
--- a/scripts/docs-media/publication.mjs
+++ b/scripts/docs-media/publication.mjs
@@ -21,6 +21,7 @@ function publicationPath(file, version) {
     file === 'README.md' ||
     /^docs\/(?:[^/]+\/)*[^/]+\.md$/.test(file) ||
     file === 'docs/index.json' ||
+    file === 'docs/index.html' ||
     file === 'docs/demo/index.html' ||
     ['assets/demo-overview.mp4', 'docs/assets/demo-overview.mp4'].includes(file) ||
     maintainedAssets.some((name) => file === `docs/assets/v${version}/${name}`)

--- a/scripts/docs-media/publication.test.mjs
+++ b/scripts/docs-media/publication.test.mjs
@@ -171,6 +171,25 @@ test('docs-only merge commits can publish the captured build', async (t) => {
   );
 });
 
+test('documentation index metadata can publish the captured build', async (t) => {
+  const f = await fixture(t);
+  await mkdir(path.join(f.root, 'docs'), { recursive: true });
+  await writeFile(
+    path.join(f.root, 'docs/index.html'),
+    '<meta property="og:image" content="assets/v6.1.7/board-overview.png">'
+  );
+  f.git('add', '.');
+  f.git('commit', '-qm', 'update documentation index metadata');
+  assert.doesNotThrow(() =>
+    verifyPublicationHistory({
+      root: f.root,
+      buildCommit: f.expected.commit,
+      publicationCommit: f.git('rev-parse', 'HEAD'),
+      version: f.expected.version,
+    })
+  );
+});
+
 test('dirty, stale, and unrelated publication history cannot reuse a build', async (t) => {
   const f = await fixture(t);
   await writeFile(path.join(f.root, 'README.md'), 'uncommitted edit');


### PR DESCRIPTION
Closes #1515\n\n## Summary\n- allow docs/index.html in the exact-build documentation publication boundary\n- cover index metadata updates with a regression test\n- continue rejecting application, dependency, and executable-document changes\n\n## Verification\n- pnpm test:release-native\n- pnpm prettier --check scripts/docs-media/publication.mjs scripts/docs-media/publication.test.mjs\n- git diff --check