### PR TITLE
fix: accept retained large-board evidence during release promotion

### DIFF
--- a/scripts/docs-media/restore-candidate.mjs
+++ b/scripts/docs-media/restore-candidate.mjs
@@ -38,7 +38,7 @@ export function validateArchiveEntries(names, listing) {
       name &&
         !path.posix.isAbsolute(name) &&
         !name.split('/').includes('..') &&
-        /^(?:release\/|native-ui-evidence\/|documentation-media\/|native-distribution\.sha256$|release-candidate\.json$)/.test(
+        /^(?:release\/|native-ui-evidence\/|documentation-media\/|large-board-evidence\/|native-distribution\.sha256$|release-candidate\.json$)/.test(
           name
         ),
       `Unsafe candidate archive entry: ${name}`

--- a/scripts/docs-media/restore-candidate.test.mjs
+++ b/scripts/docs-media/restore-candidate.test.mjs
@@ -79,6 +79,21 @@ test('candidate archives reject traversal, links, devices, and unexpected roots'
     assert.throws(() => validateArchiveEntries('release/file', mode), /link or special/);
 });
 
+test('signed large-board evidence survives archive validation without accepting unsafe paths', () => {
+  assert.doesNotThrow(() =>
+    validateArchiveEntries(
+      'large-board-evidence/\nlarge-board-evidence/report.json\nlarge-board-evidence/board-5000.png\n',
+      'drwxr-xr-x folder\n-rw-r--r-- report\n-rw-r--r-- image\n'
+    )
+  );
+  for (const name of ['large-board-evidence/../outside', 'large-board-evidence-other/report.json'])
+    assert.throws(() => validateArchiveEntries(name, '-rw-r--r-- file'), /Unsafe/);
+  assert.throws(
+    () => validateArchiveEntries('large-board-evidence/report.json', 'lrwxrwxrwx link'),
+    /link or special/
+  );
+});
+
 test('the distribution checksum list contains each exact release artifact once', () => {
   const names = [
     'latest-mac.yml',

--- a/scripts/docs-media/run.mjs
+++ b/scripts/docs-media/run.mjs
@@ -67,7 +67,6 @@ const report = {
     unmatched: [
       'Original showcase dataset is unavailable; uses the documentation fixture.',
       'Native content capture excludes the baseline window frame and shadow.',
-      'Host OS differs from the baseline macOS 15.7.9.',
     ],
   },
 };
@@ -279,6 +278,13 @@ try {
   const launched = await session.launch();
   ({ app, page } = launched);
   report.identity = launched.identity;
+  const baseline = JSON.parse(
+    await readFile(path.join(root, report.taskModeComparison.baseline), 'utf8')
+  );
+  const osMatch = baseline.host.osVersion === launched.identity.osVersion;
+  report.taskModeComparison[osMatch ? 'matched' : 'unmatched'].push(
+    `Host macOS: baseline ${baseline.host.osVersion}; candidate ${launched.identity.osVersion}.`
+  );
   await app.evaluate(({ BrowserWindow }, sizes) => {
     const win = BrowserWindow.getAllWindows().find((w) => w.isVisible());
     win.webContents.setZoomFactor(1);


### PR DESCRIPTION
The signed release workflow now retains `large-board-evidence/`, but promotion rejected that expected archive root. Add it to the explicit allowlist so the verified board report and image survive restoration. Absolute paths, traversal, unexpected roots, links and special files remain rejected.

Capture metadata now compares the actual candidate OS to the retained baseline manifest, so moving from the local Mac to the signing runner does not leave a hardcoded OS mismatch claim.

Local verification: all 57 release/native/media contract tests passed, including accepted board evidence and rejected traversal, prefix lookalikes and symlinks. Changed-file lint and diff review passed. The initial signed build was cancelled before publication; a new capture will start from the merged correction.
