### PR TITLE
perf: keep large boards responsive with compact cards and virtualization

### DIFF
--- a/docs/testing/board-performance.md
+++ b/docs/testing/board-performance.md
@@ -1,0 +1,60 @@
+# Large-board performance
+
+The board loads one compact card snapshot. Description previews are
+limited to 400 characters. Checklist progress, artifact counts, attempt status and readiness
+are calculated from the complete task on the server; transcripts, checklist text and
+artifact bodies are loaded only when a task is opened. Search still matches the complete
+description, title and ID. The full-task API and its existing summary view remain compatible.
+
+Card projections have a separate query cache. A single snapshot preserves the complete
+ordering context without combining pages fetched across concurrent updates. Task WebSocket
+events and reconnection refresh the board. Moves use the revision in the card projection
+and retain the complete filtered/unfiltered ordering context. Existing API pagination remains
+available to other clients. The board avoids repeated full SQLite reads for each page.
+
+Columns above 80 tasks use measured card heights and six rows of overscan on each side.
+Focused and dragged cards stay mounted. Keyboard selection brings offscreen tasks into
+view; Previous tasks and Next tasks controls make the remaining list available without
+requiring a pointer. List items retain their position and total-count announcements.
+Dependency lookups use one index for the complete task snapshot. Done metrics load for
+mounted cards, not an entire large column.
+
+## Baseline and candidate budgets
+
+The retained 6.1.7 package (build `ed5094c6a5f9dd6958ceb952d8d018a40135bf33`, whole-app
+SHA-256 `a23df6443940aff4d9b5013b97ab753b986a63f3bb15dc0d3a8c6aaace866f94`)
+was measured on macOS arm64, with a 1360×900 content viewport and disposable SQLite
+profiles. Fixtures use four columns, explicit positions, 4096-character descriptions,
+and a dependency on the first To Do task for every fifth task. No operator data is used.
+
+| Tasks | Load and render | Input p95 | Mounted cards | DOM elements | Decoded task bytes |
+| ----: | --------------: | --------: | ------------: | -----------: | -----------------: |
+|   100 |          191 ms |     25 ms |           100 |        2,446 |            433,029 |
+| 1,000 |        1,634 ms |    238 ms |         1,000 |       19,370 |          4,330,119 |
+| 5,000 |        5,682 ms |  1,068 ms |         5,000 |       94,566 |         21,654,519 |
+
+These are single local samples, not statistical estimates. Input measures dispatch to two
+animation frames for ten sequential selection operations. The 100/1,000 samples were
+retained before that run was interrupted; the separate 5,000-task run completed. The
+baseline package predates the audit's source-only commit; its package identity is explicit.
+
+Candidate acceptance budgets, chosen before candidate measurements:
+
+- Load and render: at most 1 second for 100, 2 seconds for 1,000, and 5 seconds for 5,000 tasks.
+- Input p95: at most 100 ms for each dataset under the same two-frame method.
+- At most 120 mounted cards at this viewport; scrolling or keyboard selection must not grow
+  this count with total task count. Focus/drag retention is included in the budget.
+- At most 6 MB decoded card data for 5,000 fixtures; no initial full-task list request.
+- Full details, pointer/keyboard moves, filtered placement, distant keyboard selection,
+  screen-reader list positions and realtime convergence must pass separately.
+
+Run from the repository root with a clean build-bound candidate and a new output directory:
+
+```bash
+node --import tsx scripts/native-ui/board-performance.mjs /absolute/path/candidate.app /absolute/path/new-board-evidence
+```
+
+The runner uses only an isolated synthetic profile, stops its packaged server before seeding,
+refuses to overwrite evidence, and asserts package identity and the budgets above. Report its exact revision,
+version and package hash. Candidate measurements and native interaction acceptance remain
+release evidence, separate from focused unit checks. A passing build is not a performance result.

--- a/scripts/native-ui/board-performance.mjs
+++ b/scripts/native-ui/board-performance.mjs
@@ -1,0 +1,204 @@
+/* global AbortSignal, window, document, KeyboardEvent, requestAnimationFrame, PerformanceObserver */
+import { createRequire } from 'node:module';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { mkdir, writeFile, readFile, realpath } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { performance } from 'node:perf_hooks';
+const root = path.resolve(import.meta.dirname, '../..');
+const { createNativeSession } = await import(
+  pathToFileURL(`${root}/scripts/native-ui/session.mjs`)
+);
+const { SqliteDatabase } = await import(
+  pathToFileURL(`${root}/server/src/storage/sqlite/database.ts`)
+);
+const { SqliteTaskRepository } = await import(
+  pathToFileURL(`${root}/server/src/storage/sqlite/task-repository.ts`)
+);
+const { packageDigest } = await import(pathToFileURL(`${root}/scripts/native-ui/contract.mjs`));
+const require = createRequire(`${root}/package.json`);
+const { expect } = require('@playwright/test');
+assert(
+  process.argv[2]?.endsWith('.app') && process.argv[3],
+  'Usage: node --import tsx scripts/native-ui/board-performance.mjs <candidate.app> <new-evidence-directory>'
+);
+const output = path.resolve(process.argv[3]);
+await mkdir(output);
+const packagePath = await realpath(process.argv[2]);
+const git = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' });
+assert.equal(git.status, 0);
+const commit = git.stdout.trim();
+const version = JSON.parse(await readFile(path.join(root, 'desktop/package.json'), 'utf8')).version;
+const session = await createNativeSession({ packagePath, commit, version });
+const report = {
+  commit,
+  version,
+  packageDigest: await packageDigest(packagePath),
+  profile: session.profile,
+  status: 'running',
+  origin: session.origin,
+  entries: [],
+  fixture: {
+    descriptionBytes: 4096,
+    columns: ['todo', 'in-progress', 'blocked', 'done'],
+    dependencies: 'every fifth task depends on first To Do task',
+    order: 'explicit position',
+    seeding: 'offline canonical SQLite repository, packaged server confirmed stopped',
+  },
+  viewport: { width: 1360, height: 900 },
+  environment: { node: process.version, platform: process.platform, arch: process.arch },
+};
+const persist = () => writeFile(`${output}/report.json`, JSON.stringify(report, null, 2) + '\n');
+let app, page;
+try {
+  ({ app, page } = await session.launch());
+  report.identity = await page.evaluate(() => window.veritasDesktop.getAppInfo());
+  await app.evaluate(({ BrowserWindow }) =>
+    BrowserWindow.getAllWindows()[0].setContentSize(1360, 900)
+  );
+  let seeded = 0;
+  for (const count of [100, 1000, 5000]) {
+    await app.close();
+    app = null;
+    let serverStopped = false;
+    try {
+      await fetch(`${session.origin}/api/health`, { signal: AbortSignal.timeout(1000) });
+    } catch (error) {
+      serverStopped = error.cause?.code === 'ECONNREFUSED';
+    }
+    if (!serverStopped) throw new Error('Packaged server must be stopped before offline seeding');
+    const database = new SqliteDatabase({
+      databasePath: `${session.profile}/profiles/native-ui-conformance/workspaces/local/data/.veritas-kanban/veritas.db`,
+    });
+    database.open();
+    try {
+      const repository = new SqliteTaskRepository(database);
+      for (let i = seeded; i < count; i++)
+        await repository.create({
+          id: `task_scale_${String(i).padStart(5, '0')}`,
+          revision: 1,
+          title: `Scale fixture ${String(i).padStart(5, '0')}`,
+          description: 'Public-safe board performance fixture. '.repeat(120).slice(0, 4096),
+          status: report.fixture.columns[i % 4],
+          type: 'code',
+          priority: 'medium',
+          position: i,
+          created: new Date(1700000000000 + i).toISOString(),
+          updated: new Date(1700000000000 + i).toISOString(),
+          ...(i > 0 && i % 5 === 0 ? { blockedBy: ['task_scale_00000'] } : {}),
+        });
+    } finally {
+      database.close();
+    }
+    seeded = count;
+    console.log(`Seeded ${count} disposable tasks offline`);
+    ({ app, page } = await session.launch());
+    await app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()[0].setContentSize(1360, 900)
+    );
+    await page.addInitScript(() => {
+      performance.setResourceTimingBufferSize(1000);
+      window.__scaleLongTasks = [];
+      new PerformanceObserver((list) =>
+        window.__scaleLongTasks.push(...list.getEntries().map((e) => e.duration))
+      ).observe({ type: 'longtask', buffered: true });
+    });
+    const started = performance.now();
+    await page.goto(session.origin);
+    await expect
+      .poll(
+        () =>
+          page
+            .locator('[data-column-status] .vk-column-status-count')
+            .evaluateAll((elements) =>
+              elements.reduce((sum, element) => sum + Number(element.textContent), 0)
+            ),
+        { timeout: 30000 }
+      )
+      .toBe(count);
+    await page.mouse.move(10, 10);
+    await page.evaluate(
+      () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    );
+    const loadRenderMs = performance.now() - started;
+    const input = [];
+    for (let i = 0; i < 10; i++)
+      input.push(
+        await page.evaluate(
+          () =>
+            new Promise((resolve) => {
+              const start = performance.now();
+              window.dispatchEvent(new KeyboardEvent('keydown', { key: 'j', bubbles: true }));
+              requestAnimationFrame(() =>
+                requestAnimationFrame(() => resolve(performance.now() - start))
+              );
+            })
+        )
+      );
+    input.sort((a, b) => a - b);
+    const metrics = await page.evaluate(() => ({
+      cards: document.querySelectorAll('[data-task-id][role="article"]').length,
+      elements: document.querySelectorAll('*').length,
+      longTasks: window.__scaleLongTasks ?? [],
+      heapUsed: performance.memory?.usedJSHeapSize,
+    }));
+    const responses = await page.evaluate(() =>
+      performance
+        .getEntriesByType('resource')
+        .filter((entry) => new URL(entry.name).pathname === '/api/tasks')
+        .map((entry) => ({
+          query: new URL(entry.name).search,
+          decodedBytes: entry.decodedBodySize,
+          encodedBytes: entry.encodedBodySize,
+          durationMs: entry.duration,
+        }))
+    );
+    const entry = {
+      count,
+      loadRenderMs,
+      inputMedianMs: input[5],
+      inputP95Ms: input[9],
+      responses,
+      ...metrics,
+    };
+    report.entries.push(entry);
+    await persist();
+    console.log(
+      JSON.stringify({
+        count,
+        loadRenderMs,
+        inputP95Ms: entry.inputP95Ms,
+        cards: metrics.cards,
+        elements: metrics.elements,
+      })
+    );
+    await page.screenshot({ path: `${output}/board-${count}.png` });
+    entry.budgets = {
+      loadRenderMs: count === 100 ? 1000 : count === 1000 ? 2000 : 5000,
+      inputP95Ms: 100,
+      cards: 120,
+      decodedBytes: count * 1200,
+    };
+    entry.failures = [];
+    for (const key of ['loadRenderMs', 'inputP95Ms', 'cards'])
+      if (entry[key] > entry.budgets[key])
+        entry.failures.push(`${key}: ${entry[key]} > ${entry.budgets[key]}`);
+    const decodedBytes = responses.reduce((sum, response) => sum + response.decodedBytes, 0);
+    if (decodedBytes > entry.budgets.decodedBytes)
+      entry.failures.push(`decodedBytes: ${decodedBytes} > ${entry.budgets.decodedBytes}`);
+    if (responses.some((response) => !response.query.includes('view=board')))
+      entry.failures.push('Initial board requested full task records');
+    await persist();
+  }
+  report.status = report.entries.some((entry) => entry.failures.length) ? 'failed' : 'passed';
+  if (report.status === 'failed') process.exitCode = 1;
+} catch (error) {
+  report.status = 'failed';
+  report.error = String(error?.stack ?? error);
+  process.exitCode = 1;
+} finally {
+  if (app) await app.close();
+  await persist();
+  console.log(JSON.stringify({ status: report.status, error: report.error, output }));
+}

