### PR TITLE
fix: preserve pending Settings edits across navigation

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2082,6 +2082,8 @@ Optimizations spanning server, frontend, and data lifecycle.
 
 ## Settings & Customization
 
+Settings edits are batched across sections and continue saving when you switch tabs or close Settings. If a save fails, the changes remain available in the current authenticated session and Settings shows a Retry action. A failed save is never labelled Saved.
+
 Modular settings system with focused, permission-aware sections.
 
 ![6.1.7 Maintenance Center settings surface](assets/v6.1.7/maintenance-center.png)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,6 @@
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { resetFeatureSettingsWrites } from './lib/feature-settings-writes';
 import { Box } from '@mantine/core';
 import { Header } from './components/layout/Header';
 import { Toaster } from './components/ui/toaster';
@@ -188,6 +190,20 @@ function DesktopAwareAppShell({
 
 // Main app content (only rendered when authenticated)
 function AppContent() {
+  const queryClient = useQueryClient();
+  const settingsSessionMounted = useRef(false);
+  useEffect(() => {
+    settingsSessionMounted.current = true;
+    return () => {
+      settingsSessionMounted.current = false;
+      // Strict Mode may remount effects synchronously. End the writer only when
+      // the authenticated application really leaves, never on a Settings tab change.
+      queueMicrotask(() => {
+        if (!settingsSessionMounted.current) resetFeatureSettingsWrites(queryClient);
+      });
+    };
+  }, [queryClient]);
+
   // Connect to WebSocket for real-time task updates
   const { isConnected, connectionState, reconnectAttempt, reconnect } = useTaskSync();
   const { status: authStatus, refreshStatus } = useAuth();

--- a/web/src/__tests__/feature-settings-writes.test.tsx
+++ b/web/src/__tests__/feature-settings-writes.test.tsx
@@ -1,0 +1,161 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { DEFAULT_FEATURE_SETTINGS, type FeatureSettings } from '@veritas-kanban/shared';
+const mocks = vi.hoisted(() => ({ update: vi.fn(), get: vi.fn(), toast: vi.fn() }));
+vi.mock('@/lib/api', () => ({
+  settings: {},
+  api: { settings: { updateFeatures: mocks.update, getFeatures: mocks.get } },
+}));
+vi.mock('@/hooks/useToast', () => ({ toast: mocks.toast }));
+import {
+  useDebouncedFeatureUpdate,
+  useFeatureSettings,
+  useUpdateFeatureSettings,
+} from '@/hooks/useFeatureSettings';
+import {
+  resetFeatureSettingsWrites,
+  FEATURE_SETTINGS_QUERY_KEY,
+} from '@/lib/feature-settings-writes';
+
+describe('feature settings write ownership', () => {
+  let client: QueryClient;
+  let stored: FeatureSettings;
+  function wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+  async function advance() {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+  }
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.toast.mockReturnValue({ dismiss: vi.fn() });
+    client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    stored = structuredClone(DEFAULT_FEATURE_SETTINGS);
+    client.setQueryData(FEATURE_SETTINGS_QUERY_KEY, stored);
+    mocks.get.mockImplementation(async () => stored);
+    mocks.update.mockImplementation(async (patch: Record<string, object>) => {
+      for (const [section, values] of Object.entries(patch)) {
+        const data = stored as unknown as Record<string, object>;
+        data[section] = { ...data[section], ...values };
+      }
+      return structuredClone(stored);
+    });
+  });
+  afterEach(() => {
+    cleanup();
+    client.clear();
+    vi.useRealTimers();
+  });
+
+  it('persists a pending edit after immediate tab or Settings unmount', async () => {
+    const hook = renderHook(() => useDebouncedFeatureUpdate(), { wrapper });
+    act(() =>
+      hook.result.current.debouncedUpdate({ general: { humanDisplayName: 'Retained name' } })
+    );
+    hook.unmount();
+    await advance();
+    expect(stored.general.humanDisplayName).toBe('Retained name');
+    const reopened = renderHook(() => useFeatureSettings(), { wrapper });
+    expect(reopened.result.current.settings.general.humanDisplayName).toBe('Retained name');
+  });
+
+  it('batches sections without dropping unrelated settings', async () => {
+    const original = structuredClone(stored);
+    const hook = renderHook(
+      () => ({ first: useDebouncedFeatureUpdate(), second: useDebouncedFeatureUpdate() }),
+      { wrapper }
+    );
+    act(() => {
+      hook.result.current.first.debouncedUpdate({ general: { humanDisplayName: 'Changed' } });
+      hook.result.current.second.debouncedUpdate({ board: { showDashboard: false } });
+    });
+    await advance();
+    expect(mocks.update).toHaveBeenCalledOnce();
+    expect(stored.general.humanDisplayName).toBe('Changed');
+    expect(stored.board.showDashboard).toBe(false);
+    expect(stored.tasks).toEqual(original.tasks);
+  });
+
+  it('serializes writes and overlays newer edits on earlier responses', async () => {
+    let finish!: (settings: FeatureSettings) => void;
+    mocks.update.mockImplementationOnce(
+      () =>
+        new Promise<FeatureSettings>((resolve) => {
+          finish = resolve;
+        })
+    );
+    const hook = renderHook(() => useDebouncedFeatureUpdate(), { wrapper });
+    act(() => hook.result.current.debouncedUpdate({ general: { humanDisplayName: 'First' } }));
+    await advance();
+    act(() => hook.result.current.debouncedUpdate({ general: { humanDisplayName: 'Latest' } }));
+    await advance();
+    expect(mocks.update).toHaveBeenCalledOnce();
+    await act(async () => {
+      finish({ ...stored, general: { ...stored.general, humanDisplayName: 'First' } });
+      await Promise.resolve();
+    });
+    expect(
+      client.getQueryData<FeatureSettings>(FEATURE_SETTINGS_QUERY_KEY)?.general.humanDisplayName
+    ).toBe('Latest');
+    expect(mocks.update).toHaveBeenCalledTimes(2);
+    expect(stored.general.humanDisplayName).toBe('Latest');
+  });
+
+  it('retains rejected edits across unmount and exposes explicit retry', async () => {
+    mocks.update.mockRejectedValueOnce(new Error('Offline'));
+    const hook = renderHook(() => useDebouncedFeatureUpdate(), { wrapper });
+    act(() => hook.result.current.debouncedUpdate({ general: { humanDisplayName: 'Retry me' } }));
+    await advance();
+    expect(hook.result.current.error?.message).toBe('Offline');
+    expect(hook.result.current.isPending).toBe(false);
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Settings could not be saved' })
+    );
+    hook.unmount();
+    await advance();
+    expect(mocks.update).toHaveBeenCalledOnce();
+    const reopened = renderHook(() => useDebouncedFeatureUpdate(), { wrapper });
+    expect(reopened.result.current.error?.message).toBe('Offline');
+    await act(async () => {
+      reopened.result.current.retry();
+    });
+    expect(stored.general.humanDisplayName).toBe('Retry me');
+    expect(reopened.result.current.error).toBeNull();
+  });
+
+  it('does not carry queued edits into another authenticated session', async () => {
+    const hook = renderHook(() => useDebouncedFeatureUpdate(), { wrapper });
+    act(() =>
+      hook.result.current.debouncedUpdate({ general: { humanDisplayName: 'Old session' } })
+    );
+    hook.unmount();
+    resetFeatureSettingsWrites(client);
+    await advance();
+    expect(mocks.update).not.toHaveBeenCalled();
+    const next = renderHook(() => useDebouncedFeatureUpdate(), { wrapper });
+    expect(next.result.current.isPending).toBe(false);
+    expect(client.getQueryData(FEATURE_SETTINGS_QUERY_KEY)).toBeUndefined();
+  });
+
+  it('shares serialization with immediate setting mutations', async () => {
+    const hook = renderHook(
+      () => ({ queued: useDebouncedFeatureUpdate(), immediate: useUpdateFeatureSettings() }),
+      { wrapper }
+    );
+    act(() =>
+      hook.result.current.queued.debouncedUpdate({ general: { humanDisplayName: 'Queued' } })
+    );
+    act(() => hook.result.current.immediate.mutate({ board: { showDashboard: false } }));
+    await advance();
+    expect(stored.general.humanDisplayName).toBe('Queued');
+    expect(stored.board.showDashboard).toBe(false);
+    expect(mocks.update).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/__tests__/settings-dialog-mantine.test.tsx
+++ b/web/src/__tests__/settings-dialog-mantine.test.tsx
@@ -199,7 +199,7 @@ describe('SettingsDialog Mantine shell', () => {
     renderWithProviders(<SettingsDialog open onOpenChange={vi.fn()} />);
     expect(await screen.findByRole('alert')).toBeDefined();
     expect(screen.getByText('Changes not saved.')).toBeDefined();
-    fireEvent.click(screen.getByRole('button', { name: 'Retry', exact: true }));
+    fireEvent.click(screen.getByRole('button', { name: /^Retry$/ }));
     expect(mocks.retrySave).toHaveBeenCalledOnce();
   });
 

--- a/web/src/__tests__/settings-dialog-mantine.test.tsx
+++ b/web/src/__tests__/settings-dialog-mantine.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { SETTINGS_NAVIGATION_GROUPS, SettingsDialog } from '@/components/settings/SettingsDialog';
 import { renderWithProviders } from './test-utils';
 

--- a/web/src/__tests__/settings-dialog-mantine.test.tsx
+++ b/web/src/__tests__/settings-dialog-mantine.test.tsx
@@ -5,6 +5,7 @@ import { renderWithProviders } from './test-utils';
 
 const mocks = vi.hoisted(() => ({
   debouncedUpdate: vi.fn(),
+  importSettings: vi.fn(),
   retrySave: vi.fn(),
   saveError: null as Error | null,
   hasPermission: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock('@/hooks/useFeatureSettings', () => ({
       productMode: mocks.productMode,
     },
   }),
+  useUpdateFeatureSettings: () => ({ mutateAsync: mocks.importSettings }),
   useDebouncedFeatureUpdate: () => ({
     debouncedUpdate: mocks.debouncedUpdate,
     error: mocks.saveError,
@@ -121,6 +123,46 @@ describe('SettingsDialog Mantine shell', () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+  });
+
+  it('announces import completion only after persistence and reports failed saves', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    let resolveSave: () => void = () => {
+      throw new Error('Save was not started');
+    };
+    mocks.importSettings.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+    renderWithProviders(<SettingsDialog open onOpenChange={vi.fn()} />);
+    const file = {
+      text: async () => JSON.stringify({ general: { humanDisplayName: 'Imported' } }),
+    };
+    fireEvent.change(screen.getByLabelText('Import settings file'), { target: { files: [file] } });
+    await waitFor(() => expect(mocks.importSettings).toHaveBeenCalledTimes(1));
+    expect(mocks.toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Import complete' })
+    );
+    resolveSave();
+    await waitFor(() =>
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Import complete' })
+      )
+    );
+    mocks.toast.mockClear();
+    mocks.importSettings.mockRejectedValueOnce(new Error('Save unavailable'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    fireEvent.change(screen.getByLabelText('Import settings file'), { target: { files: [file] } });
+    await waitFor(() =>
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Import failed', description: 'Save unavailable' })
+      )
+    );
+    expect(mocks.toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Import complete' })
+    );
   });
 
   it('renders the settings shell with direct Mantine controls', async () => {

--- a/web/src/__tests__/settings-dialog-mantine.test.tsx
+++ b/web/src/__tests__/settings-dialog-mantine.test.tsx
@@ -5,6 +5,8 @@ import { renderWithProviders } from './test-utils';
 
 const mocks = vi.hoisted(() => ({
   debouncedUpdate: vi.fn(),
+  retrySave: vi.fn(),
+  saveError: null as Error | null,
   hasPermission: vi.fn(),
   toast: vi.fn(),
   productMode: { selectedMode: 'advanced' as string },
@@ -32,7 +34,11 @@ vi.mock('@/hooks/useFeatureSettings', () => ({
       productMode: mocks.productMode,
     },
   }),
-  useDebouncedFeatureUpdate: () => ({ debouncedUpdate: mocks.debouncedUpdate }),
+  useDebouncedFeatureUpdate: () => ({
+    debouncedUpdate: mocks.debouncedUpdate,
+    error: mocks.saveError,
+    retry: mocks.retrySave,
+  }),
 }));
 
 vi.mock('@/hooks/useIdentity', () => ({
@@ -105,6 +111,7 @@ vi.mock('@/components/settings/tabs/MultiUserTab', () => ({
 
 describe('SettingsDialog Mantine shell', () => {
   beforeEach(() => {
+    mocks.saveError = null;
     mocks.hasPermission.mockReturnValue(true);
     mocks.productMode.selectedMode = 'advanced';
     mocks.showSidebar = true;
@@ -185,6 +192,15 @@ describe('SettingsDialog Mantine shell', () => {
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Reset All' }));
     expect(await screen.findByRole('dialog', { name: 'Reset all settings?' })).toBeDefined();
     expect(mocks.debouncedUpdate).not.toHaveBeenCalled();
+  });
+
+  it('keeps failed saves visible with an explicit retry action', async () => {
+    mocks.saveError = new Error('Offline');
+    renderWithProviders(<SettingsDialog open onOpenChange={vi.fn()} />);
+    expect(await screen.findByRole('alert')).toBeDefined();
+    expect(screen.getByText('Changes not saved.')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry', exact: true }));
+    expect(mocks.retrySave).toHaveBeenCalledOnce();
   });
 
   it('keeps compact section navigation in the mobile header flow', async () => {

--- a/web/src/__tests__/settings-general-mantine.test.tsx
+++ b/web/src/__tests__/settings-general-mantine.test.tsx
@@ -77,6 +77,17 @@ describe('General settings Mantine migration', () => {
     cleanup();
   });
 
+  it('queues display-name edits before blur or unmount', () => {
+    const view = renderWithProviders(<GeneralTab />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Display Name (Squad Chat)' }), {
+      target: { value: 'Retained name' },
+    });
+    view.unmount();
+    expect(mocks.debouncedUpdate).toHaveBeenCalledWith({
+      general: { humanDisplayName: 'Retained name' },
+    });
+  });
+
   it('renders the base general settings controls through direct Mantine primitives', async () => {
     const { container } = renderWithProviders(<GeneralTab />);
 

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -3,7 +3,11 @@ import { UiPill, UiAction, UiIconAction } from '@/components/ui/UiVocabulary';
 import { useState, useRef, useCallback, lazy, Suspense, useEffect, useMemo } from 'react';
 import { Group, Menu, Select, Skeleton, Stack, Text } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
-import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
+import {
+  useFeatureSettings,
+  useDebouncedFeatureUpdate,
+  useUpdateFeatureSettings,
+} from '@/hooks/useFeatureSettings';
 import { useIdentity } from '@/hooks/useIdentity';
 import { useToast } from '@/hooks/useToast';
 import {
@@ -291,6 +295,7 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
     }
   }, [activeTab, canUseTab]);
   const { debouncedUpdate, error: saveError, retry: retrySave } = useDebouncedFeatureUpdate();
+  const importSettings = useUpdateFeatureSettings();
   const settingsFileInputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
   const dialogContentRef = useRef<HTMLDivElement>(null);
@@ -379,7 +384,7 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
           `Import ${Object.keys(validPatch).length} setting sections: ${Object.keys(validPatch).join(', ')}?\n\nThis will overwrite current values.`
         )
       ) {
-        debouncedUpdate(validPatch);
+        await importSettings.mutateAsync(validPatch);
         toast({
           title: 'Import complete',
           description: 'Settings imported successfully!',

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -290,7 +290,7 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
       setActiveTab(TABS.find(canUseTab)?.id ?? 'general');
     }
   }, [activeTab, canUseTab]);
-  const { debouncedUpdate } = useDebouncedFeatureUpdate();
+  const { debouncedUpdate, error: saveError, retry: retrySave } = useDebouncedFeatureUpdate();
   const settingsFileInputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
   const dialogContentRef = useRef<HTMLDivElement>(null);
@@ -541,6 +541,16 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
             Settings
           </Text>
           {isBoardOnly && <UiPill>Board Only</UiPill>}
+          {saveError && (
+            <Group gap="xs" role="alert">
+              <Text size="xs" c="red">
+                Changes not saved.
+              </Text>
+              <UiAction variant="quiet" onClick={retrySave}>
+                Retry
+              </UiAction>
+            </Group>
+          )}
         </Group>
       }
       centered

--- a/web/src/components/settings/shared/SaveIndicator.tsx
+++ b/web/src/components/settings/shared/SaveIndicator.tsx
@@ -1,12 +1,15 @@
 import { useState, useEffect } from 'react';
 import { Check, Save } from 'lucide-react';
 
-export function SaveIndicator({ isPending }: { isPending: boolean }) {
+export function SaveIndicator({ isPending, error }: { isPending: boolean; error?: unknown }) {
   const [showSaved, setShowSaved] = useState(false);
   const [wasPending, setWasPending] = useState(false);
 
   useEffect(() => {
-    if (isPending) {
+    if (error) {
+      setShowSaved(false);
+      setWasPending(false);
+    } else if (isPending) {
       setWasPending(true);
     } else if (wasPending) {
       setShowSaved(true);
@@ -14,8 +17,14 @@ export function SaveIndicator({ isPending }: { isPending: boolean }) {
       const timer = setTimeout(() => setShowSaved(false), 1500);
       return () => clearTimeout(timer);
     }
-  }, [isPending, wasPending]);
+  }, [isPending, wasPending, error]);
 
+  if (error)
+    return (
+      <div className="text-xs text-destructive" role="status">
+        Not saved
+      </div>
+    );
   if (isPending) {
     return (
       <div

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -133,7 +133,7 @@ export function AgentsTab() {
   const harnessSupport = harnessCompatibility?.supportStatuses ?? [];
   const { data: sandboxPresets = [], isLoading: isSandboxPoliciesLoading } = useSandboxPolicies();
   const { settings } = useFeatureSettings();
-  const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const { debouncedUpdate, isPending, error: saveError } = useDebouncedFeatureUpdate();
   const updateAgents = useUpdateAgents();
   const [showAddForm, setShowAddForm] = useState(false);
   const [editingAgent, setEditingAgent] = useState<string | null>(null);
@@ -325,7 +325,7 @@ export function AgentsTab() {
           <SettingsGroup className="space-y-4">
             <SectionHeader
               title="Agent Behavior"
-              actions={<SaveIndicator isPending={isPending} />}
+              actions={<SaveIndicator isPending={isPending} error={saveError} />}
               onReset={resetAgents}
               contained
             />

--- a/web/src/components/settings/tabs/BoardTab.tsx
+++ b/web/src/components/settings/tabs/BoardTab.tsx
@@ -14,7 +14,7 @@ import { Plus, Trash2 } from 'lucide-react';
 
 export function BoardTab() {
   const { settings } = useFeatureSettings();
-  const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const { debouncedUpdate, isPending, error: saveError } = useDebouncedFeatureUpdate();
   const boardSettings = settings.board ?? DEFAULT_FEATURE_SETTINGS.board;
   const columns = normalizeBoardColumns(boardSettings.columns);
   const defaultStatus = normalizeBoardDefaultStatus(boardSettings.defaultStatus, columns);
@@ -83,7 +83,7 @@ export function BoardTab() {
     <SettingsPage
       title="Board"
       description="Control board structure, card density, visible metadata, and direct manipulation."
-      actions={<SaveIndicator isPending={isPending} />}
+      actions={<SaveIndicator isPending={isPending} error={saveError} />}
     >
       <SettingsSection
         id="board-display"

--- a/web/src/components/settings/tabs/DataTab.tsx
+++ b/web/src/components/settings/tabs/DataTab.tsx
@@ -13,7 +13,7 @@ import {
 
 export function DataTab() {
   const { settings } = useFeatureSettings();
-  const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const { debouncedUpdate, isPending, error: saveError } = useDebouncedFeatureUpdate();
 
   const updateTelemetry = (key: string, value: unknown) => {
     debouncedUpdate({ telemetry: { [key]: value } });
@@ -56,7 +56,7 @@ export function DataTab() {
     <SettingsPage
       title="Data"
       description="Manage telemetry retention, operating budgets, and archive lifecycle."
-      actions={<SaveIndicator isPending={isPending} />}
+      actions={<SaveIndicator isPending={isPending} error={saveError} />}
     >
       <SettingsLocalNav
         label="Data settings sections"

--- a/web/src/components/settings/tabs/DocFreshnessTab.tsx
+++ b/web/src/components/settings/tabs/DocFreshnessTab.tsx
@@ -11,7 +11,7 @@ import {
 
 export function DocFreshnessTab() {
   const { settings } = useFeatureSettings();
-  const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const { debouncedUpdate, isPending, error: saveError } = useDebouncedFeatureUpdate();
 
   const docFreshness = settings.docFreshness || DEFAULT_FEATURE_SETTINGS.docFreshness;
 
@@ -31,7 +31,7 @@ export function DocFreshnessTab() {
       <SettingsSection
         title="Freshness Policy"
         description="Set the scan cadence and response when documents become stale."
-        actions={<SaveIndicator isPending={isPending} />}
+        actions={<SaveIndicator isPending={isPending} error={saveError} />}
         onReset={resetDocFreshness}
         divided
       >

--- a/web/src/components/settings/tabs/EnforcementTab.tsx
+++ b/web/src/components/settings/tabs/EnforcementTab.tsx
@@ -45,7 +45,7 @@ function formatCeremonyTarget(requirement: CeremonyRequirement): string {
 
 export function EnforcementTab() {
   const { settings } = useFeatureSettings();
-  const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const { debouncedUpdate, isPending, error: saveError } = useDebouncedFeatureUpdate();
   const { data: config } = useConfig();
   const { data: pendingCeremonies = [] } = useQuery({
     queryKey: ['ceremonies', 'pending', 'settings'],
@@ -77,7 +77,7 @@ export function EnforcementTab() {
       <SettingsSection
         title="Completion Gates"
         description="Require review and ceremony evidence before eligible work can complete."
-        actions={<SaveIndicator isPending={isPending} />}
+        actions={<SaveIndicator isPending={isPending} error={saveError} />}
         onReset={resetEnforcement}
       >
         <div className="space-y-4">

--- a/web/src/components/settings/tabs/GeneralTab.tsx
+++ b/web/src/components/settings/tabs/GeneralTab.tsx
@@ -146,10 +146,11 @@ export function GeneralTab() {
                 </Group>
               }
               value={localDisplayName}
-              onChange={(e) => setLocalDisplayName(e.target.value)}
-              onBlur={() =>
-                debouncedUpdate({ general: { humanDisplayName: localDisplayName || 'Human' } })
-              }
+              onChange={(e) => {
+                const value = e.target.value;
+                setLocalDisplayName(value);
+                debouncedUpdate({ general: { humanDisplayName: value || 'Human' } });
+              }}
               placeholder="Human"
               maw={320}
             />

--- a/web/src/components/settings/tabs/NotificationsTab.tsx
+++ b/web/src/components/settings/tabs/NotificationsTab.tsx
@@ -178,7 +178,7 @@ function formToInput(form: AdapterFormState): CommunicationAdapterInput {
 
 export function NotificationsTab() {
   const { settings } = useFeatureSettings();
-  const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const { debouncedUpdate, isPending, error: saveError } = useDebouncedFeatureUpdate();
   const queryClient = useQueryClient();
   const { data: outboundEndpoints = [] } = useQuery({
     queryKey: ['integrations', 'outbound', 'endpoints'],
@@ -709,7 +709,7 @@ export function NotificationsTab() {
         id="notifications-preferences"
         title="Preferences"
         description="Choose the events and broad destination used for routine notifications."
-        actions={<SaveIndicator isPending={isPending} />}
+        actions={<SaveIndicator isPending={isPending} error={saveError} />}
         onReset={resetNotifications}
         divided
       >

--- a/web/src/components/settings/tabs/SharedResourcesTab.tsx
+++ b/web/src/components/settings/tabs/SharedResourcesTab.tsx
@@ -18,7 +18,7 @@ const TYPE_OPTIONS: Array<{
 
 export function SharedResourcesTab() {
   const { settings } = useFeatureSettings();
-  const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const { debouncedUpdate, isPending, error: saveError } = useDebouncedFeatureUpdate();
 
   const sharedResources = settings?.sharedResources ?? DEFAULT_FEATURE_SETTINGS.sharedResources;
 
@@ -50,7 +50,7 @@ export function SharedResourcesTab() {
       <SettingsSection
         title="Resource Sharing"
         description="Choose which resource types can be mounted across projects."
-        actions={<SaveIndicator isPending={isPending} />}
+        actions={<SaveIndicator isPending={isPending} error={saveError} />}
         onReset={resetSharedResources}
         divided
       >

--- a/web/src/components/settings/tabs/TasksTab.tsx
+++ b/web/src/components/settings/tabs/TasksTab.tsx
@@ -16,7 +16,7 @@ import {
 
 export function TasksTab() {
   const { settings } = useFeatureSettings();
-  const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const { debouncedUpdate, isPending, error: saveError } = useDebouncedFeatureUpdate();
 
   const update = <K extends keyof TaskBehaviorSettings>(key: K, value: TaskBehaviorSettings[K]) => {
     debouncedUpdate({ tasks: { [key]: value } });
@@ -38,7 +38,7 @@ export function TasksTab() {
     <SettingsPage
       title="Tasks"
       description="Set defaults and optional capabilities for task authoring and completion."
-      actions={<SaveIndicator isPending={isPending} />}
+      actions={<SaveIndicator isPending={isPending} error={saveError} />}
     >
       <SettingsSection
         id="task-behavior"

--- a/web/src/hooks/useFeatureSettings.ts
+++ b/web/src/hooks/useFeatureSettings.ts
@@ -1,10 +1,16 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useRef, useEffect } from 'react';
+import { createElement, useCallback, useSyncExternalStore } from 'react';
+import { toast } from './useToast';
+import {
+  FEATURE_SETTINGS_QUERY_KEY,
+  getFeatureSettingsWrites,
+  type FeatureSettingsPatch,
+} from '@/lib/feature-settings-writes';
 import { api } from '@/lib/api';
 import type { FeatureSettings } from '@veritas-kanban/shared';
 import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 
-const QUERY_KEY = ['settings', 'features'] as const;
+const QUERY_KEY = FEATURE_SETTINGS_QUERY_KEY;
 const STALE_TIME = 5 * 60 * 1000; // 5 minutes — settings don't change often
 
 /**
@@ -12,9 +18,10 @@ const STALE_TIME = 5 * 60 * 1000; // 5 minutes — settings don't change often
  * Returns defaults while loading so consumers never see undefined.
  */
 export function useFeatureSettings() {
+  const writer = getFeatureSettingsWrites(useQueryClient());
   const query = useQuery({
     queryKey: QUERY_KEY,
-    queryFn: api.settings.getFeatures,
+    queryFn: async () => writer.overlay(await api.settings.getFeatures()),
     staleTime: STALE_TIME,
     placeholderData: DEFAULT_FEATURE_SETTINGS,
   });
@@ -48,90 +55,41 @@ export function useFeatureSetting<
  *   update.mutate({ board: { showDashboard: false } });
  */
 export function useUpdateFeatureSettings() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (patch: Record<string, any>) => api.settings.updateFeatures(patch),
-    onMutate: async (patch) => {
-      // Cancel in-flight fetches
-      await queryClient.cancelQueries({ queryKey: QUERY_KEY });
-
-      // Snapshot current value
-      const previous = queryClient.getQueryData<FeatureSettings>(QUERY_KEY);
-
-      // Optimistically update
-      if (previous) {
-        // SAFETY: FeatureSettings sections are all objects — use Record view for dynamic key access
-        const optimistic = { ...previous } as unknown as Record<string, Record<string, unknown>>;
-        for (const section of Object.keys(patch) as Array<keyof FeatureSettings>) {
-          if (section in optimistic && typeof patch[section] === 'object') {
-            optimistic[section] = {
-              ...optimistic[section],
-              ...patch[section],
-            };
-          }
-        }
-        queryClient.setQueryData(QUERY_KEY, optimistic as unknown as FeatureSettings);
-      }
-
-      return { previous };
-    },
-    onError: (_err, _patch, context) => {
-      // Rollback on error
-      if (context?.previous) {
-        queryClient.setQueryData(QUERY_KEY, context.previous);
-      }
-    },
-    onSettled: () => {
-      // Refetch to ensure consistency
-      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
-    },
-  });
+  const writer = useFeatureWriter();
+  return useMutation({ mutationFn: (patch: FeatureSettingsPatch) => writer.save(patch) });
 }
 
-/**
- * Returns a debounced updater function that batches rapid changes.
- * Useful for toggle switches and sliders that fire frequently.
- */
+function useFeatureWriter() {
+  const writer = getFeatureSettingsWrites(useQueryClient());
+  writer.onFailure = () => {
+    return toast({
+      title: 'Settings could not be saved',
+      description: 'Your changes are kept for retry. They have not been saved to the server.',
+      variant: 'destructive',
+      duration: 10000,
+      action: createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: writer.retry,
+          className: 'text-sm underline rounded focus-visible:outline focus-visible:outline-2',
+        },
+        'Retry settings save'
+      ),
+    }).dismiss;
+  };
+  return writer;
+}
+
+/** Batches edits across sections and retains failed writes until they are retried. */
 export function useDebouncedFeatureUpdate(delayMs = 500) {
-  const update = useUpdateFeatureSettings();
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingRef = useRef<Record<string, any>>({});
-
-  // Cleanup timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, []);
-
-  const flush = useCallback(() => {
-    if (Object.keys(pendingRef.current).length > 0) {
-      update.mutate({ ...pendingRef.current });
-      pendingRef.current = {};
-    }
-  }, [update]);
-
+  const writer = useFeatureWriter();
+  const state = useSyncExternalStore(writer.subscribe, writer.getSnapshot, writer.getSnapshot);
   const debouncedUpdate = useCallback(
-    (patch: Record<string, any>) => {
-      // Merge into pending batch
-      for (const section of Object.keys(patch)) {
-        pendingRef.current[section] = {
-          ...(pendingRef.current[section] || {}),
-          ...patch[section],
-        };
-      }
-
-      // Reset timer
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-      timeoutRef.current = setTimeout(flush, delayMs);
+    (patch: FeatureSettingsPatch) => {
+      writer.enqueue(patch, delayMs);
     },
-    [flush, delayMs]
+    [writer, delayMs]
   );
-
-  return { debouncedUpdate, isPending: update.isPending };
+  return { debouncedUpdate, ...state, retry: writer.retry };
 }

--- a/web/src/hooks/usePendingProductMode.ts
+++ b/web/src/hooks/usePendingProductMode.ts
@@ -19,6 +19,8 @@ export function usePendingProductMode(): void {
       return;
     }
 
+    if (update.isError) return; // Failed settings remain queued for explicit retry.
+
     update.mutate(
       {
         productMode: {

--- a/web/src/lib/feature-settings-writes.ts
+++ b/web/src/lib/feature-settings-writes.ts
@@ -1,0 +1,169 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { DEFAULT_FEATURE_SETTINGS, type FeatureSettings } from '@veritas-kanban/shared';
+import { api } from '@/lib/api';
+
+export const FEATURE_SETTINGS_QUERY_KEY = ['settings', 'features'] as const;
+export type FeatureSettingsPatch = Record<string, unknown>;
+
+function mergePatch(base: FeatureSettingsPatch, patch: FeatureSettingsPatch): FeatureSettingsPatch {
+  const merged = { ...base };
+  for (const [section, values] of Object.entries(patch)) {
+    const previous = merged[section];
+    merged[section] =
+      values !== null && typeof values === 'object' && !Array.isArray(values)
+        ? { ...(previous !== null && typeof previous === 'object' ? previous : {}), ...values }
+        : values;
+  }
+  return merged;
+}
+
+function overlay(settings: FeatureSettings, patch: FeatureSettingsPatch): FeatureSettings {
+  return mergePatch(
+    settings as unknown as FeatureSettingsPatch,
+    patch
+  ) as unknown as FeatureSettings;
+}
+
+/** One serialized writer per query cache; tab unmounts do not own pending work. */
+class FeatureSettingsWrites {
+  private pending: FeatureSettingsPatch = {};
+  private disposed = false;
+  private activeWaiters: Array<{
+    resolve: (settings: FeatureSettings) => void;
+    reject: (error: Error) => void;
+  }> = [];
+  private active: FeatureSettingsPatch | null = null;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private listeners = new Set<() => void>();
+  private waiters: Array<{
+    resolve: (settings: FeatureSettings) => void;
+    reject: (error: Error) => void;
+  }> = [];
+  private snapshot = { isPending: false, error: null as Error | null };
+  onFailure: ((error: Error) => () => void) | undefined;
+  private dismissFailure: (() => void) | undefined;
+
+  constructor(private client: QueryClient) {}
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+  getSnapshot = () => this.snapshot;
+  overlay = (settings: FeatureSettings) =>
+    overlay(overlay(settings, this.active ?? {}), this.pending);
+
+  private publish(error: Error | null = null) {
+    this.snapshot = {
+      isPending: !error && (this.active !== null || Object.keys(this.pending).length > 0),
+      error,
+    };
+    this.listeners.forEach((listener) => listener());
+  }
+
+  enqueue = (patch: FeatureSettingsPatch, delay: number) => {
+    if (this.disposed) throw new Error('The settings session has ended');
+    for (const [section, values] of Object.entries(patch)) {
+      if (!values || typeof values !== 'object' || Array.isArray(values)) {
+        throw new Error(`Settings section ${section} must be an object`);
+      }
+    }
+    this.pending = mergePatch(this.pending, patch);
+    // Do not let cancellation restore an older query snapshot over this edit.
+    void this.client.cancelQueries({ queryKey: FEATURE_SETTINGS_QUERY_KEY }, { revert: false });
+    this.client.setQueryData<FeatureSettings>(FEATURE_SETTINGS_QUERY_KEY, (current) =>
+      overlay(current ?? DEFAULT_FEATURE_SETTINGS, patch)
+    );
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      void this.flush();
+    }, delay);
+    this.publish();
+  };
+
+  save = (patch: FeatureSettingsPatch): Promise<FeatureSettings> =>
+    new Promise((resolve, reject) => {
+      if (Object.keys(patch).length === 0) {
+        resolve(
+          this.client.getQueryData<FeatureSettings>(FEATURE_SETTINGS_QUERY_KEY) ??
+            DEFAULT_FEATURE_SETTINGS
+        );
+        return;
+      }
+      this.enqueue(patch, 0);
+      this.waiters.push({ resolve, reject });
+    });
+
+  retry = () => {
+    this.publish();
+    void this.flush();
+  };
+
+  dispose() {
+    this.disposed = true;
+    this.dismissFailure?.();
+    if (this.timer) clearTimeout(this.timer);
+    const error = new Error('The settings session has ended');
+    [...this.waiters, ...this.activeWaiters].forEach(({ reject }) => reject(error));
+    this.waiters = [];
+    this.activeWaiters = [];
+    this.pending = {};
+    this.active = null;
+  }
+
+  private async flush() {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = undefined;
+    if (this.active || Object.keys(this.pending).length === 0) return;
+    const batch = this.pending;
+    const waiters = this.waiters;
+    this.activeWaiters = waiters;
+    this.pending = {};
+    this.waiters = [];
+    this.active = batch;
+    this.publish();
+    try {
+      const saved = await api.settings.updateFeatures(batch as Partial<FeatureSettings>);
+      if (this.disposed) return;
+      this.activeWaiters = [];
+      this.active = null;
+      this.dismissFailure?.();
+      this.dismissFailure = undefined;
+      this.client.setQueryData(FEATURE_SETTINGS_QUERY_KEY, overlay(saved, this.pending));
+      waiters.forEach(({ resolve }) => resolve(saved));
+      this.publish();
+      if (Object.keys(this.pending).length > 0 && !this.timer) void this.flush();
+    } catch (cause) {
+      if (this.disposed) return;
+      this.activeWaiters = [];
+      const error = cause instanceof Error ? cause : new Error('Settings could not be saved');
+      // Newer edits win over failed fields; retain both sections for explicit retry.
+      this.pending = mergePatch(batch, this.pending);
+      this.active = null;
+      if (this.timer) clearTimeout(this.timer);
+      this.timer = undefined;
+      [...waiters, ...this.waiters].forEach(({ reject }) => reject(error));
+      this.waiters = [];
+      this.publish(error);
+      this.dismissFailure?.();
+      this.dismissFailure = this.onFailure?.(error);
+    }
+  }
+}
+
+const writers = new WeakMap<QueryClient, FeatureSettingsWrites>();
+export function getFeatureSettingsWrites(client: QueryClient) {
+  let writer = writers.get(client);
+  if (!writer) {
+    writer = new FeatureSettingsWrites(client);
+    writers.set(client, writer);
+  }
+  return writer;
+}
+
+export function resetFeatureSettingsWrites(client: QueryClient) {
+  writers.get(client)?.dispose();
+  writers.delete(client);
+  client.removeQueries({ queryKey: FEATURE_SETTINGS_QUERY_KEY });
+}


### PR DESCRIPTION
Pending Settings writes now live outside individual tab components, so switching tabs or closing Settings retains edits. Writes are serialized, failed values remain available for retry, and unsaved state stays visible. Settings import reports completion only after the server has persisted the imported values and shows a failure if saving fails.

Local verification on the delivery branch: web typecheck, changed-file ESLint (zero errors), diff check and 18 focused persistence/Settings tests passed. The integrated packaged candidate also passed pending-write, retry, import and native Settings persistence checks. This branch includes only persistence behavior; search and native window presentation are delivered separately. No dependency changes.

Closes #1525.
