### PR TITLE
feat: offer system appearance with explicit light and dark overrides

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -114,7 +114,7 @@ The Kanban board is the central interface — a drag-and-drop workspace that ref
 - **Task types** — Configurable type system with icons and color-coded card borders (code, research, content, automation, and custom types)
 - **Priority levels** — Low, medium, and high with visual indicators on cards
 - **Markdown storage** — Tasks stored as human-readable `.md` files with YAML frontmatter
-- **Dark/light mode** — Ships dark by default with a toggle in Settings → General → Appearance; persists to localStorage; inline script in `index.html` prevents flash of wrong theme on load
+- **Appearance** — Choose Follow System, Light, or Dark in Settings → General → Appearance. System responds to OS/browser changes while open; explicit preferences and the default dark appearance are preserved across relaunches. The toolbar toggle selects an explicit override. Preferences stay local to the browser or desktop profile; the initial page script applies the choice before rendering
 - **Filter bar** — Search tasks by text, filter by project and task type; filters persist in URL query params
 - **Desktop shell controls** — Native-app-style toolbar with workspace selection, health state, a left-sidebar control, a Board-only right-sidebar control, and visually distinct Board Chat and Squad Chat actions; auxiliary rails and Workbench collapse when the native window crosses into compact width
 - **Primary page shell** — Activity, Backlog, Archive, Templates, Workflows, Operations Digest, Evidence Timeline, Time Breakdowns, Drift Monitor, Decision Audit Trail, Scoring, and Policies share one macOS route header with an icon-only Back action, one focused page heading, tokenized subtitle/status/action slots, and a common content baseline; dense data routes use the documented full-width `wide` variant while action groups move to a predictable second row below 1280px
@@ -2095,7 +2095,7 @@ closed instead of replacing newer data from an older backup.
 
 | Tab               | What It Controls                                                                                               |
 | ----------------- | -------------------------------------------------------------------------------------------------------------- |
-| **General**       | Application-wide preferences, appearance (dark/light mode toggle with moon/sun icon)                           |
+| **General**       | Application-wide preferences, appearance (Follow System, Light, or Dark)                                       |
 | **Board**         | Column visibility and board layout                                                                             |
 | **Tasks**         | Default values, auto-complete behavior                                                                         |
 | **Agents**        | Agent CRUD (add/edit/remove), default agent selection, custom agent types with any string slug                 |

--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,11 @@
         } catch (error) {
           value = null;
         }
-        var theme = value === 'light' ? 'light' : 'dark';
+        var theme =
+          value === 'light' ||
+          (value === 'auto' && window.matchMedia('(prefers-color-scheme: light)').matches)
+            ? 'light'
+            : 'dark';
         document.documentElement.dataset.mantineColorScheme = theme;
         if (theme === 'dark') {
           document.documentElement.classList.add('dark');

--- a/web/src/__tests__/mantine-theme.test.tsx
+++ b/web/src/__tests__/mantine-theme.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { TextInput, useMantineTheme } from '@mantine/core';
 import { useTheme } from '@/hooks/useTheme';
 import { MantineRoot, testColorSchemeManager } from '@/theme/MantineRoot';
@@ -24,6 +24,21 @@ function ThemeControlProbe() {
     <button type="button" onClick={() => setTheme('light')}>
       {theme}
     </button>
+  );
+}
+
+function PreferenceProbe() {
+  const { theme, preference, setTheme } = useTheme();
+  return (
+    <>
+      <output data-testid="resolved">{theme}</output>
+      <output data-testid="preference">{preference}</output>
+      {(['system', 'light', 'dark'] as const).map((value) => (
+        <button key={value} onClick={() => setTheme(value)}>
+          {value}
+        </button>
+      ))}
+    </>
   );
 }
 
