### PR TITLE
fix: address migration and navigation regressions found in native acceptance

### DIFF
--- a/server/src/__tests__/middleware/rate-limit.test.ts
+++ b/server/src/__tests__/middleware/rate-limit.test.ts
@@ -11,6 +11,7 @@ import {
   rateLimit,
   apiRateLimit,
   authRateLimit,
+  authStatusRateLimit,
   writeRateLimit,
   readRateLimit,
   uploadRateLimit,
@@ -47,6 +48,35 @@ function createUploadLimiter(limit = 2) {
 // ── Factory tests ──────────────────────────────────────────────────────────────
 
 describe('Rate Limit Middleware', () => {
+  it('keeps ordinary auth context reads separate from the login attempt budget', async () => {
+    const app = express();
+    app.set('trust proxy', 1);
+    app.use('/auth', authRateLimit);
+    app.get('/auth/context', authStatusRateLimit, (_req, res) => res.json({ ok: true }));
+    app.post('/auth/login', (_req, res) => res.json({ ok: true }));
+    app.post('/auth/context', (_req, res) => res.json({ ok: true }));
+    const remote = '198.51.100.63';
+    for (let i = 0; i < 12; i++) {
+      const response = await request(app).get('/auth/context').set('X-Forwarded-For', remote);
+      expect(response.status).toBe(200);
+      expectConfiguredLimit(response, 120);
+    }
+    for (let i = 0; i < 10; i++) {
+      expect((await request(app).post('/auth/login').set('X-Forwarded-For', remote)).status).toBe(
+        200
+      );
+    }
+    expect((await request(app).post('/auth/login').set('X-Forwarded-For', remote)).status).toBe(
+      429
+    );
+    expect((await request(app).post('/auth/context').set('X-Forwarded-For', remote)).status).toBe(
+      429
+    );
+    expect((await request(app).get('/auth/context').set('X-Forwarded-For', remote)).status).toBe(
+      200
+    );
+  });
+
   describe('rateLimit factory', () => {
     it('should create middleware with default options', () => {
       const limiter = rateLimit();

--- a/server/src/__tests__/runtime-paths.test.ts
+++ b/server/src/__tests__/runtime-paths.test.ts
@@ -83,6 +83,52 @@ describe('runtime storage contract', () => {
     }
   });
 
+  it.each(['veritas.db', 'veritas.db-wal'])(
+    'does not mix legacy SQLite files with retained %s',
+    async (retainedFile) => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-migration-'));
+      const legacy = path.join(root, 'legacy');
+      const current = path.join(root, 'current');
+      try {
+        await fs.mkdir(legacy);
+        await fs.mkdir(current);
+        for (const suffix of ['', '-wal', '-shm', '-journal']) {
+          await fs.writeFile(path.join(legacy, `veritas.db${suffix}`), `legacy${suffix}`);
+        }
+        await fs.writeFile(path.join(current, retainedFile), 'retained generation');
+        await fs.writeFile(path.join(legacy, 'config.json'), 'legacy configuration');
+        await expect(migrateLegacyRuntimeState([legacy], current)).resolves.toBe(1);
+        expect((await fs.readdir(current)).sort()).toEqual(['config.json', retainedFile].sort());
+        await expect(fs.readFile(path.join(current, retainedFile), 'utf8')).resolves.toBe(
+          'retained generation'
+        );
+        expect(await fs.readdir(legacy)).toHaveLength(5);
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it('copies a legacy SQLite family only into an empty destination family', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-migration-'));
+    const legacy = path.join(root, 'legacy');
+    const current = path.join(root, 'current');
+    try {
+      await fs.mkdir(legacy);
+      for (const suffix of ['', '-wal', '-shm']) {
+        await fs.writeFile(path.join(legacy, `veritas.db${suffix}`), `legacy${suffix}`);
+      }
+      await expect(migrateLegacyRuntimeState([legacy], current)).resolves.toBe(3);
+      for (const suffix of ['', '-wal', '-shm']) {
+        await expect(fs.readFile(path.join(current, `veritas.db${suffix}`), 'utf8')).resolves.toBe(
+          `legacy${suffix}`
+        );
+      }
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps Docker persistence on the single DATA_DIR volume', async () => {
     const projectRoot = getProjectRoot();
     const dockerfile = await fs.readFile(path.join(projectRoot, 'Dockerfile'), 'utf-8');

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -51,8 +51,8 @@ function isLocalhost(req: Request): boolean {
   return ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1';
 }
 
-function isAuthStatusRequest(req: Request): boolean {
-  return req.method === 'GET' && req.path === '/status';
+function isAuthReadRequest(req: Request): boolean {
+  return req.method === 'GET' && (req.path === '/status' || req.path === '/context');
 }
 
 // ── Factory ────────────────────────────────────────────────────────────────────
@@ -112,12 +112,12 @@ export const authRateLimit = rateLimit({
   limit: 10,
   windowMs: 15 * 60_000, // 15 minutes
   message: 'Too many authentication attempts. Please try again later.',
-  skip: (req) => isLocalhost(req) || isAuthStatusRequest(req),
+  skip: (req) => isLocalhost(req) || isAuthReadRequest(req),
 });
 
 /**
- * Read-style limiter for the auth status polling endpoint.
- * This endpoint is called on normal route loads and must not consume login/setup attempts.
+ * Read-style limiter for auth status and authenticated context reads.
+ * Normal route loads must not consume login/setup attempts.
  */
 export const authStatusRateLimit = rateLimit({
   limit: 120,

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -238,6 +238,7 @@ router.get(
  */
 router.get(
   '/context',
+  authStatusRateLimit,
   authenticate,
   asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
     res.json({

--- a/server/src/utils/migrate-legacy-runtime.ts
+++ b/server/src/utils/migrate-legacy-runtime.ts
@@ -29,6 +29,26 @@ async function copyMissingTree(
 
   await fs.mkdir(destination, { recursive: true });
   let copied = 0;
+  // SQLite files belong to one database generation. Copying a missing legacy
+  // WAL beside an existing canonical database can corrupt that database.
+  // Snapshot destination presence before copying anything from this source.
+  const sqliteFamily = (name: string) =>
+    /^(.*\.(?:db|sqlite|sqlite3))(?:-(?:wal|shm|journal))?$/i.exec(name)?.[1];
+  const retainedFamilies = new Set<string>();
+  const families = entries
+    .map((entry) => sqliteFamily(entry.name))
+    .filter((family): family is string => Boolean(family));
+  for (const family of new Set(families)) {
+    for (const suffix of ['', '-wal', '-shm', '-journal']) {
+      try {
+        await fs.lstat(path.join(destination, `${family}${suffix}`));
+        retainedFamilies.add(family);
+        break;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+    }
+  }
 
   for (const entry of entries) {
     const from = path.join(source, entry.name);
@@ -46,6 +66,8 @@ async function copyMissingTree(
 
     // Runtime state is files and directories. Never follow legacy symlinks.
     if (!entry.isFile()) continue;
+    const family = sqliteFamily(entry.name);
+    if (family && retainedFamilies.has(family)) continue;
 
     try {
       await fs.copyFile(from, to, fs.constants.COPYFILE_EXCL);

--- a/web/src/__tests__/desktop-shell-context.test.tsx
+++ b/web/src/__tests__/desktop-shell-context.test.tsx
@@ -153,6 +153,33 @@ describe('desktop shell recovery', () => {
     expect(window.localStorage.getItem('veritas.desktop.rightRailOpen')).toBe('false');
   });
 
+  it('keeps the task history and focus when resize collapses the chat behind it', async () => {
+    const user = userEvent.setup();
+    render(
+      <DesktopShellProvider>
+        <ShellProbe />
+      </DesktopShellProvider>
+    );
+    await user.click(screen.getByRole('button', { name: 'Open board chat' }));
+    const taskState = { ...window.history.state, veritasTaskDetail: 'task-open-above-chat' };
+    window.history.pushState(taskState, '', '/');
+    const taskControl = screen.getByRole('button', { name: 'Reset layout' });
+    taskControl.focus();
+    const back = vi.spyOn(window.history, 'back').mockImplementation(() => {});
+    try {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1180 });
+      act(() => window.dispatchEvent(new Event('resize')));
+      expect(screen.getByLabelText('bottom panel').textContent).toBe('closed');
+      expect(window.history.state.veritasTaskDetail).toBe('task-open-above-chat');
+      expect(window.history.state.veritasBottomPanel).toBeUndefined();
+      expect(back).not.toHaveBeenCalled();
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      expect(document.activeElement).toBe(taskControl);
+    } finally {
+      back.mockRestore();
+    }
+  });
+
   it('minimizes both sidebars before opening Workbench at compact width', async () => {
     const user = userEvent.setup();
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1180 });

--- a/web/src/components/layout/DesktopShellContext.tsx
+++ b/web/src/components/layout/DesktopShellContext.tsx
@@ -314,7 +314,15 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
       setRightRailOpenState(false);
       writeStoredValue(LEFT_RAIL_STORAGE_KEY, 'false');
       writeStoredValue(RIGHT_RAIL_STORAGE_KEY, 'false');
-      if (bottomPanel) closeBottomPanel();
+      if (bottomPanel) {
+        // A layout collapse is not navigation: a task opened above the dock
+        // inherits its history marker. Going Back would dismiss that task.
+        setBottomPanel(null);
+        removeStoredValue(BOTTOM_PANEL_STORAGE_KEY);
+        panelTriggerRef.current = null;
+        const { [BOTTOM_PANEL_HISTORY_STATE_KEY]: _panel, ...rest } = window.history.state ?? {};
+        window.history.replaceState(rest, '', window.location.href);
+      }
     };
 
     window.addEventListener('keydown', handleKeyDown, true);


### PR DESCRIPTION
## Changes
Address three regressions reproduced during packaged macOS acceptance:

- Repeated authenticated context reads use the read limiter instead of exhausting the login-attempt allowance. Authentication mutations retain their existing limits.
- Legacy migration preserves an existing destination SQLite database family, including its WAL, SHM, and journal companions, instead of combining files from different database generations.
- Collapsing chat at compact window widths clears the chat history marker without navigating back and dismissing the open task.

## Verification
Local server and web typechecks, 38 server tests, eight desktop-shell renderer tests, changed-file ESLint, and diff checks passed. The retained integrated package also passed the affected migration, navigation, and authenticated Settings journeys. Prior review and final diff review completed; no dependencies added.

Follow-up acceptance fixes for #1545. Final release packaging and media will identify the integrated public revision.
