### PR TITLE
fix: preserve platform shortcuts and IME input on the board

### DIFF
--- a/web/src/__tests__/useKeyboard.test.tsx
+++ b/web/src/__tests__/useKeyboard.test.tsx
@@ -113,6 +113,62 @@ describe('KeyboardProvider', () => {
     );
   });
 
+  it.each(['metaKey', 'ctrlKey', 'altKey', 'shiftKey'] as const)(
+    'leaves %s combinations to the platform',
+    (modifier) => {
+      const create = vi.fn();
+      const move = vi.fn();
+      function RegisterCreate() {
+        const { setOpenCreateDialog } = useKeyboard();
+        React.useEffect(() => setOpenCreateDialog(create), [setOpenCreateDialog]);
+        return null;
+      }
+      render(
+        <KeyboardProvider>
+          <RegisterCreate />
+          <TestConsumer tasks={[createMockTask({ id: 'task_one' })]} onMoveTask={move} />
+        </KeyboardProvider>
+      );
+      for (const key of ['c', 'j', 'k', '1', 'ArrowDown', 'ArrowUp', 'Enter']) {
+        const event = new KeyboardEvent('keydown', { key, [modifier]: true, cancelable: true });
+        fireEvent(window, event);
+        expect(event.defaultPrevented).toBe(false);
+      }
+      expect(create).not.toHaveBeenCalled();
+      expect(move).not.toHaveBeenCalled();
+      expect(screen.getByTestId('selected').textContent).toBe('none');
+      fireEvent.keyDown(window, { key: 'c' });
+      expect(create).toHaveBeenCalledOnce();
+    }
+  );
+
+  it('preserves the intentional chat chord and ignores IME composition', () => {
+    const chat = vi.fn();
+    const create = vi.fn();
+    function RegisterCommands() {
+      const { setOpenChatPanel, setOpenCreateDialog } = useKeyboard();
+      React.useEffect(() => {
+        setOpenChatPanel(chat);
+        setOpenCreateDialog(create);
+      }, [setOpenChatPanel, setOpenCreateDialog]);
+      return null;
+    }
+    render(
+      <KeyboardProvider>
+        <RegisterCommands />
+      </KeyboardProvider>
+    );
+    fireEvent.keyDown(window, { key: 'C', metaKey: true, shiftKey: true });
+    fireEvent.keyDown(window, { key: 'C', ctrlKey: true, shiftKey: true });
+    expect(chat).toHaveBeenCalledTimes(2);
+    fireEvent.keyDown(window, { key: 'C', ctrlKey: true, shiftKey: true, altKey: true });
+    fireEvent.keyDown(window, { key: 'C', metaKey: true, shiftKey: true, isComposing: true });
+    fireEvent.keyDown(window, { key: 'c', isComposing: true });
+    fireEvent.keyDown(window, { key: 'c', keyCode: 229 });
+    expect(chat).toHaveBeenCalledTimes(2);
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it('starts with no selected task and help closed', () => {
     renderWithProvider();
     expect(screen.getByTestId('selected').textContent).toBe('none');

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -375,6 +375,7 @@ export function KanbanBoard() {
   // Register filtered tasks with keyboard context
   useEffect(() => {
     setTasks(filteredTasks);
+    return () => setTasks([]);
   }, [filteredTasks, setTasks]);
 
   // Handler for opening a task

--- a/web/src/hooks/useKeyboard.tsx
+++ b/web/src/hooks/useKeyboard.tsx
@@ -116,6 +116,8 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
       const target = e.target instanceof HTMLElement ? e.target : null;
       if (
         e.defaultPrevented ||
+        e.isComposing ||
+        e.keyCode === 229 ||
         target?.isContentEditable ||
         target?.closest(
           'input, textarea, select, button, a[href], summary, [role="button"], [role="link"], [role="switch"], [role="checkbox"], [role="radio"], [role="combobox"], [role="listbox"], [role="option"], [role="slider"], [role="spinbutton"], [role="tab"], [role="menuitem"]'
@@ -143,11 +145,15 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
       const currentIndex = selectedTaskId ? taskList.findIndex((t) => t.id === selectedTaskId) : -1;
 
       // Cmd+Shift+C (or Ctrl+Shift+C on Windows/Linux) - Toggle chat panel
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'C') {
+      if (e.metaKey !== e.ctrlKey && !e.altKey && e.shiftKey && e.key.toLowerCase() === 'c') {
         e.preventDefault();
         openChatPanel();
         return;
       }
+
+      // Unregistered modifiers belong to the platform or focused application.
+      // Shift is permitted only for '?' so shortcut help remains reachable.
+      if (e.metaKey || e.ctrlKey || e.altKey || (e.shiftKey && e.key !== '?')) return;
 
       switch (e.key) {
         case 'c':
@@ -215,7 +221,7 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
             });
             return;
           }
-          if (selectedTaskId && onMoveTaskRef.current) {
+          if (selectedTaskId && currentIndex >= 0 && onMoveTaskRef.current) {
             onMoveTaskRef.current(selectedTaskId, newStatus);
           } else {
             // Show toast when no task is selected


### PR DESCRIPTION
Board shortcuts now leave unregistered Command, Control, Option/Alt and Shift combinations to the platform and ignore IME composition events. The registered chat shortcut and shortcut help still work. Unmounting the board clears its keyboard task list, and task movement requires the selection to remain in that list.

Local verification: web typecheck, changed-file ESLint, diff check and all 27 keyboard regression tests passed. Packaged native modifier and IME checks also passed in the integrated candidate. No dependency changes.

Closes #1526.
