### PR TITLE
fix: improve primary-action and code contrast in dark mode

### DIFF
--- a/desktop/src/main/__tests__/menu.test.ts
+++ b/desktop/src/main/__tests__/menu.test.ts
@@ -141,6 +141,7 @@ describe('desktop native menu', () => {
         'Veritas Kanban',
         'File',
         'editMenu',
+        'View',
         'Navigate',
         'Desktop',
         'windowMenu',
@@ -172,5 +173,42 @@ describe('desktop native menu', () => {
 
     expect(template.some((item) => item.role === 'windowMenu')).toBe(false);
     expect(template.some((item) => item.role === 'help')).toBe(false);
+  });
+});
+
+describe('standard platform menu roles', () => {
+  const roles = (platform: NodeJS.Platform) =>
+    createDesktopMenuTemplate({
+      platform,
+      status: status(),
+      dispatch: vi.fn(),
+      copyVersionInfo: vi.fn(),
+      openHelp: vi.fn(),
+    }).flatMap((item) => (Array.isArray(item.submenu) ? item.submenu : [item]));
+  it('declares standard macOS roles and accelerators while retaining custom actions', () => {
+    const items = roles('darwin');
+    for (const [role, accelerator] of [
+      ['quit', 'CommandOrControl+Q'],
+      ['close', 'CommandOrControl+W'],
+      ['hide', 'Command+H'],
+      ['hideOthers', 'Command+Alt+H'],
+      ['resetZoom', 'CommandOrControl+0'],
+      ['zoomIn', 'CommandOrControl+Plus'],
+      ['zoomOut', 'CommandOrControl+-'],
+      ['togglefullscreen', 'Control+Command+F'],
+    ]) {
+      expect(items.find((item) => item.role === role)).toMatchObject({ accelerator });
+    }
+    expect(items.some((item) => item.role === 'services')).toBe(true);
+    expect(items.some((item) => item.role === 'unhide')).toBe(true);
+    // The native quit role emits app.before-quit, which owns managed shutdown.
+    expect(items.find((item) => item.role === 'quit')?.click).toBeUndefined();
+  });
+  it.each(['linux', 'win32'] as const)('does not install Mac-only roles on %s', (platform) => {
+    const items = roles(platform);
+    expect(
+      items.some((item) => ['services', 'hide', 'hideOthers', 'unhide'].includes(item.role ?? ''))
+    ).toBe(false);
+    expect(items.find((item) => item.role === 'togglefullscreen')?.accelerator).toBe('F11');
   });
 });

--- a/desktop/src/main/__tests__/titlebar-action.test.ts
+++ b/desktop/src/main/__tests__/titlebar-action.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyTitlebarAction, resolveTitlebarAction } from '../titlebar-action.js';
+
+describe('system titlebar action', () => {
+  it.each([
+    ['Maximize', 'zoom'],
+    ['Fill', 'zoom'],
+    ['Minimize', 'minimize'],
+    ['None', 'none'],
+    ['', 'zoom'],
+    ['future-value', 'none'],
+  ] as const)('maps macOS preference %s to %s', (preference, action) => {
+    expect(resolveTitlebarAction('darwin', preference)).toBe(action);
+  });
+  it.each(['linux', 'win32'] as const)('preserves maximize on %s', (platform) => {
+    expect(resolveTitlebarAction(platform, 'Minimize')).toBe('zoom');
+  });
+  it('applies only the selected action and restores a zoomed window', () => {
+    let maximized = false;
+    const window = {
+      isMaximized: () => maximized,
+      maximize: vi.fn(() => {
+        maximized = true;
+      }),
+      unmaximize: vi.fn(() => {
+        maximized = false;
+      }),
+      minimize: vi.fn(),
+    };
+    applyTitlebarAction(window as never, 'none');
+    expect(window.maximize).not.toHaveBeenCalled();
+    expect(window.minimize).not.toHaveBeenCalled();
+    expect(applyTitlebarAction(window as never, 'zoom')).toEqual({ maximized: true });
+    expect(applyTitlebarAction(window as never, 'zoom')).toEqual({ maximized: false });
+    applyTitlebarAction(window as never, 'minimize');
+    expect(window.minimize).toHaveBeenCalledOnce();
+    expect(window.maximize).toHaveBeenCalledOnce();
+    expect(window.unmaximize).toHaveBeenCalledOnce();
+  });
+});

--- a/desktop/src/main/__tests__/window-state.test.ts
+++ b/desktop/src/main/__tests__/window-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import path from 'node:path';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { createDesktopPaths } from '../paths.js';
 import {
   applyDesktopWindowState,
+  captureDesktopWindowState,
   readDesktopWindowState,
   writeDesktopWindowState,
   writeDesktopWindowStateSync,
@@ -66,5 +67,54 @@ describe('desktop window state', () => {
       x: 10,
       y: 20,
     });
+  });
+});
+
+describe('visible display restoration', () => {
+  const primary = { x: 0, y: 25, width: 1440, height: 875 };
+  const left = { x: -1920, y: -200, width: 1920, height: 1080 };
+  it('moves disconnected-monitor windows to the primary work area', () => {
+    expect(
+      applyDesktopWindowState({ x: 5000, y: 300, width: 1200, height: 800 }, undefined, [primary])
+    ).toEqual({ x: 120, y: 63, width: 1200, height: 800 });
+  });
+  it('preserves valid negative monitor coordinates', () => {
+    expect(
+      applyDesktopWindowState({ x: -1800, y: -100, width: 1200, height: 800 }, undefined, [
+        primary,
+        left,
+      ])
+    ).toEqual({ x: -1800, y: -100, width: 1200, height: 800 });
+  });
+  it('clamps dimensions and titlebar to a smaller scaled work area', () => {
+    expect(
+      applyDesktopWindowState({ x: -300, y: -200, width: 4000, height: 4000 }, undefined, [
+        { x: 0, y: 24, width: 1024, height: 700 },
+      ])
+    ).toEqual({ x: 0, y: 24, width: 1024, height: 700 });
+  });
+  it('recovers malformed coordinates on a single screen', () => {
+    expect(
+      applyDesktopWindowState(
+        { x: Number.NaN, y: Number.POSITIVE_INFINITY, width: 0, height: Number.NaN },
+        undefined,
+        [primary]
+      )
+    ).toEqual({ x: 130, y: 25, width: 1180, height: 875 });
+  });
+  it('captures normal bounds independently of maximized bounds', () => {
+    const window = {
+      getNormalBounds: vi.fn(() => ({ x: 30, y: 40, width: 1200, height: 800 })),
+      getBounds: vi.fn(() => primary),
+      isMaximized: () => true,
+    };
+    expect(captureDesktopWindowState(window as never)).toEqual({
+      x: 30,
+      y: 40,
+      width: 1200,
+      height: 800,
+      maximized: true,
+    });
+    expect(window.getBounds).not.toHaveBeenCalled();
   });
 });

