### PR TITLE
fix: make CLI and MCP task requests safe and bounded

### DIFF
--- a/cli/src/__tests__/task-identifiers.test.ts
+++ b/cli/src/__tests__/task-identifiers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError } from '@veritas-kanban/shared';
 import { Command } from 'commander';
 const { mockApi } = vi.hoisted(() => ({ mockApi: vi.fn() }));
 vi.mock('../utils/api.js', () => ({ api: mockApi }));
@@ -37,6 +38,23 @@ describe('task mutation identifier resolution', () => {
     });
   });
   afterEach(() => vi.restoreAllMocks());
+
+  it('writes structured API error metadata for JSON commands', async () => {
+    mockApi.mockRejectedValue(
+      new ApiError('Conflict', { status: 409, code: 'CONFLICT', details: { currentRevision: 4 } })
+    );
+    await expect(execute('update', 'task_target_abc')).rejects.toThrow('CLI exit');
+    const output = vi.mocked(console.error).mock.calls.at(-1)?.[0];
+    expect(JSON.parse(output)).toEqual({
+      error: {
+        message: 'HTTP 409 [CONFLICT] Conflict',
+        status: 409,
+        code: 'CONFLICT',
+        details: { currentRevision: 4 },
+      },
+    });
+    expect(mockApi).toHaveBeenCalledOnce();
+  });
 
   for (const command of ['update', 'archive', 'delete']) {
     it(`${command} rejects blank and ambiguous IDs without a write`, async () => {

--- a/cli/src/__tests__/task-identifiers.test.ts
+++ b/cli/src/__tests__/task-identifiers.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+const { mockApi } = vi.hoisted(() => ({ mockApi: vi.fn() }));
+vi.mock('../utils/api.js', () => ({ api: mockApi }));
+import { registerTaskCommands } from '../commands/tasks.js';
+
+const task = (id: string) => ({
+  id,
+  title: 'Fixture',
+  type: 'code',
+  status: 'todo',
+  priority: 'medium',
+  created: '2026-09-07T00:00:00Z',
+  updated: '2026-09-07T00:00:00Z',
+});
+const tasks = [task('task_prefix_task_target_abc'), task('task_target_abc'), task('task_unique')];
+async function execute(command: string, id: string) {
+  const program = new Command();
+  program.exitOverride();
+  registerTaskCommands(program);
+  await program.parseAsync(
+    [command, id, ...(command === 'update' ? ['--title', 'Updated'] : []), '--json'],
+    { from: 'user' }
+  );
+}
+
+describe('task mutation identifier resolution', () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+    mockApi.mockImplementation(async (path, options) =>
+      options?.method ? task(path.split('/')[3]) : tasks
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('CLI exit');
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  for (const command of ['update', 'archive', 'delete']) {
+    it(`${command} rejects blank and ambiguous IDs without a write`, async () => {
+      for (const id of ['', '   ', 'abc']) {
+        mockApi.mockClear();
+        await expect(execute(command, id)).rejects.toThrow('CLI exit');
+        expect(mockApi.mock.calls.filter(([, options]) => options?.method)).toEqual([]);
+        if (!id.trim()) expect(mockApi).not.toHaveBeenCalled();
+      }
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Ambiguous task identifier')
+      );
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('task_target_abc'));
+    });
+
+    it(`${command} prefers exact IDs and supports unique suffixes`, async () => {
+      for (const [id, expected] of [
+        ['task_target_abc', 'task_target_abc'],
+        ['unique', 'task_unique'],
+      ]) {
+        mockApi.mockClear();
+        await execute(command, id);
+        const writes = mockApi.mock.calls.filter(([, options]) => options?.method);
+        expect(writes).toHaveLength(1);
+        expect(writes[0][0]).toBe(
+          `/api/tasks/${expected}${command === 'archive' ? '/archive' : ''}`
+        );
+      }
+    });
+
+    it(`${command} reports a missing task without a write`, async () => {
+      await expect(execute(command, 'missing')).rejects.toThrow('CLI exit');
+      expect(mockApi.mock.calls.filter(([, options]) => options?.method)).toEqual([]);
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Task not found'));
+    });
+  }
+});

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -243,6 +243,7 @@ export function registerAgentCommands(program: Command): void {
         }
 
         const result = await api<{ attemptId: string }>(`/api/agents/${task.id}/start`, {
+          timeoutMs: 120_000, // Provider preflight and worktree preparation can take longer.
           method: 'POST',
           body: JSON.stringify({
             agent: options.profile ? undefined : options.agent,

--- a/cli/src/commands/tasks.ts
+++ b/cli/src/commands/tasks.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { api } from '../utils/api.js';
+import { formatApiError } from '@veritas-kanban/shared';
 import { findTask } from '../utils/find.js';
 import { formatTask, formatTaskJson, formatTasksJson } from '../utils/format.js';
 import type { Task } from '../utils/types.js';
@@ -43,7 +44,9 @@ export function registerTaskCommands(program: Command): void {
           filtered.forEach((task: Task) => console.log(formatTask(task, options.verbose)));
         }
       } catch (err) {
-        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        console.error(
+          options.json ? formatApiError(err, true) : chalk.red(`Error: ${formatApiError(err)}`)
+        );
         process.exit(1);
       }
     });
@@ -79,7 +82,9 @@ export function registerTaskCommands(program: Command): void {
           }
         }
       } catch (err) {
-        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        console.error(
+          options.json ? formatApiError(err, true) : chalk.red(`Error: ${formatApiError(err)}`)
+        );
         process.exit(1);
       }
     });
