### PR TITLE
fix: restore Docker builds and prepare 6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.1] - 2026-09-09
+
+### Fixed
+
+- Restored Docker builds by moving browser/desktop command contracts into the shared package. The web build no longer depends on desktop source or test-only Node type declarations (#1578).
+
+### Compatibility
+
+- All maintained packages move together to 6.2.1. Existing command payloads, REST API v1, and stored data remain compatible; no database migration is required.
+
 ## [6.2.0] - 2026-09-07
 
 Veritas Kanban 6.2.0 improves Settings persistence, keyboard and native macOS interactions, and large-board behavior.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-6.2.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-6.2.1-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/desktop/src/shared/desktop-bridge-contracts.ts
+++ b/desktop/src/shared/desktop-bridge-contracts.ts
@@ -1,5 +1,19 @@
 import type { DesktopAppInfo, DesktopStatusSnapshot } from '../main/types.js';
-import { blockedRemoteConnectionDestinationReason } from '@veritas-kanban/shared';
+import {
+  blockedRemoteConnectionDestinationReason,
+  DESKTOP_COMMAND_NAMES,
+  type DesktopCommandName,
+  type DesktopCommandSource,
+  type DesktopCommandDispatchRequest,
+  type DesktopCommandDispatchResult,
+} from '@veritas-kanban/shared';
+export {
+  DESKTOP_COMMAND_NAMES,
+  type DesktopCommandName,
+  type DesktopCommandSource,
+  type DesktopCommandDispatchRequest,
+  type DesktopCommandDispatchResult,
+} from '@veritas-kanban/shared';
 
 export const DESKTOP_REDACTED_VALUE = '[redacted]';
 export const DESKTOP_RESTART_CONFIRMATION = 'restart-local-server';
@@ -82,47 +96,6 @@ export interface DesktopSetupDiagnostics {
   generatedAt: string;
   checks: DesktopSetupDiagnosticCheck[];
   supportSnapshot: DesktopSupportSnapshot;
-}
-
-export const DESKTOP_COMMAND_NAMES = [
-  'new-task',
-  'open-onboarding',
-  'open-search',
-  'open-settings',
-  'open-command-center',
-  'reset-layout',
-  'import-data',
-  'export-data',
-  'create-backup',
-  'open-logs',
-  'restart-local-server',
-  'communication-health',
-  'show-diagnostics',
-  'create-debug-bundle',
-  'check-for-updates',
-  'download-update',
-  'install-update',
-  'test-notification',
-  'test-squad-webhook',
-  'copy-redacted-diagnostics',
-  'export-work-product',
-  'quit',
-] as const;
-
-export type DesktopCommandName = (typeof DESKTOP_COMMAND_NAMES)[number];
-export type DesktopCommandSource = 'renderer' | 'menu' | 'shortcut' | 'deep-link';
-
-export interface DesktopCommandDispatchRequest {
-  command: DesktopCommandName;
-  source?: DesktopCommandSource;
-  payload?: Record<string, unknown>;
-}
-
-export interface DesktopCommandDispatchResult {
-  command: DesktopCommandName;
-  accepted: boolean;
-  handledBy: 'desktop' | 'renderer' | 'unsupported';
-  message?: string;
 }
 
 export const DESKTOP_FILE_PICKER_PURPOSES = [

--- a/docs/V6-COMPATIBILITY-AND-RELEASE-POLICY.md
+++ b/docs/V6-COMPATIBILITY-AND-RELEASE-POLICY.md
@@ -1,11 +1,11 @@
 # Veritas Kanban v6 Compatibility And Release Policy
 
-This policy defines the v6.1.6 stable combinations, harness evidence, release
+This policy defines the v6 stable combinations, harness evidence, release
 channels, and rollback limits. The machine-readable harness record at
 `GET /api/config/harness-compatibility` is authoritative for exact capability
 digests, fixture revisions, and the current host's live state.
 
-Documentation freshness: 2026-09-07 for the 6.2.0 candidate. The latest published stable release remains 6.1.7.
+Documentation freshness: 2026-09-09 for the 6.2.1 candidate. The latest published stable release remains 6.2.0.
 
 ## Harness Support Tiers
 
@@ -25,7 +25,7 @@ are incompatible with v6.
 
 | Component                              | Supported v6 combination                                                                               | Detection/evidence                                                                                      | Fail-closed boundary                                                                                                            |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Server, web, shared, CLI, MCP, desktop | All candidate packages are exactly 6.2.0.                                                              | Package manifests, `/api/health.version`, `vk --version`, MCP metadata, desktop bundle/update metadata. | Mixed release packages are unsupported for publication.                                                                         |
+| Server, web, shared, CLI, MCP, desktop | All candidate packages are exactly 6.2.1.                                                              | Package manifests, `/api/health.version`, `vk --version`, MCP metadata, desktop bundle/update metadata. | Mixed release packages are unsupported for publication.                                                                         |
 | Public API                             | REST API remains `v1` at `/api/v1`, with `/api` compatibility aliases where documented.                | `X-API-Version`, OpenAPI/reference docs, CLI/MCP smoke.                                                 | Unknown API versions or incompatible auth fail before mutation.                                                                 |
 | Buzz Agent                             | Buzz v0.4.24 commit `710ed9fff57878a1d69f809b80a6ee0416c53fc4`; `buzz-agent 0.1.0`; ACP v1.            | Exact initialize identity, capability digest, probe revision, composed Buzz fixtures.                   | Unknown build, `buzz-acp`, resume, HTTP/SSE MCP, or capability drift blocks.                                                    |
 | Buzz relay integration                 | Buzz v0.4.24; NIP-11, NIP-29, NIP-42; optional NIP-43 membership.                                      | Pinned relay compatibility evidence, signed query/event fixtures, mapping state.                        | Host/TLS drift, unsafe URL, bad signature, identity mismatch, replay, or disabled mapping blocks.                               |
@@ -37,7 +37,7 @@ are incompatible with v6.
 | GitHub Copilot CLI                     | v1.0.74 public-preview ACP; tag commit `2b809c84e87dbcc88f897cb4f3fb97c43b77af95`.                     | Version and ACP initialize handshake; authentication remains provider-managed.                          | Version drift, broad allow, remote/plugin/config injection, or unsupported controls blocks.                                     |
 | Hermes Agent                           | v2026.7.7.2 one-shot process adapter.                                                                  | `hermes --version` and allowlisted boot authentication.                                                 | Resume/follow-up remains unsupported.                                                                                           |
 | OpenClaw                               | v2026.6.11 gateway adapter.                                                                            | Gateway health, runtime manifest, explicit operator tool policy.                                        | Missing `sessions_spawn`/`sessions_send`, unknown evidence, or unsupported task controls blocks.                                |
-| macOS desktop                          | Signed/notarized macOS 13 Ventura or later arm64 app with bundled 6.2.0 server/web for this candidate. | Bundle version, signature, Gatekeeper, stapling, `/api/health.version`, update metadata.                | Mixed bundle/runtime, failed readiness, signature, or metadata checks blocks stable publication.                                |
+| macOS desktop                          | Signed/notarized macOS 13 Ventura or later arm64 app with bundled 6.2.1 server/web for this candidate. | Bundle version, signature, Gatekeeper, stapling, `/api/health.version`, update metadata.                | Mixed bundle/runtime, failed readiness, signature, or metadata checks blocks stable publication.                                |
 | Linux/Windows desktop                  | Unsigned preview artifacts only.                                                                       | Cross-platform packaging workflows.                                                                     | Not a supported stable install or update channel.                                                                               |
 | Desktop SQLite/profile                 | Existing v5.2.5 workspace upgraded in place after a complete backup.                                   | Data/profile counts, integrity check, startup normalization, board/runtime smoke.                       | Competing writers, unsafe filesystem, failed migration, or missing recovery evidence blocks acceptance.                         |
 

--- a/docs/V6-RELEASE-NOTES.md
+++ b/docs/V6-RELEASE-NOTES.md
@@ -1,6 +1,6 @@
-# Veritas Kanban 6.2.0 Candidate Release Notes
+# Veritas Kanban 6.2.1 Candidate Release Notes
 
-The 6.2.0 candidate improves Settings persistence, native macOS interactions, keyboard navigation and large-board behavior. Read the [6.2.0 release source](releases/v6.2.0.md) for current changes and compatibility notes. Verification and publication remain separate stages in the [candidate evidence packet](V6-RC-EVIDENCE-PACKET.md).
+The 6.2.1 candidate restores Docker builds by moving browser/desktop command contracts into the shared package. Read the [6.2.1 release source](releases/v6.2.1.md) for changes and compatibility notes. Verification and publication remain separate stages in the [candidate evidence packet](V6-RC-EVIDENCE-PACKET.md).
 
 The latest published stable release remains 6.1.7. Veritas Kanban 6.0.0 remains quarantined.
 

--- a/docs/releases/v6.2.1.md
+++ b/docs/releases/v6.2.1.md
@@ -1,0 +1,9 @@
+Veritas Kanban 6.2.1 restores Docker builds for centrally hosted browser/server installations.
+
+## Fixed
+
+The web build now reads command contracts from the shared package instead of importing desktop source. Docker builds no longer require the desktop workspace or a Node type declaration supplied only by test files. This addresses #1578.
+
+## Compatibility
+
+All maintained packages move together to 6.2.1. Desktop command payloads, REST API v1, and existing stored data remain compatible. No database migration is required.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/src/types/desktop-commands.ts
+++ b/shared/src/types/desktop-commands.ts
@@ -1,0 +1,41 @@
+// Command contracts shared by browser settings and the desktop bridge.
+export const DESKTOP_COMMAND_NAMES = [
+  'new-task',
+  'open-onboarding',
+  'open-search',
+  'open-settings',
+  'open-command-center',
+  'reset-layout',
+  'import-data',
+  'export-data',
+  'create-backup',
+  'open-logs',
+  'restart-local-server',
+  'communication-health',
+  'show-diagnostics',
+  'create-debug-bundle',
+  'check-for-updates',
+  'download-update',
+  'install-update',
+  'test-notification',
+  'test-squad-webhook',
+  'copy-redacted-diagnostics',
+  'export-work-product',
+  'quit',
+] as const;
+
+export type DesktopCommandName = (typeof DESKTOP_COMMAND_NAMES)[number];
+export type DesktopCommandSource = 'renderer' | 'menu' | 'shortcut' | 'deep-link';
+
+export interface DesktopCommandDispatchRequest {
+  command: DesktopCommandName;
+  source?: DesktopCommandSource;
+  payload?: Record<string, unknown>;
+}
+
+export interface DesktopCommandDispatchResult {
+  command: DesktopCommandName;
+  accepted: boolean;
+  handledBy: 'desktop' | 'renderer' | 'unsupported';
+  message?: string;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -81,3 +81,5 @@ export * from './tool-control-plane.types.js';
 export * from './acp.types.js';
 export * from './workspace-execution-trust.types.js';
 export * from './phase-capability.types.js';
+
+export * from './desktop-commands.js';

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/lib/desktop-settings.ts
+++ b/web/src/lib/desktop-settings.ts
@@ -1,7 +1,7 @@
 import type {
   DesktopCommandDispatchRequest,
   DesktopCommandDispatchResult,
-} from '../../../desktop/src/shared/desktop-bridge-contracts';
+} from '@veritas-kanban/shared';
 
 export function desktopSettingsBridge() {
   return (


### PR DESCRIPTION
The v6.2.0 Docker web build fails because browser settings imports command types through the desktop source tree, which the image does not include. Move the unchanged command contracts into the shared package and re-export them from the desktop module, removing the web build dependency on desktop source and test-only Node declarations.

Prepare the 6.2.1 patch with coordinated workspace versions, changelog, README badge, compatibility notes, and the canonical release source. Existing command payloads and stored data remain compatible; no migration is required.

Local verification: reproduced the exact v6.2.0 linux/amd64 Docker failure; built the 6.2.1 image and passed its complete runtime contract; all 4,911 workspace unit tests passed (24 intentionally skipped); typecheck, lint budget, release-format/readiness checks, source preflight, 18 desktop bridge tests, and local macOS packaging checks passed. The macOS package is unsigned local verification, not a signed or published release.

Fixes #1578.
