### PR TITLE
docs: record installed v6.1.7 acceptance

### DIFF
--- a/docs/V6-GA-CHECKLIST.md
+++ b/docs/V6-GA-CHECKLIST.md
@@ -1,13 +1,24 @@
 # Veritas Kanban v6 GA Checklist
 
 This checklist contains the active stable-release gate for Veritas Kanban
-6.1.6 and retains the completed 6.1.5, 6.1.4, 6.1.3, 6.1.2, 6.1.1, 6.1.0, and 6.0.2 evidence below.
+6.1.7 and retains the completed 6.1.6, 6.1.5, 6.1.4, 6.1.3, 6.1.2, 6.1.1, 6.1.0, and 6.0.2 evidence below.
 Command results, platform details, workflow links, limitations, and artifact hashes belong in
 [v6 Release Candidate Evidence Packet](V6-RC-EVIDENCE-PACKET.md).
 
-Documentation freshness: 2026-09-03 for the completed Veritas Kanban 6.1.6 release.
+Documentation freshness: 2026-09-04 for the completed Veritas Kanban 6.1.7 release.
 
-## 6.1.6 Release Gate
+## 6.1.7 Release Gate
+
+- [x] macOS UI tracker #1389 and child issues #1378-#1388 are complete through focused merged work, the final signed candidate, refreshed documentation media, and the separately verified installed app.
+- [x] Root, shared, server, web, CLI, MCP, desktop, changelog, reviewed release source, and public documentation identify 6.1.7 without an API or database migration.
+- [x] Signed capture run [33926469724](https://github.com/BradGroux/veritas-kanban/actions/runs/33926469724) passed 144 of 144 required native states, detected all six seeded defects, and retained the exact build `ed5094c6a5f9dd6958ceb952d8d018a40135bf33` with whole-bundle SHA-256 `a23df6443940aff4d9b5013b97ab753b986a63f3bb15dc0d3a8c6aaace866f94`.
+- [x] The 14 maintained screenshots and GIFs were captured from that exact candidate, verified by digest, visually reviewed, and published unchanged in commit `6befd39cbc1264b18fa272d25bc64642f2b60383`.
+- [x] Annotated tag `v6.1.7` (`9c3bf5b60bdd836e0a248a150892fc59ef5a6703`) peels to the documentation-media commit, and promotion run [33928175193](https://github.com/BradGroux/veritas-kanban/actions/runs/33928175193) passed after publishing the live release and signed assets.
+- [x] Homebrew tap [PR #63](https://github.com/BradGroux/homebrew-tap/pull/63) publishes the signed 6.1.7 ZIP with SHA-256 `ac0b84ced655b02a87b2964f1036916683ba95628ef9acfeace6beac8142ff17`; strict audit, fetch, livecheck, installed version, signature, notarization, staple, listener, and exact health checks pass.
+- [x] The Homebrew-installed app passed first launch, dark/light 1180×760 Workbench and rail checks, draft retention, wide-to-compact resizing, fullscreen recovery, and compact quit/relaunch without clipped controls, blank space, dead actions, or the retired bottom dock.
+- [x] The coordinated private security advisory was closed without publication at the owner's direction after the fixed versions were available in every supported distribution channel.
+
+## Historical 6.1.6 Release Gate
 
 - [x] Focused fixes #1367-#1373 close dependency, app-shell containment, Settings, Command+K, desktop wordmark, consecutive drag, and action/navigation consistency issues #1360-#1366.
 - [x] Production and complete dependency audits report no known vulnerabilities, and the default branch has zero open Dependabot alerts.
@@ -148,7 +159,7 @@ Documentation freshness: 2026-09-03 for the completed Veritas Kanban 6.1.6 relea
 Apply `ci:full` to the release pull request and keep it applied through the
 final candidate synchronization. That single milestone runs the complete
 workspace suite, critical-path coverage, unsigned desktop artifacts, and
-Docker image contract. Run the following commands once from the clean 6.1.6
+Docker image contract. Run the following commands once from the clean 6.1.7
 release candidate at the supported Node floor and current supported Node:
 
 ```bash
@@ -178,8 +189,8 @@ pnpm desktop:dev:fresh
 pnpm desktop:smoke:mac:local
 pnpm desktop:package:mac:unsigned
 pnpm test:release-format
-pnpm validate:release -- --version 6.1.6 --skip-build-output --source-only
-pnpm validate:release -- --version 6.1.6 --native-evidence /absolute/path/evidence.json --native-app /absolute/path/veritas-kanban.app --docker-build
+pnpm validate:release -- --version 6.1.7 --skip-build-output --source-only
+pnpm validate:release -- --version 6.1.7 --native-evidence /absolute/path/evidence.json --native-app /absolute/path/veritas-kanban.app --docker-build
 ```
 
 Source preflight is not release acceptance. Full validation requires the exact clean candidate's fresh native matrix and retained screenshots; signing, installed-app, documentation-media, and publication evidence remain separate gates. See [desktop release verification](DESKTOP-RELEASE.md#native-gate-before-macos-upload).
@@ -193,12 +204,13 @@ gates at Node 22.22.1 and the current supported Node runtime.
 
 ## Distribution And Post-Publication
 
-The 6.1.6 release is published and verified. Release PR #1375 merged as
-`655df233d5b0ed0e8ebf1e54076b692c8cae893c`; annotated `v6.1.6`, the exact live
-release body, signed/notarized assets, updater metadata, isolated downloaded-app
-readiness, post-publication validation, and Homebrew PR #61 passed. Homebrew
-upgraded the installed 6.1.5 app to 6.1.6 while retaining its existing user
-profile. Exact evidence is recorded in the release candidate evidence packet.
+The 6.1.7 release is published and verified. Annotated tag `v6.1.7` peels to
+`6befd39cbc1264b18fa272d25bc64642f2b60383`; the exact live release body,
+signed/notarized assets, updater metadata, retained native matrix,
+post-publication validation, Homebrew PR #63, and the independently exercised
+installed app passed. The coordinated private advisory was closed without
+publication at the owner's direction. Exact evidence is recorded in the
+release candidate evidence packet.
 
 ## Historical 6.0.2 Source And Scope
 

--- a/docs/V6-RC-EVIDENCE-PACKET.md
+++ b/docs/V6-RC-EVIDENCE-PACKET.md
@@ -1,16 +1,79 @@
 # Veritas Kanban v6 Release Candidate Evidence Packet
 
-This packet records the completed Veritas Kanban 6.1.6 desktop reliability release and
-retains historical evidence for the completed 6.1.5, 6.1.4, 6.1.3, 6.1.2, 6.1.1, and 6.1.0 releases, the quarantined 6.0.0 prerelease, the 6.0.1
+This packet records the completed Veritas Kanban 6.1.7 macOS UI and interaction release and
+retains historical evidence for the completed 6.1.6, 6.1.5, 6.1.4, 6.1.3, 6.1.2, 6.1.1, and 6.1.0 releases, the quarantined 6.0.0 prerelease, the 6.0.1
 stabilization release, and the 6.0.2 desktop recovery hotfix. It separates
 merged implementation, deterministic conformance, local runtime proof, signed
 publication, and Homebrew availability.
 
-Veritas Kanban 6.1.6 is the active stable release. Do not use 6.0.0 for installation or upgrade validation.
+Veritas Kanban 6.1.7 is the active stable release. Do not use 6.0.0 for installation or upgrade validation.
 
-Documentation freshness: 2026-09-03 for the completed Veritas Kanban 6.1.6 release.
+Documentation freshness: 2026-09-04 for the completed Veritas Kanban 6.1.7 release.
 
-## 6.1.6 Desktop Reliability Release
+## 6.1.7 macOS UI and interaction release
+
+| Field                     | Value                                                                                                                                                                                                   |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Release version           | 6.1.7                                                                                                                                                                                                   |
+| Release tracker           | [#1389](https://github.com/BradGroux/veritas-kanban/issues/1389), covering child issues #1378-#1388                                                                                                     |
+| Version preparation       | [PR #1494](https://github.com/BradGroux/veritas-kanban/pull/1494), merged as `62b95ee9a72ed7ca2010737b1b88f4956a469b50`                                                                                 |
+| Signed candidate          | Build `ed5094c6a5f9dd6958ceb952d8d018a40135bf33`, whole-bundle SHA-256 `a23df6443940aff4d9b5013b97ab753b986a63f3bb15dc0d3a8c6aaace866f94`                                                               |
+| Release source            | Annotated tag object `9c3bf5b60bdd836e0a248a150892fc59ef5a6703` peels to `6befd39cbc1264b18fa272d25bc64642f2b60383`, which contains the exact captured documentation media                              |
+| Version and compatibility | All maintained packages are 6.1.7; REST API remains `v1`; no database migration; valid 6.1.6 workspaces remain compatible; macOS 13 arm64 minimum                                                       |
+| Native and media evidence | 144 of 144 required states passed, all six seeded defects were detected, and 14 maintained screenshots and GIFs were captured, hash-verified, visually reviewed, and published from the exact candidate |
+| Publication status        | Complete: live tag and release body, signed/notarized assets, updater metadata, Homebrew cask, installed-app verification, and owner-directed private advisory disposition all passed                   |
+
+The signed capture run
+[33926469724](https://github.com/BradGroux/veritas-kanban/actions/runs/33926469724)
+completed the full packaged macOS matrix in light and dark appearance at the
+1700×760 expanded and 1180×760 compact content sizes. It covered every required
+route, task drawer and expanded mode, Board Chat, Squad Chat, Task Chat,
+Settings, shared popouts, relaunch behavior, keyboard behavior, reduced motion,
+and the final HTTP ledger. All six deliberate faults were detected. The only
+accepted HTTP exceptions were documented optional task-chat 404 responses; no
+429 or 5xx response remained.
+
+The same run retained the candidate and the 14 documentation assets. Those
+exact files were verified by digest, visually reviewed, and published unchanged
+in commit `6befd39cbc1264b18fa272d25bc64642f2b60383`. Promotion run
+[33928175193](https://github.com/BradGroux/veritas-kanban/actions/runs/33928175193)
+then validated and published the live v6.1.7 tag, release body, and signed
+artifacts.
+
+### 6.1.7 published macOS assets
+
+| Asset                                         |              Size | Published SHA-256                                                  |
+| --------------------------------------------- | ----------------: | ------------------------------------------------------------------ |
+| `Veritas-Kanban-6.1.7-mac-arm64.dmg`          | 280,160,406 bytes | `172531cdad55b6a3683a03da3d0287fd52cebc0ddcc05eb2087dda10f65f2665` |
+| `Veritas-Kanban-6.1.7-mac-arm64.zip`          | 284,591,165 bytes | `ac0b84ced655b02a87b2964f1036916683ba95628ef9acfeace6beac8142ff17` |
+| `Veritas-Kanban-6.1.7-mac-arm64.dmg.blockmap` |     289,072 bytes | `4e68a8bf8614d727362fd6095e026ea0f8d9dc3af2c32c4ea8286fb1b876adc0` |
+| `Veritas-Kanban-6.1.7-mac-arm64.zip.blockmap` |     297,160 bytes | `7b03f01309de28785ee06099f327c7fb301b6a78683bae2022e4798aefda2bd5` |
+| `latest-mac.yml`                              |         530 bytes | `17f1f5fd19f21f1ae3fd455a052f43db0609aa702fe2abd62aebdd1143b87509` |
+
+Homebrew tap [PR #63](https://github.com/BradGroux/homebrew-tap/pull/63)
+merged as `e83f9b53d9ede0826683715ee2e04a84b84a3b82` and publishes the
+verified ZIP digest above. The registered cask reports 6.1.7 and passed Ruby
+syntax, strict online audit, fetch, and livecheck before installation.
+
+After explicit operator approval of macOS's first-launch confirmation,
+`/Applications/Veritas Kanban.app` reported version 6.1.7, passed deep strict
+signature verification, Gatekeeper assessment as a notarized Developer ID
+application, and staple validation. Its bundled server owned the port 3001
+listener and returned `ok: true`, service `veritas-kanban`, and version `6.1.7`
+from `/api/health`.
+
+The installed app was exercised at 1180×760 in both themes. Board Chat, Squad
+Chat, the compact Squad actions popover, sender selection, and composers were
+contained and readable. Opening either auxiliary rail closed Workbench;
+opening Workbench collapsed both rails. A non-sent Squad draft survived channel
+switching and a 1500×900-to-1180×760 resize without being sent. Fullscreen exit
+and a quit/relaunch at the saved minimum size both restored the compact state
+with Workbench and both rails closed. No bottom dock, blank canvas, clipped
+control, or dead chat action remained. The coordinated private advisory was
+closed without publication at the owner's direction after the fixed versions
+were available in every supported distribution channel.
+
+## Historical 6.1.6 Desktop Reliability Release
 
 | Field                      | Value                                                                                                                                                      |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/audits/NATIVE-UI-CONFORMANCE-1387.md
+++ b/docs/audits/NATIVE-UI-CONFORMANCE-1387.md
@@ -3,8 +3,8 @@
 Status: accepted for v6.1.7. Signed capture run
 [`33926469724`](https://github.com/BradGroux/veritas-kanban/actions/runs/33926469724)
 passed the complete packaged macOS gate from build commit
-`ed5094c6a5f9dd6958ceb952d8d018a40135bf33`. Installed Homebrew first-launch
-verification remains a separate release-train boundary under #1389.
+`ed5094c6a5f9dd6958ceb952d8d018a40135bf33`. The Homebrew-installed app also
+passed its separate first-launch and compact-window verification on September 4, 2026.
 
 ## Boundary
 
@@ -48,4 +48,24 @@ The final run closed the diagnostic gaps without weakening the contract:
 - The run retained the signed release candidate, native evidence, and documentation media. The 14 maintained assets were published from those exact captures in commit `6befd39cbc1264b18fa272d25bc64642f2b60383`.
 - Promotion run [`33928175193`](https://github.com/BradGroux/veritas-kanban/actions/runs/33928175193) published v6.1.7, and the post-publication release validator passed against the live tag, release body, and assets.
 
-The packaged-candidate gate is complete. Browser fixtures remain diagnostic, and the Homebrew-installed copy is not counted as opened until the operator accepts macOS's first-launch confirmation and the launched app is checked separately under #1389.
+The packaged-candidate gate is complete. Browser fixtures remain diagnostic.
+After explicit operator approval of macOS's first-launch confirmation, the
+Homebrew-installed `/Applications/Veritas Kanban.app` reported version 6.1.7,
+owned the port 3001 listener through its bundled server, and returned
+`{"ok":true,"service":"veritas-kanban","version":"6.1.7"}` from
+`/api/health`. Deep strict signature verification, Gatekeeper assessment as a
+notarized Developer ID application, and staple validation all passed.
+
+The installed app was then exercised at the 1180×760 minimum window size in
+dark and light appearance. Board Chat, Squad Chat, the compact Squad actions
+popover, sender selector, and composers remained contained and readable.
+Opening either auxiliary rail closed Workbench; reopening either chat channel
+collapsed both rails. A non-sent Squad Chat draft survived channel switching
+and a 1500×900-to-1180×760 resize, while the compact transition closed
+Workbench without sending or clearing the draft. Entering fullscreen with
+Squad Chat open and returning to the saved 1180×760 window also closed
+Workbench and restored the compact rail state. A quit and relaunch at the saved
+minimum size reopened with both rails and Workbench collapsed. No bottom dock,
+blank canvas, clipped controls, or dead chat action was present. This closes
+the installed-app boundary for #1383 and #1389 without treating it as a rerun
+of the separate 144-state packaged-candidate matrix.

--- a/docs/design/OVERLAY-CONTRACT.md
+++ b/docs/design/OVERLAY-CONTRACT.md
@@ -1,6 +1,6 @@
 # Shared popout contract
 
-Tracking: #1383; foundation and Template family slice #1401. Status: packaged-candidate contract accepted for v6.1.7. The inventory below preserves the original audit snapshot; final reconciliation and evidence follow it. The issue remains open for its Homebrew-installed compact-window check.
+Tracking: #1383; foundation and Template family slice #1401. Status: accepted for v6.1.7 in both the packaged candidate and the Homebrew-installed app. The inventory below preserves the original audit snapshot; final reconciliation and evidence follow it.
 
 ## Geometry
 
@@ -101,4 +101,13 @@ Open `?ui-gallery=1` and use the Popout geometry cards. Each variant opens the a
 
 Final signed capture run [`33926469724`](https://github.com/BradGroux/veritas-kanban/actions/runs/33926469724) passed all 144 packaged macOS states and detected all six seeded defects from exact build commit `ed5094c6a5f9dd6958ceb952d8d018a40135bf33`. The matrix records computed overlay padding, route geometry, compact-shell behavior, Workbench chat, task drawer/expanded/chat presentations, Preview, confirmations, and functional controls in both themes at 1700×760 and 1180×760. The 14 maintained screenshots and GIFs were captured from that candidate and published in commit `6befd39cbc1264b18fa272d25bc64642f2b60383`. Browser evidence and native evidence remain distinct; both passed their declared scopes.
 
-#1383 and the umbrella #1389 remain open until the Homebrew-installed app is launched through macOS's first-run confirmation and its compact-window behavior is checked. That installed-app requirement is not implied by the packaged-candidate acceptance above.
+The separate Homebrew-installed check passed after explicit operator approval
+of macOS's first-launch confirmation. At 1180×760 in both themes, Board Chat,
+Squad Chat, the compact Squad actions popover, sender selection, and composers
+remained contained. Opening a rail closed Workbench, and opening Workbench
+collapsed both rails. A non-sent Squad Chat draft survived channel switching
+and wide-to-compact resizing; the resize did not send the draft or recreate the
+three-panel squeeze. Fullscreen exit and a quit/relaunch at the saved minimum
+size restored the compact state with Workbench and both rails closed. This
+installed-app evidence completes #1383 and the umbrella #1389; it supplements
+rather than replaces the commit-bound packaged-candidate matrix above.

--- a/docs/design/TASK-OVERLAY-ACCEPTANCE.md
+++ b/docs/design/TASK-OVERLAY-ACCEPTANCE.md
@@ -1,6 +1,6 @@
 # Task overlay family acceptance
 
-Tracking: #1444, parent #1383. Status: accepted for the v6.1.7 packaged release candidate. Homebrew first-launch verification remains a separate boundary under #1389.
+Tracking: #1444, parent #1383. Status: accepted for the v6.1.7 packaged release candidate and the separately verified Homebrew-installed app.
 
 ## Implementation
 


### PR DESCRIPTION
## Summary

- records first-launch and compact-window verification for the Homebrew-installed v6.1.7 app
- updates the active GA checklist and release evidence packet to 6.1.7
- records the owner-directed private advisory disposition without publishing advisory details

## Verification

- installed app version and bundled `/api/health` readback
- deep strict signature, Gatekeeper, and staple validation
- dark/light 1180x760 Board Chat, Squad Chat, actions popover, rail interaction, resizing, fullscreen, draft-retention, and relaunch checks
- `pnpm check:public-docs`
- Prettier check and `git diff --check`
- `pnpm validate:release -- --version 6.1.7 --skip-build-output --source-only`

Closes #1383
Closes #1389