@@ -121,7 +126,9 @@ export function registerTaskCommands(program: Command): void {
           console.log(formatTask(task, true));
         }
       } catch (err) {
-        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        console.error(
+          options.json ? formatApiError(err, true) : chalk.red(`Error: ${formatApiError(err)}`)
+        );
         process.exit(1);
       }
     });
@@ -175,7 +182,9 @@ export function registerTaskCommands(program: Command): void {
           console.log(formatTask(task, true));
         }
       } catch (err) {
-        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        console.error(
+          options.json ? formatApiError(err, true) : chalk.red(`Error: ${formatApiError(err)}`)
+        );
         process.exit(1);
       }
     });
@@ -202,7 +211,9 @@ export function registerTaskCommands(program: Command): void {
           console.log(chalk.green('✓ Task archived'));
         }
       } catch (err) {
-        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        console.error(
+          options.json ? formatApiError(err, true) : chalk.red(`Error: ${formatApiError(err)}`)
+        );
         process.exit(1);
       }
     });
@@ -229,7 +240,9 @@ export function registerTaskCommands(program: Command): void {
           console.log(chalk.green('✓ Task deleted'));
         }
       } catch (err) {
-        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        console.error(
+          options.json ? formatApiError(err, true) : chalk.red(`Error: ${formatApiError(err)}`)
+        );
         process.exit(1);
       }
     });

