### PR TITLE
perf: make notification storage operations incremental

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -6461,3 +6461,17 @@ No query params required.
 _For workflow engine endpoints, see [API-WORKFLOWS.md](API-WORKFLOWS.md)._  
 _For MCP server tools, see [MCP Server Guide](mcp/README.md)._  
 _For agent workflow SOPs, see [SOP-agent-task-workflow.md](SOP-agent-task-workflow.md)._
+
+## Notification pagination and storage
+
+`GET /api/notifications` accepts `limit` (integer 1–1000) and `offset` (nonnegative integer), alongside the existing `agent`, `undelivered`, and `taskId` filters. Omit pagination to retain the existing all-results response. Invalid pagination returns HTTP 400. Responses remain arrays, ordered newest first with notification ID as the stable tie-breaker.
+
+SQLite applies filtering and pagination in the query, aggregates notification statistics in SQL, and updates delivery state by row ID. Subscription creation preserves an existing subscription's original reason and timestamp. The file backend keeps the same operation semantics with locked, atomic file updates; its read and write costs still depend on retained history. No database migration is required.
+
+Run the disposable SQLite delivery benchmark from the repository root:
+
+```bash
+pnpm --filter @veritas-kanban/server exec tsx scripts/benchmark-notifications.ts
+```
+
+It seeds 100, 1,000, and 10,000 public-safe notifications in temporary databases, reports cold delivery latency and 25 warm samples per size, and removes only its temporary fixtures. `changedRowsPerWrite` should remain `[1]`. Timings depend on hardware and current host load; compare matching environments and use the row-change count as the deterministic regression check.

--- a/server/scripts/benchmark-notifications.ts
+++ b/server/scripts/benchmark-notifications.ts
@@ -1,0 +1,67 @@
+import { performance } from 'node:perf_hooks';
+import { createTestSqliteDatabase } from '../src/storage/sqlite/test-helpers.js';
+import { SqliteNotificationRepository } from '../src/storage/sqlite/notification-repository.js';
+import { NotificationService } from '../src/services/notification-service.js';
+const entries = [];
+for (const count of [100, 1000, 10000]) {
+  const fixture = createTestSqliteDatabase();
+  fixture.database.open();
+  const repo = new SqliteNotificationRepository(fixture.database);
+  const rows = Array.from({ length: count }, (_, i) => ({
+    id: `benchmark-${String(i).padStart(5, '0')}`,
+    taskId: 'benchmark',
+    targetAgent: 'test',
+    fromAgent: 'fixture',
+    content: 'Public-safe benchmark notification',
+    type: 'mention',
+    delivered: false,
+    createdAt: new Date(1700000000000 + i).toISOString(),
+  }));
+  repo.saveNotifications(rows);
+  const service = new NotificationService({
+    storageType: 'sqlite',
+    sqliteDatabase: fixture.database,
+    dataDir: fixture.rootDir,
+  });
+  const db = fixture.database.getConnection();
+  const changes = () => Number(db.prepare('SELECT total_changes() AS n').get()?.n);
+  const before = changes();
+  const coldStart = performance.now();
+  await service.markDelivered(rows[0].id);
+  const coldMs = performance.now() - coldStart;
+  const coldChangedRows = changes() - before;
+  const durations = [];
+  const touched = [];
+  for (let i = 1; i <= 25; i++) {
+    const startChanges = changes();
+    const start = performance.now();
+    await service.markDelivered(rows[i].id);
+    durations.push(performance.now() - start);
+    touched.push(changes() - startChanges);
+  }
+  durations.sort((a, b) => a - b);
+  entries.push({
+    count,
+    coldMs,
+    coldChangedRows,
+    warmMedianMs: durations[12],
+    warmP95Ms: durations[23],
+    changedRowsPerWrite: [...new Set(touched)],
+  });
+  service.dispose();
+  fixture.cleanup();
+}
+console.log(
+  JSON.stringify(
+    {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      operation: 'NotificationService.markDelivered',
+      warmSamples: 25,
+      entries,
+    },
+    null,
+    2
+  )
+);

--- a/server/src/__tests__/notification-service.test.ts
+++ b/server/src/__tests__/notification-service.test.ts
@@ -3,37 +3,28 @@
  * Tests @mention parsing, notification creation, delivery tracking, and thread subscriptions.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { parseMentions } from '../services/notification-service.js';
+import { parseMentions, NotificationService } from '../services/notification-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../storage/sqlite/test-helpers.js';
 
