### PR TITLE
fix: preserve notification data through storage failures

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -605,6 +605,10 @@ Smoke-test the path in this order:
 
 Generic Squad Chat webhooks send a `squad.message` payload with `event`, `message.id`, `message.agent`, `message.message`, `message.timestamp`, and `isHuman`. If a webhook secret is configured, VK signs the request with `X-VK-Signature`. The Communication Health panel redacts webhook paths, query strings, secrets, and bearer tokens; avoid pasting full webhook URLs into screenshots or support notes.
 
+### Notification state cannot be loaded
+
+In file storage mode, `notifications.json` and `thread-subscriptions.json` in the configured runtime directory must contain JSON arrays. Missing files initialize normally. Malformed JSON and read failures stop the operation instead of resetting notification history. Preserve a copy of the affected file, restore a known-good copy or correct its read permissions, then retry. Writes replace the complete file atomically; a failed write leaves the previous file available.
+
 ### Notifications do not send externally
 
 Notification delivery channels are optional. Local notifications, broadcasts, and Squad Chat can work while external webhook delivery is disabled. Use `/api/broadcasts` for durable system-wide messages and verify delivery-specific settings before expecting an external wake or push.

--- a/server/src/__tests__/notification-service.test.ts
+++ b/server/src/__tests__/notification-service.test.ts
@@ -5,18 +5,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { parseMentions } from '../services/notification-service.js';
 