--- a/cli/src/utils/api.ts
+++ b/cli/src/utils/api.ts
@@ -10,6 +10,9 @@ import {
 export {
   API_BASE,
   ClientPermissionError,
+  ApiError,
+  formatApiError,
+  type ApiRequestOptions,
   buildApiHeaders,
   createApiClient,
   createGuardedApiClient,
@@ -21,6 +24,6 @@ export {
 export const api = createGuardedApiClient(API_BASE);
 
 const contextApi = createApiClient(API_BASE);
-export const assertApiPermissionForRequest = createApiPermissionGuard(() =>
-  contextApi<ClientAuthContext>('/api/auth/context')
+export const assertApiPermissionForRequest = createApiPermissionGuard((options) =>
+  contextApi<ClientAuthContext>('/api/auth/context', options)
 );

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -1190,7 +1190,7 @@ alias vkai='vk agent idle'
 
 ### Partial ID Matching
 
-You don't need to type the full task ID. `vk show` and other commands support partial matching:
+You can use an exact task ID or a unique suffix. Exact IDs take precedence. Empty identifiers and suffixes matching more than one task are rejected before any update, archive, or deletion; ambiguity errors list candidate IDs so you can choose explicitly:
 
 ```bash
 # Full ID

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -1242,3 +1242,9 @@ vk list --status in-progress
 ---
 
 _Part of [Veritas Kanban](../README.md) · Built by [Digital Meld](https://digitalmeld.io)_
+
+### API deadlines and errors
+
+Shared API requests have a 30-second deadline, including response-body reads. Set `VK_API_TIMEOUT_MS` to a positive integer of milliseconds for a different default. Agent launch requests explicitly allow 120 seconds for provider preflight and worktree preparation. Client integrations can set `timeoutMs` per request and supply an `AbortSignal`; cancellation also covers uncached permission preflight. Writes are never retried automatically. A timeout does not prove that the server rejected or rolled back a write: inspect the task or operation before trying it again.
+
+API errors retain HTTP status and server error code. MCP tool errors and CLI task commands using `--json` include structured metadata. Forwarded details use an allowlist for validation, revision, permission, and retry fields; complete task snapshots and credential fields are omitted. A rejected preflight does not remain cached as a permanent transport failure.

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -889,3 +889,9 @@ An exact ID takes precedence over suffix matches. A suffix is accepted only when
 ---
 
 _Last updated: 2026-08-30 · VK v6.1.3 · 42 tools / 9 categories_
+
+### API deadlines and errors
+
+Shared API requests have a 30-second deadline, including response-body reads. Set `VK_API_TIMEOUT_MS` to a positive integer of milliseconds for a different default. Agent launch requests explicitly allow 120 seconds for provider preflight and worktree preparation. Client integrations can set `timeoutMs` per request and supply an `AbortSignal`; cancellation also covers uncached permission preflight. Writes are never retried automatically. A timeout does not prove that the server rejected or rolled back a write: inspect the task or operation before trying it again.
+
+API errors retain HTTP status and server error code. MCP tool errors and CLI task commands using `--json` include structured metadata. Forwarded details use an allowlist for validation, revision, permission, and retry fields; complete task snapshots and credential fields are omitted. A rejected preflight does not remain cached as a permanent transport failure.

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -797,7 +797,7 @@ All tool errors return:
 
 | Error                                 | Cause                                             | Fix                                                                        |
 | ------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
-| `Task not found: abc123`              | ID doesn't match any task                         | Check the ID — partial match needs ≥ 6 characters                          |
+| `Task not found: abc123`              | ID doesn't match any task                         | Use an exact ID or a suffix unique to one task                             |
 | `Can only start agents on code tasks` | Tried `start_agent` on a non-code task            | Change task type to `code` first                                           |
 | `Task needs a worktree first`         | `start_agent` on a task without git worktree      | Create a worktree via the VK UI or API before starting an agent            |
 | `Provider runtime does not support…`  | Required launch or stop capability is unavailable | Select a capable provider or refresh its validated manifest                |
@@ -884,7 +884,7 @@ Yes. Any MCP-compatible client works — Cursor, Cline, Continue, Zed, or custom
 Not currently. The server uses stdio only. If you need HTTP transport, use the VK REST API directly.
 
 **Q: How do partial task IDs work?**
-The `findTask` utility matches the last N characters of a task ID (minimum 6). If multiple tasks match, it returns the first match. Use more characters for precision.
+An exact ID takes precedence over suffix matches. A suffix is accepted only when it identifies one task. Empty or whitespace-only IDs are rejected, and ambiguous suffixes return an error listing candidate IDs without updating, archiving, or deleting any task. Use an exact ID to resolve ambiguity.
 
 ---
 

--- a/mcp/src/__tests__/agent-tools.test.ts
+++ b/mcp/src/__tests__/agent-tools.test.ts
@@ -53,6 +53,7 @@ describe('MCP agent runtime capability controls', () => {
     });
 
     expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/start', {
+      timeoutMs: 120_000,
       method: 'POST',
       body: JSON.stringify({
         agent: 'claude-code',
@@ -69,6 +70,7 @@ describe('MCP agent runtime capability controls', () => {
     });
 
     expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/start', {
+      timeoutMs: 120_000,
       method: 'POST',
       body: JSON.stringify({
         agent: 'claude-code',
@@ -86,6 +88,7 @@ describe('MCP agent runtime capability controls', () => {
     });
 
     expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/start', {
+      timeoutMs: 120_000,
       method: 'POST',
       body: JSON.stringify({
         agent: 'claude-code',

--- a/mcp/src/__tests__/task-identifiers.test.ts
+++ b/mcp/src/__tests__/task-identifiers.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const { mockApi } = vi.hoisted(() => ({ mockApi: vi.fn() }));
+vi.mock('../utils/api.js', () => ({ api: mockApi }));
+import { handleTaskTool } from '../tools/tasks.js';
+const task = (id: string) => ({
+  id,
+  title: 'Fixture',
+  type: 'code',
+  status: 'todo',
+  priority: 'medium',
+  created: '2026-09-07T00:00:00Z',
+  updated: '2026-09-07T00:00:00Z',
+});
+const tasks = [task('task_prefix_task_target_abc'), task('task_target_abc'), task('task_unique')];
+
+describe('task mutation identifier resolution', () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+    mockApi.mockImplementation(async (path, options) =>
+      options?.method ? task(path.split('/')[3]) : tasks
+    );
+  });
+  for (const name of ['update_task', 'archive_task', 'delete_task']) {
+    it(`${name} rejects blank and ambiguous IDs without a write`, async () => {
+      for (const id of ['', '   ', 'abc']) {
+        mockApi.mockClear();
+        await expect(
+          handleTaskTool(name, { id, ...(name === 'update_task' ? { title: 'Updated' } : {}) })
+        ).rejects.toThrow();
+        expect(mockApi.mock.calls.filter(([, options]) => options?.method)).toEqual([]);
+        if (!id.trim()) expect(mockApi).not.toHaveBeenCalled();
+      }
+      await expect(handleTaskTool(name, { id: 'abc' })).rejects.toThrow(
+        'Ambiguous task identifier'
+      );
+    });
+    it(`${name} prefers exact IDs and accepts unique suffixes`, async () => {
+      for (const [id, expected] of [
+        ['task_target_abc', 'task_target_abc'],
+        ['unique', 'task_unique'],
+      ]) {
+        mockApi.mockClear();
+        await handleTaskTool(name, { id, ...(name === 'update_task' ? { title: 'Updated' } : {}) });
+        const writes = mockApi.mock.calls.filter(([, options]) => options?.method);
+        expect(writes).toHaveLength(1);
+        expect(writes[0][0]).toBe(
+          `/api/tasks/${expected}${name === 'archive_task' ? '/archive' : ''}`
+        );
+      }
+    });
+    it(`${name} reports missing IDs without a write`, async () => {
+      const result = await handleTaskTool(name, { id: 'missing' });
+      expect(result.isError).toBe(true);
+      expect(mockApi.mock.calls.filter(([, options]) => options?.method)).toEqual([]);
+    });
+  }
+});

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 // Import utilities
-import { api } from './utils/api.js';
+import { api, ApiError, formatApiError } from './utils/api.js';
 import { findTask } from './utils/find.js';
 import { Task } from './utils/types.js';
 
@@ -106,7 +106,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       content: [
         {
           type: 'text',
-          text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+          text:
+            error instanceof ApiError
+              ? formatApiError(error, true)
+              : `Error: ${formatApiError(error)}`,
         },
       ],
       isError: true,

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -222,6 +222,7 @@ export async function handleAgentTool(name: string, args: any): Promise<any> {
       }
 
       const result = await api<{ attemptId: string }>(`/api/agents/${task.id}/start`, {
+        timeoutMs: 120_000, // Provider preflight and worktree preparation can take longer.
         method: 'POST',
         body: JSON.stringify({
           agent,

--- a/mcp/src/utils/api.ts
+++ b/mcp/src/utils/api.ts
@@ -10,6 +10,9 @@ import {
 export {
   API_BASE,
   ClientPermissionError,
+  ApiError,
+  formatApiError,
+  type ApiRequestOptions,
   buildApiHeaders,
   createApiClient,
   createGuardedApiClient,
@@ -21,6 +24,6 @@ export {
 export const api = createGuardedApiClient(API_BASE);
 
 const contextApi = createApiClient(API_BASE);
-export const assertApiPermissionForRequest = createApiPermissionGuard(() =>
-  contextApi<ClientAuthContext>('/api/auth/context')
+export const assertApiPermissionForRequest = createApiPermissionGuard((options) =>
+  contextApi<ClientAuthContext>('/api/auth/context', options)
 );

--- a/server/src/__tests__/shared-api-client.test.ts
+++ b/server/src/__tests__/shared-api-client.test.ts
@@ -1,0 +1,154 @@
+import { createServer, type Server } from 'node:http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ApiError,
+  createApiClient,
+  createGuardedApiClient,
+  formatApiError,
+} from '../../../shared/src/utils/api-client.js';
+
+describe('shared API deadlines and errors', () => {
+  let server: Server;
+  let origin: string;
+  let requests: string[];
+  beforeEach(async () => {
+    requests = [];
+    server = createServer((req, res) => {
+      requests.push(req.url ?? '');
+      if (req.url === '/body-stall') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.write('{');
+        return;
+      }
+      if (req.url === '/stall' || req.url === '/api/auth/context') return;
+      if (req.url === '/slow') {
+        setTimeout(() => {
+          res.end(JSON.stringify({ ok: true }));
+        }, 80);
+        return;
+      }
+      const status = Number(req.url?.slice(1));
+      res.writeHead(status || 200, {
+        'Content-Type': 'application/json',
+        ...(status === 429 ? { 'Retry-After': '12' } : {}),
+      });
+      res.end(
+        JSON.stringify(
+          status
+            ? {
+                success: false,
+                error: {
+                  code:
+                    status === 409 ? 'CONFLICT' : status === 401 ? 'UNAUTHORIZED' : 'RATE_LIMITED',
+                  message: 'Request failed with fixture-api-key',
+                  details: {
+                    currentRevision: 3,
+                    password: 'do-not-forward',
+                    current: { description: 'private task body' },
+                    message: 'Bearer fixture-api-key',
+                  },
+                },
+              }
+            : { success: true, data: { ok: true } }
+        )
+      );
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing fixture address');
+    origin = `http://127.0.0.1:${address.port}`;
+  });
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    );
+  });
+
+  it.each(['/stall', '/body-stall'])(
+    'bounds a real nonresponding server at %s without retries',
+    async (path) => {
+      const api = createApiClient(origin, undefined, { timeoutMs: 100 });
+      const started = performance.now();
+      await expect(api(path, { method: 'POST' })).rejects.toMatchObject({ code: 'TIMEOUT' });
+      expect(performance.now() - started).toBeLessThan(1500);
+      expect(requests).toEqual([path]);
+    }
+  );
+
+  it('honors a longer explicit deadline', async () => {
+    const api = createApiClient(origin, undefined, { timeoutMs: 20 });
+    expect(await api('/slow', { timeoutMs: 500 })).toEqual({ ok: true });
+    expect(requests).toEqual(['/slow']);
+  });
+
+  it('cancels permission preflight and does not send the mutation', async () => {
+    const api = createGuardedApiClient(origin, undefined, { timeoutMs: 1000 });
+    const controller = new AbortController();
+    const pending = api('/api/tasks', { method: 'POST', signal: controller.signal });
+    const failure = expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    await vi.waitFor(() => expect(requests).toEqual(['/api/auth/context']));
+    controller.abort();
+    await failure;
+    expect(requests).toEqual(['/api/auth/context']);
+  });
+
+  it('does not send a request for a signal already cancelled', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      createApiClient(origin)('/stall', { signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(requests).toEqual([]);
+  });
+
+  it.each([409, 401, 429])('retains safe structured HTTP %s metadata', async (status) => {
+    const api = createApiClient(origin, 'fixture-api-key');
+    const error = await api(`/${status}`).catch((value) => value);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(status);
+    expect(error.details.currentRevision).toBe(3);
+    const output = formatApiError(error, true);
+    expect(JSON.parse(output).error.status).toBe(status);
+    expect(output).not.toContain('fixture-api-key');
+    expect(output).not.toContain('do-not-forward');
+    expect(output).not.toContain('private task body');
+    if (status === 429) expect(error.details.retryAfter).toBe('12');
+  });
+
+  it('does not cache a failed preflight or retry it automatically', async () => {
+    const transport = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('offline'))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ permissions: ['task:read'] })))
+      .mockResolvedValueOnce(new Response('[]'));
+    vi.stubGlobal('fetch', transport);
+    const api = createGuardedApiClient(origin);
+    await expect(api('/api/tasks')).rejects.toMatchObject({ code: 'NETWORK_ERROR' });
+    expect(transport).toHaveBeenCalledTimes(1);
+    expect(await api('/api/tasks')).toEqual([]);
+    expect(transport).toHaveBeenCalledTimes(3);
+  });
+
+  it('clears request timers and cancellation listeners on success and HTTP errors', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const remove = vi.spyOn(controller.signal, 'removeEventListener');
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(new Response('{}'))
+        .mockResolvedValueOnce(new Response('{}', { status: 409 }))
+    );
+    const api = createApiClient(origin);
+    await api('/success', { signal: controller.signal });
+    expect(vi.getTimerCount()).toBe(0);
+    await expect(api('/error', { signal: controller.signal })).rejects.toBeInstanceOf(ApiError);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(remove).toHaveBeenCalledTimes(2);
+  });
+});

