### PR TITLE
fix: align permission matching with router behavior

### DIFF
--- a/server/src/__tests__/routes/codex-review.test.ts
+++ b/server/src/__tests__/routes/codex-review.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import type { AuthPermission, AuthenticatedRequest } from '../../middleware/auth.js';
+import { diffAccess } from '../../routes/v1/permissions.js';
 import { errorHandler } from '../../middleware/error-handler.js';
 
 const { mockDiffService, mockCodexReviewService } = vi.hoisted(() => ({
@@ -72,4 +74,40 @@ describe('Codex review route', () => {
     expect(response.status).toBe(400);
     expect(mockCodexReviewService.reviewTask).not.toHaveBeenCalled();
   });
+});
+
+describe('mounted review permissions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function appFor(permissions: AuthPermission[]) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as AuthenticatedRequest).auth = { role: 'agent', isLocalhost: false, permissions };
+      next();
+    });
+    app.use(['/api/diff', '/api/v1/diff'], diffAccess, diffRoutes);
+    app.use(errorHandler);
+    return app;
+  }
+
+  for (const prefix of ['/api/diff', '/api/v1/diff']) {
+    for (const suffix of ['codex-review', 'CODEX-REVIEW', 'CoDeX-ReViEw/']) {
+      it(`enforces execution authority at ${prefix}/:taskId/${suffix}`, async () => {
+        const taskId = 'task_MixedCase';
+        const path = `${prefix}/${taskId}/${suffix}`;
+        const denied = await request(appFor(['task:write']))
+          .post(path)
+          .send({});
+        expect(denied.status).toBe(403);
+        expect(mockCodexReviewService.reviewTask).not.toHaveBeenCalled();
+        mockCodexReviewService.reviewTask.mockResolvedValue({ taskId, decision: 'approved' });
+        const allowed = await request(appFor(['workflow:execute']))
+          .post(path)
+          .send({});
+        expect(allowed.status).toBe(201);
+        expect(mockCodexReviewService.reviewTask).toHaveBeenCalledExactlyOnceWith({ taskId });
+      });
+    }
+  }
 });

--- a/server/src/__tests__/routes/work-product-artifacts.test.ts
+++ b/server/src/__tests__/routes/work-product-artifacts.test.ts
@@ -1,8 +1,9 @@
 import express from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AuthenticatedRequest } from '../../middleware/auth.js';
+import type { AuthPermission, AuthenticatedRequest } from '../../middleware/auth.js';
 import { errorHandler } from '../../middleware/error-handler.js';
+import { workProductAccess } from '../../routes/v1/permissions.js';
 import { workProductRoutes } from '../../routes/work-products.js';
 
 const mocks = vi.hoisted(() => ({
@@ -301,4 +302,56 @@ describe('work product artifact routes', () => {
       confirmation: productId,
     });
   });
+});
+
+describe('mounted artifact permissions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function appFor(permissions: AuthPermission[]) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as AuthenticatedRequest).auth = {
+        role: 'agent',
+        isLocalhost: false,
+        workspaceId: 'local',
+        permissions,
+      };
+      next();
+    });
+    app.use(['/api/work-products', '/api/v1/work-products'], workProductAccess, workProductRoutes);
+    app.use(errorHandler);
+    return app;
+  }
+
+  it('preserves read-scoped preview audit access for mixed-case routes', async () => {
+    mocks.listVersions.mockResolvedValue([
+      { id: 'wpa_html', version: 1, mediaType: 'text/html', state: 'available' },
+    ]);
+    const response = await request(appFor(['work_product:read']))
+      .post('/api/v1/work-products/wp_MixedCase/ARTIFACT/Preview/Audit/')
+      .send({ action: 'close', version: 1 });
+    expect(response.status).toBe(204);
+    expect(mocks.auditLog).toHaveBeenCalledOnce();
+  });
+
+  for (const prefix of ['/api/work-products', '/api/v1/work-products']) {
+    for (const suffix of ['artifact', 'ARTIFACT', 'ArTiFaCt/']) {
+      it(`enforces purge authority at ${prefix}/:id/${suffix}`, async () => {
+        const productId = `wp_${'MixedCase'.repeat(3)}`;
+        const path = `${prefix}/${productId}/${suffix}?confirm=${productId}`;
+        const denied = await request(appFor(['work_product:write'])).delete(path);
+        expect(denied.status).toBe(403);
+        expect(mocks.purge).not.toHaveBeenCalled();
+        mocks.purge.mockResolvedValue({ productId, artifactsDeleted: 1, bytesDeleted: 14 });
+        const allowed = await request(appFor(['admin:manage'])).delete(path);
+        expect(allowed.status).toBe(200);
+        expect(mocks.purge).toHaveBeenCalledExactlyOnceWith({
+          workspaceId: 'local',
+          productId,
+          confirmation: productId,
+        });
+      });
+    }
+  }
 });