--- a/server/src/__tests__/board-task.test.ts
+++ b/server/src/__tests__/board-task.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { toBoardTask, evaluateTaskReadiness, type Task } from '@veritas-kanban/shared';
+
+describe('board task projection', () => {
+  it('bounds growing task content while preserving readiness, revisions and progress', () => {
+    const task: Task = {
+      id: 'task_board',
+      title: 'Implement board projection',
+      description: 'Acceptance criteria and verification report. '.repeat(10000),
+      type: 'code',
+      priority: 'medium',
+      status: 'todo',
+      created: '2026-09-07',
+      updated: '2026-09-07',
+      revision: 7,
+      subtasks: Array.from({ length: 1000 }, (_, i) => ({
+        id: String(i),
+        title: 'Checklist text '.repeat(100),
+        completed: i < 300,
+      })),
+      blockedBy: ['task_blocker'],
+      position: 3,
+    };
+    const result = toBoardTask(task);
+    expect(result.description).toHaveLength(400);
+    expect(result).not.toHaveProperty('subtasks');
+    const readiness = evaluateTaskReadiness(task, { isCodeTask: true });
+    expect(result.boardSummary).toMatchObject({
+      subtaskTotal: 1000,
+      subtaskCompleted: 300,
+      readiness: {
+        ready: readiness.ready,
+        percent: readiness.percent,
+        missingRequired: readiness.missingRequired.map((check) => ({ label: check.label })),
+      },
+    });
+    expect(result).toMatchObject({ revision: 7, position: 3, blockedBy: ['task_blocker'] });
+    expect(JSON.stringify(result).length).toBeLessThan(5000);
+  });
+});