--- a/desktop/src/main/bridge.ts
+++ b/desktop/src/main/bridge.ts
@@ -26,7 +26,7 @@ import {
   type DesktopBridgeResponse,
   type DesktopConnectionConfigRequest,
   type DesktopConnectionValidationResult,
-  type DesktopWindowToggleMaximizeResult,
+  type DesktopWindowTitlebarActionResult,
 } from '../shared/desktop-bridge-contracts.js';
 
 type MaybePromise<T> = T | Promise<T>;
@@ -38,7 +38,7 @@ export type DesktopBridgeHandlerMap = {
 };
 
 export interface DesktopWindowControls {
-  toggleMaximize(): DesktopWindowToggleMaximizeResult;
+  performTitlebarAction(): DesktopWindowTitlebarActionResult;
 }
 
 async function remoteConnectionDestinationError(serverUrl: string): Promise<string | null> {
@@ -289,7 +289,7 @@ export function createDesktopBridgeHandlers(
       await shell.openExternal(url);
       return undefined;
     },
-    toggleWindowMaximize: () => windowControls?.toggleMaximize() ?? { maximized: false },
+    performTitlebarAction: () => windowControls?.performTitlebarAction() ?? { maximized: false },
   };
 }
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,4 +1,13 @@
-import { app, BrowserWindow, clipboard, ipcMain, Notification, safeStorage, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  ipcMain,
+  Notification,
+  safeStorage,
+  shell,
+  screen,
+} from 'electron';
 import path from 'node:path';
 import { mkdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -97,12 +106,17 @@ if (!app.requestSingleInstanceLock()) {
 
 function createMainWindow(savedState: DesktopWindowState): BrowserWindow {
   const preloadPath = path.join(__dirname, '../preload/index.cjs');
-  const windowBounds = applyDesktopWindowState(savedState);
+  const primary = screen.getPrimaryDisplay();
+  const workAreas = [
+    primary,
+    ...screen.getAllDisplays().filter((display) => display.id !== primary.id),
+  ].map((display) => display.workArea);
+  const windowBounds = applyDesktopWindowState(savedState, undefined, workAreas);
 
   const window = new BrowserWindow({
     title: DESKTOP_APP_NAME,
-    minWidth: DESKTOP_MIN_WINDOW.width,
-    minHeight: DESKTOP_MIN_WINDOW.height,
+    minWidth: Math.min(DESKTOP_MIN_WINDOW.width, windowBounds.width),
+    minHeight: Math.min(DESKTOP_MIN_WINDOW.height, windowBounds.height),
     ...windowBounds,
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     trafficLightPosition: process.platform === 'darwin' ? { x: 16, y: 18 } : undefined,

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import {
   safeStorage,
   shell,
   screen,
+  systemPreferences,
 } from 'electron';
 import path from 'node:path';
 import { mkdirSync } from 'node:fs';
@@ -15,6 +16,7 @@ import { createRequire } from 'node:module';
 import { DESKTOP_APP_ID, DESKTOP_APP_NAME, DESKTOP_MIN_WINDOW } from './app-metadata.js';
 import { registerDesktopBridge } from './bridge.js';
 import { DesktopCommandDispatcher } from './commands.js';
+import { applyTitlebarAction, resolveTitlebarAction } from './titlebar-action.js';
 import { sendAcknowledgedRendererCommand } from './renderer-commands.js';
 import { extractDeepLinkFromArgv, parseDesktopDeepLink } from './deep-links.js';
 import { configureDesktopMenu, dispatchDesktopMenuCommand } from './menu.js';
@@ -347,18 +349,16 @@ async function boot(): Promise<void> {
     commandDispatcher,
     updateService,
     {
-      toggleMaximize: () => {
-        const window = activeMainWindow();
-        if (!window) {
-          return { maximized: false };
-        }
-        if (window.isMaximized()) {
-          window.unmaximize();
-        } else {
-          window.maximize();
-        }
-        return { maximized: window.isMaximized() };
-      },
+      performTitlebarAction: () =>
+        applyTitlebarAction(
+          activeMainWindow(),
+          resolveTitlebarAction(
+            process.platform,
+            process.platform === 'darwin'
+              ? systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string')
+              : ''
+          )
+        ),
     }
   );
   refreshDesktopMenu();

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -402,13 +402,31 @@ app.on('before-quit', (event) => {
 });
 
 app.on('window-all-closed', () => {
-  app.quit();
+  if (process.platform !== 'darwin') app.quit();
 });
 
+let reopeningWindow = false;
 app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) {
-    void boot();
-  }
+  if (activeMainWindow() || reopeningWindow || quitting) return;
+  reopeningWindow = true;
+  void (async () => {
+    // Closing the last Mac window keeps its managed server and IPC handlers alive.
+    if (runtime && windowStatePaths) {
+      const savedState = await readDesktopWindowState(windowStatePaths);
+      if (quitting) return;
+      mainWindow = createMainWindow(savedState);
+      await mainWindow.loadURL(runtime.getRendererOrigin());
+      flushPendingDeepLinks();
+    } else {
+      await boot();
+    }
+  })()
+    .catch((error: unknown) => {
+      showDesktopError(error instanceof Error ? error.message : 'Unable to reopen the window.');
+    })
+    .finally(() => {
+      reopeningWindow = false;
+    });
 });
 
 process.on('uncaughtException', (error) => {

--- a/desktop/src/main/menu.ts
+++ b/desktop/src/main/menu.ts
@@ -27,6 +27,7 @@ export function configureDesktopMenu(options: ConfigureDesktopMenuOptions): void
 export function createDesktopMenuTemplate(
   options: ConfigureDesktopMenuOptions
 ): MenuItemConstructorOptions[] {
+  const isMac = (options.platform ?? process.platform) === 'darwin';
   const command = (name: DesktopCommandName): MenuItemConstructorOptions => {
     const definition = DESKTOP_COMMAND_REGISTRY[name];
     return {
@@ -37,25 +38,24 @@ export function createDesktopMenuTemplate(
     };
   };
 
-  const macosMenus: MenuItemConstructorOptions[] =
-    (options.platform ?? process.platform) === 'darwin'
-      ? [
-          { role: 'windowMenu' },
-          {
-            role: 'help',
-            submenu: [
-              {
-                label: 'Veritas Kanban Help',
-                click: () => options.openHelp(),
-              },
-              {
-                ...command('open-onboarding'),
-                label: 'Show Setup && Diagnostics',
-              },
-            ],
-          },
-        ]
-      : [];
+  const macosMenus: MenuItemConstructorOptions[] = isMac
+    ? [
+        { role: 'windowMenu' },
+        {
+          role: 'help',
+          submenu: [
+            {
+              label: 'Veritas Kanban Help',
+              click: () => options.openHelp(),
+            },
+            {
+              ...command('open-onboarding'),
+              label: 'Show Setup && Diagnostics',
+            },
+          ],
+        },
+      ]
+    : [];
 
   return [
     {
@@ -76,7 +76,17 @@ export function createDesktopMenuTemplate(
         command('download-update'),
         command('install-update'),
         { type: 'separator' },
-        command('quit'),
+        ...(isMac
+          ? [
+              { role: 'services' as const },
+              { type: 'separator' as const },
+              { role: 'hide' as const, accelerator: 'Command+H' },
+              { role: 'hideOthers' as const, accelerator: 'Command+Alt+H' },
+              { role: 'unhide' as const },
+              { type: 'separator' as const },
+            ]
+          : []),
+        { role: 'quit', accelerator: 'CommandOrControl+Q' },
       ],
     },
     {
@@ -86,9 +96,21 @@ export function createDesktopMenuTemplate(
         command('import-data'),
         command('export-data'),
         command('create-backup'),
+        { type: 'separator' },
+        { role: 'close', accelerator: 'CommandOrControl+W' },
       ],
     },
     { role: 'editMenu' },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'resetZoom', accelerator: 'CommandOrControl+0' },
+        { role: 'zoomIn', accelerator: 'CommandOrControl+Plus' },
+        { role: 'zoomOut', accelerator: 'CommandOrControl+-' },
+        { type: 'separator' },
+        { role: 'togglefullscreen', accelerator: isMac ? 'Control+Command+F' : 'F11' },
+      ],
+    },
     {
       label: 'Navigate',
       submenu: [

--- a/desktop/src/main/titlebar-action.ts
+++ b/desktop/src/main/titlebar-action.ts
@@ -1,0 +1,33 @@
+import type { BrowserWindow } from 'electron';
+
+export type TitlebarAction = 'zoom' | 'minimize' | 'none';
+
+export function resolveTitlebarAction(
+  platform: NodeJS.Platform,
+  preference: string
+): TitlebarAction {
+  if (platform !== 'darwin') return 'zoom';
+  switch (preference) {
+    case '': // Unset macOS preference uses the standard zoom behavior.
+    case 'Maximize':
+    case 'Fill':
+      return 'zoom';
+    case 'Minimize':
+      return 'minimize';
+    default:
+      return 'none';
+  }
+}
+
+export function applyTitlebarAction(
+  window: BrowserWindow | null,
+  action: TitlebarAction
+): { maximized: boolean } {
+  if (!window) return { maximized: false };
+  if (action === 'minimize') window.minimize();
+  if (action === 'zoom') {
+    if (window.isMaximized()) window.unmaximize();
+    else window.maximize();
+  }
+  return { maximized: window.isMaximized() };
+}

--- a/desktop/src/main/window-state.ts
+++ b/desktop/src/main/window-state.ts
@@ -4,6 +4,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { DesktopPaths } from './types.js';
+import { DESKTOP_MIN_WINDOW } from './app-metadata.js';
 
 export interface DesktopWindowState {
   width: number;
@@ -45,7 +46,7 @@ export function writeDesktopWindowStateSync(paths: DesktopPaths, state: DesktopW
 }
 
 export function captureDesktopWindowState(window: BrowserWindow): DesktopWindowState {
-  const bounds = window.getBounds();
+  const bounds = window.getNormalBounds();
   return {
     ...boundsToWindowState(bounds),
     maximized: window.isMaximized(),
@@ -54,14 +55,56 @@ export function captureDesktopWindowState(window: BrowserWindow): DesktopWindowS
 
 export function applyDesktopWindowState(
   state: DesktopWindowState,
-  fallback = DEFAULT_DESKTOP_WINDOW_STATE
+  fallback = DEFAULT_DESKTOP_WINDOW_STATE,
+  workAreas: readonly Rectangle[] = []
 ): Required<Pick<DesktopWindowState, 'width' | 'height'>> & Pick<DesktopWindowState, 'x' | 'y'> {
   const sanitized = sanitizeWindowState(state);
-  return {
+  const bounds = {
     width: sanitized.width || fallback.width,
     height: sanitized.height || fallback.height,
     x: sanitized.x,
     y: sanitized.y,
+  };
+  const areas = workAreas.filter(
+    (area) =>
+      [area.x, area.y, area.width, area.height].every(Number.isFinite) &&
+      area.width > 0 &&
+      area.height > 0
+  );
+  if (!areas.length) return bounds;
+  // Electron's bounds and display work areas both use device-independent pixels.
+  // Keep the monitor containing the largest part of the saved window. With no
+  // intersection (disconnected display), use the first, primary work area.
+  let area = areas[0];
+  let largest = 0;
+  if (bounds.x !== undefined && bounds.y !== undefined) {
+    for (const candidate of areas) {
+      const overlap =
+        Math.max(
+          0,
+          Math.min(bounds.x + bounds.width, candidate.x + candidate.width) -
+            Math.max(bounds.x, candidate.x)
+        ) *
+        Math.max(
+          0,
+          Math.min(bounds.y + bounds.height, candidate.y + candidate.height) -
+            Math.max(bounds.y, candidate.y)
+        );
+      if (overlap > largest) {
+        largest = overlap;
+        area = candidate;
+      }
+    }
+  }
+  const width = Math.min(area.width, Math.max(DESKTOP_MIN_WINDOW.width, bounds.width));
+  const height = Math.min(area.height, Math.max(DESKTOP_MIN_WINDOW.height, bounds.height));
+  const x = largest > 0 && bounds.x !== undefined ? bounds.x : area.x + (area.width - width) / 2;
+  const y = largest > 0 && bounds.y !== undefined ? bounds.y : area.y + (area.height - height) / 2;
+  return {
+    width,
+    height,
+    x: Math.round(Math.max(area.x, Math.min(x, area.x + area.width - width))),
+    y: Math.round(Math.max(area.y, Math.min(y, area.y + area.height - height))),
   };
 }
 

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -16,7 +16,7 @@ import type {
   DesktopSetupDiagnostics,
   DesktopSupportSnapshot,
   DesktopUpdateStatus,
-  DesktopWindowToggleMaximizeResult,
+  DesktopWindowTitlebarActionResult,
   DesktopWorkProductExportRequest,
   DesktopWorkProductExportResult,
 } from '../shared/desktop-bridge-contracts.js';
@@ -37,7 +37,7 @@ const DESKTOP_BRIDGE_METHODS = {
   performNotificationAction: { channel: 'desktop:perform-notification-action' },
   exportWorkProduct: { channel: 'desktop:export-work-product' },
   openExternal: { channel: 'desktop:open-external' },
-  toggleWindowMaximize: { channel: 'desktop:toggle-window-maximize' },
+  performTitlebarAction: { channel: 'desktop:perform-titlebar-action' },
 } as const;
 
 const DESKTOP_BRIDGE_EVENTS = {
@@ -90,7 +90,7 @@ export interface VeritasDesktopApi {
     request: DesktopWorkProductExportRequest
   ): Promise<DesktopWorkProductExportResult>;
   openExternal(url: string): Promise<void>;
-  toggleWindowMaximize(): Promise<DesktopWindowToggleMaximizeResult>;
+  performTitlebarAction(): Promise<DesktopWindowTitlebarActionResult>;
   onSetupProgress(listener: BridgeEventListener<'setupProgress'>): () => void;
   onCommunicationCheck(listener: BridgeEventListener<'communicationCheck'>): () => void;
   onServerStatus(listener: (status: DesktopStatusSnapshot) => void): () => void;
@@ -177,9 +177,9 @@ const api: VeritasDesktopApi = {
     ),
   openExternal: (url: string) =>
     invokeDesktop<void>(DESKTOP_BRIDGE_METHODS.openExternal.channel, { url }),
-  toggleWindowMaximize: () =>
-    invokeDesktop<DesktopWindowToggleMaximizeResult>(
-      DESKTOP_BRIDGE_METHODS.toggleWindowMaximize.channel
+  performTitlebarAction: () =>
+    invokeDesktop<DesktopWindowTitlebarActionResult>(
+      DESKTOP_BRIDGE_METHODS.performTitlebarAction.channel
     ),
   onSetupProgress: (listener) => onDesktopEvent('setupProgress', listener),
   onCommunicationCheck: (listener) => onDesktopEvent('communicationCheck', listener),

--- a/desktop/src/shared/desktop-bridge-contracts.ts
+++ b/desktop/src/shared/desktop-bridge-contracts.ts
@@ -204,7 +204,7 @@ export interface DesktopWorkProductExportResult {
   warnings: string[];
 }
 
-export interface DesktopWindowToggleMaximizeResult {
+export interface DesktopWindowTitlebarActionResult {
   maximized: boolean;
 }
 
@@ -295,9 +295,9 @@ export const DESKTOP_BRIDGE_METHODS = {
     dangerous: true,
     validator: 'openExternal',
   },
-  toggleWindowMaximize: {
+  performTitlebarAction: {
     capability: 'shell',
-    channel: 'desktop:toggle-window-maximize',
+    channel: 'desktop:perform-titlebar-action',
     desktopOnly: true,
     dangerous: false,
   },
@@ -317,7 +317,7 @@ export const DESKTOP_BRIDGE_METHOD_NAMES = [
   'performNotificationAction',
   'exportWorkProduct',
   'openExternal',
-  'toggleWindowMaximize',
+  'performTitlebarAction',
 ] as const;
 
 export type DesktopBridgeMethod = (typeof DESKTOP_BRIDGE_METHOD_NAMES)[number];
@@ -425,7 +425,7 @@ export interface DesktopBridgeRequestMap {
   performNotificationAction: DesktopNotificationActionRequest;
   exportWorkProduct: DesktopWorkProductExportRequest;
   openExternal: OpenExternalRequest;
-  toggleWindowMaximize: undefined;
+  performTitlebarAction: undefined;
 }
 
 export interface DesktopBridgeResponseMap {
@@ -442,7 +442,7 @@ export interface DesktopBridgeResponseMap {
   performNotificationAction: DesktopNotificationActionResult;
   exportWorkProduct: DesktopWorkProductExportResult;
   openExternal: undefined;
-  toggleWindowMaximize: DesktopWindowToggleMaximizeResult;
+  performTitlebarAction: DesktopWindowTitlebarActionResult;
 }
 
 export interface DesktopBridgeEventPayloadMap {

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -326,3 +326,8 @@ application menu; View provides text zoom and full screen.
 Saved window bounds are fitted to the current display work areas at launch or
 reopen. If a monitor was disconnected, the window returns to the primary display.
 Maximized windows retain their previous normal bounds for unmaximizing.
+
+The custom header follows the macOS title-bar double-click preference (zoom/fill,
+minimize, or no action). Configure it in [Desktop & Dock settings](https://support.apple.com/guide/mac-help/change-desktop-dock-settings-mchlp1119/mac).
+The native gate records the current preference and verifies its action without
+changing the operator's system preferences.

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -322,3 +322,7 @@ On macOS, Command-W closes the window while the managed server stays running.
 Reopen the window from the Dock. Command-Q quits and stops the managed server.
 Standard Hide, Hide Others, Show All and Services commands are available in the
 application menu; View provides text zoom and full screen.
+
+Saved window bounds are fitted to the current display work areas at launch or
+reopen. If a monitor was disconnected, the window returns to the primary display.
+Maximized windows retain their previous normal bounds for unmaximizing.

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -317,3 +317,8 @@ menu and the mounted renderer. File data commands and Debug Bundle open the exis
 Maintenance flow; they do not automatically export, restore, or create files.
 Renderer commands wait for an acknowledgement. Finish setup and unlock the workspace
 before using them; unavailable actions display a reason instead of reporting success.
+
+On macOS, Command-W closes the window while the managed server stays running.
+Reopen the window from the Dock. Command-Q quits and stops the managed server.
+Standard Hide, Hide Others, Show All and Services commands are available in the
+application menu; View provides text zoom and full screen.

--- a/docs/design/BOARD-COLOR-SYSTEM.md
+++ b/docs/design/BOARD-COLOR-SYSTEM.md
@@ -39,3 +39,13 @@ Identity tokens are `neutral`, `violet`, `cyan`, `orange`, `emerald`, `rose`, `a
 ## Responsive and accessibility behavior
 
 The plate and stamp stay compact in both board densities. Columns retain the board's existing responsive layout, while card metadata continues to wrap on narrow surfaces. Status glyphs, labels, counts, signal text, focus rings, and border changes preserve meaning in grayscale and common color-vision-deficiency conditions. Essential text and controls continue to use the established foreground and focus tokens; semantic color is supplemental.
+
+### Filled action contrast
+
+Filled controls use `--primary-action` with `--primary-foreground`, and
+`--primary-action-hover` for hover. These are separate from the brighter `--primary`
+accent used for text and focus in dark mode. Mantine filled Veritas controls and
+Tailwind filled selections share this pair. Do not use opacity to lighten a
+filled control with small white text. The native route gate measures normal,
+hover and focus text contrast on shared actions, Drift filters and populated
+Operations task identifiers in both themes.

--- a/scripts/native-ui/contrast.mjs
+++ b/scripts/native-ui/contrast.mjs
@@ -1,0 +1,72 @@
+/* global document, getComputedStyle */
+import assert from 'node:assert/strict';
+import { expect } from '@playwright/test';
+
+export async function measureTextContrast(locator) {
+  return locator.evaluate((element) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = 1;
+    const context = canvas.getContext('2d', { willReadFrequently: true });
+    const rgba = (color) => {
+      context.clearRect(0, 0, 1, 1);
+      context.fillStyle = color;
+      context.fillRect(0, 0, 1, 1);
+      return [...context.getImageData(0, 0, 1, 1).data];
+    };
+    const blend = (front, back) =>
+      front
+        .slice(0, 3)
+        .map((value, index) => (value * front[3]) / 255 + back[index] * (1 - front[3] / 255));
+    const ancestors = [];
+    for (let node = element; node; node = node.parentElement) ancestors.unshift(node);
+    let background = [255, 255, 255];
+    for (const node of ancestors)
+      background = blend(rgba(getComputedStyle(node).backgroundColor), background);
+    const style = getComputedStyle(element);
+    const foreground = blend(rgba(style.color), background);
+    const luminance = (rgb) =>
+      rgb
+        .map((value) => {
+          const v = value / 255;
+          return v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+        })
+        .reduce((sum, value, index) => sum + value * [0.2126, 0.7152, 0.0722][index], 0);
+    const values = [luminance(foreground), luminance(background)].sort((a, b) => b - a);
+    return {
+      text: element.textContent.trim().slice(0, 80),
+      foreground,
+      background,
+      ratio: (values[0] + 0.05) / (values[1] + 0.05),
+      outline: style.outline,
+      shadow: style.boxShadow,
+    };
+  });
+}
+
+export async function verifyRouteContrast(page, route) {
+  const targets = [];
+  const primary = page.getByRole('button', { name: 'New Task', exact: true });
+  targets.push(['primary-action', primary]);
+  if (route === 'drift')
+    targets.push(['selected-filter', page.getByRole('button', { name: 'all', exact: true })]);
+  if (route === 'operations') {
+    const code = page.locator('main code').first();
+    await expect(code).toBeVisible(); // Requires the real seeded blocked task, never an empty-state pass.
+    targets.push(['task-id', code]);
+  }
+  const results = [];
+  for (const [label, target] of targets) {
+    await expect(target).toBeVisible();
+    for (const state of label === 'task-id' ? ['normal'] : ['normal', 'hover', 'focus']) {
+      if (state === 'hover') await target.hover();
+      if (state === 'focus') {
+        await page.mouse.move(0, 0);
+        await target.focus();
+      }
+      const measured = await measureTextContrast(target);
+      assert(measured.ratio >= 4.5, `${route}/${label}/${state}: ${measured.ratio.toFixed(2)}:1`);
+      results.push({ label, state, ...measured });
+    }
+  }
+  return results;
+}

--- a/scripts/native-ui/menu-commands.mjs
+++ b/scripts/native-ui/menu-commands.mjs
@@ -159,3 +159,33 @@ export async function verifyNativeWindowMenu(app, page) {
     .toEqual(normalBounds);
   return { page: reopened, roles: items, normalBounds };
 }
+
+export async function verifyConfiguredTitlebarAction(app, page) {
+  const preference = await app.evaluate(({ systemPreferences }) =>
+    systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string')
+  );
+  await app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    window.restore();
+    window.unmaximize();
+  });
+  const state = () =>
+    app.evaluate(({ BrowserWindow }) => ({
+      maximized: BrowserWindow.getAllWindows()[0].isMaximized(),
+      minimized: BrowserWindow.getAllWindows()[0].isMinimized(),
+    }));
+  await expect.poll(state).toEqual({ maximized: false, minimized: false });
+  await page.getByRole('navigation', { name: 'Main navigation' }).dispatchEvent('dblclick');
+  const expected = {
+    maximized: ['', 'Maximize', 'Fill'].includes(preference),
+    minimized: preference === 'Minimize',
+  };
+  await expect.poll(state).toEqual(expected);
+  await app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    window.restore();
+    window.unmaximize();
+    window.focus();
+  });
+  return { preference: preference || 'system default', expected };
+}

--- a/scripts/native-ui/menu-commands.mjs
+++ b/scripts/native-ui/menu-commands.mjs
@@ -61,3 +61,85 @@ export async function verifyNativeMenuCommands(app, page) {
   assert(unsupported.message);
   return results;
 }
+
+/** Native roles must be wired in Electron, including a live managed-server lifecycle. */
+export async function verifyNativeWindowMenu(app, page) {
+  const items = await app.evaluate(({ Menu }) => {
+    const flatten = (menu) =>
+      menu.items.flatMap((item) => [
+        { role: item.role, accelerator: item.accelerator },
+        ...(item.submenu ? flatten(item.submenu) : []),
+      ]);
+    return flatten(Menu.getApplicationMenu());
+  });
+  for (const role of [
+    'quit',
+    'close',
+    'hide',
+    'hideOthers',
+    'unhide',
+    'services',
+    'resetZoom',
+    'zoomIn',
+    'zoomOut',
+    'togglefullscreen',
+  ]) {
+    assert(
+      items.some((item) => item.role === role),
+      `Missing native role: ${role}`
+    );
+  }
+  const clickRole = (role) =>
+    app.evaluate(({ Menu }, role) => {
+      const find = (menu) => {
+        for (const item of menu.items) {
+          if (item.role === role) return item;
+          const nested = item.submenu && find(item.submenu);
+          if (nested) return nested;
+        }
+      };
+      const item = find(Menu.getApplicationMenu());
+      if (!item?.enabled) throw new Error(`Role unavailable: ${role}`);
+      item.click();
+    }, role);
+  const zoom = () =>
+    app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()[0].webContents.getZoomFactor()
+    );
+  await clickRole('zoomIn');
+  await expect.poll(zoom).toBeGreaterThan(1);
+  await clickRole('resetZoom');
+  await expect.poll(zoom).toBe(1);
+  await clickRole('zoomOut');
+  await expect.poll(zoom).toBeLessThan(1);
+  await clickRole('resetZoom');
+  await expect.poll(zoom).toBe(1);
+  await clickRole('togglefullscreen');
+  await expect
+    .poll(() =>
+      app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].isFullScreen())
+    )
+    .toBe(true);
+  await clickRole('togglefullscreen');
+  await expect
+    .poll(() =>
+      app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].isFullScreen())
+    )
+    .toBe(false);
+  const before = await page.evaluate(() => window.veritasDesktop.getConnectionStatus());
+  const closed = page.waitForEvent('close');
+  await clickRole('close');
+  await closed;
+  assert.equal(await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length), 0);
+  const opened = app.waitForEvent('window');
+  await app.evaluate(({ app }) => app.emit('activate'));
+  const reopened = await opened;
+  await expect(reopened.getByRole('button', { name: 'Settings', exact: true })).toBeVisible();
+  const after = await reopened.evaluate(() => window.veritasDesktop.getConnectionStatus());
+  assert.equal(
+    after.server.pid,
+    before.server.pid,
+    'Closing the window restarted the managed server'
+  );
+  return { page: reopened, roles: items };
+}

--- a/scripts/native-ui/menu-commands.mjs
+++ b/scripts/native-ui/menu-commands.mjs
@@ -126,6 +126,15 @@ export async function verifyNativeWindowMenu(app, page) {
       app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].isFullScreen())
     )
     .toBe(false);
+  const normalBounds = await app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    const bounds = window.getNormalBounds();
+    window.maximize();
+    return bounds;
+  });
+  await expect
+    .poll(() => app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].isMaximized()))
+    .toBe(true);
   const before = await page.evaluate(() => window.veritasDesktop.getConnectionStatus());
   const closed = page.waitForEvent('close');
   await clickRole('close');
@@ -141,5 +150,12 @@ export async function verifyNativeWindowMenu(app, page) {
     before.server.pid,
     'Closing the window restarted the managed server'
   );
-  return { page: reopened, roles: items };
+  await expect
+    .poll(() => app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].isMaximized()))
+    .toBe(true);
+  await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].unmaximize());
+  await expect
+    .poll(() => app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].getBounds()))
+    .toEqual(normalBounds);
+  return { page: reopened, roles: items, normalBounds };
 }

--- a/scripts/native-ui/run.mjs
+++ b/scripts/native-ui/run.mjs
@@ -6,7 +6,7 @@ import { mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { expect } from '@playwright/test';
 import { createNativeSession } from './session.mjs';
-import { verifyNativeMenuCommands } from './menu-commands.mjs';
+import { verifyNativeMenuCommands, verifyNativeWindowMenu } from './menu-commands.mjs';
 import {
   fileDigest,
   evidenceFailures,
@@ -654,6 +654,9 @@ async function checkSeededRendererFailures() {
 try {
   await launch();
   report.menuCommands = await verifyNativeMenuCommands(app, page);
+  const windowMenu = await verifyNativeWindowMenu(app, page);
+  page = windowMenu.page;
+  report.menuRoles = windowMenu.roles;
   await persist();
   for (const mode of modes) {
     for (const state of states) {

--- a/scripts/native-ui/run.mjs
+++ b/scripts/native-ui/run.mjs
@@ -6,6 +6,7 @@ import { mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { expect } from '@playwright/test';
 import { createNativeSession } from './session.mjs';
+import { verifyRouteContrast } from './contrast.mjs';
 import {
   verifyNativeMenuCommands,
   verifyNativeWindowMenu,
@@ -214,6 +215,9 @@ async function capture(entry) {
   entry.screenshot = { path: name, sha256: await fileDigest(path.join(output, name)) };
   assert.deepEqual(geometryFailures(entry.geometry), [], entry.id);
   const route = routes.find(([name]) => entry.id.endsWith(`/route-${name}`));
+  if (route && ['board', 'drift', 'operations'].includes(route[0])) {
+    entry.contrast = await verifyRouteContrast(page, route[0]);
+  }
   if (route)
     assert.deepEqual(
       pageHeaderFailures(
@@ -662,6 +666,15 @@ try {
   const windowMenu = await verifyNativeWindowMenu(app, page);
   page = windowMenu.page;
   report.menuRoles = windowMenu.roles;
+  fixtureTask = await createTask('Native public-safe fixture');
+  await page.evaluate(async (id) => {
+    const response = await fetch(`/api/tasks/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'blocked' }),
+    });
+    if (!response.ok) throw new Error(`Fixture status failed: ${response.status}`);
+  }, fixtureTask.id);
   await persist();
   for (const mode of modes) {
     for (const state of states) {

--- a/scripts/native-ui/run.mjs
+++ b/scripts/native-ui/run.mjs
@@ -6,7 +6,11 @@ import { mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { expect } from '@playwright/test';
 import { createNativeSession } from './session.mjs';
-import { verifyNativeMenuCommands, verifyNativeWindowMenu } from './menu-commands.mjs';
+import {
+  verifyNativeMenuCommands,
+  verifyNativeWindowMenu,
+  verifyConfiguredTitlebarAction,
+} from './menu-commands.mjs';
 import {
   fileDigest,
   evidenceFailures,
@@ -653,6 +657,7 @@ async function checkSeededRendererFailures() {
 }
 try {
   await launch();
+  report.titlebarAction = await verifyConfiguredTitlebarAction(app, page);
   report.menuCommands = await verifyNativeMenuCommands(app, page);
   const windowMenu = await verifyNativeWindowMenu(app, page);
   page = windowMenu.page;

--- a/web/src/__tests__/KanbanBoard.test.tsx
+++ b/web/src/__tests__/KanbanBoard.test.tsx
@@ -267,7 +267,7 @@ function renderDesktopBoard() {
   Object.defineProperty(window, 'veritasDesktop', {
     configurable: true,
     value: {
-      toggleWindowMaximize: vi.fn(),
+      performTitlebarAction: vi.fn(),
     },
   });
   window.localStorage.setItem('veritas.desktop.rightRailOpen', 'false');

--- a/web/src/__tests__/layout-chrome-mantine.test.tsx
+++ b/web/src/__tests__/layout-chrome-mantine.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ViewProvider } from '@/contexts/ViewContext';
@@ -143,7 +143,7 @@ function renderDesktopHeaderChrome(options: { withBottomPanel?: boolean } = {}) 
   Object.defineProperty(window, 'veritasDesktop', {
     configurable: true,
     value: {
-      toggleWindowMaximize: vi.fn(),
+      performTitlebarAction: vi.fn(),
     },
   });
   document.documentElement.dataset.client = 'desktop';
@@ -381,10 +381,26 @@ describe('layout chrome Mantine migration', () => {
     expect(container.querySelector('.lucide-panel-right-close')).toBeNull();
   });
 
+  it('sends titlebar double clicks only from the header background', () => {
+    renderDesktopHeaderChrome();
+    const action = (
+      window as unknown as { veritasDesktop: { performTitlebarAction: ReturnType<typeof vi.fn> } }
+    ).veritasDesktop.performTitlebarAction;
+    fireEvent.doubleClick(screen.getByRole('button', { name: 'New Task' }));
+    fireEvent.doubleClick(screen.getByRole('button', { name: 'Settings' }));
+    const input = document.createElement('input');
+    screen.getByRole('navigation', { name: 'Main navigation' }).append(input);
+    fireEvent.doubleClick(input);
+    expect(action).not.toHaveBeenCalled();
+    input.remove();
+    fireEvent.doubleClick(screen.getByRole('navigation', { name: 'Main navigation' }));
+    expect(action).toHaveBeenCalledOnce();
+  });
+
   it('uses the filled brand treatment with white text for the active desktop navigation item', () => {
     Object.defineProperty(window, 'veritasDesktop', {
       configurable: true,
-      value: { toggleWindowMaximize: vi.fn() },
+      value: { performTitlebarAction: vi.fn() },
     });
     document.documentElement.dataset.client = 'desktop';
     window.history.replaceState({}, '', '/drift');

--- a/web/src/__tests__/ui-vocabulary.test.tsx
+++ b/web/src/__tests__/ui-vocabulary.test.tsx
@@ -63,6 +63,19 @@ describe('desktop UI vocabulary', () => {
     expect(click).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps filled action text above AA contrast in both schemes and hover states', () => {
+    const css = readFileSync('src/globals.css', 'utf8');
+    const fills = [...css.matchAll(/--primary-action(?:-hover)?: (#[a-f0-9]{6});/g)].map(
+      (match) => match[1]
+    );
+    expect(fills).toHaveLength(4);
+    for (const fill of fills) {
+      expect((luminance('#ffffff') + 0.05) / (luminance(fill) + 0.05), fill).toBeGreaterThanOrEqual(
+        4.5
+      );
+    }
+  });
+
   it('keeps every semantic foreground above 4.5:1 and the rendered CSS palette in sync', () => {
     const css = readFileSync('src/globals.css', 'utf8');
     for (const [scheme, palette] of Object.entries(VERITAS_SEMANTIC_PALETTE)) {

--- a/web/src/components/chat/FloatingChat.tsx
+++ b/web/src/components/chat/FloatingChat.tsx
@@ -57,7 +57,7 @@ export function FloatingChat() {
         classNames={{ icon: 'floating-chat-icon' }}
         className={cn(
           'floating-chat-trigger z-40 h-14 w-14 rounded-full shadow-lg',
-          'bg-primary hover:bg-primary/90 text-primary-foreground',
+          'bg-primary-action hover:bg-primary-action-hover text-primary-foreground',
           'transition-colors duration-150',
           open && 'hidden'
         )}

--- a/web/src/components/digest/OperationsDigestPage.tsx
+++ b/web/src/components/digest/OperationsDigestPage.tsx
@@ -714,7 +714,10 @@ function SourceList({
             <div key={`${item.kind}:${item.id}`} className="min-w-0 text-sm">
               <div className="truncate">{item.label}</div>
               <div className="mt-0.5 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-                <Code className="truncate" color="dark">
+                <Code
+                  className="truncate"
+                  style={{ color: 'var(--foreground)', backgroundColor: 'var(--muted)' }}
+                >
                   {item.id}
                 </Code>
                 <span className="shrink-0">{formatDateTime(item.timestamp)}</span>

--- a/web/src/components/drift/DriftMonitor.tsx
+++ b/web/src/components/drift/DriftMonitor.tsx
@@ -405,9 +405,10 @@ export function DriftMonitor({ onBack }: DriftMonitorProps) {
                 className={cn(
                   'rounded-md px-3 py-1.5 text-sm capitalize transition-colors',
                   severity === level
-                    ? 'bg-primary text-primary-foreground'
+                    ? 'bg-primary-action text-primary-foreground'
                     : 'text-muted-foreground'
                 )}
+                aria-pressed={severity === level}
                 onClick={() => setSeverity(level)}
               >
                 {level}

--- a/web/src/components/feedback/FeedbackPanel.tsx
+++ b/web/src/components/feedback/FeedbackPanel.tsx
@@ -215,7 +215,7 @@ function SubmitTab() {
               className={[
                 'rounded-full border px-3 py-1 text-sm transition-colors',
                 selectedCategories.includes(cat)
-                  ? 'border-primary bg-primary text-primary-foreground'
+                  ? 'border-primary bg-primary-action text-primary-foreground'
                   : 'border-border bg-transparent hover:bg-muted',
               ].join(' ')}
             >

--- a/web/src/components/layout/CommandPalette.tsx
+++ b/web/src/components/layout/CommandPalette.tsx
@@ -422,7 +422,7 @@ export function CommandPalette({
                             cmd.disabledReason
                               ? 'cursor-not-allowed border border-dashed border-border/70 bg-muted/15 text-muted-foreground'
                               : isSelected
-                                ? 'bg-primary text-white shadow-sm'
+                                ? 'bg-primary-action text-white shadow-sm'
                                 : 'text-foreground hover:bg-muted/50'
                           )}
                           style={

--- a/web/src/components/layout/DesktopLeftSidebar.tsx
+++ b/web/src/components/layout/DesktopLeftSidebar.tsx
@@ -73,7 +73,7 @@ export function DesktopLeftSidebar() {
                 className={cn(
                   'desktop-no-drag flex min-h-9 items-center gap-2 rounded-md px-2 text-left text-sm transition-colors',
                   active
-                    ? 'bg-primary text-white shadow-sm hover:bg-primary/90'
+                    ? 'bg-primary-action text-white shadow-sm hover:bg-primary-action-hover'
                     : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
                   !leftRailOpen && 'justify-center px-0'
                 )}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -423,9 +423,9 @@ export function Header({
       }
       void (
         window as Window & {
-          veritasDesktop?: { toggleWindowMaximize?: () => Promise<{ maximized: boolean }> };
+          veritasDesktop?: { performTitlebarAction?: () => Promise<{ maximized: boolean }> };
         }
-      ).veritasDesktop?.toggleWindowMaximize?.();
+      ).veritasDesktop?.performTitlebarAction?.();
     },
     [isDesktopClient]
   );

--- a/web/src/components/shared/ErrorFallback.tsx
+++ b/web/src/components/shared/ErrorFallback.tsx
@@ -57,7 +57,7 @@ function PageFallback({ error, onRetry: _onRetry }: Omit<ErrorFallbackProps, 'le
 
         <button
           onClick={() => window.location.reload()}
-          className="inline-flex items-center gap-2 px-6 py-2.5 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          className="inline-flex items-center gap-2 px-6 py-2.5 text-sm font-medium rounded-md bg-primary-action text-primary-foreground hover:bg-primary-action-hover transition-colors"
         >
           <RefreshCw className="h-4 w-4" />
           Reload

--- a/web/src/components/shared/SkipToContent.tsx
+++ b/web/src/components/shared/SkipToContent.tsx
@@ -12,7 +12,7 @@ export function SkipToContent() {
         sr-only focus:not-sr-only
         focus:fixed focus:top-2 focus:left-2 focus:z-[100]
         focus:px-4 focus:py-2 focus:rounded-md
-        focus:bg-primary focus:text-primary-foreground
+        focus:bg-primary-action focus:text-primary-foreground
         focus:text-sm focus:font-medium
         focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2
         focus:shadow-lg

--- a/web/src/components/task/TaskCard.tsx
+++ b/web/src/components/task/TaskCard.tsx
@@ -400,7 +400,7 @@ export const TaskCard = memo(function TaskCard({
               className={cn(
                 'h-4 w-4 rounded border-2 flex items-center justify-center flex-shrink-0 mt-0.5 transition-colors',
                 isChecked
-                  ? 'bg-primary border-primary text-primary-foreground'
+                  ? 'bg-primary-action border-primary text-primary-foreground'
                   : 'border-muted-foreground/50 hover:border-primary'
               )}
             >

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -10,7 +10,7 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',
+        default: 'bg-primary-action text-primary-foreground [a]:hover:bg-primary-action-hover',
         secondary: 'bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80',
         destructive:
           'bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20',

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -15,7 +15,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',
+        default: 'bg-primary-action text-primary-foreground [a]:hover:bg-primary-action-hover',
         outline:
           'border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary:

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -720,6 +720,8 @@ html[data-client='desktop'] .desktop-board-with-right-rail {
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
   --primary: #6541d5;
+  --primary-action: #6541d5;
+  --primary-action-hover: #5132b4;
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
@@ -794,8 +796,10 @@ html[data-client='desktop'] .desktop-board-with-right-rail {
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.145 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  /* Keep Tailwind controls on the same bright Veritas shade as Mantine. */
+  /* Preserve bright accent text; filled actions have their own contrast pair. */
   --primary: #8d68f8;
+  --primary-action: #754fe8;
+  --primary-action-hover: #6541d5;
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
@@ -1334,6 +1338,8 @@ html[data-client='desktop'] .desktop-board-with-right-rail {
   --color-secondary: var(--secondary);
   --color-primary-foreground: var(--primary-foreground);
   --color-primary: var(--primary);
+  --color-primary-action: var(--primary-action);
+  --color-primary-action-hover: var(--primary-action-hover);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);

--- a/web/src/theme/mantine-theme.ts
+++ b/web/src/theme/mantine-theme.ts
@@ -1,4 +1,4 @@
-import { createTheme, type MantineColorsTuple } from '@mantine/core';
+import { createTheme, defaultVariantColorsResolver, type MantineColorsTuple } from '@mantine/core';
 import { VERITAS_UI_METRICS } from './ui-contract';
 
 export const veritasPrimary: MantineColorsTuple = [
@@ -27,6 +27,19 @@ export const veritasStatusColors = {
 
 export const veritasMantineTheme = createTheme({
   primaryColor: 'veritas',
+  // Filled surfaces need a darker swatch than accent text on dark backgrounds.
+  variantColorResolver: (input) => {
+    const resolved = defaultVariantColorsResolver(input);
+    if (input.variant === 'filled' && (input.color ?? input.theme.primaryColor) === 'veritas') {
+      return {
+        ...resolved,
+        background: 'var(--primary-action)',
+        hover: 'var(--primary-action-hover)',
+        color: '#ffffff',
+      };
+    }
+    return resolved;
+  },
   primaryShade: { light: 6, dark: 4 },
   colors: {
     veritas: veritasPrimary,


### PR DESCRIPTION
Separate filled action colors from accent text colors so dark-mode buttons and badges retain readable foregrounds. Update affected primary actions and code tokens consistently, and add explicit contrast measurements to the native visual checks.

Local verification: web typecheck, changed-file ESLint, diff review and four UI vocabulary regressions passed. Contrast measurements and visual inspection passed in the integrated packaged candidate. No dependency changes.

The branch includes the native fixture prerequisites from #1553, #1554, #1555 and #1560; merge this change after those PRs.
Closes #1532.