--- a/server/src/__tests__/shared-api-permissions.test.ts
+++ b/server/src/__tests__/shared-api-permissions.test.ts
@@ -203,3 +203,17 @@ describe('shared API permission metadata', () => {
     ).toEqual(['agent:write']);
   });
 });
+
+describe('case-insensitive API permission metadata', () => {
+  it.each([
+    ['/API/V1/WORK-PRODUCTS/wp_MixedCase/ARTIFACT', 'DELETE', 'admin:manage'],
+    ['/api/work-products/wp_MixedCase/ArTiFaCt/', 'DELETE', 'admin:manage'],
+    ['/API/DIFF/task_MixedCase/CODEX-REVIEW', 'POST', 'workflow:execute'],
+    ['/api/v1/diff/task_MixedCase/CoDeX-ReViEw/', 'POST', 'workflow:execute'],
+    ['/api/work-products/wp_MixedCase/ARTIFACT/PREVIEW/AUDIT', 'POST', 'work_product:read'],
+  ])('matches server permissions for %s', (path, method, permission) => {
+    const requirement = getApiPermissionRequirement(path, { method });
+    expect(requirement.permissions).toEqual([permission]);
+    expect(requirement.path).toContain('MixedCase');
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -724,7 +724,15 @@ function normalizePermissions(permissions: PermissionInput): AuthPermission[] {
 export function authorizePermissionByMethod(config: MethodPermissionConfig) {
   const readPermissions = normalizePermissions(config.read);
   const writePermissions = normalizePermissions(config.write ?? config.read);
-  const overrides = config.overrides ?? [];
+  // Express routers match route literals case-insensitively by default. Match
+  // their permission overrides the same way without changing parameter values.
+  // Stateful regex flags must not make authorization depend on earlier requests.
+  const overrides = (config.overrides ?? []).map((override) => ({
+    ...override,
+    path: override.path
+      ? new RegExp(override.path.source, override.path.flags.replace(/[giy]/g, '') + 'i')
+      : undefined,
+  }));
 
   return (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
     const override = overrides.find((candidate) => {

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -81,9 +81,9 @@ function normalizeApiPath(path: string): string {
   const url = new URL(path, 'http://veritas.local');
   let normalized = url.pathname.replace(/\/+$/, '') || '/';
 
-  if (normalized === '/api/v1') {
+  if (normalized.toLowerCase() === '/api/v1') {
     normalized = '/api';
-  } else if (normalized.startsWith('/api/v1/')) {
+  } else if (normalized.toLowerCase().startsWith('/api/v1/')) {
     normalized = `/api${normalized.slice('/api/v1'.length)}`;
   }
 
@@ -95,11 +95,12 @@ function routeRequirement(
   path: string,
   method: string
 ): ApiPermissionRequirement | null {
-  if (path !== config.prefix && !path.startsWith(`${config.prefix}/`)) {
+  const matchingPath = path.toLowerCase();
+  if (matchingPath !== config.prefix && !matchingPath.startsWith(`${config.prefix}/`)) {
     return null;
   }
 
-  const relativePath = path.slice(config.prefix.length) || '/';
+  const relativePath = matchingPath.slice(config.prefix.length) || '/';
   const override = config.overrides?.find((candidate) => {
     const methodMatches =
       !candidate.methods ||
@@ -500,7 +501,7 @@ export function getApiPermissionRequirement(
   const method = (options.method || 'GET').toUpperCase();
   const normalizedPath = normalizeApiPath(path);
 
-  if (isPublicApiPath(normalizedPath)) {
+  if (isPublicApiPath(normalizedPath.toLowerCase())) {
     return { permissions: [], path: normalizedPath, method, public: true };
   }
 


### PR DESCRIPTION
Align permission override matching with Express route matching, including mixed-case API prefixes and route literals, while preserving parameter values. Remove stateful regular-expression flags so permission decisions do not depend on previous requests.

Local verification on the isolated remediation branch: shared build, server typecheck, diff review and 47 focused authorization/route regression tests passed. The integrated candidate also passed the full server gate.

Closes #1520.