@@ -52,6 +67,7 @@ describe('Mantine foundation', () => {
 
     Object.defineProperty(window, 'matchMedia', {
       configurable: true,
+      writable: true,
       value: vi.fn().mockImplementation((query: string) => ({
         matches: false,
         media: query,
@@ -107,6 +123,67 @@ describe('Mantine foundation', () => {
       expect(document.documentElement.dataset.mantineColorScheme).toBe('light');
       expect(document.documentElement.classList.contains('dark')).toBe(false);
     });
+  });
+
+  it('follows live system changes only for System and persists explicit overrides across remounts', async () => {
+    let dark = false;
+    const listeners = new Map<string, Set<(event: { matches: boolean }) => void>>();
+    window.matchMedia = vi.fn((query: string) => {
+      const callbacks = listeners.get(query) ?? new Set();
+      listeners.set(query, callbacks);
+      return {
+        media: query,
+        get matches() {
+          return query === '(prefers-color-scheme: dark)' ? dark : !dark;
+        },
+        addEventListener: (_type: string, callback: (event: { matches: boolean }) => void) =>
+          callbacks.add(callback),
+        removeEventListener: (_type: string, callback: (event: { matches: boolean }) => void) =>
+          callbacks.delete(callback),
+      } as unknown as MediaQueryList;
+    });
+    const changeSystem = (value: boolean) =>
+      act(() => {
+        dark = value;
+        for (const [query, callbacks] of listeners)
+          for (const callback of callbacks)
+            callback({ matches: query === '(prefers-color-scheme: dark)' ? dark : !dark });
+      });
+    window.localStorage.setItem('veritas-kanban-theme', 'light');
+    let view = render(
+      <MantineRoot>
+        <PreferenceProbe />
+      </MantineRoot>
+    );
+    await waitFor(() => expect(screen.getByTestId('preference').textContent).toBe('light'));
+    changeSystem(true);
+    expect(screen.getByTestId('resolved').textContent).toBe('light');
+    fireEvent.click(screen.getByRole('button', { name: 'system' }));
+    await waitFor(() => expect(screen.getByTestId('resolved').textContent).toBe('dark'));
+    expect(window.localStorage.getItem('veritas-kanban-theme')).toBe('auto');
+    changeSystem(false);
+    await waitFor(() => expect(document.documentElement.dataset.mantineColorScheme).toBe('light'));
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    view.unmount();
+    view = render(
+      <MantineRoot>
+        <PreferenceProbe />
+      </MantineRoot>
+    );
+    await waitFor(() => expect(screen.getByTestId('preference').textContent).toBe('system'));
+    changeSystem(true);
+    await waitFor(() => expect(document.documentElement.classList.contains('dark')).toBe(true));
+    fireEvent.click(screen.getByRole('button', { name: 'dark' }));
+    changeSystem(false);
+    expect(screen.getByTestId('resolved').textContent).toBe('dark');
+    view.unmount();
+    render(
+      <MantineRoot>
+        <PreferenceProbe />
+      </MantineRoot>
+    );
+    await waitFor(() => expect(screen.getByTestId('preference').textContent).toBe('dark'));
+    expect(screen.getByTestId('resolved').textContent).toBe('dark');
   });
 
   it('covers required v5 status semantics and accessibility defaults', () => {

--- a/web/src/__tests__/settings-general-mantine.test.tsx
+++ b/web/src/__tests__/settings-general-mantine.test.tsx
@@ -62,6 +62,7 @@ vi.mock('@/hooks/useFeatureSettings', () => ({
 vi.mock('@/hooks/useTheme', () => ({
   useTheme: () => ({
     theme: 'dark',
+    preference: 'dark',
     setTheme: mocks.setTheme,
   }),
 }));
@@ -80,13 +81,13 @@ describe('General settings Mantine migration', () => {
   it('renders the base general settings controls through direct Mantine primitives', async () => {
     const { container } = renderWithProviders(<GeneralTab />);
 
-    expect(screen.getByRole('switch', { name: 'Toggle dark mode' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Appearance' })).toBeDefined();
     expect(screen.getByRole('combobox', { name: 'Product Mode' })).toBeDefined();
     expect(screen.getAllByText('Advanced / Operator').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByRole('textbox', { name: 'Display Name (Squad Chat)' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Add Repo' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Default' })).toBeDefined();
-    expect(container.querySelector('.mantine-Switch-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Select-root')).not.toBeNull();
     expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
     expect(container.querySelector('.mantine-Button-root')).toBeDefined();
     expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
@@ -99,9 +100,10 @@ describe('General settings Mantine migration', () => {
         ?.className
     ).toContain('w-full');
 
-    fireEvent.click(screen.getByRole('switch', { name: 'Toggle dark mode' }));
+    fireEvent.click(screen.getByRole('combobox', { name: 'Appearance' }));
 
-    expect(mocks.setTheme).toHaveBeenCalledWith('light');
+    fireEvent.click(await screen.findByRole('option', { name: 'Follow System' }));
+    expect(mocks.setTheme).toHaveBeenCalledWith('system');
 
     fireEvent.click(screen.getByRole('combobox', { name: 'Product Mode' }));
     fireEvent.click(await screen.findByRole('option', { name: 'QA Review' }));

--- a/web/src/components/settings/tabs/GeneralTab.tsx
+++ b/web/src/components/settings/tabs/GeneralTab.tsx
@@ -2,7 +2,7 @@ import { UiModal as Modal, OverlayFooter } from '@/components/ui/UiOverlay';
 import { UiPill, UiAction, UiIconAction } from '@/components/ui/UiVocabulary';
 import { SettingsGroup } from '@/components/settings/shared/SettingsLayout';
 import { useState } from 'react';
-import { Group, Select, SimpleGrid, Stack, Switch, Text, TextInput } from '@mantine/core';
+import { Group, Select, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
 import {
   useConfig,
   useAddRepo,
@@ -11,19 +11,7 @@ import {
   useSetDefaultAgent,
 } from '@/hooks/useConfig';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
-import {
-  Plus,
-  Trash2,
-  Check,
-  X,
-  Loader2,
-  FolderGit2,
-  Bot,
-  Star,
-  Moon,
-  Sun,
-  User,
-} from 'lucide-react';
+import { Plus, Trash2, Check, X, Loader2, FolderGit2, Bot, Star, User } from 'lucide-react';
 import type { RepoConfig, AgentConfig, ProductModeId } from '@veritas-kanban/shared';
 import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 import { cn } from '@/lib/utils';
@@ -39,7 +27,7 @@ const PRODUCT_MODE_OPTIONS = PRODUCT_MODE_DEFINITIONS.map((mode) => ({
 export function GeneralTab() {
   const { data: config, isLoading } = useConfig();
   const [showAddForm, setShowAddForm] = useState(false);
-  const { theme, setTheme } = useTheme();
+  const { theme, preference, setTheme } = useTheme();
   const { settings } = useFeatureSettings();
   const { debouncedUpdate } = useDebouncedFeatureUpdate();
   const selectedProductMode =
@@ -61,23 +49,26 @@ export function GeneralTab() {
         description="Theme preference for this browser or desktop app."
       >
         <SettingRow
-          label="Dark mode"
-          description={theme === 'dark' ? 'Dark theme active' : 'Light theme active'}
+          label="Appearance"
+          description={
+            preference === 'system'
+              ? `Following system (${theme})`
+              : `${theme === 'dark' ? 'Dark' : 'Light'} theme active`
+          }
         >
-          <div className="flex items-center justify-end gap-3">
-            {theme === 'dark' ? (
-              <Moon className="h-4 w-4 text-muted-foreground" />
-            ) : (
-              <Sun className="h-4 w-4 text-muted-foreground" />
-            )}
-            <Switch
-              checked={theme === 'dark'}
-              onChange={(event) => setTheme(event.currentTarget.checked ? 'dark' : 'light')}
-              aria-label="Toggle dark mode"
-              className="flex min-h-8 items-center"
-              size="sm"
-            />
-          </div>
+          <Select
+            aria-label="Appearance"
+            value={preference}
+            data={[
+              { value: 'system', label: 'Follow System' },
+              { value: 'light', label: 'Light' },
+              { value: 'dark', label: 'Dark' },
+            ]}
+            allowDeselect={false}
+            onChange={(value) => {
+              if (value === 'system' || value === 'light' || value === 'dark') setTheme(value);
+            }}
+          />
         </SettingRow>
       </SettingsSection>
 

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -3,13 +3,13 @@ import { useComputedColorScheme, useMantineColorScheme } from '@mantine/core';
 import {
   applyVeritasColorScheme,
   normalizeVeritasColorScheme,
-  type VeritasColorScheme,
+  type VeritasThemePreference,
 } from '@/theme/color-scheme';
 
-type Theme = VeritasColorScheme;
+type Theme = VeritasThemePreference;
 
 export function useTheme() {
-  const { setColorScheme } = useMantineColorScheme();
+  const { colorScheme, setColorScheme } = useMantineColorScheme();
   const computedColorScheme = useComputedColorScheme('dark', {
     getInitialValueInEffect: true,
   });
@@ -21,8 +21,8 @@ export function useTheme() {
 
   const setTheme = useCallback(
     (t: Theme) => {
-      applyVeritasColorScheme(t);
-      setColorScheme(t);
+      if (t !== 'system') applyVeritasColorScheme(t);
+      setColorScheme(t === 'system' ? 'auto' : t);
     },
     [setColorScheme]
   );
@@ -31,5 +31,10 @@ export function useTheme() {
     setTheme(theme === 'dark' ? 'light' : 'dark');
   }, [setTheme, theme]);
 
-  return { theme, setTheme, toggleTheme };
+  return {
+    theme,
+    preference: colorScheme === 'auto' ? 'system' : colorScheme,
+    setTheme,
+    toggleTheme,
+  };
 }

--- a/web/src/theme/color-scheme.ts
+++ b/web/src/theme/color-scheme.ts
@@ -1,6 +1,8 @@
 import type { MantineColorScheme } from '@mantine/core';
 
 export type VeritasColorScheme = 'light' | 'dark';
+// Mantine persists the System preference as `auto` under the existing key.
+export type VeritasThemePreference = VeritasColorScheme | 'system';
 
 export const VERITAS_COLOR_SCHEME_STORAGE_KEY = 'veritas-kanban-theme';
 


### PR DESCRIPTION
Appearance now offers Follow System, Light and Dark. System mode responds to OS/browser changes while the app is open; explicit overrides persist, and the toolbar selects an explicit preference. The initial page script applies the saved choice before rendering, preserving the existing dark default for profiles without a preference.

Local verification: web typecheck, changed-file ESLint, diff review and theme/Settings regressions passed. The integrated packaged candidate passed system appearance changes and explicit overrides. No dependency changes.

Closes #1541.
