### PR TITLE
fix(openclaw): clarify authenticated completion prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Clarified that native OpenClaw dispatch does not provision completion credentials. Generated instructions now require separately authenticated tooling and explain the localhost callback limitation; automatic authenticated delivery remains tracked in #1587.
+
 - Restored Docker builds by moving browser/desktop command contracts into the shared package. The web build no longer depends on desktop source or test-only Node type declarations (#1578).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -695,6 +695,8 @@ VK also documents the Codex and Hermes operating model:
 
 ### Any Platform (REST API)
 
+These examples assume an already authenticated REST client. Native OpenClaw dispatch does not provision callback credentials for its child; see [OpenClaw completion authentication](docs/AGENT-PROVIDERS.md#completion-authentication-in-620) before relying on automatic completion.
+
 > 💡 **Using the CLI?** Skip the curl commands — `vk begin <id>` and `vk done <id> "summary"` handle the full lifecycle in one shot. See the [CLI Guide](docs/CLI-GUIDE.md) for details.
 
 ```bash
@@ -708,11 +710,11 @@ curl -X POST http://localhost:3001/api/tasks \
 curl -X POST http://localhost:3001/api/tasks/<id>/time/start \
   -H "X-API-Key: $YOUR_KEY"
 
-# Mark complete
+# Report completion using the active managed attempt provenance
 curl -X POST http://localhost:3001/api/agents/<id>/complete \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $YOUR_KEY" \
-  -d '{"success": true, "summary": "What was done"}'
+  -d '{"attemptId": "<active-attempt-id>", "providerRuntimeManifestDigest": "<active-provider-runtime-manifest-digest>", "success": true, "summary": "What was done"}'
 ```
 
 ### GitHub Issues Sync

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -1292,6 +1292,18 @@ and policy check: if it fails, Veritas returns an actionable configuration error
 attempt back to `todo` rather than leaving it in a stuck `running` state. Veritas does not issue a
 separate probe because OpenClaw v2026.6.11 ignores the endpoint's reserved `dryRun` field.
 
+### Completion authentication in 6.2.0
+
+Native OpenClaw dispatch does **not** provision callback credentials or an authenticated completion tool for the spawned child. This remains an integration gap, tracked in [#1587](https://github.com/BradGroux/veritas-kanban/issues/1587), rather than a missing gateway setting. Successful `sessions_spawn` proves dispatch, not authenticated end-to-end completion.
+
+Both `/api/agents/:taskId/complete` and `/api/v1/agents/:taskId/complete` require Veritas API authentication and `task:write` permission. `attemptId` and `providerRuntimeManifestDigest` bind completion to the attempt; they are not credentials. `OPENCLAW_GATEWAY_TOKEN` authenticates requests to OpenClaw and does not authorize a callback to Veritas. The credential-broker exclusion described above does not provide another callback-authentication path.
+
+A separately trusted worker can use existing, operator-provisioned Veritas API authentication through its own completion tooling. That is a manually integrated REST client, not automatic native child provisioning. Configure its credentials outside the task prompt, use the narrowest available API access, and verify callback delivery from that worker with authentication enabled before relying on it. Existing general API credentials do not become task/attempt-scoped or single-use merely because an environment variable holds them. Veritas does not implement a native per-spawn credential/environment handoff here.
+
+If that trusted completion path is unavailable, use a provider with harness-owned terminal capture, such as Codex CLI/SDK, rather than relying on a native OpenClaw task to complete automatically. Do not disable API authentication or distribute an administrator key to make the example work. For remote/container workers, the generated localhost:3001 callback address also requires an independently verified reachable origin; changing the origin does not solve authentication.
+
+A completion-only capability is a possible implementation direction for #1587, not a configuration option in 6.2.0. It needs server-enforced scope, expiry, terminal revocation, replay/idempotency semantics, and a verified delivery channel before it can be documented as supported.
+
 ### Required gateway tool policy
 
 `sessions_spawn` and `sessions_send` are **blocked by default** in a fresh OpenClaw v2026.6.11
@@ -1308,7 +1320,8 @@ install at the operator-level endpoint. You must explicitly allow them:
 2. Configure the gateway tool policy (see above).
 3. Set `OPENCLAW_GATEWAY_URL` to the gateway base URL (default: `http://127.0.0.1:18789`).
 4. Optionally set `OPENCLAW_GATEWAY_TOKEN` for bearer-authenticated gateways.
-5. Enable the OpenClaw provider profile in **Settings → Agents**.
+5. Establish and verify the separately trusted completion path described above before enabling native task runs. Gateway policy alone does not provision it.
+6. Enable the OpenClaw provider profile in **Settings → Agents**.
 
 ### Environment variables
 
@@ -1327,13 +1340,14 @@ install at the operator-level endpoint. You must explicitly allow them:
    `providerRuntimeManifestDigest` completion provenance.
 2. A policy or connection failure rolls the task attempt back to `todo` with an error message.
 3. OpenClaw returns a `childSessionKey` which Veritas stores in the attempt record.
-4. The OpenClaw sub-session runs autonomously and calls the Veritas callback URL when done.
+4. The OpenClaw sub-session can report completion only through separately provisioned authenticated tooling. Without that operator-managed path, native dispatch does not provide automatic completion.
 
 Late or replayed callbacks are rejected when either provenance value differs
 from the active attempt.
 
 ### Limitations
 
+- Callback authentication is not provisioned by native dispatch; see [Completion authentication in 6.2.0](#completion-authentication-in-620).
 - Stop/cancel is not supported for individual sub-sessions in OpenClaw v2026.6.11. A stop request
   logs a warning but cannot forcibly terminate the sub-session.
 - Session resume is driven by the callback flow; no explicit `--resume` flag is used.
@@ -1342,9 +1356,10 @@ from the active attempt.
 
 ### Troubleshooting
 
-| Symptom                                                      | Fix                                                                                     |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| `sessions_spawn is not allowed` on start                     | Add `sessions_spawn` to `gateway.tools.allow`; add `sessions_send` for workflow reuse   |
-| `OpenClaw gateway did not respond`                           | Check `OPENCLAW_GATEWAY_URL` and gateway process is running                             |
-| Task stuck in `running` after old request files appear       | Old request-file artifacts can be safely deleted from `.veritas-kanban/agent-requests/` |
-| `OpenClaw sessions_spawn did not return a child session key` | Verify the gateway is running OpenClaw v2026.6.11 or later                              |
+| Symptom                                                      | Fix                                                                                                                                  |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Callback returns `401` or `403`                              | Verify the separately provisioned Veritas authentication and `task:write` permission; the gateway token is not a callback credential |
+| `sessions_spawn is not allowed` on start                     | Add `sessions_spawn` to `gateway.tools.allow`; add `sessions_send` for workflow reuse                                                |
+| `OpenClaw gateway did not respond`                           | Check `OPENCLAW_GATEWAY_URL` and gateway process is running                                                                          |
+| Task stuck in `running` after old request files appear       | Old request-file artifacts can be safely deleted from `.veritas-kanban/agent-requests/`                                              |
+| `OpenClaw sessions_spawn did not return a child session key` | Verify the gateway is running OpenClaw v2026.6.11 or later                                                                           |

--- a/docs/releases/v6.2.1.md
+++ b/docs/releases/v6.2.1.md
@@ -4,6 +4,8 @@ Veritas Kanban 6.2.1 restores Docker builds for centrally hosted browser/server 
 
 The web build now reads command contracts from the shared package instead of importing desktop source. Docker builds no longer require the desktop workspace or a Node type declaration supplied only by test files. This addresses #1578.
 
+The OpenClaw callback instructions now state the authentication prerequisite and localhost address limitation. Native child credential provisioning remains an open integration issue (#1587); this clarification does not add a completion token or change API authentication.
+
 ## Updated
 
 The dependency refresh includes Electron 44.2, Mantine 9.6, Codex SDK 0.153.3, and compatible updates to runtime validation, rate limiting, icons, and messaging libraries.

--- a/server/src/__tests__/__snapshots__/provider-task-envelope-renderer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/provider-task-envelope-renderer.test.ts.snap
@@ -551,14 +551,18 @@ Continue from this checkpoint. Do not repeat work already represented in the sav
 
 ## Completion (OpenClaw callback)
 
-When the work reaches a terminal state, report it to Veritas.
+When the work reaches a terminal state, report it through an operator-provisioned authenticated completion tool.
+
+Native OpenClaw dispatch does not provision callback credentials. Before starting work, confirm that the operator has separately configured a trusted completion tool with Veritas API authentication and \`task:write\` permission. The gateway token authenticates Veritas to OpenClaw; it is not a Veritas callback credential. The attempt and manifest identifiers below are provenance, not authentication.
+
+If authenticated completion tooling is unavailable, report that blocker in the OpenClaw session for the operator to resolve. Do not send an unauthenticated callback, obtain an administrator key, disable authentication, or claim that Veritas recorded completion. Do not place credential values in the task prompt or completion payload.
 
 - Endpoint: \`POST http://localhost:3001/api/agents/task_transport/complete\`
+- This generated address assumes Veritas is reachable at localhost:3001 from the worker. A remote or container worker requires an operator-verified callback address as well as authentication.
+- Use the existing completion tool's authenticated request mechanism with this JSON payload:
 
-\`\`\`bash
-curl -X POST http://localhost:3001/api/agents/task_transport/complete \\
-  -H "Content-Type: application/json" \\
-  -d '{"attemptId":"attempt_transport","providerRuntimeManifestDigest":"sha256:be3844c45a6aef384fb2c6d8dd0e15365b9cd06170272607396278beb052db68","success":true,"summary":"Brief description of what was done"}'
+\`\`\`json
+{"attemptId":"attempt_transport","providerRuntimeManifestDigest":"sha256:be3844c45a6aef384fb2c6d8dd0e15365b9cd06170272607396278beb052db68","success":true,"summary":"Brief description of what was done"}
 \`\`\`
 
 For failure, send \`success: false\` and include an \`error\` message.

--- a/server/src/__tests__/provider-task-envelope-renderer.test.ts
+++ b/server/src/__tests__/provider-task-envelope-renderer.test.ts
@@ -159,6 +159,14 @@ describe('provider task-envelope renderers', () => {
     expect(transport.content).toContain(
       'No native structured-output support is assumed; Veritas validates and normalizes the callback.'
     );
+    expect(transport.content).toContain(
+      'Native OpenClaw dispatch does not provision callback credentials.'
+    );
+    expect(transport.content).toContain('`task:write` permission');
+    expect(transport.content).toContain('provenance, not authentication');
+    expect(transport.content).toContain('Do not send an unauthenticated callback');
+    expect(transport.content).toContain('operator-verified callback address');
+    expect(transport.content).not.toContain('curl -X POST');
     expect(transport.content).toMatchSnapshot();
   });
 

--- a/server/src/services/provider-task-envelope-renderer.ts
+++ b/server/src/services/provider-task-envelope-renderer.ts
@@ -427,14 +427,18 @@ function renderOpenClawCompletion(taskEnvelope: TaskEnvelope): string {
   });
   return `## Completion (OpenClaw callback)
 
-When the work reaches a terminal state, report it to Veritas.
+When the work reaches a terminal state, report it through an operator-provisioned authenticated completion tool.
+
+Native OpenClaw dispatch does not provision callback credentials. Before starting work, confirm that the operator has separately configured a trusted completion tool with Veritas API authentication and \`task:write\` permission. The gateway token authenticates Veritas to OpenClaw; it is not a Veritas callback credential. The attempt and manifest identifiers below are provenance, not authentication.
+
+If authenticated completion tooling is unavailable, report that blocker in the OpenClaw session for the operator to resolve. Do not send an unauthenticated callback, obtain an administrator key, disable authentication, or claim that Veritas recorded completion. Do not place credential values in the task prompt or completion payload.
 
 - Endpoint: \`POST ${callbackUrl}\`
+- This generated address assumes Veritas is reachable at localhost:3001 from the worker. A remote or container worker requires an operator-verified callback address as well as authentication.
+- Use the existing completion tool's authenticated request mechanism with this JSON payload:
 
-\`\`\`bash
-curl -X POST ${callbackUrl} \\
-  -H "Content-Type: application/json" \\
-  -d '${payload}'
+\`\`\`json
+${payload}
 \`\`\`
 
 For failure, send \`success: false\` and include an \`error\` message.


### PR DESCRIPTION
The native OpenClaw task envelope supplied an unauthenticated curl command even though completion requires Veritas API authentication and task-write permission. Replace it with the completion payload plus an explicit prerequisite for operator-provisioned authenticated tooling, guidance to report the missing-tooling blocker, and the existing localhost callback-address limitation. The README example now includes managed-attempt provenance, and provider docs and 6.2.1 notes describe the actual support boundary.

This addresses the misleading instructions reported in discussion #1586. It does not implement native child credential provisioning or alter API authentication; that integration bug remains open in #1587 with acceptance criteria for an authenticated terminal-delivery path and fail-closed launch readiness.

Local verification: ten renderer tests with the reviewed snapshot; 108 OpenClaw adapter, authentication and permission tests; server typecheck; changed-file ESLint and Prettier; release source preflight. No live OpenClaw child was launched. GitHub Actions remain disabled. The unsigned 6.2.1 DMG/ZIP candidate was rebuilt from merged revision `61c120352afabc6d9fade991f7959094ba0e9182`. The actual ZIP-extracted app passed exact build/version and isolated startup checks; its packaged server contains the corrected instructions. Artifact SHA256 verification passed. This is not signed release publication or a live OpenClaw completion test.