--- a/server/src/__tests__/middleware/cache-control.test.ts
+++ b/server/src/__tests__/middleware/cache-control.test.ts
@@ -4,7 +4,12 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
-import { cacheControl, apiCacheHeaders, setLastModified, type CacheProfile } from '../../middleware/cache-control.js';
+import {
+  cacheControl,
+  apiCacheHeaders,
+  setLastModified,
+  type CacheProfile,
+} from '../../middleware/cache-control.js';
 
 function mockRequest(overrides: Partial<Request> = {}): Request {
   return {
@@ -18,7 +23,9 @@ function mockResponse(): Response & { _headers: Record<string, string> } {
   const headers: Record<string, string> = {};
   return {
     _headers: headers,
-    set: vi.fn((key: string, value: string) => { headers[key] = value; }),
+    set: vi.fn((key: string, value: string) => {
+      headers[key] = value;
+    }),
   } as unknown as Response & { _headers: Record<string, string> };
 }
 
@@ -53,7 +60,7 @@ describe('Cache Control Middleware', () => {
       const next = vi.fn();
 
       middleware(req, res, next);
-      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=10, must-revalidate');
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, no-cache');
       expect(next).toHaveBeenCalled();
     });
 
@@ -64,7 +71,7 @@ describe('Cache Control Middleware', () => {
       const next = vi.fn();
 
       middleware(req, res, next);
-      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=60');
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, no-cache');
       expect(next).toHaveBeenCalled();
     });
 
@@ -140,7 +147,7 @@ describe('Cache Control Middleware', () => {
       const next = vi.fn();
 
       apiCacheHeaders(req, res, next);
-      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=10, must-revalidate');
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, no-cache');
       expect(next).toHaveBeenCalled();
     });
 
@@ -150,7 +157,7 @@ describe('Cache Control Middleware', () => {
       const next = vi.fn();
 
       apiCacheHeaders(req, res, next);
-      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=10, must-revalidate');
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, no-cache');
       expect(next).toHaveBeenCalled();
     });
 
@@ -160,7 +167,7 @@ describe('Cache Control Middleware', () => {
       const next = vi.fn();
 
       apiCacheHeaders(req, res, next);
-      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=60');
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, no-cache');
       expect(next).toHaveBeenCalled();
     });
 

--- a/server/src/__tests__/routes/tasks-coverage.test.ts
+++ b/server/src/__tests__/routes/tasks-coverage.test.ts
@@ -140,6 +140,28 @@ describe('Tasks Routes (actual module)', () => {
   });
 
   describe('GET /api/tasks', () => {
+    it('returns bounded card records and searches the full description beyond the preview', async () => {
+      const tasks = Array.from({ length: 201 }, (_, index) => ({
+        id: `task_${index}`,
+        title: 'Board fixture',
+        description: 'a'.repeat(1000) + (index === 200 ? 'needle' : ''),
+        type: 'code',
+        status: 'todo',
+        priority: 'medium',
+        created: '2026-09-07',
+        updated: '2026-09-07',
+        revision: 1,
+      }));
+      mockTaskService.listTasks.mockResolvedValue(tasks);
+      const snapshot = await request(app).get('/api/tasks?view=board');
+      expect(snapshot.status).toBe(200);
+      expect(snapshot.body).toHaveLength(201);
+      expect(snapshot.body[0].description).toHaveLength(400);
+      expect(snapshot.body[200].boardSummary).toHaveProperty('readiness');
+      const search = await request(app).get('/api/tasks?fields=id&search=needle');
+      expect(search.body).toEqual([{ id: 'task_200' }]);
+    });
+
     it('should list all tasks', async () => {
       const tasks = [
         { id: 't1', title: 'Task 1', created: '2025-01-01', updated: '2025-01-02' },

--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -41,6 +41,7 @@ import {
 } from '../schemas/telemetry-schemas.js';
 import {
   MAX_TASK_REORDER_ITEMS,
+  MoveTaskBodySchema,
   ReorderTasksBodySchema,
   ApplyTemplateBodySchema,
 } from '../schemas/task-mutation-schemas.js';
@@ -683,6 +684,20 @@ describe('Telemetry Schemas', () => {
 // ============ New Mutation Schemas ============
 
 describe('Task Mutation Schemas', () => {
+  it('allows a single move into a large column while rejecting invalid positions', () => {
+    const move = {
+      operationId: '00000000-0000-4000-8000-000000000001',
+      sourceStatus: 'todo',
+      sourcePosition: 0,
+      destinationStatus: 'blocked',
+      destinationIndex: 1250,
+    };
+    expect(MoveTaskBodySchema.parse(move).destinationIndex).toBe(1250);
+    for (const destinationIndex of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() => MoveTaskBodySchema.parse({ ...move, destinationIndex })).toThrow();
+    }
+  });
+
   describe('ReorderTasksBodySchema', () => {
     it('should accept valid orderedIds', () => {
       const result = ReorderTasksBodySchema.parse({ orderedIds: ['task_1', 'task_2'] });

--- a/server/src/middleware/cache-control.ts
+++ b/server/src/middleware/cache-control.ts
@@ -10,26 +10,23 @@ import type { Request, Response, NextFunction } from 'express';
  * Profiles:
  *   static-immutable  – Vite hashed assets (1 year, immutable)
  *   static-html       – SPA shell (must revalidate every request)
- *   task-list          – GET /api/tasks (short TTL, private)
- *   task-detail        – GET /api/tasks/:id (moderate TTL, private)
+ *   task-list          – GET /api/tasks (private, revalidate)
+ *   task-detail        – GET /api/tasks/:id (private, revalidate)
  *   config             – GET /api/config (always revalidate)
  *   no-store           – Mutating responses / sensitive data
  */
 
 export type CacheProfile =
-  | 'static-immutable'
-  | 'static-html'
-  | 'task-list'
-  | 'task-detail'
-  | 'config'
-  | 'no-store';
+  'static-immutable' | 'static-html' | 'task-list' | 'task-detail' | 'config' | 'no-store';
 
 const CACHE_PROFILES: Record<CacheProfile, string> = {
   'static-immutable': 'public, max-age=31536000, immutable',
   'static-html': 'no-cache',
-  'task-list': 'private, max-age=10, must-revalidate',
-  'task-detail': 'private, max-age=60',
-  'config': 'private, no-cache',
+  // Subresource mutations (such as /tasks/:id/move) do not invalidate the
+  // browser's cached parent URL. Revalidate mutable task data using its ETag.
+  'task-list': 'private, no-cache',
+  'task-detail': 'private, no-cache',
+  config: 'private, no-cache',
   'no-store': 'no-store',
 };
 

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -1,3 +1,4 @@
+import { toBoardTask } from '@veritas-kanban/shared';
 import { assertLegacyAttemptEditable } from '../utils/task-attempt-edit.js';
 import { Router, type NextFunction, type Response, type Router as RouterType } from 'express';
 import { z } from 'zod';
@@ -426,8 +427,12 @@ const appendProgressSchema = z.object({
  *         description: Filter by agent name (exact match)
  *       - in: query
  *         name: view
- *         schema: { type: string, enum: [summary] }
- *         description: '"summary" returns lightweight TaskSummary objects'
+ *         schema: { type: string, enum: [summary, board] }
+ *         description: '"summary" returns TaskSummary objects; "board" returns bounded card content'
+ *       - in: query
+ *         name: search
+ *         schema: { type: string }
+ *         description: Case-insensitive search across full title, description and ID
  *       - in: query
  *         name: fields
  *         schema: { type: string }
@@ -479,6 +484,14 @@ router.get(
       tasks = tasks.filter((t) => t.agent === agentFilter);
     }
 
+    const search = typeof req.query.search === 'string' ? req.query.search.toLowerCase() : '';
+    if (search)
+      tasks = tasks.filter(
+        (task) =>
+          task.title.toLowerCase().includes(search) ||
+          task.description.toLowerCase().includes(search) ||
+          task.id.toLowerCase().includes(search)
+      );
     const total = tasks.length;
 
     // --- Last-Modified (computed before slicing) ---
@@ -526,6 +539,8 @@ router.get(
         }
         return picked;
       });
+    } else if (viewParam === 'board') {
+      result = tasks.map(toBoardTask);
     } else if (viewParam === 'summary') {
       // Summary mode: lightweight board-view payload
       result = tasks.map((task): TaskSummary => ({

--- a/server/src/schemas/task-mutation-schemas.ts
+++ b/server/src/schemas/task-mutation-schemas.ts
@@ -23,7 +23,8 @@ export const MoveTaskBodySchema = z.object({
   sourceStatus: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN),
   sourcePosition: z.number().finite().nullable(),
   destinationStatus: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN),
-  destinationIndex: z.number().int().min(0).max(MAX_TASK_REORDER_ITEMS),
+  // This is one position, not a bulk payload. The service checks column length.
+  destinationIndex: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
   expectedRevision: z.number().int().min(0).optional(),
 });
 

--- a/shared/src/utils/board-task.ts
+++ b/shared/src/utils/board-task.ts
@@ -1,0 +1,77 @@
+import type { Task } from '../types/task.types.js';
+import { evaluateTaskReadiness, type TaskReadinessSummary } from './task-readiness.js';
+
+/** Card projection only. Never place this in the full-task/detail query cache. */
+export interface BoardTask extends Task {
+  boardSummary: {
+    subtaskTotal: number;
+    subtaskCompleted: number;
+    verificationTotal: number;
+    verificationChecked: number;
+    attachmentCount: number;
+    deliverableCount: number;
+    awaitingReview: boolean;
+    attempt?: Pick<NonNullable<Task['attempt']>, 'status' | 'agent'>;
+    checkpoint?: Pick<NonNullable<Task['checkpoint']>, 'step' | 'resumeCount'>;
+    readiness:
+      | (Pick<TaskReadinessSummary, 'ready' | 'percent'> & {
+          missingRequired: Array<{ label: string }>;
+        })
+      | null;
+  };
+}
+
+/** Large descriptions, run transcripts, checklist text and artifact bodies stay in detail. */
+export function toBoardTask(task: Task): BoardTask {
+  const readiness = task.type === 'code' ? evaluateTaskReadiness(task, { isCodeTask: true }) : null;
+  return {
+    id: task.id,
+    title: task.title,
+    description: task.description.slice(0, 400),
+    type: task.type,
+    status: task.status,
+    priority: task.priority,
+    project: task.project,
+    sprint: task.sprint,
+    agent: task.agent,
+    created: task.created,
+    updated: task.updated,
+    revision: task.revision,
+    position: task.position,
+    boardRank: task.boardRank,
+    blockedBy: task.blockedBy,
+    dependencies: task.dependencies,
+    blockedReason: task.blockedReason
+      ? { ...task.blockedReason, note: task.blockedReason.note?.slice(0, 400) }
+      : undefined,
+    timeTracking: task.timeTracking
+      ? {
+          totalSeconds: task.timeTracking.totalSeconds,
+          isRunning: task.timeTracking.isRunning,
+          entries: [],
+        }
+      : undefined,
+    boardSummary: {
+      subtaskTotal: task.subtasks?.length ?? 0,
+      subtaskCompleted: task.subtasks?.filter((item) => item.completed).length ?? 0,
+      verificationTotal: task.verificationSteps?.length ?? 0,
+      verificationChecked: task.verificationSteps?.filter((item) => item.checked).length ?? 0,
+      attachmentCount: task.attachments?.length ?? 0,
+      deliverableCount: task.deliverables?.length ?? 0,
+      awaitingReview: (task.reviewComments?.length ?? 0) > 0 && !task.review?.decision,
+      attempt: task.attempt
+        ? { status: task.attempt.status, agent: task.attempt.agent }
+        : undefined,
+      checkpoint: task.checkpoint
+        ? { step: task.checkpoint.step, resumeCount: task.checkpoint.resumeCount }
+        : undefined,
+      readiness: readiness
+        ? {
+            ready: readiness.ready,
+            percent: readiness.percent,
+            missingRequired: readiness.missingRequired.map((check) => ({ label: check.label })),
+          }
+        : null,
+    },
+  };
+}

--- a/shared/src/utils/index.ts
+++ b/shared/src/utils/index.ts
@@ -15,3 +15,5 @@ export * from './acp-json-rpc-peer.js';
 export * from './task-readiness.js';
 export * from './workflow-pipeline.js';
 export * from './task-board-order.js';
+
+export * from './board-task.js';

--- a/web/src/__tests__/api-tasks.test.ts
+++ b/web/src/__tests__/api-tasks.test.ts
@@ -65,6 +65,20 @@ describe('tasksApi', () => {
     expect(result[0].id).toBe('t1');
   });
 
+  it('loads the card snapshot separately from full tasks with cancellation', async () => {
+    const controller = new AbortController();
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [{ id: 'card' }],
+    } as Response);
+    expect(await tasksApi.listBoard(controller.signal)).toEqual([{ id: 'card' }]);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://test-api/tasks?view=board',
+      expect.objectContaining({ cache: 'no-store', signal: controller.signal })
+    );
+  });
+
   it('get() calls GET /tasks/:id', async () => {
     const task = createMockTask({ id: 'abc123' });
     vi.mocked(fetch).mockResolvedValueOnce({

--- a/web/src/__tests__/board-color-system.test.tsx
+++ b/web/src/__tests__/board-color-system.test.tsx
@@ -7,6 +7,7 @@ import type { TaskTypeConfig } from '@veritas-kanban/shared';
 const { dropState } = vi.hoisted(() => ({ dropState: { isOver: false } }));
 
 vi.mock('@dnd-kit/core', () => ({
+  useDndContext: () => ({ active: null }),
   useDroppable: () => ({ setNodeRef: vi.fn(), isOver: dropState.isOver }),
 }));
 

--- a/web/src/__tests__/board-move-query.test.tsx
+++ b/web/src/__tests__/board-move-query.test.tsx
@@ -2,21 +2,22 @@ import { createElement, type ReactNode } from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MoveTaskResult, Task } from '@veritas-kanban/shared';
-import { useMoveTask, useTasks } from '@/hooks/useTasks';
+import { toBoardTask, type MoveTaskResult, type Task } from '@veritas-kanban/shared';
+import { useMoveTask, useTasks, useBoardTasks } from '@/hooks/useTasks';
 import { useTaskSync } from '@/hooks/useTaskSync';
 import type { UseWebSocketOptions } from '@/hooks/useWebSocket';
 import { createMockTask } from './test-utils';
 
 const mocks = vi.hoisted(() => ({
   list: vi.fn(),
+  listBoard: vi.fn(),
   move: vi.fn(),
   socketOptions: null as UseWebSocketOptions | null,
   toast: vi.fn(),
 }));
 
 vi.mock('@/lib/api', () => ({
-  api: { tasks: { list: mocks.list, move: mocks.move } },
+  api: { tasks: { listBoard: mocks.listBoard, list: mocks.list, move: mocks.move } },
 }));
 
 vi.mock('@/hooks/useToast', () => ({ toast: mocks.toast }));
@@ -68,6 +69,38 @@ describe('board move QueryClient and WebSocket convergence', () => {
   function wrapper({ children }: { children: ReactNode }) {
     return createElement(QueryClientProvider, { client: queryClient }, children);
   }
+
+  it('uses summary revisions for moves and updates the separate board cache', async () => {
+    queryClient.removeQueries({ queryKey: ['tasks'], exact: true });
+    queryClient.setQueryData(['tasks', 'board'], [toBoardTask(original)]);
+    mocks.move.mockResolvedValue({
+      task: moved,
+      orderedTaskIds: [moved.id],
+      replayed: false,
+      operationId: 'board-move',
+    });
+    mocks.listBoard.mockResolvedValue([toBoardTask(moved)]);
+    const { result } = renderHook(() => ({ board: useBoardTasks(), move: useMoveTask() }), {
+      wrapper,
+    });
+    await act(async () =>
+      result.current.move.mutateAsync({
+        id: original.id,
+        input: {
+          operationId: 'board-move',
+          sourceStatus: 'todo',
+          sourcePosition: 0,
+          destinationStatus: 'blocked',
+          destinationIndex: 0,
+        },
+      })
+    );
+    expect(mocks.move).toHaveBeenCalledWith(original.id, expect.anything(), 3);
+    await waitFor(() => expect(result.current.board.data?.[0].status).toBe('blocked'));
+    expect(queryClient.getQueryData(['tasks'])).toBeUndefined();
+    expect(queryClient.getQueryData(['tasks', moved.id])).toEqual(moved);
+    expect(result.current.board.data?.[0]).toHaveProperty('boardSummary');
+  });
 
   it('keeps the old cache stable while pending, then converges with an echoed move event', async () => {
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');

--- a/web/src/__tests__/task-blocker-index.test.ts
+++ b/web/src/__tests__/task-blocker-index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getTaskBlockers, isTaskBlocked } from '@/hooks/useTasks';
+import { createMockTask } from './test-utils';
+
+describe('board dependency index', () => {
+  it('looks up only referenced IDs, deduplicates references and ignores completed/missing tasks', () => {
+    const blocker = createMockTask({ id: 'blocker', status: 'todo' });
+    const complete = createMockTask({ id: 'complete', status: 'done' });
+    const unrelated = Array.from({ length: 5000 }, (_, i) => createMockTask({ id: `other-${i}` }));
+    const index = new Map([blocker, complete, ...unrelated].map((task) => [task.id, task]));
+    const get = vi.spyOn(index, 'get');
+    const task = createMockTask({ blockedBy: ['blocker', 'blocker', 'complete', 'missing'] });
+    expect(getTaskBlockers(task, index)).toEqual([blocker]);
+    expect(get).toHaveBeenCalledTimes(3);
+    expect(isTaskBlocked(task, index)).toBe(true);
+  });
+
+  it('retains blockers excluded by board filters and matches legacy array callers', () => {
+    const task = createMockTask({ id: 'visible', blockedBy: ['hidden'] });
+    const hidden = createMockTask({
+      id: 'hidden',
+      title: 'Excluded by title filter',
+      status: 'blocked',
+    });
+    const allTasks = [task, hidden];
+    expect(getTaskBlockers(task, new Map(allTasks.map((value) => [value.id, value])))).toEqual(
+      getTaskBlockers(task, allTasks)
+    );
+    expect(getTaskBlockers(createMockTask(), new Map())).toEqual([]);
+  });
+});

--- a/web/src/__tests__/virtual-column.test.tsx
+++ b/web/src/__tests__/virtual-column.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { useVirtualColumn } from '@/hooks/useVirtualColumn';
+
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+afterEach(cleanup);
+const ids = Array.from({ length: 5000 }, (_, index) => `task_${index}`);
+
+describe('large column card window', () => {
+  it('bounds DOM work across scrolling, selection and an offscreen drag', () => {
+    const { result, rerender } = renderHook(
+      ({ selected, active }) => useVirtualColumn(ids, selected, active),
+      { initialProps: { selected: null as string | null, active: null as string | null } }
+    );
+    expect(result.current.rows.length).toBeLessThan(20);
+    const element = document.createElement('div');
+    Object.defineProperty(element, 'clientHeight', { value: 800 });
+    result.current.viewport.current = element;
+    act(() => {
+      element.scrollTop = 180 * 2500;
+      result.current.updateView();
+    });
+    expect(result.current.rows.length).toBeLessThan(20);
+    expect(result.current.rows.some((row) => row.id === 'task_2500')).toBe(true);
+    act(() => {
+      element.scrollTop = 2_000_000;
+      result.current.updateView();
+    });
+    expect(result.current.rows.length).toBeLessThan(20);
+    expect(result.current.rows.some((row) => row.id === 'task_4999')).toBe(true);
+    rerender({ selected: 'task_4999', active: 'task_0' });
+    expect(element.scrollTop).toBeGreaterThan(180 * 4900);
+    expect(result.current.rows.some((row) => row.id === 'task_4999')).toBe(true);
+    expect(result.current.rows.some((row) => row.id === 'task_0')).toBe(true);
+    expect(result.current.rows.length).toBeLessThan(20);
+  });
+
+  it('keeps a focused offscreen card mounted and small columns unchanged', () => {
+    const { result } = renderHook(() => useVirtualColumn(ids));
+    act(() => result.current.setFocusedId('task_4000'));
+    expect(result.current.rows.some((row) => row.id === 'task_4000')).toBe(true);
+    expect(result.current.rows.length).toBeLessThan(20);
+    const small = renderHook(() => useVirtualColumn(ids.slice(0, 20)));
+    expect(small.result.current.enabled).toBe(false);
+    expect(small.result.current.rows).toHaveLength(20);
+  });
+});

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -357,6 +357,8 @@ export function KanbanBoard() {
     return tasks ? filterTasks(tasks, filters) : [];
   }, [tasks, filters]);
 
+  const taskIndex = useMemo(() => new Map((tasks ?? []).map((task) => [task.id, task])), [tasks]);
+
   // Group filtered tasks by status
   const tasksByStatus = useTasksByStatus(filteredTasks, columns);
   const allTasksByStatus = useTasksByStatus(tasks ?? [], columns);
@@ -696,6 +698,7 @@ export function KanbanBoard() {
                       title={column.title}
                       tasks={liveTasksByStatus[column.id] ?? []}
                       allTasks={filteredTasks}
+                      taskIndex={taskIndex}
                       onTaskClick={handleTaskClick}
                       onTaskStatusChange={handleMoveTask}
                       selectedTaskId={selectedTaskId}
@@ -733,6 +736,7 @@ export function KanbanBoard() {
                     title={column.title}
                     tasks={tasksByStatus[column.id] ?? []}
                     allTasks={filteredTasks}
+                    taskIndex={taskIndex}
                     onTaskClick={handleTaskClick}
                     onTaskStatusChange={handleMoveTask}
                     selectedTaskId={selectedTaskId}

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -726,7 +726,11 @@ export function KanbanBoard() {
                       taskIndex={taskIndex}
                       onTaskClick={handleTaskClick}
                       onTaskStatusChange={handleMoveTask}
-                      selectedTaskId={selectedTaskId}
+                      selectedTaskId={
+                        selectedTaskId && taskIndex.get(selectedTaskId)?.status === column.id
+                          ? selectedTaskId
+                          : null
+                      }
                       canChangeStatus={canWriteTasks && isOnline}
                       dragEnabled={canDragTasks && !isMovePending}
                       isDragActive={isDragActive}
@@ -764,7 +768,11 @@ export function KanbanBoard() {
                     taskIndex={taskIndex}
                     onTaskClick={handleTaskClick}
                     onTaskStatusChange={handleMoveTask}
-                    selectedTaskId={selectedTaskId}
+                    selectedTaskId={
+                      selectedTaskId && taskIndex.get(selectedTaskId)?.status === column.id
+                        ? selectedTaskId
+                        : null
+                    }
                     canChangeStatus={canWriteTasks && isOnline}
                     dragEnabled={false}
                     showStatusControls={isMobileLayout}

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -1,4 +1,10 @@
-import { useMoveTask, useTasks, useTasksByStatus } from '@/hooks/useTasks';
+import {
+  useMoveTask,
+  useBoardTasks,
+  useBoardSearch,
+  useTask,
+  useTasksByStatus,
+} from '@/hooks/useTasks';
 import { useBoardDragDrop } from '@/hooks/useBoardDragDrop';
 import { KanbanColumn } from './KanbanColumn';
 import { BoardLoadingSkeleton } from './BoardLoadingSkeleton';
@@ -102,7 +108,7 @@ const BoardSidebar = lazy(() =>
 const EMPTY_SAVED_VIEWS: BoardSavedView[] = [];
 
 export function KanbanBoard() {
-  const { data: tasks, isLoading, error, refetch, isFetching } = useTasks();
+  const { data: tasks, isLoading, error, refetch, isFetching } = useBoardTasks();
   const { settings: featureSettings, isPlaceholderData } = useFeatureSettings();
   const updateFeatureSettings = useUpdateFeatureSettings();
   const boardSettings = featureSettings.board ?? DEFAULT_FEATURE_SETTINGS.board;
@@ -143,6 +149,8 @@ export function KanbanBoard() {
     return { search: '', project: null, type: null, agent: null };
   });
   const [selectedSavedViewId, setSelectedSavedViewId] = useState<string | null>(null);
+  const searchMatches = useBoardSearch(filters.search);
+  const detailQuery = useTask(selectedTask?.id ?? '');
 
   const { selectedTaskId, setTasks, setOnOpenTask, setOnMoveTask } = useKeyboard();
   const { isSelecting, toggleSelecting } = useBulkActions();
@@ -354,8 +362,13 @@ export function KanbanBoard() {
 
   // Filter tasks
   const filteredTasks = useMemo(() => {
-    return tasks ? filterTasks(tasks, filters) : [];
-  }, [tasks, filters]);
+    const matches = filters.search ? new Set(searchMatches.data ?? []) : null;
+    return tasks
+      ? filterTasks(tasks, { ...filters, search: '' }).filter(
+          (task) => !matches || matches.has(task.id)
+        )
+      : [];
+  }, [tasks, filters, searchMatches.data]);
 
   const taskIndex = useMemo(() => new Map((tasks ?? []).map((task) => [task.id, task])), [tasks]);
 
@@ -580,9 +593,8 @@ export function KanbanBoard() {
   };
 
   // Keep selected task in sync with updated data
-  const currentSelectedTask = selectedTask
-    ? tasks?.find((t) => t.id === selectedTask.id) || selectedTask
-    : null;
+  const currentSelectedTask =
+    detailQuery.data ?? (selectedTask && !('boardSummary' in selectedTask) ? selectedTask : null);
 
   if (isLoading) {
     return <BoardLoadingSkeleton columns={columns} />;
@@ -658,6 +670,19 @@ export function KanbanBoard() {
         )}
       </div>
 
+      {filters.search && searchMatches.isFetching && (
+        <p role="status" className="px-2 text-sm text-muted-foreground">
+          Searching tasks…
+        </p>
+      )}
+      {filters.search && searchMatches.error && (
+        <div role="alert" className="px-2 text-sm">
+          Search could not be completed.{' '}
+          <Button variant="subtle" onClick={() => void searchMatches.refetch()}>
+            Retry search
+          </Button>
+        </div>
+      )}
       <BulkActionsBar tasks={filteredTasks} />
 
       {boardSettings.showArchiveSuggestions && <ArchiveSuggestionBanner />}
@@ -792,6 +817,16 @@ export function KanbanBoard() {
         )}
       </FeatureErrorBoundary>
 
+      {detailOpen && !currentSelectedTask && (
+        <div
+          role="status"
+          className="fixed bottom-4 right-4 z-50 rounded border bg-background p-4 shadow"
+        >
+          {detailQuery.error ? 'Task details could not be loaded.' : 'Loading task details…'}
+          {detailQuery.error && <Button onClick={() => void detailQuery.refetch()}>Retry</Button>}
+          <Button onClick={() => handleDetailClose(false)}>Close</Button>
+        </div>
+      )}
       {detailPanelMounted && (
         <Suspense fallback={null}>
           <TaskDetailPanel

--- a/web/src/components/board/KanbanColumn.tsx
+++ b/web/src/components/board/KanbanColumn.tsx
@@ -1,5 +1,6 @@
+import { useVirtualColumn } from '@/hooks/useVirtualColumn';
 import { useMemo } from 'react';
-import { useDroppable } from '@dnd-kit/core';
+import { useDndContext, useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { BadgeCheck, Ban, CircleDashed, CircleDot, OctagonAlert, Play } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -72,11 +73,15 @@ export function KanbanColumn({
   const statusPresentation = getStatusPresentation(id);
   const StatusIcon = statusPresentation.icon;
 
+  const { active } = useDndContext();
+  const taskIds = useMemo(() => tasks.map((task) => task.id), [tasks]);
+  const windowed = useVirtualColumn(taskIds, selectedTaskId, active ? String(active.id) : null);
+
   // Get task IDs for done column to fetch bulk metrics
   const doneTaskIds = useMemo(() => {
     if (id !== 'done' || !showDoneMetrics) return [];
-    return tasks.map((t) => t.id);
-  }, [id, tasks, showDoneMetrics]);
+    return windowed.rows.map((row) => row.id);
+  }, [id, windowed.rows, showDoneMetrics]);
 
   // Fetch bulk metrics only for done column
   const { data: metricsMap } = useBulkTaskMetrics(doneTaskIds, id === 'done' && showDoneMetrics);
@@ -132,44 +137,106 @@ export function KanbanColumn({
       </div>
 
       <SortableContext items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
-        <div className="flex-1 p-2 space-y-2 min-h-24 overflow-y-auto md:min-h-[calc(100vh-200px)]">
-          {tasks.length === 0 ? (
-            <div
-              className={cn(
-                'flex items-center justify-center h-24 text-sm text-muted-foreground rounded-md border-2 border-dashed',
-                dragEnabled && isOver && 'border-primary/50 bg-primary/5'
-              )}
-            >
-              {dragEnabled && isOver ? 'Drop here' : 'No tasks'}
-            </div>
-          ) : (
-            tasks.map((task) => {
-              const blockers = getTaskBlockers(task, dependencyIndex);
-              const blocked = blockers.length > 0;
-              const taskMetrics =
-                id === 'done' && showDoneMetrics ? metricsMap?.get(task.id) : undefined;
-              return (
-                <ErrorBoundary key={task.id} level="widget">
-                  <TaskCard
-                    task={task}
-                    dragEnabled={dragEnabled}
-                    onClick={() => onTaskClick?.(task)}
-                    onStatusChange={(status) => onTaskStatusChange?.(task.id, status)}
-                    isSelected={task.id === selectedTaskId}
-                    isBlocked={blocked}
-                    blockerTitles={blockers.map((b) => b.title)}
-                    cardMetrics={taskMetrics}
-                    canChangeStatus={canChangeStatus}
-                    isDragActive={isDragActive}
-                    showStatusControl={showStatusControls}
-                    statusOptions={statusOptions}
-                  />
-                </ErrorBoundary>
-              );
-            })
+        <div
+          ref={windowed.viewport}
+          onScroll={windowed.updateView}
+          onFocusCapture={(event) =>
+            windowed.setFocusedId(
+              (event.target as HTMLElement).closest<HTMLElement>('[data-virtual-task]')?.dataset
+                .virtualTask ?? null
+            )
+          }
+          onBlurCapture={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget)) windowed.setFocusedId(null);
+          }}
+          className={cn(
+            'flex-1 p-2 min-h-24 overflow-y-auto',
+            windowed.enabled
+              ? 'h-[calc(100dvh-240px)] max-h-[calc(100dvh-240px)]'
+              : 'space-y-2 md:min-h-[calc(100vh-200px)]'
           )}
+        >
+          <div
+            role="list"
+            aria-label={`${title} tasks`}
+            className={windowed.enabled ? 'relative' : 'space-y-2'}
+            style={windowed.enabled ? { height: windowed.height } : undefined}
+          >
+            {tasks.length === 0 ? (
+              <div
+                className={cn(
+                  'flex items-center justify-center h-24 text-sm text-muted-foreground rounded-md border-2 border-dashed',
+                  dragEnabled && isOver && 'border-primary/50 bg-primary/5'
+                )}
+              >
+                {dragEnabled && isOver ? 'Drop here' : 'No tasks'}
+              </div>
+            ) : (
+              windowed.rows.map((row) => {
+                const task = tasks[row.index];
+                const blockers = getTaskBlockers(task, dependencyIndex);
+                const blocked = blockers.length > 0;
+                const taskMetrics =
+                  id === 'done' && showDoneMetrics ? metricsMap?.get(task.id) : undefined;
+                return (
+                  <div
+                    key={task.id}
+                    role="listitem"
+                    aria-posinset={row.index + 1}
+                    aria-setsize={tasks.length}
+                    data-virtual-task={task.id}
+                    ref={(element) => windowed.measure(task.id, element)}
+                    style={
+                      windowed.enabled
+                        ? { position: 'absolute', top: row.offset, left: 0, right: 0 }
+                        : undefined
+                    }
+                  >
+                    <ErrorBoundary level="widget">
+                      <TaskCard
+                        task={task}
+                        dragEnabled={dragEnabled}
+                        onClick={() => onTaskClick?.(task)}
+                        onStatusChange={(status) => onTaskStatusChange?.(task.id, status)}
+                        isSelected={task.id === selectedTaskId}
+                        isBlocked={blocked}
+                        blockerTitles={blockers.map((b) => b.title)}
+                        cardMetrics={taskMetrics}
+                        canChangeStatus={canChangeStatus}
+                        isDragActive={isDragActive}
+                        showStatusControl={showStatusControls}
+                        statusOptions={statusOptions}
+                      />
+                    </ErrorBoundary>
+                  </div>
+                );
+              })
+            )}
+          </div>
         </div>
       </SortableContext>
+      {windowed.enabled && (
+        <div className="flex items-center justify-between gap-2 px-3 py-2 text-xs">
+          <button
+            className="rounded px-1 focus-visible:outline disabled:opacity-40"
+            disabled={windowed.start === 0}
+            onClick={() => windowed.reveal(tasks[Math.max(0, windowed.start - 10)].id, true)}
+            aria-label={`Previous tasks in ${title}`}
+          >
+            Previous tasks
+          </button>
+          <button
+            className="rounded px-1 focus-visible:outline disabled:opacity-40"
+            disabled={windowed.end >= tasks.length}
+            onClick={() =>
+              windowed.reveal(tasks[Math.min(tasks.length - 1, windowed.end)].id, true)
+            }
+            aria-label={`Next tasks in ${title}`}
+          >
+            Next tasks
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/board/KanbanColumn.tsx
+++ b/web/src/components/board/KanbanColumn.tsx
@@ -4,7 +4,7 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { BadgeCheck, Ban, CircleDashed, CircleDot, OctagonAlert, Play } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TaskCard } from '@/components/task/TaskCard';
-import { isTaskBlocked, getTaskBlockers } from '@/hooks/useTasks';
+import { getTaskBlockers, type TaskDependencyIndex } from '@/hooks/useTasks';
 import { useBulkTaskMetrics } from '@/hooks/useBulkTaskMetrics';
 import { useBulkActions } from '@/hooks/useBulkActions';
 import { useFeatureSettings } from '@/hooks/useFeatureSettings';
@@ -16,6 +16,7 @@ interface KanbanColumnProps {
   title: string;
   tasks: Task[];
   allTasks: Task[];
+  taskIndex?: TaskDependencyIndex;
   onTaskClick?: (task: Task) => void;
   onTaskStatusChange?: (taskId: string, status: TaskStatus) => void;
   selectedTaskId?: string | null;
@@ -50,6 +51,7 @@ export function KanbanColumn({
   title,
   tasks,
   allTasks,
+  taskIndex,
   onTaskClick,
   onTaskStatusChange,
   selectedTaskId,
@@ -62,6 +64,10 @@ export function KanbanColumn({
   const { setNodeRef, isOver } = useDroppable({ id, disabled: !dragEnabled });
   const { settings: featureSettings } = useFeatureSettings();
   const { isSelecting, selectedIds, toggleGroup } = useBulkActions();
+  const dependencyIndex = useMemo(
+    () => taskIndex ?? new Map(allTasks.map((task) => [task.id, task])),
+    [taskIndex, allTasks]
+  );
   const showDoneMetrics = featureSettings.board.showDoneMetrics;
   const statusPresentation = getStatusPresentation(id);
   const StatusIcon = statusPresentation.icon;
@@ -138,8 +144,8 @@ export function KanbanColumn({
             </div>
           ) : (
             tasks.map((task) => {
-              const blocked = isTaskBlocked(task, allTasks);
-              const blockers = blocked ? getTaskBlockers(task, allTasks) : [];
+              const blockers = getTaskBlockers(task, dependencyIndex);
+              const blocked = blockers.length > 0;
               const taskMetrics =
                 id === 'done' && showDoneMetrics ? metricsMap?.get(task.id) : undefined;
               return (

--- a/web/src/components/board/KanbanColumn.tsx
+++ b/web/src/components/board/KanbanColumn.tsx
@@ -1,5 +1,5 @@
 import { useVirtualColumn } from '@/hooks/useVirtualColumn';
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { useDndContext, useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { BadgeCheck, Ban, CircleDashed, CircleDot, OctagonAlert, Play } from 'lucide-react';
@@ -47,7 +47,7 @@ function getStatusPresentation(status: string) {
   );
 }
 
-export function KanbanColumn({
+export const KanbanColumn = memo(function KanbanColumn({
   id,
   title,
   tasks,
@@ -136,7 +136,7 @@ export function KanbanColumn({
         </div>
       </div>
 
-      <SortableContext items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
+      <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
         <div
           ref={windowed.viewport}
           onScroll={windowed.updateView}
@@ -239,4 +239,4 @@ export function KanbanColumn({
       )}
     </div>
   );
-}
+});

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -9,7 +9,7 @@ import {
   type MetricsPeriod,
   type TrendDirection,
 } from '@/hooks/useMetrics';
-import { useTasks } from '@/hooks/useTasks';
+import { useBoardTasks } from '@/hooks/useTasks';
 import { useProjects } from '@/hooks/useProjects';
 import { TrendingUp, TrendingDown, Minus, RefreshCw } from 'lucide-react';
 import { ExportDialog } from './ExportDialog';
@@ -170,7 +170,7 @@ export function Dashboard({ onTaskClick }: DashboardProps = {}) {
   } = useMetrics(period, project, customFrom, customTo);
   const { data: taskCost } = useTaskCost(period, project, customFrom, customTo);
   const { data: utilization } = useUtilization(period, customFrom, customTo);
-  const { data: tasks } = useTasks();
+  const { data: tasks } = useBoardTasks();
   const { data: projectsList = [] } = useProjects();
 
   // Get unique project IDs from tasks, then map to project configs for labels

--- a/web/src/components/task/DependenciesSection.tsx
+++ b/web/src/components/task/DependenciesSection.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef } from 'react';
 import { Plus, X, Ban, CheckCircle2, Link as LinkIcon } from 'lucide-react';
 import { ActionIcon, Badge, Button, Group, Paper, Select, Stack, Text } from '@mantine/core';
-import { useTasks, isTaskBlocked } from '@/hooks/useTasks';
+import { useBoardTasks, isTaskBlocked } from '@/hooks/useTasks';
 import { cn } from '@/lib/utils';
 import { useToast } from '@/hooks/useToast';
 import type { Task } from '@veritas-kanban/shared';
@@ -17,7 +17,7 @@ export function DependenciesSection({
   task,
   onBlockedByChange: _onBlockedByChange,
 }: DependenciesSectionProps) {
-  const { data: allTasks } = useTasks();
+  const { data: allTasks } = useBoardTasks();
   const [isAddingDependsOn, setIsAddingDependsOn] = useState(false);
   const [isAddingBlocks, setIsAddingBlocks] = useState(false);
   const { toast } = useToast();

--- a/web/src/components/task/TaskCard.tsx
+++ b/web/src/components/task/TaskCard.tsx
@@ -4,7 +4,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
 import { evaluateTaskReadiness } from '@veritas-kanban/shared';
-import type { Task, TaskPriority, BlockedCategory } from '@veritas-kanban/shared';
+import type { BoardTask, Task, TaskPriority, BlockedCategory } from '@veritas-kanban/shared';
 import {
   Check,
   Ban,
@@ -60,7 +60,7 @@ const blockedCategoryInfo: Record<
 };
 
 interface TaskCardProps {
-  task: Task;
+  task: Task & { boardSummary?: BoardTask['boardSummary'] };
   dragEnabled?: boolean;
   isDragging?: boolean;
   isDragActive?: boolean;
@@ -97,6 +97,7 @@ function areTaskCardPropsEqual(prev: TaskCardProps, next: TaskCardProps): boolea
   const pt = prev.task;
   const nt = next.task;
   if (pt !== nt) {
+    if (pt.boardSummary !== nt.boardSummary) return false;
     if (pt.id !== nt.id) return false;
     if (pt.title !== nt.title) return false;
     if (pt.description !== nt.description) return false;
@@ -206,6 +207,11 @@ export const TaskCard = memo(function TaskCard({
   showStatusControl = false,
   statusOptions,
 }: TaskCardProps) {
+  const summary = task.boardSummary;
+  const attempt = summary?.attempt ?? task.attempt;
+  const checkpoint = summary?.checkpoint ?? task.checkpoint;
+  const attachmentCount = summary?.attachmentCount ?? task.attachments?.length ?? 0;
+  const deliverableCount = summary?.deliverableCount ?? task.deliverables?.length ?? 0;
   const { taskTypes, projects, sprints } = useTaskConfig();
   const {
     attributes,
@@ -295,12 +301,12 @@ export const TaskCard = memo(function TaskCard({
     toggleSelect(task.id);
   };
 
-  const isAgentRunning = task.attempt?.status === 'running';
-  const isAttemptFailed = task.attempt?.status === 'failed';
+  const isAgentRunning = attempt?.status === 'running';
+  const isAttemptFailed = attempt?.status === 'failed';
   const isBlockedState = isBlocked || task.status === 'blocked';
   const isAwaitingReview =
     task.status.toLowerCase().includes('review') ||
-    ((task.reviewComments?.length ?? 0) > 0 && !task.review?.decision);
+    (summary?.awaitingReview ?? ((task.reviewComments?.length ?? 0) > 0 && !task.review?.decision));
 
   // Memoize type info
   const { typeLabel, TypeIconComponent, typeColorToken } = useMemo(() => {
@@ -325,30 +331,35 @@ export const TaskCard = memo(function TaskCard({
   // Memoize subtask progress
   const { subtaskTotal, subtaskCompleted, allSubtasksDone } = useMemo(() => {
     const subtasks = task.subtasks || [];
-    const total = subtasks.length;
-    const completed = subtasks.filter((s) => s.completed).length;
+    const total = summary?.subtaskTotal ?? subtasks.length;
+    const completed = summary?.subtaskCompleted ?? subtasks.filter((s) => s.completed).length;
     return {
       subtaskTotal: total,
       subtaskCompleted: completed,
       allSubtasksDone: total > 0 && completed === total,
     };
-  }, [task.subtasks]);
+  }, [task.subtasks, summary]);
 
   // Memoize verification progress
   const { verificationTotal, verificationChecked, allVerificationDone } = useMemo(() => {
     const steps = task.verificationSteps || [];
-    const total = steps.length;
-    const checked = steps.filter((s) => s.checked).length;
+    const total = summary?.verificationTotal ?? steps.length;
+    const checked = summary?.verificationChecked ?? steps.filter((s) => s.checked).length;
     return {
       verificationTotal: total,
       verificationChecked: checked,
       allVerificationDone: total > 0 && checked === total,
     };
-  }, [task.verificationSteps]);
+  }, [task.verificationSteps, summary]);
 
   const readinessSummary = useMemo(
-    () => (task.type === 'code' ? evaluateTaskReadiness(task, { isCodeTask: true }) : null),
-    [task]
+    () =>
+      summary
+        ? summary.readiness
+        : task.type === 'code'
+          ? evaluateTaskReadiness(task, { isCodeTask: true })
+          : null,
+    [task, summary]
   );
   const readinessColor = readinessSummary?.ready
     ? 'vk-signal-chip--verified'
@@ -450,19 +461,18 @@ export const TaskCard = memo(function TaskCard({
                 <div>
                   <p className="font-medium">Agent Active</p>
                   <p className="text-sm">
-                    {agentNames[task.attempt?.agent || ''] || task.attempt?.agent} is working on
-                    this task
+                    {agentNames[attempt?.agent || ''] || attempt?.agent} is working on this task
                   </p>
                 </div>
               }
             >
               <span className="vk-signal-chip vk-signal-chip--running">
                 <span className="sr-only">
-                  Agent {agentNames[task.attempt?.agent || ''] || task.attempt?.agent} is actively
-                  running on this task
+                  Agent {agentNames[attempt?.agent || ''] || attempt?.agent} is actively running on
+                  this task
                 </span>
                 <Loader2 className="h-3 w-3 animate-spin" />
-                {agentNames[task.attempt?.agent || ''] || 'Agent'} running
+                {agentNames[attempt?.agent || ''] || 'Agent'} running
               </span>
             </Tooltip>
           )}
@@ -531,16 +541,16 @@ export const TaskCard = memo(function TaskCard({
             );
           })()}
           {/* Checkpoint indicator */}
-          {task.checkpoint && (
+          {checkpoint && (
             <Tooltip
               label={
                 <div className="space-y-1">
                   <p className="font-medium">Checkpoint Saved</p>
-                  <p className="text-sm">Step {task.checkpoint.step}</p>
-                  {task.checkpoint.resumeCount && task.checkpoint.resumeCount > 0 && (
+                  <p className="text-sm">Step {checkpoint.step}</p>
+                  {checkpoint.resumeCount && checkpoint.resumeCount > 0 && (
                     <p className="text-sm flex items-center gap-1">
                       <RotateCcw className="h-3 w-3" aria-hidden="true" />
-                      Resumed {task.checkpoint.resumeCount} time(s)
+                      Resumed {checkpoint.resumeCount} time(s)
                     </p>
                   )}
                 </div>
@@ -549,7 +559,7 @@ export const TaskCard = memo(function TaskCard({
               <span className="text-xs px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 flex items-center gap-1">
                 <Save className="h-3 w-3" aria-hidden="true" />
                 <span className="sr-only">Checkpoint saved at </span>
-                Step {task.checkpoint.step}
+                Step {checkpoint.step}
               </span>
             </Tooltip>
           )}
@@ -626,17 +636,17 @@ export const TaskCard = memo(function TaskCard({
             </Tooltip>
           )}
           {/* Attachment indicator */}
-          {task.attachments && task.attachments.length > 0 && (
+          {attachmentCount > 0 && (
             <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground flex items-center gap-1">
               <Paperclip className="h-3 w-3" />
-              {task.attachments.length}
+              {attachmentCount}
             </span>
           )}
           {/* Deliverable indicator */}
-          {task.deliverables && task.deliverables.length > 0 && (
+          {deliverableCount > 0 && (
             <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground flex items-center gap-1">
               <FileText className="h-3 w-3" />
-              {task.deliverables.length}
+              {deliverableCount}
             </span>
           )}
           {/* Plan indicator removed — planning was agent-internal */}

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -1,4 +1,4 @@
-import { createElement, useEffect, useRef } from 'react';
+import { createElement, useEffect, useMemo, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient, QueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
@@ -800,26 +800,28 @@ export function useTasksByStatus(
   tasks: Task[] | undefined,
   columns?: BoardColumnConfig[]
 ): Record<string, Task[]> {
-  const statuses = normalizeBoardColumns(columns ?? DEFAULT_FEATURE_SETTINGS.board.columns).map(
-    (column) => column.id
-  );
-  const grouped = Object.fromEntries(statuses.map((status) => [status, [] as Task[]])) as Record<
-    string,
-    Task[]
-  >;
+  return useMemo(() => {
+    const statuses = normalizeBoardColumns(columns ?? DEFAULT_FEATURE_SETTINGS.board.columns).map(
+      (column) => column.id
+    );
+    const grouped = Object.fromEntries(statuses.map((status) => [status, [] as Task[]])) as Record<
+      string,
+      Task[]
+    >;
 
-  for (const task of tasks ?? []) {
-    if (!grouped[task.status]) {
-      grouped[task.status] = [];
+    for (const task of tasks ?? []) {
+      if (!grouped[task.status]) {
+        grouped[task.status] = [];
+      }
+      grouped[task.status].push(task);
     }
-    grouped[task.status].push(task);
-  }
 
-  for (const status of Object.keys(grouped)) {
-    grouped[status] = sortTasksByBoardPosition(grouped[status]);
-  }
+    for (const status of Object.keys(grouped)) {
+      grouped[status] = sortTasksByBoardPosition(grouped[status]);
+    }
 
-  return grouped;
+    return grouped;
+  }, [tasks, columns]);
 }
 
 // A shared snapshot index avoids scanning the whole board for every card.

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -780,19 +780,23 @@ export function useTasksByStatus(
   return grouped;
 }
 
-// Check if a task is blocked by incomplete dependencies
-export function isTaskBlocked(task: Task, allTasks: Task[]): boolean {
-  if (!task.blockedBy?.length) return false;
+// A shared snapshot index avoids scanning the whole board for every card.
+export type TaskDependencyIndex = ReadonlyMap<string, Task>;
 
-  const blockingTasks = allTasks.filter((t) => task.blockedBy?.includes(t.id));
-  return blockingTasks.some((t) => t.status !== 'done');
+export function isTaskBlocked(task: Task, allTasks: Task[] | TaskDependencyIndex): boolean {
+  return getTaskBlockers(task, allTasks).length > 0;
 }
 
-// Get the blockers for a task
-export function getTaskBlockers(task: Task, allTasks: Task[]): Task[] {
+export function getTaskBlockers(task: Task, allTasks: Task[] | TaskDependencyIndex): Task[] {
   if (!task.blockedBy?.length) return [];
-
-  return allTasks.filter((t) => task.blockedBy?.includes(t.id) && t.status !== 'done');
+  if (Array.isArray(allTasks)) {
+    const ids = new Set(task.blockedBy);
+    return allTasks.filter((candidate) => ids.has(candidate.id) && candidate.status !== 'done');
+  }
+  return [...new Set(task.blockedBy)].flatMap((id) => {
+    const blocker = allTasks.get(id);
+    return blocker && blocker.status !== 'done' ? [blocker] : [];
+  });
 }
 
 // Archive suggestions - sprints where all tasks are done

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -1,4 +1,4 @@
-import { createElement } from 'react';
+import { createElement, useEffect, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient, QueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
@@ -13,6 +13,8 @@ import {
 } from '@/hooks/useTaskConflicts';
 import {
   DEFAULT_FEATURE_SETTINGS,
+  toBoardTask,
+  type BoardTask,
   normalizeBoardColumns,
   normalizeBoardDefaultStatus,
   sortTasksByBoardPosition,
@@ -40,6 +42,10 @@ function patchTaskInCaches(queryClient: QueryClient, task: Task): void {
   );
   // Also update the individual task cache
   queryClient.setQueryData(['tasks', task.id], task);
+  queryClient.setQueryData<BoardTask[]>(['tasks', 'board'], (old) =>
+    old?.map((item) => (item.id === task.id ? toBoardTask(task) : item))
+  );
+  queryClient.invalidateQueries({ queryKey: ['tasks', 'search'] });
 }
 
 type ApiMutationError = Error & { code?: string; details?: unknown };
@@ -47,7 +53,10 @@ type ApiMutationError = Error & { code?: string; details?: unknown };
 function cachedTaskRevision(queryClient: QueryClient, taskId: string): number | undefined {
   const detailTask = queryClient.getQueryData<Task>(['tasks', taskId]);
   const listTask = queryClient.getQueryData<Task[]>(['tasks'])?.find((task) => task.id === taskId);
-  const revisions = [detailTask?.revision, listTask?.revision].filter(
+  const boardTask = queryClient
+    .getQueryData<BoardTask[]>(['tasks', 'board'])
+    ?.find((task) => task.id === taskId);
+  const revisions = [detailTask?.revision, listTask?.revision, boardTask?.revision].filter(
     (revision): revision is number => typeof revision === 'number'
   );
   return revisions.length > 0 ? Math.max(...revisions) : undefined;
@@ -151,6 +160,33 @@ export function useTasks() {
   });
 }
 
+/** Separate card projection cache; realtime invalidates the shared tasks prefix. */
+export function useBoardTasks() {
+  const { isConnected } = useWebSocketStatus();
+  const queryClient = useQueryClient();
+  const wasConnected = useRef(isConnected);
+  useEffect(() => {
+    if (isConnected && !wasConnected.current) {
+      queryClient.invalidateQueries({ queryKey: ['tasks', 'board'] });
+      queryClient.invalidateQueries({ queryKey: ['tasks', 'search'] });
+    }
+    wasConnected.current = isConnected;
+  }, [isConnected, queryClient]);
+  return useQuery({
+    queryKey: ['tasks', 'board'],
+    retry: false,
+    queryFn: ({ signal }) => api.tasks.listBoard(signal),
+  });
+}
+
+export function useBoardSearch(search: string) {
+  return useQuery({
+    queryKey: ['tasks', 'search', search],
+    queryFn: ({ signal }) => api.tasks.searchIds(search, signal),
+    enabled: Boolean(search),
+  });
+}
+
 export function useArchivedTasks() {
   return useQuery({
     queryKey: ['tasks', 'archived'],
@@ -250,6 +286,12 @@ export function useUpdateTask() {
 
       const cachedTask = queryClient.getQueryData<Task>(['tasks', serverTask.id]);
       queryClient.setQueryData(['tasks', serverTask.id], mergeWithCachedTimeTracking(cachedTask));
+      queryClient.setQueryData<BoardTask[]>(['tasks', 'board'], (old) =>
+        old?.map((task) =>
+          task.id === serverTask.id ? toBoardTask(mergeWithCachedTimeTracking(task)) : task
+        )
+      );
+      queryClient.invalidateQueries({ queryKey: ['tasks', 'search'] });
 
       // GH-87: Invalidate metrics cache if status changed to keep sidebar in sync.
       // The sidebar relies on useMetrics() which has a 30s refetch interval + 10s staleTime.

--- a/web/src/hooks/useVirtualColumn.ts
+++ b/web/src/hooks/useVirtualColumn.ts
@@ -1,0 +1,117 @@
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+const ESTIMATED_HEIGHT = 180;
+const OVERSCAN = 6;
+export const VIRTUAL_COLUMN_THRESHOLD = 80;
+
+/** Variable-height card window. Measurements and focus are keyed by stable task ID. */
+export function useVirtualColumn(
+  ids: string[],
+  selectedId?: string | null,
+  activeId?: string | null
+) {
+  const enabled = ids.length > VIRTUAL_COLUMN_THRESHOLD;
+  const viewport = useRef<HTMLDivElement>(null);
+  const sizes = useRef(new Map<string, number>());
+  const elements = useRef(new Map<string, HTMLElement>());
+  const observer = useRef<ResizeObserver | null>(null);
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const [measurement, setMeasurement] = useState(0);
+  const [view, setView] = useState({ top: 0, height: 800 });
+  const layout = useMemo(() => {
+    let offset = 0;
+    const rows = ids.map((id, index) => {
+      const size = sizes.current.get(id) ?? ESTIMATED_HEIGHT;
+      const row = { id, index, offset, size };
+      offset += size;
+      return row;
+    });
+    return { rows, height: offset };
+    // Measurements are stored outside render so ResizeObserver can batch updates.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ResizeObserver mutates the size map; its revision invalidates this layout.
+  }, [ids, measurement]);
+  const updateView = useCallback(() => {
+    const element = viewport.current;
+    if (element) setView({ top: element.scrollTop, height: element.clientHeight });
+  }, []);
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    observer.current = new ResizeObserver((entries) => {
+      let changed = false;
+      for (const entry of entries) {
+        const id = (entry.target as HTMLElement).dataset.virtualTask;
+        if (!id) continue;
+        const height = Math.ceil(entry.target.getBoundingClientRect().height) + 8;
+        if (height > 8 && sizes.current.get(id) !== height) {
+          sizes.current.set(id, height);
+          changed = true;
+        }
+      }
+      if (changed) setMeasurement((value) => value + 1);
+    });
+    for (const element of elements.current.values()) observer.current.observe(element);
+    const resize = new ResizeObserver(updateView);
+    if (viewport.current) resize.observe(viewport.current);
+    updateView();
+    return () => {
+      observer.current?.disconnect();
+      observer.current = null;
+      resize.disconnect();
+    };
+  }, [enabled, updateView]);
+  const measure = useCallback((id: string, element: HTMLDivElement | null) => {
+    const previous = elements.current.get(id);
+    if (previous && previous !== element) observer.current?.unobserve(previous);
+    if (element) {
+      elements.current.set(id, element);
+      observer.current?.observe(element);
+    } else elements.current.delete(id);
+  }, []);
+  const reveal = useCallback(
+    (id: string, focus = false) => {
+      const element = viewport.current;
+      const row = layout.rows.find((item) => item.id === id);
+      if (!element || !row) return;
+      if (
+        row.offset < element.scrollTop ||
+        row.offset + row.size > element.scrollTop + element.clientHeight
+      ) {
+        element.scrollTop = Math.max(0, row.offset - 8);
+        updateView();
+      }
+      if (focus)
+        requestAnimationFrame(() =>
+          elements.current.get(id)?.querySelector<HTMLElement>('[data-task-id]')?.focus()
+        );
+    },
+    [layout, updateView]
+  );
+  const lastSelected = useRef<string | null | undefined>(undefined);
+  useLayoutEffect(() => {
+    if (enabled && selectedId && selectedId !== lastSelected.current) reveal(selectedId);
+    lastSelected.current = selectedId;
+  }, [enabled, selectedId, reveal]);
+  const visible = useMemo(() => {
+    if (!enabled) return { rows: layout.rows, start: 0, end: ids.length };
+    const foundFirst = layout.rows.findIndex((row) => row.offset + row.size >= view.top);
+    const first = foundFirst < 0 ? Math.max(0, ids.length - 1) : foundFirst;
+    const last = layout.rows.findIndex((row) => row.offset > view.top + view.height);
+    const start = Math.max(0, first - OVERSCAN);
+    const end = Math.min(ids.length, (last < 0 ? ids.length : last) + OVERSCAN);
+    const rows = layout.rows.filter(
+      (row) =>
+        (row.index >= start && row.index < end) || row.id === activeId || row.id === focusedId
+    );
+    return { rows, start, end };
+  }, [enabled, layout, view, ids.length, activeId, focusedId]);
+  return {
+    enabled,
+    viewport,
+    setFocusedId,
+    height: layout.height,
+    ...visible,
+    measure,
+    updateView,
+    reveal,
+  };
+}

--- a/web/src/lib/api/tasks.ts
+++ b/web/src/lib/api/tasks.ts
@@ -1,3 +1,4 @@
+import type { BoardTask } from '@veritas-kanban/shared';
 /**
  * Task API endpoints: CRUD, archive, subtasks, comments, blocking, reorder.
  */
@@ -11,6 +12,15 @@ import type {
 import { API_BASE, apiFetch } from './helpers';
 
 export const tasksApi = {
+  listBoard: async (signal?: AbortSignal): Promise<BoardTask[]> =>
+    apiFetch<BoardTask[]>(`${API_BASE}/tasks?view=board`, { cache: 'no-store', signal }),
+  searchIds: async (search: string, signal?: AbortSignal): Promise<string[]> => {
+    const result = await apiFetch<Array<{ id: string }>>(
+      `${API_BASE}/tasks?fields=id&search=${encodeURIComponent(search)}`,
+      { signal }
+    );
+    return result.map((task) => task.id);
+  },
   list: async (): Promise<Task[]> => {
     return apiFetch<Task[]>(`${API_BASE}/tasks`, { cache: 'no-store' });
   },


### PR DESCRIPTION
## Changes
Large boards previously loaded complete task records and mounted every card. Load compact card projections, fetch complete details when opened, and virtualize long columns while retaining focused and dragged cards. Search continues to match full descriptions, and card revisions preserve optimistic move validation.

Document the measured baseline, candidate budgets, and isolated packaged-app runner in `docs/testing/board-performance.md`.

## Verification
- Local shared build, server and web typechecks passed.
- 213 server tests and 26 web tests passed across nine focused files; changed-file ESLint and diff checks passed.
- The same implementation passed retained packaged macOS 100/1,000/5,000-task budget and interaction checks. Final release packaging will bind that evidence to the integrated public revision.
- Final diff review completed. No production dependencies added.

Closes #1537.
