### PR TITLE
fix(deps): patch Hono and js-yaml security advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restored Docker builds by moving browser/desktop command contracts into the shared package. The web build no longer depends on desktop source or test-only Node type declarations (#1578).
 
+### Security
+
+- Updated transitive Hono and js-yaml dependencies to patched versions for the four September dependency advisories.
+
 ### Compatibility
 
 - All maintained packages move together to 6.2.1. Existing command payloads, REST API v1, and stored data remain compatible; no database migration is required.

--- a/docs/releases/v6.2.1.md
+++ b/docs/releases/v6.2.1.md
@@ -1,8 +1,12 @@
-Veritas Kanban 6.2.1 restores Docker builds for centrally hosted browser/server installations.
+Veritas Kanban 6.2.1 restores Docker builds for centrally hosted browser/server installations and updates vulnerable transitive dependencies.
 
 ## Fixed
 
 The web build now reads command contracts from the shared package instead of importing desktop source. Docker builds no longer require the desktop workspace or a Node type declaration supplied only by test files. This addresses #1578.
+
+## Security
+
+Hono is updated to 4.13.7 and js-yaml to 4.3.2, addressing the four September dependency advisories. These updates retain the existing MCP stdio transport and desktop update feed.
 
 ## Compatibility
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,9 @@ overrides:
   esbuild@<0.28.1: 0.28.1
   fast-uri@<3.1.6: 3.1.6
   form-data@<4.0.6: 4.0.6
-  hono: '>=4.12.34'
+  hono: '>=4.13.5 <5'
   ip-address: '>=10.3.1'
-  js-yaml@<4.3.1: 4.3.1
+  js-yaml@<4.3.2: 4.3.2
   nanoid@<3.3.18: 3.3.18
   postcss: '>=8.5.23'
   postcss-selector-parser: 7.1.5
@@ -935,7 +935,7 @@ packages:
     resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.34'
+      hono: '>=4.13.5 <5'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2979,8 +2979,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.13.3:
-    resolution: {integrity: sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==}
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
@@ -3276,8 +3276,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5327,7 +5327,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.0.1':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
 
   '@apidevtools/openapi-schemas@2.1.0': {}
 
@@ -5805,9 +5805,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@hono/node-server@2.1.1(hono@4.13.3)':
+  '@hono/node-server@2.1.1(hono@4.13.7)':
     dependencies:
-      hono: 4.13.3
+      hono: 4.13.7
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -5910,7 +5910,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.5.1)':
     dependencies:
-      '@hono/node-server': 2.1.1(hono@4.13.3)
+      '@hono/node-server': 2.1.1(hono@4.13.7)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -5920,7 +5920,7 @@ snapshots:
       eventsource-parser: 3.1.1
       express: 5.2.1
       express-rate-limit: 8.6.2(express@5.2.1)
-      hono: 4.13.3
+      hono: 4.13.7
       jose: 6.2.9
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -6665,7 +6665,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.6
@@ -6927,7 +6927,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -7300,7 +7300,7 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       fs-extra: 10.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -7439,7 +7439,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -8152,7 +8152,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.13.3: {}
+  hono@4.13.7: {}
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -8435,7 +8435,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,9 +23,9 @@ overrides:
   'esbuild@<0.28.1': 0.28.1
   'fast-uri@<3.1.6': 3.1.6
   'form-data@<4.0.6': 4.0.6
-  hono: '>=4.12.34'
+  hono: '>=4.13.5 <5'
   ip-address: '>=10.3.1'
-  'js-yaml@<4.3.1': 4.3.1
+  'js-yaml@<4.3.2': 4.3.2
   'nanoid@<3.3.18': 3.3.18
   postcss: '>=8.5.23'
   postcss-selector-parser: 7.1.5


### PR DESCRIPTION
Updates transitive Hono from 4.13.3 to 4.13.7 and js-yaml from 4.3.1 to 4.3.2 to address Dependabot alerts #5–#8. The existing Hono override now requires the patched release within major version 4; the js-yaml override rejects older releases. Changelog and unpublished 6.2.1 release notes include the updates.

Local verification: frozen-lockfile installation; full `pnpm audit --json` reports zero vulnerabilities; package-manager and formatting checks; shared/MCP builds; Swagger generation; MCP stdio initialization and discovery of all 42 tools; six desktop updater tests. The actual electron-updater YAML parser rejects excessive empty and nonempty merge work while accepting normal metadata and valid merges. Source-only release preflight passed. Independent diff review found no concrete regression.

The MCP application uses stdio rather than the affected Hono HTTP features. The js-yaml dependency is present in the desktop updater and Swagger dependency paths. This patch updates dependencies without claiming a demonstrated remote exploit against the application. Desktop rebuilding and broader integration checks follow with the separately scoped dependency refresh. GitHub Actions remain disabled; no CI was requested or run.
