### PR TITLE
docs: finalize 6.2.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.2.1] - 2026-09-09
+## [6.2.1] - 2026-09-10
 
 ### Fixed
 

--- a/docs/releases/v6.2.1.md
+++ b/docs/releases/v6.2.1.md
@@ -1,4 +1,4 @@
-Veritas Kanban 6.2.1 restores Docker builds for centrally hosted browser/server installations and updates vulnerable transitive dependencies.
+Veritas Kanban 6.2.1 adds authenticated native OpenClaw task completion, restores Docker builds for centrally hosted browser/server installations, and updates vulnerable transitive dependencies.
 
 ## Fixed
 


### PR DESCRIPTION
Finalize the 6.2.1 release source with the September 10 publication date and include authenticated native OpenClaw completion in the release summary. All seven package versions are already 6.2.1 from the coordinated version update.

Local verification: release source preflight, three release-format tests, and diff checks pass. The unchanged application code previously passed the full local workspace suites, build, typechecks, and native OpenClaw smoke checks.

Signed asset publication and the Homebrew cask update follow once the local signing prerequisites are available. No GitHub CI is used.