-// Mock fs and file-lock before importing the service
-vi.mock('node:fs/promises', () => ({
-  default: {
-    readFile: vi.fn().mockRejectedValue(new Error('ENOENT')),
-    writeFile: vi.fn().mockResolvedValue(undefined),
+// Persistence behavior is exercised separately against real repository files.
+vi.mock('../storage/notification-file-repository.js', () => ({
+  NotificationFileRepository: class {
+    async loadNotifications() {
+      return [];
+    }
+    async loadSubscriptions() {
+      return [];
+    }
+    async saveNotifications() {}
+    async saveSubscriptions() {}
   },
-  readFile: vi.fn().mockRejectedValue(new Error('ENOENT')),
-  writeFile: vi.fn().mockResolvedValue(undefined),
-}));
-
-vi.mock('../services/file-lock.js', () => ({
-  withFileLock: vi.fn(async (_path: string, fn: () => Promise<void>) => await fn()),
 }));
 
 const { getNotificationService } = await import('../services/notification-service.js');

--- a/server/src/__tests__/storage/notification-file-repository.test.ts
+++ b/server/src/__tests__/storage/notification-file-repository.test.ts
@@ -1,0 +1,102 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+const fault = vi.hoisted(() => ({ stage: '' }));
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...original,
+    readFile: async (...args: Parameters<typeof original.readFile>) => {
+      if (fault.stage === 'read' && String(args[0]).endsWith('.json')) {
+        throw Object.assign(new Error('Permission denied'), { code: 'EACCES' });
+      }
+      return original.readFile(...args);
+    },
+    open: async (...args: Parameters<typeof original.open>) => {
+      const handle = await original.open(...args);
+      if (fault.stage === 'write' && String(args[0]).includes('.tmp.')) {
+        const write = handle.writeFile.bind(handle);
+        handle.writeFile = async () => {
+          await write('partial JSON');
+          throw Object.assign(new Error('Interrupted write'), { code: 'EIO' });
+        };
+      }
+      return handle;
+    },
+    rename: async (...args: Parameters<typeof original.rename>) => {
+      if (fault.stage === 'rename')
+        throw Object.assign(new Error('Rename failed'), { code: 'EIO' });
+      return original.rename(...args);
+    },
+  };
+});
+import { NotificationFileRepository } from '../../storage/notification-file-repository.js';
+
+for (const kind of ['notifications', 'subscriptions'] as const) {
+  describe(`${kind} file durability`, () => {
+    let root: string;
+    let file: string;
+    let repository: NotificationFileRepository;
+    const previous = '[ { "id": "retained" } ]\n';
+    const load = () =>
+      kind === 'notifications' ? repository.loadNotifications() : repository.loadSubscriptions();
+    const save = () =>
+      kind === 'notifications'
+        ? repository.saveNotifications([{ id: 'new' }])
+        : repository.saveSubscriptions([{ id: 'new' }]);
+
+    beforeEach(async () => {
+      fault.stage = '';
+      root = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-notification-file-'));
+      file = path.join(
+        root,
+        kind === 'notifications' ? 'notifications.json' : 'thread-subscriptions.json'
+      );
+      repository = new NotificationFileRepository({ dataDir: root });
+    });
+    afterEach(async () => {
+      fault.stage = '';
+      await fs.rm(root, { recursive: true, force: true });
+    });
+
+    it('initializes only missing files and writes complete JSON', async () => {
+      expect(await load()).toEqual([]);
+      await save();
+      expect(await load()).toEqual([{ id: 'new' }]);
+      expect(await fs.readdir(root)).toEqual([path.basename(file)]);
+    });
+
+    it.each(['{broken', '{}', 'null'])(
+      'preserves malformed or non-array state: %s',
+      async (bytes) => {
+        await fs.writeFile(file, bytes);
+        await expect(load()).rejects.toThrow('Preserve the file');
+        await expect(save()).rejects.toThrow('Preserve the file');
+        expect(await fs.readFile(file, 'utf8')).toBe(bytes);
+      }
+    );
+
+    it('reports I/O errors without turning retained data into empty writable state', async () => {
+      await fs.writeFile(file, previous);
+      fault.stage = 'read';
+      await expect(load()).rejects.toMatchObject({ cause: { code: 'EACCES' } });
+      await expect(save()).rejects.toMatchObject({ cause: { code: 'EACCES' } });
+      expect(await fs.readFile(file, 'utf8')).toBe(previous);
+    });
+
+    it.each(['write', 'rename'])(
+      'retains exact previous bytes after a failed %s',
+      async (stage) => {
+        await fs.writeFile(file, previous);
+        fault.stage = stage;
+        await expect(save()).rejects.toMatchObject({ code: 'EIO' });
+        expect(await fs.readFile(file, 'utf8')).toBe(previous);
+        expect(await fs.readdir(root)).toEqual([path.basename(file)]);
+        fault.stage = '';
+        await save();
+        expect(await load()).toEqual([{ id: 'new' }]);
+      }
+    );
+  });
+}

--- a/server/src/storage/notification-file-repository.ts
+++ b/server/src/storage/notification-file-repository.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
+import { atomicWriteFile } from './fs-helpers.js';
 import path from 'node:path';
 import { withFileLock } from '../services/file-lock.js';
 
@@ -37,13 +38,24 @@ export class NotificationFileRepository {
 
   private async loadArray<T>(filePath: string): Promise<T[]> {
     try {
-      return JSON.parse(await readFile(filePath, 'utf8')) as T[];
-    } catch {
-      return [];
+      const values: unknown = JSON.parse(await readFile(filePath, 'utf8'));
+      if (!Array.isArray(values)) throw new Error('Expected a JSON array');
+      return values as T[];
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw new Error(
+        `Cannot load ${path.basename(filePath)}. Preserve the file and restore valid JSON or correct its read permissions before retrying.`,
+        { cause }
+      );
     }
   }
 
   private saveArray<T>(filePath: string, values: T[]): Promise<void> {
-    return withFileLock(filePath, () => writeFile(filePath, JSON.stringify(values, null, 2)));
+    return withFileLock(filePath, async () => {
+      // A cached service must not overwrite state that became unreadable since
+      // its last load. Validate the existing bytes while holding the same lock.
+      await this.loadArray(filePath);
+      await atomicWriteFile(filePath, JSON.stringify(values, null, 2));
+    });
   }
 }


### PR DESCRIPTION
Notification JSON writes now use atomic replacement. Missing files still start empty, but malformed JSON and read failures stop the operation with recovery guidance instead of silently replacing retained notifications. Each write validates the existing file while holding the file lock, including when the service has cached earlier state.

Local verification: shared build, server typecheck, changed-file ESLint (zero errors; three existing test warnings), diff check, and 48 focused notification service/repository tests passed. Tests cover write failure preservation, corrupt and unreadable files, missing-file initialization, and normal persistence. No dependency changes.

Closes #1528.