--- a/shared/src/utils/api-client.ts
+++ b/shared/src/utils/api-client.ts
@@ -152,12 +152,23 @@ export const API_BASE = (typeof process !== 'undefined' && process.env?.VK_API_U
 export const api = createApiClient(API_BASE);
 
 /**
- * Find task by ID (supports partial matching on ID suffix)
+ * Find a task by exact ID or an unambiguous ID suffix. Blank and ambiguous
+ * identifiers are rejected before a caller can mutate an unintended task.
  * @param id - Full or partial task ID
  * @param apiClient - Optional custom API client (defaults to shared api client)
  * @returns Task if found, null otherwise
  */
 export async function findTask(id: string, apiClient = api): Promise<Task | null> {
+  if (!id.trim()) throw new Error('Task identifier must not be empty or whitespace');
   const tasks = await apiClient<Task[]>('/api/tasks');
-  return tasks.find((t) => t.id === id || t.id.endsWith(id)) || null;
+  const exact = tasks.find((task) => task.id === id);
+  if (exact) return exact;
+  const candidates = tasks.filter((task) => task.id.endsWith(id));
+  if (candidates.length > 1) {
+    const ids = candidates.map((task) => JSON.stringify(task.id)).sort();
+    throw new Error(
+      `Ambiguous task identifier ${JSON.stringify(id)}; use an exact ID: ${ids.join(', ')}`
+    );
+  }
+  return candidates[0] ?? null;
 }

--- a/shared/src/utils/api-client.ts
+++ b/shared/src/utils/api-client.ts
@@ -2,6 +2,8 @@
  * Shared API client for CLI and MCP
  */
 
+import { ApiError, safeApiDetails, safeApiText } from './api-errors.js';
+export { ApiError, formatApiError } from './api-errors.js';
 import type { Task } from '../types/task.types.js';
 import { createApiPermissionGuard, type ClientAuthContext } from './api-permissions.js';
 export {
@@ -91,56 +93,143 @@ export function buildApiHeaders(headers?: HeadersInit, apiKey = getEnv('VK_API_K
   };
 }
 
-/**
- * Create an API client instance
- * @param baseUrl - Base URL for the API (default: http://localhost:3001)
- * @returns API client function
- */
-export function createApiClient(baseUrl = DEFAULT_BASE, apiKey = getEnv('VK_API_KEY')) {
-  return async function api<T>(path: string, options?: RequestInit): Promise<T> {
-    const res = await fetch(`${baseUrl}${path}`, {
-      ...options,
-      headers: buildApiHeaders(options?.headers, apiKey),
-    });
+export interface ApiClientOptions {
+  timeoutMs?: number;
+}
+export interface ApiRequestOptions extends RequestInit {
+  timeoutMs?: number;
+}
+export const DEFAULT_API_TIMEOUT_MS = 30_000;
 
-    if (!res.ok) {
-      const error = (await res.json().catch(() => ({ error: res.statusText }))) as unknown;
+function requestTimeout(value: number | undefined): number {
+  const timeout = value ?? Number(getEnv('VK_API_TIMEOUT_MS') ?? DEFAULT_API_TIMEOUT_MS);
+  if (!Number.isSafeInteger(timeout) || timeout < 1 || timeout > 2_147_483_647) {
+    throw new Error('API timeout must be an integer from 1 to 2147483647 milliseconds');
+  }
+  return timeout;
+}
 
-      if (isErrorEnvelope(error)) {
-        throw new Error(error.error.message || `API error: ${res.status}`);
+async function withDeadline<T>(
+  options: ApiRequestOptions,
+  timeoutMs: number,
+  run: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const caller = options.signal;
+  caller?.throwIfAborted();
+  const controller = new AbortController();
+  const cancel = () => controller.abort(caller?.reason);
+  caller?.addEventListener('abort', cancel, { once: true });
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+  try {
+    return await run(controller.signal);
+  } catch (error) {
+    if (caller?.aborted) throw caller.reason;
+    if (timedOut)
+      throw new ApiError(
+        `Request exceeded ${timeoutMs} ms. Check server availability or set an explicit longer timeout. Mutations are not retried.`,
+        { code: 'TIMEOUT' }
+      );
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    caller?.removeEventListener('abort', cancel);
+  }
+}
+
+/** A finite deadline covers both response headers and the response body. No automatic retries. */
+export function createApiClient(
+  baseUrl = DEFAULT_BASE,
+  apiKey = getEnv('VK_API_KEY'),
+  defaults: ApiClientOptions = {}
+) {
+  const defaultTimeout = requestTimeout(defaults.timeoutMs);
+  return async function api<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+    const { timeoutMs: override, ...request } = options;
+    const headers = buildApiHeaders(options.headers, apiKey);
+    const secrets = Object.entries(headers)
+      .filter(([key]) => key === 'x-api-key' || key === 'authorization')
+      .flatMap(([, value]) => [value, value.replace(/^Bearer\s+/i, '')]);
+    return withDeadline(options, requestTimeout(override ?? defaultTimeout), async (signal) => {
+      let res: Response;
+      try {
+        res = await fetch(`${baseUrl}${path}`, { ...request, signal, headers });
+      } catch (error) {
+        if (signal.aborted) throw error;
+        throw new ApiError(
+          'Cannot reach the API server. Check VK_API_URL and server availability.',
+          { code: 'NETWORK_ERROR' }
+        );
       }
-
-      const legacyError = isRecord(error) && typeof error.error === 'string' ? error.error : null;
-      const legacyMessage =
-        isRecord(error) && typeof error.message === 'string' ? error.message : null;
-
-      throw new Error(legacyError || legacyMessage || `API error: ${res.status}`);
-    }
-
-    if (res.status === 204) {
-      return undefined as T;
-    }
-
-    const body = await res.json();
-
-    // Unwrap standard API envelope { success, data, meta }
-    if (isSuccessEnvelope<T>(body)) {
-      return body.data;
-    }
-
-    return body as T;
+      if (res.status === 204) return undefined as T;
+      let body: unknown;
+      try {
+        body = await res.json();
+      } catch (error) {
+        if (signal.aborted) throw error;
+        if (res.ok)
+          throw new ApiError('API returned an invalid JSON response.', {
+            status: res.status,
+            code: 'INVALID_RESPONSE',
+          });
+      }
+      if (!res.ok || isErrorEnvelope(body)) {
+        const envelope = isErrorEnvelope(body) ? body.error : null;
+        const legacy = isRecord(body) ? body : {};
+        const rawMessage =
+          envelope?.message ?? (typeof legacy.error === 'string' ? legacy.error : legacy.message);
+        const rawCode = envelope?.code ?? legacy.code;
+        const retryAfter = res.headers.get('retry-after');
+        const details = safeApiDetails(envelope?.details ?? legacy.details, secrets);
+        throw new ApiError(
+          safeApiText(
+            typeof rawMessage === 'string' ? rawMessage : `API request failed (${res.status})`,
+            secrets
+          ),
+          {
+            status: res.status,
+            code:
+              typeof rawCode === 'string' && /^[A-Z][A-Z0-9_]{0,79}$/.test(rawCode)
+                ? rawCode
+                : 'API_ERROR',
+            details: retryAfter
+              ? {
+                  ...(isRecord(details) && !Array.isArray(details) ? details : {}),
+                  retryAfter: safeApiText(retryAfter, secrets),
+                }
+              : details,
+          }
+        );
+      }
+      if (isSuccessEnvelope<T>(body)) return body.data;
+      return body as T;
+    });
   };
 }
 
-export function createGuardedApiClient(baseUrl = DEFAULT_BASE, apiKey = getEnv('VK_API_KEY')) {
-  const rawApi = createApiClient(baseUrl, apiKey);
-  const assertPermission = createApiPermissionGuard(() =>
-    rawApi<ClientAuthContext>('/api/auth/context')
+export function createGuardedApiClient(
+  baseUrl = DEFAULT_BASE,
+  apiKey = getEnv('VK_API_KEY'),
+  defaults: ApiClientOptions = {}
+) {
+  const rawApi = createApiClient(baseUrl, apiKey, defaults);
+  const defaultTimeout = requestTimeout(defaults.timeoutMs);
+  const assertPermission = createApiPermissionGuard((options) =>
+    rawApi<ClientAuthContext>('/api/auth/context', options)
   );
-
-  return async function api<T>(path: string, options?: RequestInit): Promise<T> {
-    await assertPermission(path, options);
-    return rawApi<T>(path, options);
+  return async function api<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+    return withDeadline(
+      options,
+      requestTimeout(options.timeoutMs ?? defaultTimeout),
+      async (signal) => {
+        await assertPermission(path, { ...options, signal });
+        signal.throwIfAborted();
+        return rawApi<T>(path, { ...options, signal });
+      }
+    );
   };
 }
 

--- a/shared/src/utils/api-errors.ts
+++ b/shared/src/utils/api-errors.ts
@@ -1,0 +1,70 @@
+/** Metadata safe to forward to command-line and tool clients. Full task snapshots are omitted. */
+const SAFE_DETAIL_FIELDS = new Set([
+  'code',
+  'message',
+  'path',
+  'expectedRevision',
+  'currentRevision',
+  'retryAfter',
+  'retryAfterMs',
+  'retryAfterSeconds',
+  'requiredPermission',
+  'requiredPermissions',
+  'limit',
+]);
+
+export function safeApiText(value: string, secrets: string[] = []): string {
+  let text = value;
+  for (const secret of secrets) if (secret) text = text.replaceAll(secret, '[redacted]');
+  return text
+    .replace(/\bBearer\s+[^\s,;]+/gi, 'Bearer [redacted]')
+    .replace(/\b(?:password|token|api[_-]?key|secret)\s*[:=]\s*[^\s,;]+/gi, '[redacted]')
+    .slice(0, 2048);
+}
+
+export function safeApiDetails(value: unknown, secrets: string[] = [], depth = 0): unknown {
+  if (depth > 3) return undefined;
+  if (typeof value === 'string') return safeApiText(value, secrets);
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) return value;
+  if (Array.isArray(value))
+    return value.slice(0, 20).map((item) => safeApiDetails(item, secrets, depth + 1));
+  if (typeof value !== 'object') return undefined;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => SAFE_DETAIL_FIELDS.has(key))
+      .map(([key, item]) => [key, safeApiDetails(item, secrets, depth + 1)])
+  );
+}
+
+export class ApiError extends Error {
+  readonly status?: number;
+  readonly code: string;
+  readonly details?: unknown;
+
+  constructor(
+    message: string,
+    metadata: { status?: number; code?: string; details?: unknown } = {}
+  ) {
+    const code = metadata.code ?? 'API_ERROR';
+    super(`${metadata.status ? `HTTP ${metadata.status} ` : ''}[${code}] ${message}`);
+    this.name = 'ApiError';
+    this.status = metadata.status;
+    this.code = code;
+    this.details = metadata.details;
+  }
+
+  toJSON() {
+    return { message: this.message, status: this.status, code: this.code, details: this.details };
+  }
+}
+
+export function formatApiError(error: unknown, json = false): string {
+  if (json)
+    return JSON.stringify({
+      error:
+        error instanceof ApiError
+          ? error.toJSON()
+          : { message: error instanceof Error ? error.message : String(error) },
+    });
+  return error instanceof Error ? error.message : String(error);
+}

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -550,18 +550,24 @@ export class ClientPermissionError extends Error {
   }
 }
 
-export function createApiPermissionGuard(loadContext: () => Promise<ClientAuthContext>) {
-  let cachedContext: Promise<ClientAuthContext> | null = null;
+export function createApiPermissionGuard(
+  loadContext: (options?: Pick<RequestInit, 'signal'>) => Promise<ClientAuthContext>
+) {
+  let cachedContext: ClientAuthContext | null = null;
 
   return async function assertApiPermissionForRequest(
     path: string,
-    options: Pick<RequestInit, 'method'> = {}
+    options: Pick<RequestInit, 'method' | 'signal'> = {}
   ): Promise<ClientAuthContext | null> {
     const requirement = getApiPermissionRequirement(path, options);
     if (requirement.public) return null;
 
-    cachedContext ??= loadContext();
-    const context = await cachedContext;
+    options.signal?.throwIfAborted();
+    // Cache only successful context. Each uncached caller owns its cancellation;
+    // an aborted request must not poison later requests or cancel another caller.
+    const context = cachedContext ?? (await loadContext({ signal: options.signal }));
+    options.signal?.throwIfAborted();
+    cachedContext = context;
     const allowed = requirement.permissions.some((permission) =>
       hasClientPermission(context, permission)
     );


### PR DESCRIPTION
CLI and MCP mutations now reject blank or ambiguous task identifiers before writing, prefer exact IDs, and accept only unique suffixes. Requests have a configurable 30-second default deadline covering authorization lookup, headers and response bodies; caller cancellation is preserved and writes are never retried automatically. Typed errors retain HTTP status, error code and allowlisted details for actionable client output.

Local verification on this branch: shared build, CLI and MCP typechecks, changed-file ESLint (zero errors; two existing warnings), and 39 focused regression tests passed across CLI, MCP and the shared API client. Cases cover wrong-target mutation prevention, stalled responses, cancellation, safe error metadata and failed authorization lookup recovery. No dependency changes.

Closes #1527.
Closes #1538.