-// Persistence behavior is exercised separately against real repository files.
-vi.mock('../storage/notification-file-repository.js', () => ({
-  NotificationFileRepository: class {
-    async loadNotifications() {
-      return [];
-    }
-    async loadSubscriptions() {
-      return [];
-    }
-    async saveNotifications() {}
-    async saveSubscriptions() {}
-  },
-}));
-
-const { getNotificationService } = await import('../services/notification-service.js');
-import type { NotificationService } from '../services/notification-service.js';
-
-describe('NotificationService', () => {
+describe.each(['file', 'sqlite'] as const)('NotificationService (%s)', (storageType) => {
   let service: NotificationService;
+  let fixture: TestSqliteDatabase;
 
   beforeEach(() => {
-    service = getNotificationService();
-    // Reset internal state
-    (service as any).notifications = [];
-    (service as any).subscriptions = [];
-    (service as any).loaded = true;
+    fixture = createTestSqliteDatabase();
+    service = new NotificationService({
+      storageType,
+      dataDir: fixture.rootDir,
+      sqliteDatabase: fixture.database,
+    });
   });
 
   afterEach(() => {
+    service.dispose();
+    fixture.cleanup();
     vi.clearAllMocks();
   });
 

--- a/server/src/__tests__/routes/notifications-coverage.test.ts
+++ b/server/src/__tests__/routes/notifications-coverage.test.ts
@@ -48,6 +48,30 @@ describe('Notification Routes', () => {
   });
 
   describe('GET /api/notifications', () => {
+    it('passes validated pagination to the filtered repository query', async () => {
+      mockNotificationService.getNotifications.mockResolvedValue([]);
+      const res = await request(app).get(
+        '/api/notifications?agent=alice&undelivered=true&limit=20&offset=40'
+      );
+      expect(res.status).toBe(200);
+      expect(mockNotificationService.getNotifications).toHaveBeenCalledWith({
+        agent: 'alice',
+        undelivered: true,
+        taskId: '',
+        limit: 20,
+        offset: 40,
+      });
+    });
+
+    it.each(['limit=-1', 'limit=1.5', 'limit=1001', 'limit=nope', 'offset=-1'])(
+      'rejects invalid pagination: %s',
+      async (query) => {
+        const res = await request(app).get(`/api/notifications?${query}`);
+        expect(res.status).toBe(400);
+        expect(mockNotificationService.getAllNotifications).not.toHaveBeenCalled();
+      }
+    );
+
     it('should list all notifications when no agent is provided', async () => {
       mockNotificationService.getAllNotifications.mockResolvedValue([
         { id: 'n1', targetAgent: 'system', delivered: false },

--- a/server/src/__tests__/storage/notification-file-repository.test.ts
+++ b/server/src/__tests__/storage/notification-file-repository.test.ts
@@ -100,3 +100,45 @@ for (const kind of ['notifications', 'subscriptions'] as const) {
     );
   });
 }
+
+describe('incremental notification file rollback', () => {
+  let root: string;
+  beforeEach(async () => {
+    fault.stage = '';
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-notification-rollback-'));
+  });
+  afterEach(async () => {
+    fault.stage = '';
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it.each(['write', 'rename'])(
+    'retains delivery state and supports retry after %s failure',
+    async (stage) => {
+      const repository = new NotificationFileRepository({ dataDir: root });
+      await repository.appendNotifications([
+        {
+          id: 'retained',
+          taskId: 'task',
+          targetAgent: 'alice',
+          fromAgent: 'bob',
+          content: 'fixture',
+          type: 'mention',
+          delivered: false,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ]);
+      const file = path.join(root, 'notifications.json');
+      const before = await fs.readFile(file, 'utf8');
+      fault.stage = stage;
+      await expect(
+        repository.markDelivered('retained', '2026-01-02T00:00:00.000Z')
+      ).rejects.toMatchObject({ code: 'EIO' });
+      expect(await fs.readFile(file, 'utf8')).toBe(before);
+      expect((await repository.listNotifications())[0].delivered).toBe(false);
+      fault.stage = '';
+      expect(await repository.markDelivered('retained', '2026-01-02T00:00:00.000Z')).toBe(true);
+      expect((await repository.listNotifications())[0].delivered).toBe(true);
+    }
+  );
+});

--- a/server/src/__tests__/storage/notification-incremental.test.ts
+++ b/server/src/__tests__/storage/notification-incremental.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Notification, ThreadSubscription } from '../../services/notification-service.js';
+import type { NotificationRepository } from '../../storage/interfaces.js';
+import { NotificationFileRepository } from '../../storage/notification-file-repository.js';
+import { SqliteNotificationRepository } from '../../storage/sqlite/notification-repository.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+
+const row = (id: string, extra: Partial<Notification> = {}): Notification => ({
+  id,
+  taskId: 'task',
+  targetAgent: 'alice',
+  fromAgent: 'bob',
+  type: 'mention',
+  content: id,
+  delivered: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  dedupeKey: 'retained-metadata',
+  ...extra,
+});
+const deliveredAt = '2026-01-02T00:00:00.000Z';
+
+describe.each(['file', 'sqlite'] as const)('incremental notifications (%s)', (kind) => {
+  let fixture: TestSqliteDatabase;
+  let repository: NotificationRepository;
+  beforeEach(() => {
+    fixture = createTestSqliteDatabase();
+    fixture.database.open();
+    repository =
+      kind === 'sqlite'
+        ? new SqliteNotificationRepository(fixture.database)
+        : new NotificationFileRepository({ dataDir: fixture.rootDir });
+  });
+  afterEach(() => fixture.cleanup());
+
+  it('filters and pages in stable timestamp/id order and preserves metadata', async () => {
+    await repository.appendNotifications([
+      row('b'),
+      row('a'),
+      row('c', { createdAt: '2026-01-01T00:00:00.001Z' }),
+      row('other', { targetAgent: 'case' }),
+      row('delivered', { delivered: true }),
+    ]);
+    const page = await repository.listNotifications({
+      agent: 'ALICE',
+      undelivered: true,
+      taskId: 'task',
+      limit: 2,
+      offset: 1,
+    });
+    expect(page.map((value) => value.id)).toEqual(['a', 'b']);
+    expect(page.every((value) => value.dedupeKey === 'retained-metadata')).toBe(true);
+    expect(await repository.listNotifications({ limit: 2, offset: 99 })).toEqual([]);
+    expect(await repository.getStats()).toEqual({
+      totalNotifications: 5,
+      undelivered: 4,
+      byAgent: { alice: { total: 4, undelivered: 3 }, case: { total: 1, undelivered: 1 } },
+      byType: { mention: 5 },
+    });
+  });
+
+  it('updates only intended deliveries and counts only newly delivered batch entries', async () => {
+    const untouched = row('untouched', { targetAgent: 'case', source: { retained: true } });
+    await repository.appendNotifications([row('a'), row('b'), untouched]);
+    expect(await repository.markDelivered('missing', deliveredAt)).toBe(false);
+    expect(await repository.markDelivered('a', deliveredAt)).toBe(true);
+    expect(await repository.markManyDelivered(['a', 'b', 'b', 'missing'], deliveredAt)).toBe(1);
+    expect(await repository.markAllDelivered('ALICE', deliveredAt)).toBe(0);
+    expect((await repository.listNotifications({ agent: 'case' }))[0]).toEqual(untouched);
+    expect(await repository.markAllDelivered('CASE', deliveredAt)).toBe(1);
+    expect((await repository.getStats()).undelivered).toBe(0);
+    expect(await repository.clearNotifications()).toBe(3);
+    expect(await repository.clearNotifications()).toBe(0);
+  });
+
+  it('rolls back an append batch and keeps subscription dedupe stable', async () => {
+    await repository.appendNotifications([row('retained')]);
+    await expect(
+      Promise.resolve().then(() => repository.appendNotifications([row('new'), row('retained')]))
+    ).rejects.toThrow();
+    expect(await repository.listNotifications()).toEqual([row('retained')]);
+    const subscription: ThreadSubscription = {
+      taskId: 'task',
+      agent: 'alice',
+      reason: 'manual',
+      subscribedAt: deliveredAt,
+    };
+    await repository.subscribe(subscription);
+    await repository.subscribe({
+      ...subscription,
+      reason: 'mentioned',
+      subscribedAt: '2026-01-03T00:00:00.000Z',
+    });
+    expect(await repository.getSubscriptions('task')).toEqual([subscription]);
+  });
+
+  it('sees other repository instances without replacing their updates', async () => {
+    const other =
+      kind === 'sqlite'
+        ? new SqliteNotificationRepository(fixture.database)
+        : new NotificationFileRepository({ dataDir: fixture.rootDir });
+    await repository.appendNotifications([row('a')]);
+    await other.appendNotifications([row('b')]);
+    await repository.markDelivered('a', deliveredAt);
+    expect((await other.listNotifications()).map((value) => value.id)).toEqual(['a', 'b']);
+  });
+
+  if (kind === 'sqlite') {
+    it('changes exactly one row and keeps unrelated stored bytes intact', async () => {
+      await repository.appendNotifications([row('a'), row('b')]);
+      const db = fixture.database.getConnection();
+      db.prepare("UPDATE notifications SET notification_json = ? WHERE id = 'b'").run(
+        '{ "untouched" : true }'
+      );
+      const before = Number(db.prepare('SELECT total_changes() AS n').get()?.n);
+      expect(await repository.markDelivered('a', deliveredAt)).toBe(true);
+      expect(Number(db.prepare('SELECT total_changes() AS n').get()?.n) - before).toBe(1);
+      expect(
+        db.prepare("SELECT notification_json FROM notifications WHERE id = 'b'").get()
+          ?.notification_json
+      ).toBe('{ "untouched" : true }');
+      const updated = await repository.listNotifications({
+        undelivered: false,
+        taskId: 'task',
+        limit: 1,
+      });
+      expect(updated[0]).toEqual(row('a', { delivered: true, deliveredAt }));
+    });
+
+    it('rolls back an entire delivery statement when one row fails', async () => {
+      await repository.appendNotifications([row('a'), row('b')]);
+      const db = fixture.database.getConnection();
+      db.exec(
+        "CREATE TRIGGER reject_delivery BEFORE UPDATE ON notifications WHEN NEW.id = 'b' BEGIN SELECT RAISE(ABORT, 'injected delivery failure'); END"
+      );
+      await expect(
+        Promise.resolve().then(() => repository.markManyDelivered(['a', 'b'], deliveredAt))
+      ).rejects.toThrow('injected delivery failure');
+      expect(await repository.listNotifications()).toEqual([row('a'), row('b')]);
+      db.exec('DROP TRIGGER reject_delivery');
+      expect(await repository.markManyDelivered(['a', 'b'], deliveredAt)).toBe(2);
+    });
+  }
+});

--- a/server/src/routes/notifications.ts
+++ b/server/src/routes/notifications.ts
@@ -17,9 +17,15 @@
 import { Router, type NextFunction, type Response, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { getNotificationService } from '../services/notification-service.js';
+import { validate } from '../middleware/validate.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError } from '../middleware/error-handler.js';
 import { authorize, type AuthenticatedRequest } from '../middleware/auth.js';
+
+const notificationPagingSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+});
 
 const router: RouterType = Router();
 const requireAdmin = authorize('admin');
@@ -70,13 +76,15 @@ router.post(
 router.get(
   '/',
   requireAdminForGlobalNotifications,
+  validate({ query: notificationPagingSchema }),
   asyncHandler(async (req, res) => {
+    const paging = req.validated?.query as z.infer<typeof notificationPagingSchema>;
     const agent = String(req.query.agent || '');
     if (!agent) {
       const service = getNotificationService();
       const notifications = await service.getAllNotifications({
         undelivered: req.query.undelivered === 'true' || req.query.unsent === 'true',
-        limit: req.query.limit ? Number(String(req.query.limit)) : undefined,
+        ...paging,
       });
       return res.json(notifications);
     }
@@ -86,7 +94,7 @@ router.get(
       agent,
       undelivered: req.query.undelivered === 'true',
       taskId: String(req.query.taskId || ''),
-      limit: req.query.limit ? Number(String(req.query.limit)) : undefined,
+      ...paging,
     });
 
     res.json(notifications);

--- a/server/src/services/notification-service.ts
+++ b/server/src/services/notification-service.ts
@@ -5,6 +5,7 @@
  * and thread subscriptions for multi-agent communication.
  */
 
+import type { NotificationRepository, NotificationQuery } from '../storage/interfaces.js';
 import { createLogger } from '../lib/logger.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteNotificationRepository } from '../storage/sqlite/notification-repository.js';
@@ -93,17 +94,13 @@ export function parseMentions(text: string): string[] {
 // ─── Service ─────────────────────────────────────────────────────
 
 export class NotificationService {
-  private notifications: Notification[] = [];
-  private subscriptions: ThreadSubscription[] = [];
-  private loaded = false;
-  private readonly fileRepository: NotificationFileRepository;
-  private readonly repository: SqliteNotificationRepository | null = null;
+  private readonly repository: NotificationRepository;
   private readonly sqliteDatabase: SqliteDatabase | null = null;
   private readonly ownsSqliteDatabase: boolean = false;
 
   constructor(options: NotificationServiceOptions = {}) {
     const dataDir = options.dataDir ?? DATA_DIR;
-    this.fileRepository = new NotificationFileRepository({
+    this.repository = new NotificationFileRepository({
       dataDir,
       notificationsFile: options.notificationsFile,
       subscriptionsFile: options.subscriptionsFile,
@@ -120,38 +117,6 @@ export class NotificationService {
     }
   }
 
-  private async ensureLoaded(): Promise<void> {
-    if (this.loaded) return;
-    if (this.repository) {
-      this.notifications = this.repository.loadNotifications();
-      this.subscriptions = this.repository.loadSubscriptions();
-      this.loaded = true;
-      return;
-    }
-
-    this.notifications = await this.fileRepository.loadNotifications<Notification>();
-    this.subscriptions = await this.fileRepository.loadSubscriptions<ThreadSubscription>();
-    this.loaded = true;
-  }
-
-  private async saveNotifications(): Promise<void> {
-    if (this.repository) {
-      this.repository.saveNotifications(this.notifications);
-      return;
-    }
-
-    await this.fileRepository.saveNotifications(this.notifications);
-  }
-
-  private async saveSubscriptions(): Promise<void> {
-    if (this.repository) {
-      this.repository.saveSubscriptions(this.subscriptions);
-      return;
-    }
-
-    await this.fileRepository.saveSubscriptions(this.subscriptions);
-  }
-
   /**
    * Process a comment for @mentions and create notifications.
    * Also subscribes the commenter to the thread.
@@ -162,8 +127,6 @@ export class NotificationService {
     content: string;
     allAgents?: string[];
   }): Promise<Notification[]> {
-    await this.ensureLoaded();
-
     const mentions = parseMentions(params.content);
     const created: Notification[] = [];
 
@@ -177,9 +140,9 @@ export class NotificationService {
     targets = targets.filter((t) => t !== params.fromAgent.toLowerCase());
 
     // Also notify thread subscribers (if not already in mentions)
-    const subscribers = this.subscriptions
-      .filter((s) => s.taskId === params.taskId)
-      .map((s) => s.agent.toLowerCase());
+    const subscribers = (await this.repository.getSubscriptions(params.taskId)).map((s) =>
+      s.agent.toLowerCase()
+    );
 
     const allTargets = [...new Set([...targets, ...subscribers])].filter(
       (t) => t !== params.fromAgent.toLowerCase()
@@ -196,7 +159,6 @@ export class NotificationService {
         delivered: false,
         createdAt: new Date().toISOString(),
       };
-      this.notifications.push(notification);
       created.push(notification);
     }
 
@@ -208,7 +170,7 @@ export class NotificationService {
       await this.subscribe(params.taskId, target, 'mentioned');
     }
 
-    await this.saveNotifications();
+    await this.repository.appendNotifications(created);
 
     log.info(
       {
@@ -227,8 +189,7 @@ export class NotificationService {
    * Create a notification for task assignment.
    */
   async notifyAssignment(taskId: string, agents: string[], assignedBy: string): Promise<void> {
-    await this.ensureLoaded();
-
+    const created: Notification[] = [];
     for (const agent of agents) {
       if (agent.toLowerCase() === assignedBy.toLowerCase()) continue;
 
@@ -242,127 +203,38 @@ export class NotificationService {
         delivered: false,
         createdAt: new Date().toISOString(),
       };
-      this.notifications.push(notification);
+      created.push(notification);
 
       // Auto-subscribe assigned agents
       await this.subscribe(taskId, agent, 'assigned');
     }
 
-    await this.saveNotifications();
+    await this.repository.appendNotifications(created);
   }
 
   /**
    * Get notifications for an agent.
    */
-  async getNotifications(filters: {
-    agent: string;
-    undelivered?: boolean;
-    taskId?: string;
-    limit?: number;
-  }): Promise<Notification[]> {
-    await this.ensureLoaded();
-
-    let results = this.notifications.filter((n) => n.targetAgent === filters.agent.toLowerCase());
-
-    if (filters.undelivered) {
-      results = results.filter((n) => !n.delivered);
-    }
-    if (filters.taskId) {
-      results = results.filter((n) => n.taskId === filters.taskId);
-    }
-
-    results.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-
-    if (filters.limit) {
-      results = results.slice(0, filters.limit);
-    }
-
-    return results;
+  async getNotifications(filters: NotificationQuery & { agent: string }): Promise<Notification[]> {
+    return this.repository.listNotifications(filters);
   }
 
-  /**
-   * Get notifications across all agents.
-   *
-   * Used by the CLI notification commands, which predate the agent-scoped
-   * route shape.
-   */
   async getAllNotifications(
-    filters: {
-      undelivered?: boolean;
-      limit?: number;
-    } = {}
+    filters: Omit<NotificationQuery, 'agent' | 'taskId'> = {}
   ): Promise<Notification[]> {
-    await this.ensureLoaded();
-
-    let results = [...this.notifications];
-
-    if (filters.undelivered) {
-      results = results.filter((n) => !n.delivered);
-    }
-
-    results.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-
-    if (filters.limit) {
-      results = results.slice(0, filters.limit);
-    }
-
-    return results;
+    return this.repository.listNotifications(filters);
   }
 
-  /**
-   * Mark a notification as delivered.
-   */
   async markDelivered(notificationId: string): Promise<boolean> {
-    await this.ensureLoaded();
-
-    const notification = this.notifications.find((n) => n.id === notificationId);
-    if (!notification) return false;
-
-    notification.delivered = true;
-    notification.deliveredAt = new Date().toISOString();
-    await this.saveNotifications();
-    return true;
+    return this.repository.markDelivered(notificationId, new Date().toISOString());
   }
 
-  /**
-   * Mark multiple notifications as delivered.
-   */
   async markManyDelivered(notificationIds: string[]): Promise<number> {
-    await this.ensureLoaded();
-
-    const ids = new Set(notificationIds);
-    const now = new Date().toISOString();
-    let count = 0;
-    for (const notification of this.notifications) {
-      if (ids.has(notification.id) && !notification.delivered) {
-        notification.delivered = true;
-        notification.deliveredAt = now;
-        count++;
-      }
-    }
-
-    if (count > 0) await this.saveNotifications();
-    return count;
+    return this.repository.markManyDelivered(notificationIds, new Date().toISOString());
   }
 
-  /**
-   * Mark all notifications for an agent as delivered.
-   */
   async markAllDelivered(agent: string): Promise<number> {
-    await this.ensureLoaded();
-
-    let count = 0;
-    const now = new Date().toISOString();
-    for (const n of this.notifications) {
-      if (n.targetAgent === agent.toLowerCase() && !n.delivered) {
-        n.delivered = true;
-        n.deliveredAt = now;
-        count++;
-      }
-    }
-
-    if (count > 0) await this.saveNotifications();
-    return count;
+    return this.repository.markAllDelivered(agent.toLowerCase(), new Date().toISOString());
   }
 
   /**
@@ -381,8 +253,6 @@ export class NotificationService {
     dedupeKey?: string;
     source?: NotificationSourceMetadata;
   }): Promise<Notification> {
-    await this.ensureLoaded();
-
     const notification: Notification = {
       id: `notif_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
       taskId: params.taskId || 'system',
@@ -400,8 +270,7 @@ export class NotificationService {
       createdAt: new Date().toISOString(),
     };
 
-    this.notifications.push(notification);
-    await this.saveNotifications();
+    await this.repository.appendNotifications([notification]);
     return notification;
   }
 
@@ -409,71 +278,28 @@ export class NotificationService {
    * Clear all notifications.
    */
   async clearNotifications(): Promise<number> {
-    await this.ensureLoaded();
-
-    const count = this.notifications.length;
-    this.notifications = [];
-    if (count > 0) await this.saveNotifications();
-    return count;
+    return this.repository.clearNotifications();
   }
 
-  /**
-   * Get notification statistics.
-   */
   async getStats(): Promise<NotificationStats> {
-    await this.ensureLoaded();
-
-    const byAgent: Record<string, { total: number; undelivered: number }> = {};
-    const byType: Record<string, number> = {};
-
-    for (const n of this.notifications) {
-      if (!byAgent[n.targetAgent]) {
-        byAgent[n.targetAgent] = { total: 0, undelivered: 0 };
-      }
-      byAgent[n.targetAgent].total++;
-      if (!n.delivered) byAgent[n.targetAgent].undelivered++;
-
-      byType[n.type] = (byType[n.type] || 0) + 1;
-    }
-
-    return {
-      totalNotifications: this.notifications.length,
-      undelivered: this.notifications.filter((n) => !n.delivered).length,
-      byAgent,
-      byType,
-    };
+    return this.repository.getStats();
   }
 
-  /**
-   * Subscribe an agent to a task thread.
-   */
   async subscribe(
     taskId: string,
     agent: string,
     reason: ThreadSubscription['reason']
   ): Promise<void> {
-    await this.ensureLoaded();
-
-    const exists = this.subscriptions.some(
-      (s) => s.taskId === taskId && s.agent === agent.toLowerCase()
-    );
-    if (exists) return;
-
-    this.subscriptions.push({
+    await this.repository.subscribe({
       taskId,
       agent: agent.toLowerCase(),
       reason,
       subscribedAt: new Date().toISOString(),
     });
-    await this.saveSubscriptions();
   }
 
-  /**
-   * Get subscriptions for a task.
-   */
   async getSubscriptions(taskId: string): Promise<ThreadSubscription[]> {
-    await this.ensureLoaded();
-    return this.subscriptions.filter((s) => s.taskId === taskId);
+    return this.repository.getSubscriptions(taskId);
   }
 
   dispose(): void {

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -84,6 +84,11 @@ import type {
   RunOutputArtifactRangeQuery,
   RunOutputQuarantineReason,
 } from '@veritas-kanban/shared';
+import type {
+  Notification,
+  NotificationStats,
+  ThreadSubscription,
+} from '../services/notification-service.js';
 import type { Activity, ActivityType } from '../services/activity-service.js';
 import type {
   StatusHistoryEntry,
@@ -601,4 +606,25 @@ export interface StorageProvider {
 
   /** Graceful shutdown (close watchers, release connections, etc.). */
   shutdown(): Promise<void>;
+}
+
+/** Incremental notification operations; bulk import/export remains adapter-specific. */
+export interface NotificationQuery {
+  agent?: string;
+  undelivered?: boolean;
+  taskId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface NotificationRepository {
+  appendNotifications(notifications: Notification[]): void | Promise<void>;
+  listNotifications(query?: NotificationQuery): Notification[] | Promise<Notification[]>;
+  markDelivered(id: string, at: string): boolean | Promise<boolean>;
+  markManyDelivered(ids: string[], at: string): number | Promise<number>;
+  markAllDelivered(agent: string, at: string): number | Promise<number>;
+  clearNotifications(): number | Promise<number>;
+  getStats(): NotificationStats | Promise<NotificationStats>;
+  subscribe(subscription: ThreadSubscription): void | Promise<void>;
+  getSubscriptions(taskId: string): ThreadSubscription[] | Promise<ThreadSubscription[]>;
 }

--- a/server/src/storage/notification-file-repository.ts
+++ b/server/src/storage/notification-file-repository.ts
@@ -1,3 +1,9 @@
+import type { NotificationRepository, NotificationQuery } from './interfaces.js';
+import type {
+  Notification,
+  NotificationStats,
+  ThreadSubscription,
+} from '../services/notification-service.js';
 import { readFile } from 'node:fs/promises';
 import { atomicWriteFile } from './fs-helpers.js';
 import path from 'node:path';
@@ -9,7 +15,7 @@ export interface NotificationFileRepositoryOptions {
   subscriptionsFile?: string;
 }
 
-export class NotificationFileRepository {
+export class NotificationFileRepository implements NotificationRepository {
   private readonly notificationsFile: string;
   private readonly subscriptionsFile: string;
 
@@ -34,6 +40,130 @@ export class NotificationFileRepository {
 
   saveSubscriptions<T>(subscriptions: T[]): Promise<void> {
     return this.saveArray(this.subscriptionsFile, subscriptions);
+  }
+
+  async appendNotifications(notifications: Notification[]): Promise<void> {
+    if (!notifications.length) return;
+    await this.mutateArray<Notification, void>(this.notificationsFile, (values) => {
+      const ids = new Set(values.map((value) => value.id));
+      for (const notification of notifications) {
+        if (ids.has(notification.id))
+          throw new Error(`Duplicate notification id: ${notification.id}`);
+        ids.add(notification.id);
+        values.push(notification);
+      }
+    });
+  }
+
+  async listNotifications(query: NotificationQuery = {}): Promise<Notification[]> {
+    const values = await this.loadNotifications<Notification>();
+    const results = values
+      .filter(
+        (value) =>
+          (query.agent === undefined || value.targetAgent === query.agent.toLowerCase()) &&
+          (!query.undelivered || !value.delivered) &&
+          (!query.taskId || value.taskId === query.taskId)
+      )
+      .sort((a, b) =>
+        a.createdAt === b.createdAt
+          ? a.id < b.id
+            ? -1
+            : a.id > b.id
+              ? 1
+              : 0
+          : a.createdAt > b.createdAt
+            ? -1
+            : 1
+      );
+    const offset = query.offset ?? 0;
+    return results.slice(offset, query.limit === undefined ? undefined : offset + query.limit);
+  }
+
+  async markDelivered(id: string, at: string): Promise<boolean> {
+    return (await this.deliver((value) => value.id === id, at)) > 0;
+  }
+
+  markManyDelivered(ids: string[], at: string): Promise<number> {
+    const selected = new Set(ids);
+    return this.deliver((value) => !value.delivered && selected.has(value.id), at);
+  }
+
+  markAllDelivered(agent: string, at: string): Promise<number> {
+    return this.deliver(
+      (value) => !value.delivered && value.targetAgent === agent.toLowerCase(),
+      at
+    );
+  }
+
+  private deliver(matches: (value: Notification) => boolean, at: string): Promise<number> {
+    return this.mutateArray<Notification, number>(this.notificationsFile, (values) => {
+      let count = 0;
+      for (const value of values) {
+        if (!matches(value)) continue;
+        value.delivered = true;
+        value.deliveredAt = at;
+        count++;
+      }
+      return count;
+    });
+  }
+
+  clearNotifications(): Promise<number> {
+    return this.mutateArray<Notification, number>(this.notificationsFile, (values) => {
+      const count = values.length;
+      values.length = 0;
+      return count;
+    });
+  }
+
+  async getStats(): Promise<NotificationStats> {
+    const values = await this.loadNotifications<Notification>();
+    const byAgent: NotificationStats['byAgent'] = Object.create(null);
+    const byType: NotificationStats['byType'] = Object.create(null);
+    let undelivered = 0;
+    for (const value of values) {
+      const agent = (byAgent[value.targetAgent] ??= { total: 0, undelivered: 0 });
+      agent.total++;
+      if (!value.delivered) {
+        agent.undelivered++;
+        undelivered++;
+      }
+      byType[value.type] = (byType[value.type] ?? 0) + 1;
+    }
+    return { totalNotifications: values.length, undelivered, byAgent, byType };
+  }
+
+  subscribe(subscription: ThreadSubscription): Promise<void> {
+    return this.mutateArray<ThreadSubscription, void>(this.subscriptionsFile, (values) => {
+      if (
+        !values.some(
+          (value) => value.taskId === subscription.taskId && value.agent === subscription.agent
+        )
+      )
+        values.push(subscription);
+    });
+  }
+
+  async getSubscriptions(taskId: string): Promise<ThreadSubscription[]> {
+    return (await this.loadSubscriptions<ThreadSubscription>())
+      .filter((value) => value.taskId === taskId)
+      .sort((a, b) =>
+        a.subscribedAt === b.subscribedAt
+          ? a.agent.localeCompare(b.agent)
+          : a.subscribedAt.localeCompare(b.subscribedAt)
+      );
+  }
+
+  private mutateArray<T, R>(filePath: string, mutate: (values: T[]) => R): Promise<R> {
+    return withFileLock(filePath, async () => {
+      const values = await this.loadArray<T>(filePath);
+      const before = JSON.stringify(values);
+      const result = mutate(values);
+      if (JSON.stringify(values) !== before) {
+        await atomicWriteFile(filePath, JSON.stringify(values, null, 2));
+      }
+      return result;
+    });
   }
 
   private async loadArray<T>(filePath: string): Promise<T[]> {

--- a/server/src/storage/sqlite/notification-repository.ts
+++ b/server/src/storage/sqlite/notification-repository.ts
@@ -1,4 +1,6 @@
 import type { Notification, ThreadSubscription } from '../../services/notification-service.js';
+import type { NotificationRepository, NotificationQuery } from '../interfaces.js';
+import type { NotificationStats } from '../../services/notification-service.js';
 import type { SqliteDatabase } from './database.js';
 
 interface NotificationRow {
@@ -9,7 +11,7 @@ interface ThreadSubscriptionRow {
   subscription_json: string;
 }
 
-export class SqliteNotificationRepository {
+export class SqliteNotificationRepository implements NotificationRepository {
   constructor(private readonly database: SqliteDatabase) {}
 
   loadNotifications(): Notification[] {
@@ -35,8 +37,19 @@ export class SqliteNotificationRepository {
     try {
       db.prepare("DELETE FROM notifications WHERE workspace_id = 'local'").run();
 
-      const insertNotification = db.prepare(
-        `
+      this.insertNotifications(notifications);
+
+      db.exec('COMMIT;');
+    } catch (error) {
+      db.exec('ROLLBACK;');
+      throw error;
+    }
+  }
+
+  private insertNotifications(notifications: Notification[]): void {
+    const db = this.database.getConnection();
+    const insertNotification = db.prepare(
+      `
           INSERT INTO notifications (
             id,
             workspace_id,
@@ -58,34 +71,150 @@ export class SqliteNotificationRepository {
           )
           VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `
+    );
+
+    for (const notification of notifications) {
+      insertNotification.run(
+        notification.id,
+        notification.taskId,
+        notification.targetAgent,
+        notification.fromAgent,
+        notification.type,
+        notification.delivered ? 1 : 0,
+        notification.deliveredAt ?? null,
+        notification.content,
+        notification.title ?? null,
+        notification.taskTitle ?? null,
+        notification.project ?? null,
+        notification.targetUrl ?? null,
+        notification.dedupeKey ?? null,
+        notification.source ? JSON.stringify(notification.source) : null,
+        JSON.stringify(notification),
+        notification.createdAt
       );
+    }
+  }
 
-      for (const notification of notifications) {
-        insertNotification.run(
-          notification.id,
-          notification.taskId,
-          notification.targetAgent,
-          notification.fromAgent,
-          notification.type,
-          notification.delivered ? 1 : 0,
-          notification.deliveredAt ?? null,
-          notification.content,
-          notification.title ?? null,
-          notification.taskTitle ?? null,
-          notification.project ?? null,
-          notification.targetUrl ?? null,
-          notification.dedupeKey ?? null,
-          notification.source ? JSON.stringify(notification.source) : null,
-          JSON.stringify(notification),
-          notification.createdAt
-        );
-      }
-
+  appendNotifications(notifications: Notification[]): void {
+    if (!notifications.length) return;
+    const db = this.database.getConnection();
+    db.exec('BEGIN IMMEDIATE;');
+    try {
+      this.insertNotifications(notifications);
       db.exec('COMMIT;');
     } catch (error) {
       db.exec('ROLLBACK;');
       throw error;
     }
+  }
+
+  listNotifications(query: NotificationQuery = {}): Notification[] {
+    const clauses = ["workspace_id = 'local'"];
+    const parameters: (string | number)[] = [];
+    if (query.agent !== undefined) {
+      clauses.push('target_agent = ?');
+      parameters.push(query.agent.toLowerCase());
+    }
+    if (query.undelivered) clauses.push('delivered = 0');
+    if (query.taskId) {
+      clauses.push('task_id = ?');
+      parameters.push(query.taskId);
+    }
+    parameters.push(query.limit ?? -1, query.offset ?? 0);
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `SELECT notification_json FROM notifications WHERE ${clauses.join(' AND ')} ORDER BY created_at DESC, id ASC LIMIT ? OFFSET ?`
+      )
+      .all(...parameters) as unknown as NotificationRow[];
+    return rows.map((row) => JSON.parse(row.notification_json) as Notification);
+  }
+
+  markDelivered(id: string, at: string): boolean {
+    return this.updateDelivered('id = ?', [id], at) > 0;
+  }
+
+  private updateDelivered(where: string, parameters: string[], at: string): number {
+    return Number(
+      this.database
+        .getConnection()
+        .prepare(
+          `UPDATE notifications SET delivered = 1, delivered_at = ?, notification_json = json_set(notification_json, '$.delivered', json('true'), '$.deliveredAt', ?) WHERE workspace_id = 'local' AND ${where}`
+        )
+        .run(at, at, ...parameters).changes
+    );
+  }
+
+  markManyDelivered(ids: string[], at: string): number {
+    if (!ids.length) return 0;
+    // JSON table avoids SQLite's parameter limit for a large delivery batch.
+    return this.updateDelivered(
+      'delivered = 0 AND id IN (SELECT value FROM json_each(?))',
+      [JSON.stringify([...new Set(ids)])],
+      at
+    );
+  }
+
+  markAllDelivered(agent: string, at: string): number {
+    return this.updateDelivered('delivered = 0 AND target_agent = ?', [agent.toLowerCase()], at);
+  }
+
+  clearNotifications(): number {
+    return Number(
+      this.database
+        .getConnection()
+        .prepare("DELETE FROM notifications WHERE workspace_id = 'local'")
+        .run().changes
+    );
+  }
+
+  getStats(): NotificationStats {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        "SELECT target_agent AS agent, type, COUNT(*) AS total, SUM(delivered = 0) AS undelivered FROM notifications WHERE workspace_id = 'local' GROUP BY target_agent, type"
+      )
+      .all() as unknown as { agent: string; type: string; total: number; undelivered: number }[];
+    const byAgent: NotificationStats['byAgent'] = Object.create(null);
+    const byType: NotificationStats['byType'] = Object.create(null);
+    let totalNotifications = 0;
+    let undelivered = 0;
+    for (const row of rows) {
+      const total = Number(row.total);
+      const pending = Number(row.undelivered);
+      const agent = (byAgent[row.agent] ??= { total: 0, undelivered: 0 });
+      agent.total += total;
+      agent.undelivered += pending;
+      byType[row.type] = (byType[row.type] ?? 0) + total;
+      totalNotifications += total;
+      undelivered += pending;
+    }
+    return { totalNotifications, undelivered, byAgent, byType };
+  }
+
+  subscribe(subscription: ThreadSubscription): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `INSERT INTO thread_subscriptions (workspace_id, task_id, agent, reason, subscription_json, subscribed_at) VALUES ('local', ?, ?, ?, ?, ?) ON CONFLICT(workspace_id, task_id, agent) DO NOTHING`
+      )
+      .run(
+        subscription.taskId,
+        subscription.agent,
+        subscription.reason,
+        JSON.stringify(subscription),
+        subscription.subscribedAt
+      );
+  }
+
+  getSubscriptions(taskId: string): ThreadSubscription[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        "SELECT subscription_json FROM thread_subscriptions WHERE workspace_id = 'local' AND task_id = ? ORDER BY subscribed_at ASC, agent ASC"
+      )
+      .all(taskId) as unknown as ThreadSubscriptionRow[];
+    return rows.map((row) => JSON.parse(row.subscription_json) as ThreadSubscription);
   }
 
   loadSubscriptions(): ThreadSubscription[] {


### PR DESCRIPTION
Notification operations now read and update through a shared repository contract instead of caching the complete history in the service. SQLite appends and delivery updates target affected rows, statistics run in SQL, and listing uses deterministic pagination. File-backed operations reload and update under a lock while preserving atomic writes and corruption recovery. The API validates page bounds and documents its 100-row default and 1,000-row maximum.

Local verification: server typecheck, affected configured-file ESLint (zero errors), diff check and 130 focused service, route and storage tests passed. Coverage includes interleaved service instances, pagination, subscriptions, SQLite incremental operations and file preservation. The existing 1,000/10,000/100,000-row benchmark is retained for repeatable diagnostics. No dependency changes.

Depends on #1549 for atomic file preservation.
Closes #1536.
